### PR TITLE
chore(rust): comment on profile.release and set abort = "panic" for performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,11 @@ clap = "4.1.6"
 indextree = "4.5.0"
 
 [profile.release]
+# Configurations explicitly listed here for clarity.
+# Using the best options for performance.
+opt-level = 3
 lto = "fat"
 codegen-units = 1
-strip = true
-
-# DO NOT SET PANIC TO ABORT
-# we are using catch_unwind for panic recovery
-panic = "unwind"
+strip = "debuginfo"
+debug = false
+panic = "abort" # Let it crash and force ourselves to write safe Rust.


### PR DESCRIPTION
I found rewind and tracing logic from the compiled assembly, which slows things down a bit.

Let's aim for safe Rust - I've turned on miri on the main branch.