### PR TITLE
fix(oxc_parser): check accessor correctly

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -163,7 +163,12 @@ impl<'a> Parser<'a> {
 
         let modifier = self.parse_class_element_modifiers(false);
 
-        let accessor = self.peek_at(Kind::Ident) && self.eat(Kind::Accessor);
+        let accessor = matches!(
+            self.peek_kind(),
+            // js can use [prop] or "prop" to define a property,
+            // so we need to check `LBrack` and `Str`
+            Kind::Ident | Kind::PrivateIdentifier | Kind::LBrack | Kind::Str
+        ) && self.eat(Kind::Accessor);
 
         let accessibility = modifier.accessibility();
 
@@ -244,6 +249,8 @@ impl<'a> Parser<'a> {
         }
 
         if accessor {
+            self.parse_ts_type_annotation()?;
+
             return self.parse_class_accessor_property(span, key, computed, r#static);
         }
 

--- a/tasks/coverage/babel.snap
+++ b/tasks/coverage/babel.snap
@@ -1,5 +1,5 @@
 Babel Summary:
-AST Parsed     : 2055/2069 (99.32%)
+AST Parsed     : 2056/2069 (99.37%)
 Expect to Parse: "typescript/arrow-function/generic-tsx-babel-7/input.ts"
 
   × Expect token
@@ -19,15 +19,6 @@ Expect to Parse: "typescript/cast/satisfies/input.ts"
  2 │ x < y satisfies boolean; // (x < y) satisfies boolean;
    ╰────
   help: Try insert a semicolon here
-Expect to Parse: "typescript/class/accessor/input.ts"
-
-  × Unexpected token
-   ╭─[typescript/class/accessor/input.ts:1:1]
- 1 │ abstract class Foo {
- 2 │   accessor prop: number = 1;
-   ·                ─
- 3 │   static accessor prop2: number = 1;
-   ╰────
 Expect to Parse: "typescript/declare/function-rest-trailing-comma/input.ts"
 
   × Rest element must be last element
@@ -6541,14 +6532,6 @@ Expect to Parse: "typescript/types/const-type-parameters/input.ts"
    ·  ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
    ╰────
   help: Try insert a semicolon here
-
-  × Unexpected token
-   ╭─[typescript/class/accessor-invalid/input.ts:1:1]
- 1 │ abstract class Foo {
- 2 │   declare accessor prop7: number;
-   ·                         ─
- 3 │   private accessor #p: any;
-   ╰────
 
   × Automatic Semicolon Insertion
    ╭─[typescript/class/declare-new-line-abstract/input.ts:1:1]

--- a/tasks/coverage/typescript.snap
+++ b/tasks/coverage/typescript.snap
@@ -1,5 +1,5 @@
 TypeScript Summary:
-AST Parsed     : 4294/4865 (88.26%)
+AST Parsed     : 4310/4865 (88.59%)
 Expect to Parse: "async/es2017/asyncArrowFunction/asyncArrowFunction6_es2017.ts"
 
   × Automatic Semicolon Insertion
@@ -1401,15 +1401,6 @@ Expect to Parse: "classes/nestedClassDeclaration.ts"
  6 │     }
    ╰────
   help: Try insert a semicolon here
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor1.ts"
-
-  × Unexpected token
-   ╭─[classes/propertyMemberDeclarations/autoAccessor1.ts:4:1]
- 4 │ class C1 {
- 5 │     accessor a: any;
-   ·               ─
- 6 │     accessor b = 1;
-   ╰────
 Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor11.ts"
 
   × Automatic Semicolon Insertion
@@ -1420,28 +1411,6 @@ Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor11.ts"
     ·             ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
  15 │     d;
     ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor2.ts"
-
-  × Automatic Semicolon Insertion
-   ╭─[classes/propertyMemberDeclarations/autoAccessor2.ts:3:1]
- 3 │ class C1 {
- 4 │     accessor #a: any;
-   ·             ┬
-   ·             ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 5 │     accessor #b = 1;
-   ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor3.ts"
-
-  × Automatic Semicolon Insertion
-   ╭─[classes/propertyMemberDeclarations/autoAccessor3.ts:4:1]
- 4 │ class C1 {
- 5 │     accessor "w": any;
-   ·             ┬
-   ·             ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 6 │     accessor "x" = 1;
-   ╰────
   help: Try insert a semicolon here
 Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor4.ts"
 
@@ -1454,53 +1423,17 @@ Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor4.ts"
  6 │     accessor 1 = 1;
    ╰────
   help: Try insert a semicolon here
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor5.ts"
-
-  × Automatic Semicolon Insertion
-   ╭─[classes/propertyMemberDeclarations/autoAccessor5.ts:3:1]
- 3 │ class C1 {
- 4 │     accessor ["w"]: any;
-   ·             ┬
-   ·             ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 5 │     accessor ["x"] = 1;
-   ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor6.ts"
-
-  × Unexpected token
-   ╭─[classes/propertyMemberDeclarations/autoAccessor6.ts:4:1]
- 4 │ class C1 {
- 5 │     accessor a: any;
-   ·               ─
- 6 │ }
-   ╰────
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor7.ts"
-
-  × Unexpected token
-   ╭─[classes/propertyMemberDeclarations/autoAccessor7.ts:4:1]
- 4 │ abstract class C1 {
- 5 │     abstract accessor a: any;
-   ·                        ─
- 6 │ }
-   ╰────
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessor8.ts"
-
-  × Unexpected token
-   ╭─[classes/propertyMemberDeclarations/autoAccessor8.ts:4:1]
- 4 │ class C1 {
- 5 │     accessor a: any;
-   ·               ─
- 6 │     static accessor b: any;
-   ╰────
 Expect to Parse: "classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts"
 
-  × Unexpected token
-   ╭─[classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts:4:1]
- 4 │ abstract class C1 {
- 5 │     accessor a: any;
-   ·               ─
- 6 │     public accessor b: any;
-   ╰────
+  × Automatic Semicolon Insertion
+    ╭─[classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts:15:1]
+ 15 │     accessor "k": any;
+ 16 │     accessor 108: any;
+    ·             ┬
+    ·             ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
+ 17 │     accessor ["m"]: any;
+    ╰────
+  help: Try insert a semicolon here
 Expect to Parse: "classes/propertyMemberDeclarations/autoAccessorDisallowedModifiers.ts"
 
   × Automatic Semicolon Insertion
@@ -1512,15 +1445,6 @@ Expect to Parse: "classes/propertyMemberDeclarations/autoAccessorDisallowedModif
  6 │     readonly accessor b: any;
    ╰────
   help: Try insert a semicolon here
-Expect to Parse: "classes/propertyMemberDeclarations/autoAccessorExperimentalDecorators.ts"
-
-  × Unexpected token
-   ╭─[classes/propertyMemberDeclarations/autoAccessorExperimentalDecorators.ts:7:1]
- 7 │     @dec
- 8 │     accessor a: any;
-   ·               ─
- 9 │ 
-   ╰────
 Expect to Parse: "classes/propertyMemberDeclarations/propertyNamedConstructor.ts"
 
   × Classes can't have a field named 'constructor'
@@ -3081,79 +3005,6 @@ Expect to Parse: "es7/trailingCommasInGetter.ts"
    ·           ─
  3 │ }
    ╰────
-Expect to Parse: "esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.ts"
-
-  × Unexpected token
-    ╭─[esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.ts:10:1]
- 10 │     static x: any = this;
- 11 │     static accessor a: any = this;
-    ·                      ─
- 12 │     static m() { this; }
-    ╰────
-Expect to Parse: "esDecorators/classDeclaration/esDecorators-classDeclaration-sourceMap.ts"
-
-  × Automatic Semicolon Insertion
-    ╭─[esDecorators/classDeclaration/esDecorators-classDeclaration-sourceMap.ts:49:1]
- 49 │     @dec
- 50 │     static accessor #z = 1;
-    ·                    ┬
-    ·                    ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 51 │ }
-    ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAbstractAccessor.ts"
-
-  × Unexpected token
-    ╭─[esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAbstractAccessor.ts:9:1]
-  9 │ abstract class C {
- 10 │     @dec(1) abstract accessor field1: number;
-    ·                                     ─
- 11 │     @dec(2) abstract accessor ["field2"]: number;
-    ╰────
-Expect to Parse: "esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAccessor.ts"
-
-  × Automatic Semicolon Insertion
-    ╭─[esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAccessor.ts:10:1]
- 10 │     @dec(1) accessor field1 = 1;
- 11 │     @dec(2) accessor ["field2"] = 2;
-    ·                     ┬
-    ·                     ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 12 │     @dec(3) accessor [field3] = 3;
-    ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivateAccessor.ts"
-
-  × Automatic Semicolon Insertion
-   ╭─[esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivateAccessor.ts:7:1]
- 7 │ class C {
- 8 │     @dec accessor #field1 = 0;
-   ·                  ┬
-   ·                  ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 9 │ }
-   ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAccessor.ts"
-
-  × Automatic Semicolon Insertion
-    ╭─[esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAccessor.ts:10:1]
- 10 │     @dec(1) static accessor field1 = 1;
- 11 │     @dec(2) static accessor ["field2"] = 2;
-    ·                            ┬
-    ·                            ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 12 │     @dec(3) static accessor [field3] = 3;
-    ╰────
-  help: Try insert a semicolon here
-Expect to Parse: "esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts"
-
-  × Automatic Semicolon Insertion
-   ╭─[esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts:7:1]
- 7 │ class C {
- 8 │     @dec static accessor #field1 = 0;
-   ·                         ┬
-   ·                         ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 9 │ }
-   ╰────
-  help: Try insert a semicolon here
 Expect to Parse: "esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.1.ts"
 
   × Unexpected token
@@ -3298,17 +3149,6 @@ Expect to Parse: "esDecorators/classExpression/namedEvaluation/esDecorators-clas
     ·      ─
  10 │ [x = class { @dec y: any; }] = obj;
     ╰────
-Expect to Parse: "esDecorators/esDecorators-contextualTypes.ts"
-
-  × Automatic Semicolon Insertion
-    ╭─[esDecorators/esDecorators-contextualTypes.ts:26:1]
- 26 │     @((t, c) => { })
- 27 │     static accessor #y = 1;
-    ·                    ┬
-    ·                    ╰── Expected a semicolon or an implicit semicolon after a statement, but found none
- 28 │ 
-    ╰────
-  help: Try insert a semicolon here
 Expect to Parse: "esDecorators/esDecorators-emitDecoratorMetadata.ts"
 
   × Unexpected token


### PR DESCRIPTION
## Description

For `accessor`, not only check `Ident` but also check `PrivateIdentifier` and `LBrack`. When encountering an accessor, parse ts type first.

## Related issue

#36 