### PR TITLE
fix(oxc_parser): don't parse ambiguous await with parse_await_expression

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -994,7 +994,17 @@ impl<'a> Parser<'a> {
             if self.ctx.has_await() {
                 return true;
             }
+
             let peek_token = self.peek_token();
+            // The following expressions are ambiguous
+            // await + 0, await - 0, await ( 0 ), await [ 0 ], await / 0 /u, await ``, await of []
+            if matches!(
+                peek_token.kind,
+                Kind::Of | Kind::LParen | Kind::LBrack | Kind::Slash | Kind::RegExp
+            ) {
+                return false;
+            }
+
             return peek_token.kind.is_after_await_or_yield() && !peek_token.is_on_new_line;
         }
         false

--- a/tasks/coverage/babel.snap
+++ b/tasks/coverage/babel.snap
@@ -1,13 +1,5 @@
 Babel Summary:
-AST Parsed     : 2045/2057 (99.42%)
-Expect to Parse: "es2015/for-of/valid-script-await-as-lhs/input.js"
-
-  × Unexpected token
-   ╭─[es2015/for-of/valid-script-await-as-lhs/input.js:1:1]
- 1 │ for (await of []);
-   ·                ─
- 2 │ for (await of [0]);
-   ╰────
+AST Parsed     : 2046/2057 (99.47%)
 Expect to Parse: "typescript/arrow-function/generic-tsx-babel-7/input.ts"
 
   × Expect token
@@ -2616,6 +2608,20 @@ Expect to Parse: "typescript/type-arguments-bit-shift-left-like/decorator-call-e
  1 │ \u0061sync function() { await x }
    · ─────┬────
    ·      ╰── keyword cannot contain escape characters
+   ╰────
+
+  × Keywords cannot contain escape characters
+   ╭─[es2017/async-functions/invalid-for-await-expression-init/input.js:1:1]
+ 1 │ for (await o\u0066 [0];;);
+   ·            ───┬───
+   ·               ╰── keyword cannot contain escape characters
+   ╰────
+
+  × Expect token
+   ╭─[es2017/async-functions/invalid-for-await-expression-init/input.js:1:1]
+ 1 │ for (await o\u0066 [0];;);
+   ·                       ┬
+   ·                       ╰── Expect `)` here, but found `;`
    ╰────
 
   × Async functions can only be declared at the top level or inside a block

--- a/tasks/coverage/printer.snap
+++ b/tasks/coverage/printer.snap
@@ -1,2 +1,2 @@
 Printer Summary:
-AST Parsed     : 44469/44469 (100.00%)
+AST Parsed     : 44443/44443 (100.00%)

--- a/tasks/coverage/test262.snap
+++ b/tasks/coverage/test262.snap
@@ -1,5 +1,5 @@
 Test262 Summary:
-AST Parsed     : 43960/43960 (100.00%)
+AST Parsed     : 43934/43934 (100.00%)
 
   × Unexpected token
     ╭─[annexB/language/statements/for-in/bare-initializer.js:14:1]

--- a/tasks/coverage/typescript.snap
+++ b/tasks/coverage/typescript.snap
@@ -1,5 +1,5 @@
 TypeScript Summary:
-AST Parsed     : 4294/4865 (88.26%)
+AST Parsed     : 4291/4861 (88.27%)
 Expect to Parse: "async/es2017/asyncArrowFunction/asyncArrowFunction6_es2017.ts"
 
   × Automatic Semicolon Insertion
@@ -1410,17 +1410,6 @@ Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor1.ts"
    ·               ─
  6 │     accessor b = 1;
    ╰────
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor11.ts"
-
-  × Automatic Semicolon Insertion
-    ╭─[classes/propertyMemberDeclarations/autoAccessor11.ts:13:1]
- 13 │ 
- 14 │     accessor accessor
-    ·             ┬
-    ·             ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 15 │     d;
-    ╰────
-  help: Try insert a semicolon here
 Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor2.ts"
 
   × Automatic Semicolon Insertion


### PR DESCRIPTION
## Description

In js, the `await` can be used as a variable.In this case, we shouldn't parse the `await` with the `parse_await_expression`. 

## Additional information

In babel's parser, they filter out `+`, `-`, `(`, `[`, `of` and so on, but if I filter out the `[`, our parser cannot pass some of the top-level await in test262's test cases.

## Related issue

#36 

## References

https://github.com/babel/babel/issues/15127
https://github.com/babel/babel/blob/main/packages/babel-parser/src/parser/expression.ts#L2882-L2894