### PR TITLE
feat(oxc_ast): add RegExpFlags bitflag for storing regex flags

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -5,6 +5,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use bitflags::bitflags;
 use num_bigint::BigUint;
 use ordered_float::NotNan;
 use serde::{
@@ -110,12 +111,65 @@ pub struct RegExpLiteral {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
 pub struct RegExp {
     pub pattern: Atom,
-    pub flags: Atom,
+    pub flags: RegExpFlags,
 }
 
 impl fmt::Display for RegExp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "/{}/{}", self.pattern, self.flags)
+    }
+}
+
+bitflags! {
+    pub struct RegExpFlags: u8 {
+        const G = 1 << 0;
+        const I = 1 << 1;
+        const M = 1 << 2;
+        const S = 1 << 3;
+        const U = 1 << 4;
+        const Y = 1 << 5;
+        const D = 1 << 6;
+        /// v flag from `https://github.com/tc39/proposal-regexp-set-notation`
+        const V = 1 << 7;
+    }
+}
+
+impl fmt::Display for RegExpFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.contains(Self::G) {
+            write!(f, "g")?;
+        }
+        if self.contains(Self::I) {
+            write!(f, "i")?;
+        }
+        if self.contains(Self::M) {
+            write!(f, "m")?;
+        }
+        if self.contains(Self::S) {
+            write!(f, "s")?;
+        }
+        if self.contains(Self::U) {
+            write!(f, "u")?;
+        }
+        if self.contains(Self::Y) {
+            write!(f, "y")?;
+        }
+        if self.contains(Self::D) {
+            write!(f, "d")?;
+        }
+        if self.contains(Self::V) {
+            write!(f, "v")?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for RegExpFlags {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -1,7 +1,7 @@
 //! Token
 
 use num_bigint::BigUint;
-use oxc_ast::{Atom, Node};
+use oxc_ast::{ast::RegExpFlags, Atom, Node};
 
 use super::kind::Kind;
 
@@ -25,6 +25,13 @@ pub struct Token {
     pub value: TokenValue,
 }
 
+#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+#[test]
+fn no_bloat_token() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<Token>(), 56);
+}
+
 impl Token {
     #[must_use]
     pub const fn node(&self) -> Node {
@@ -44,7 +51,7 @@ pub enum TokenValue {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegExp {
     pub pattern: Atom,
-    pub flags: Atom,
+    pub flags: RegExpFlags,
 }
 
 impl Default for TokenValue {

--- a/crates/oxc_printer/src/gen.rs
+++ b/crates/oxc_printer/src/gen.rs
@@ -841,7 +841,7 @@ impl Gen for RegExpLiteral {
         p.print(b'/');
         p.print_str(self.regex.pattern.as_bytes());
         p.print(b'/');
-        p.print_str(self.regex.flags.as_bytes());
+        p.print_str(self.regex.flags.to_string().as_bytes());
     }
 }
 


### PR DESCRIPTION
This reduces `TokenValue` from 56 to 40 bytes, `Token` from 72 to 56 bytes.