### PR TITLE
fix(oxc_parser): support export type with star symbol

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1667,6 +1667,7 @@ pub struct ExportAllDeclaration<'a> {
     pub source: StringLiteral,
     #[cfg_attr(feature = "acorn", serde(skip_serializing_if = "Option::is_none"))]
     pub assertions: Option<Vec<'a, ImportAttribute>>, // Some(vec![]) for empty assertion
+    pub export_kind: Option<ImportOrExportKind>, // `export type *`
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, Hash)]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -957,8 +957,9 @@ impl<'a> AstBuilder<'a> {
         exported: Option<ModuleExportName>,
         source: StringLiteral,
         assertions: Option<Vec<'a, ImportAttribute>>, // Some(vec![]) for empty assertion
+        export_kind: Option<ImportOrExportKind>,
     ) -> Box<'a, ExportAllDeclaration<'a>> {
-        self.alloc(ExportAllDeclaration { exported, source, assertions })
+        self.alloc(ExportAllDeclaration { exported, source, assertions, export_kind })
     }
 
     #[must_use]

--- a/tasks/coverage/babel.snap
+++ b/tasks/coverage/babel.snap
@@ -1,5 +1,5 @@
 Babel Summary:
-AST Parsed     : 2056/2069 (99.37%)
+AST Parsed     : 2057/2069 (99.42%)
 Expect to Parse: "typescript/arrow-function/generic-tsx-babel-7/input.ts"
 
   × Expect token
@@ -42,14 +42,6 @@ Expect to Parse: "typescript/dts/valid-trailing-comma-for-rest/input.ts"
  1 │ function foo(...args: any[], );
    ·              ───────┬──────
    ·                     ╰── Rest element must be last element
-   ╰────
-Expect to Parse: "typescript/export/export-type-star-from/input.ts"
-
-  × Unexpected token
-   ╭─[typescript/export/export-type-star-from/input.ts:1:1]
- 1 │ export type * from './mod';
-   ·             ─
- 2 │ export type * as ns from './mod';
    ╰────
 Expect to Parse: "typescript/interface/get-set-properties/input.ts"
 


### PR DESCRIPTION
## Description

Also check `Kind::Star` when we encounter a `Kind::Type` to support export all.

## Related issue

#36 