### PR TITLE
feat(coverage): print parsing conformance for test262 (currently 100%)

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -23,7 +23,7 @@ unsafe impl<'a> Sync for Program<'a> {}
 impl<'a> Program<'a> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.body.is_empty()
+        self.body.is_empty() && self.directives.is_empty()
     }
 }
 

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+oxc_allocator = { path = "../../crates/oxc_allocator" }
+oxc_parser = { path = "../../crates/oxc_parser" }
 oxc_ast = { path = "../../crates/oxc_ast" }
 serde = { workspace = true, features = ["derive"] }
 rayon = { workspace = true }

--- a/tasks/coverage/test262.snap
+++ b/tasks/coverage/test262.snap
@@ -1,3 +1,2 @@
 Test262 Summary:
-Positive Passed: 0/43934 (0.00%)
-Negative Passed: 3917/3917 (100.00%)
+AST Parsed     : 43934/43934 (100.00%)


### PR DESCRIPTION
Running `cargo coverage` prints

```
Test262 Summary:
AST Parsed     : 43934/43934 (100.00%)
```

The current parser parses all of test262.

"Positive Passed" and "Negative Passed" are commented out in the code because they not meaningful right now. They will become meaningful once semantic analysis is in place.

