### PR TITLE
perf(lexer): utilize jump table for distinguishing tokens (~5% improvement)

### DIFF
--- a/crates/oxc_parser/src/lexer/constants.rs
+++ b/crates/oxc_parser/src/lexer/constants.rs
@@ -31,14 +31,16 @@ pub const FF: char = '\u{c}';
 /// U+00A0 NON-BREAKING SPACE, abbreviated <NBSP>.
 pub const NBSP: char = '\u{a0}';
 
-pub const fn is_regular_whitespace(c: char) -> bool {
-    matches!(c, ' ' | '\t')
-}
+// Unused
+// pub const fn is_regular_whitespace(c: char) -> bool {
+//     matches!(c, ' ' | '\t')
+// }
 
+/// Whitespace where ASCII code > 127
 pub const fn is_irregular_whitespace(c: char) -> bool {
     matches!(
         c,
-        VT | FF | NBSP | ZWNBSP | '\u{85}' | '\u{1680}' | '\u{2000}'
+        NBSP | ZWNBSP | '\u{85}' | '\u{1680}' | '\u{2000}'
             ..='\u{200a}' | '\u{202f}' | '\u{205f}' | '\u{3000}'
     )
 }
@@ -82,133 +84,133 @@ pub fn is_identifier_part(c: char) -> bool {
     c == '$' || is_id_continue(c) || c == ZWNJ || c == ZWJ
 }
 
-pub const SINGLE_CHAR_TOKENS: &[Kind; 128] = &[
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::LParen, // 0x28
-    Kind::RParen, // 0x29
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Comma, // 0x2C
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Colon,     // 0x3A
-    Kind::Semicolon, // 0x3B
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::RAngle, // 0x3E
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::LBrack, // 0x5B
-    Kind::Undetermined,
-    Kind::RBrack, // 0x5D
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::Undetermined,
-    Kind::LCurly, // 0x7B
-    Kind::Undetermined,
-    Kind::RCurly, // 0x7D
-    Kind::Tilde,  // 0x7E
-    Kind::Undetermined,
+pub const JUMP_TABLE: &[Kind; 128] = &[
+    /*   0 */ Kind::Eof,
+    /*   1 */ Kind::Undetermined,
+    /*   2 */ Kind::Undetermined,
+    /*   3 */ Kind::Undetermined,
+    /*   4 */ Kind::Undetermined,
+    /*   5 */ Kind::Undetermined,
+    /*   6 */ Kind::Undetermined,
+    /*   7 */ Kind::Undetermined,
+    /*   8 */ Kind::Undetermined,
+    /*   9 */ Kind::WhiteSpace, // Horizontal Tab
+    /*  10 */ Kind::NewLine, // Line Feed
+    /*  11 */ Kind::WhiteSpace, // Vertical Tab
+    /*  12 */ Kind::WhiteSpace, // Form Feed
+    /*  13 */ Kind::NewLine, // Carriage Return
+    /*  14 */ Kind::Undetermined,
+    /*  15 */ Kind::Undetermined,
+    /*  16 */ Kind::Undetermined,
+    /*  17 */ Kind::Undetermined,
+    /*  18 */ Kind::Undetermined,
+    /*  19 */ Kind::Undetermined,
+    /*  20 */ Kind::Undetermined,
+    /*  21 */ Kind::Undetermined,
+    /*  22 */ Kind::Undetermined,
+    /*  23 */ Kind::Undetermined,
+    /*  24 */ Kind::Undetermined,
+    /*  25 */ Kind::Undetermined,
+    /*  26 */ Kind::Undetermined,
+    /*  27 */ Kind::Undetermined,
+    /*  28 */ Kind::Undetermined,
+    /*  29 */ Kind::Undetermined,
+    /*  30 */ Kind::Undetermined,
+    /*  31 */ Kind::Undetermined,
+    /*  32 */ Kind::WhiteSpace, // Space
+    /*  33 */ Kind::Bang,
+    /*  34 */ Kind::Str, // "
+    /*  35 */ Kind::PrivateIdentifier, // #
+    /*  36 */ Kind::Ident, // $
+    /*  37 */ Kind::Percent,
+    /*  38 */ Kind::Amp,
+    /*  39 */ Kind::Str, // '
+    /*  40 */ Kind::LParen,
+    /*  41 */ Kind::RParen,
+    /*  42 */ Kind::Star,
+    /*  43 */ Kind::Plus,
+    /*  44 */ Kind::Comma,
+    /*  45 */ Kind::Minus,
+    /*  46 */ Kind::Dot,
+    /*  47 */ Kind::Slash,
+    /*  48 */ Kind::Octal, // placeholder for 0 start
+    /*  49 */ Kind::Decimal, // 1
+    /*  50 */ Kind::Decimal, // 2
+    /*  51 */ Kind::Decimal, // 3
+    /*  52 */ Kind::Decimal, // 4
+    /*  53 */ Kind::Decimal, // 5
+    /*  54 */ Kind::Decimal, // 6
+    /*  55 */ Kind::Decimal, // 7
+    /*  56 */ Kind::Decimal, // 8
+    /*  57 */ Kind::Decimal, // 9
+    /*  58 */ Kind::Colon,
+    /*  59 */ Kind::Semicolon,
+    /*  60 */ Kind::LAngle,
+    /*  61 */ Kind::Eq,
+    /*  62 */ Kind::RAngle,
+    /*  63 */ Kind::Question,
+    /*  64 */ Kind::At,
+    /*  65 */ Kind::Ident,
+    /*  66 */ Kind::Ident,
+    /*  67 */ Kind::Ident,
+    /*  68 */ Kind::Ident,
+    /*  69 */ Kind::Ident,
+    /*  70 */ Kind::Ident,
+    /*  71 */ Kind::Ident,
+    /*  72 */ Kind::Ident,
+    /*  73 */ Kind::Ident,
+    /*  74 */ Kind::Ident,
+    /*  75 */ Kind::Ident,
+    /*  76 */ Kind::Ident,
+    /*  77 */ Kind::Ident,
+    /*  78 */ Kind::Ident,
+    /*  79 */ Kind::Ident,
+    /*  80 */ Kind::Ident,
+    /*  81 */ Kind::Ident,
+    /*  82 */ Kind::Ident,
+    /*  83 */ Kind::Ident,
+    /*  84 */ Kind::Ident,
+    /*  85 */ Kind::Ident,
+    /*  86 */ Kind::Ident,
+    /*  87 */ Kind::Ident,
+    /*  88 */ Kind::Ident,
+    /*  89 */ Kind::Ident,
+    /*  90 */ Kind::Ident,
+    /*  91 */ Kind::LBrack,
+    /*  92 */ Kind::Unknown, // placeholder for `\`
+    /*  93 */ Kind::RBrack,
+    /*  94 */ Kind::Caret,
+    /*  95 */ Kind::Ident, // _
+    /*  96 */ Kind::NoSubstitutionTemplate,
+    /*  97 */ Kind::Ident,
+    /*  98 */ Kind::Ident,
+    /*  99 */ Kind::Ident,
+    /* 100 */ Kind::Ident,
+    /* 101 */ Kind::Ident,
+    /* 102 */ Kind::Ident,
+    /* 103 */ Kind::Ident,
+    /* 104 */ Kind::Ident,
+    /* 105 */ Kind::Ident,
+    /* 106 */ Kind::Ident,
+    /* 107 */ Kind::Ident,
+    /* 108 */ Kind::Ident,
+    /* 109 */ Kind::Ident,
+    /* 110 */ Kind::Ident,
+    /* 111 */ Kind::Ident,
+    /* 112 */ Kind::Ident,
+    /* 113 */ Kind::Ident,
+    /* 114 */ Kind::Ident,
+    /* 115 */ Kind::Ident,
+    /* 116 */ Kind::Ident,
+    /* 117 */ Kind::Ident,
+    /* 118 */ Kind::Ident,
+    /* 119 */ Kind::Ident,
+    /* 120 */ Kind::Ident,
+    /* 121 */ Kind::Ident,
+    /* 122 */ Kind::Ident,
+    /* 123 */ Kind::LCurly,
+    /* 124 */ Kind::Pipe,
+    /* 125 */ Kind::RCurly,
+    /* 126 */ Kind::Tilde,
+    /* 127 */ Kind::Undetermined,
 ];

--- a/tasks/coverage/typescript.snap
+++ b/tasks/coverage/typescript.snap
@@ -1,5 +1,5 @@
 TypeScript Summary:
-AST Parsed     : 4287/4861 (88.19%)
+AST Parsed     : 4288/4861 (88.21%)
 Expect to Parse: "async/es2017/asyncArrowFunction/asyncArrowFunction6_es2017.ts"
 Expect to Parse: "async/es2017/asyncArrowFunction/asyncArrowFunction7_es2017.ts"
 Expect to Parse: "async/es2017/asyncArrowFunction/asyncArrowFunction8_es2017.ts"
@@ -538,7 +538,6 @@ Expect to Parse: "scanner/ecmascript5/scannerS7.4_A2_T2.ts"
 Expect to Parse: "scanner/ecmascript5/scannerS7.8.3_A6.1_T1.ts"
 Expect to Parse: "scanner/ecmascript5/scannerS7.8.4_A7.1_T4.ts"
 Expect to Parse: "scanner/ecmascript5/scannerStringLiterals.ts"
-Expect to Parse: "scanner/ecmascript5/scannerUnexpectedNullCharacter1.ts"
 Expect to Parse: "scanner/ecmascript5/scannerUnicodeEscapeInKeyword1.ts"
 Expect to Parse: "statements/for-ofStatements/ES5For-of12.ts"
 Expect to Parse: "statements/for-ofStatements/ES5For-of20.ts"


### PR DESCRIPTION
I had a gut feeling this will make it faster but I don't know the precise reason.

Something along the lines of LLVM / branch prediction / cache friendliness ...