### PR TITLE
docs(oxc_parser): add header symbol for `parser.unexpected`'s doc comment

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -123,7 +123,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Return error info at current token
-    /// Panics
+    /// # Panics
     ///   * The lexer did not push a diagnostic when `Kind::Undetermined` is returned
     fn unexpected<T>(&self) -> Result<T> {
         // The lexer should have reported a more meaningful diagnostic


### PR DESCRIPTION
## Description

It seems that there should exist a `#` symbol to make `Panics` be an title when user see the document comment.

## Additional Information

I'm highly interested in this project, but I'm a newbie in Rust and compiler. Currently trying to understand the compiler concepts from [the guide you wrote](https://boshen.github.io/javascript-parser-in-rust/docs/intro/) and trying to understand this great project :)

I'm also not good at english writing, so if I have written anything that offend you, please accept my apologies.