### PR TITLE
refactor(diagnostic): change Err type to miette::Error

### DIFF
--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -5,13 +5,15 @@ use std::{cell::RefCell, ops::Deref, rc::Rc};
 use oxc_ast::{Atom, Span};
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, Diagnostic>;
+pub type PError = miette::Error;
+
+pub type Result<T> = std::result::Result<T, PError>;
 
 #[derive(Debug, Default, Clone)]
-pub struct Diagnostics(Rc<RefCell<Vec<Diagnostic>>>);
+pub struct Diagnostics(Rc<RefCell<Vec<PError>>>);
 
 impl Deref for Diagnostics {
-    type Target = Rc<RefCell<Vec<Diagnostic>>>;
+    type Target = Rc<RefCell<Vec<PError>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -21,7 +23,7 @@ impl Deref for Diagnostics {
 impl Diagnostics {
     /// # Panics
     #[must_use]
-    pub fn into_inner(self) -> Vec<Diagnostic> {
+    pub fn into_inner(self) -> Vec<PError> {
         Rc::try_unwrap(self.0).unwrap().into_inner()
     }
 }

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -141,7 +141,7 @@ impl<'a> Parser<'a> {
     pub fn asi(&mut self) -> Result<()> {
         if !self.can_insert_semicolon() {
             let span = Span::new(self.prev_token_end, self.cur_token().start);
-            return Err(Diagnostic::AutoSemicolonInsertion(span));
+            return Err(Diagnostic::AutoSemicolonInsertion(span).into());
         }
         if self.at(Kind::Semicolon) {
             self.advance(Kind::Semicolon);
@@ -163,7 +163,9 @@ impl<'a> Parser<'a> {
     pub fn expect(&mut self, kind: Kind) -> Result<()> {
         if !self.at(kind) {
             let range = self.current_range();
-            return Err(Diagnostic::ExpectToken(kind.to_str(), self.cur_kind().to_str(), range));
+            return Err(
+                Diagnostic::ExpectToken(kind.to_str(), self.cur_kind().to_str(), range).into()
+            );
         }
         self.advance(kind);
         Ok(())

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -45,7 +45,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
                 let span = expr.span;
                 match expr.unbox().expression {
                     Expression::ObjectExpression(_) | Expression::ArrayExpression(_) => {
-                        Err(Diagnostic::InvalidAssignment(span))
+                        Err(Diagnostic::InvalidAssignment(span).into())
                     }
                     expr => SimpleAssignmentTarget::cover(expr, p),
                 }
@@ -55,7 +55,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
                 Ok(SimpleAssignmentTarget::TSNonNullExpression(expr))
             }
             Expression::TSTypeAssertion(expr) => Ok(SimpleAssignmentTarget::TSTypeAssertion(expr)),
-            expr => Err(Diagnostic::InvalidAssignment(expr.span())),
+            expr => Err(Diagnostic::InvalidAssignment(expr.span()).into()),
         }
     }
 }
@@ -80,7 +80,7 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
                                 p.error(Diagnostic::RestElementTraillingComma(span));
                             }
                         } else {
-                            return Err(Diagnostic::SpreadLastElement(elem.span));
+                            return Err(Diagnostic::SpreadLastElement(elem.span).into());
                         }
                     }
                 }
@@ -135,7 +135,7 @@ impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
                     if i == len - 1 {
                         rest = Some(AssignmentTarget::cover(spread.unbox().argument, p)?);
                     } else {
-                        return Err(Diagnostic::SpreadLastElement(spread.span));
+                        return Err(Diagnostic::SpreadLastElement(spread.span).into());
                     }
                 }
             }
@@ -166,7 +166,7 @@ impl<'a> CoverGrammar<'a, Property<'a>> for AssignmentTargetProperty<'a> {
             let binding = match property.value {
                 PropertyValue::Expression(expr) => AssignmentTargetMaybeDefault::cover(expr, p)?,
                 PropertyValue::Pattern(_) => {
-                    return Err(Diagnostic::InvalidAssignment(property.value.span()));
+                    return Err(Diagnostic::InvalidAssignment(property.value.span()).into());
                 }
             };
             let target = AssignmentTargetPropertyProperty {

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -242,7 +242,7 @@ impl<'a> Lexer<'a> {
 
     // ---------- Private Methods ---------- //
     fn error(&mut self, error: Diagnostic) {
-        self.errors.borrow_mut().push(error);
+        self.errors.borrow_mut().push(error.into());
     }
 
     /// Get the length offset from the source, in UTF-8 bytes


### PR DESCRIPTION
This is the prerequisite for breaking up the large Diagnostic enum.