### PR TITLE
chore(gitignore): ignore `benchmark/package-lock.json`

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,1 +1,2 @@
 tmp
+package-lock.json


### PR DESCRIPTION
# Summary

After running the benchmarks, a `benchmark/package-lock.json` file is generated.

This PR simply ignores it so it doesn't clutter the local git tree.

Alternatively we can configure npm to not emit and use a lockfile.