### PR TITLE
feat(cli): support linting glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +826,7 @@ name = "oxc_cli"
 version = "0.0.0"
 dependencies = [
  "clap 4.1.6",
+ "glob",
  "ignore",
  "jemallocator",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.93"
 thiserror = "1.0.38"
 clap = "4.1.6"
 indextree = "4.5.0"
+glob = "0.3.1"
 
 [profile.release]
 # Configurations explicitly listed here for clarity.

--- a/crates/oxc_cli/Cargo.toml
+++ b/crates/oxc_cli/Cargo.toml
@@ -24,6 +24,7 @@ oxc_semantic = { path  = "../oxc_semantic" }
 oxc_linter = { path  = "../oxc_linter" }
 
 clap = { workspace = true }
+glob = { workspace = true }
 rayon = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 

--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -33,6 +33,7 @@ impl Command {
             .arg(
                 Arg::new("path")
                     .value_name("PATH")
+                    .num_args(1..)
                     .required(true)
                     .help("File or Directory paths to scan. Directories are scanned recursively.")
                     .value_parser(ValueParser::path_buf()),
@@ -64,6 +65,18 @@ mod test {
         let matches = matches.subcommand_matches("lint");
         assert!(matches.is_some());
         assert_eq!(matches.unwrap().get_one::<PathBuf>("path"), Some(&PathBuf::from(".")));
+    }
+
+    #[test]
+    fn test_lint_multiple_paths() {
+        let arg = "oxc lint foo bar baz";
+        let matches = Command::new().build().try_get_matches_from(arg.split(' ')).unwrap();
+        let matches = matches.subcommand_matches("lint");
+        assert!(matches.is_some());
+        assert_eq!(
+            matches.unwrap().get_many::<PathBuf>("path").unwrap().collect::<Vec<_>>(),
+            [&PathBuf::from("foo"), &PathBuf::from("bar"), &PathBuf::from("baz")]
+        );
     }
 
     #[test]

--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -18,8 +18,12 @@ pub use crate::{command::Command, result::CliRunResult};
 pub struct Cli;
 
 impl Cli {
-    pub fn lint<P: AsRef<Path>>(path: P) -> CliRunResult {
-        let paths = Walk::new(path).iter().collect::<Vec<_>>();
+    #[must_use]
+    pub fn lint<P: AsRef<Path>>(paths: &[P]) -> CliRunResult {
+        let paths = paths
+            .iter()
+            .flat_map(|path| Walk::new(path).iter().collect::<Vec<_>>())
+            .collect::<Vec<_>>();
 
         let number_of_diagnostics = paths
             .par_iter()

--- a/crates/oxc_cli/src/main.rs
+++ b/crates/oxc_cli/src/main.rs
@@ -15,13 +15,22 @@ use oxc_cli::{Cli, CliRunResult, Command};
 fn main() -> CliRunResult {
     match Command::new().build().get_matches().subcommand() {
         Some(("lint", matches)) => {
-            let path = matches.get_one::<PathBuf>("path").unwrap();
+            let mut paths = vec![];
 
-            if path.canonicalize().is_err() {
-                return CliRunResult::PathNotFound { path: path.clone() };
+            for path in matches.get_many::<PathBuf>("path").unwrap() {
+                let globbed = glob::glob(&path.to_string_lossy())
+                    .expect("Failed to read glob pattern")
+                    .map(|path| path.expect("Failed to read glob pattern"))
+                    .collect::<Vec<_>>();
+
+                if globbed.is_empty() && path.canonicalize().is_err() {
+                    return CliRunResult::PathNotFound { path: path.clone() };
+                }
+
+                paths.extend(globbed);
             }
 
-            Cli::lint(path)
+            Cli::lint(&paths)
         }
         _ => CliRunResult::None,
     }


### PR DESCRIPTION
# Summary

Closes #55.

- Adds support for `oxc_cli lint "/path/with/glob/**/*.js"`
- Adds support for `oxc_cli lint path1 path2 ...` to account for shell-expanded globs as well.

Wasn't sure the approach of always globbing whatever args we're getting is solid enough.
To keep throwing path not found errors - I had to check whether `glob` returned no matches, not sure that's good enough.