### PR TITLE
feat(cli): implement `--max-warnings` CLI option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.defaultFormatter": "rust-lang.rust-analyzer"
-}

--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -58,6 +58,12 @@ impl Command {
                 .help("This option allows you to specify patterns of files to ignore (in addition to those in .eslintignore).")
             )
             .arg(
+                Arg::new("max-warnings")
+                  .long("max-warnings")
+                  .required(false)
+                  .help("This option allows you to specify a warning threshold, which can be used to force oxc_lint to exit with an error status if there are too many warning-level rule violations in your project.")
+              )
+            .arg(
                 Arg::new("path")
                     .value_name("PATH")
                     .num_args(1..)

--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -60,6 +60,7 @@ impl Command {
             .arg(
                 Arg::new("max-warnings")
                   .long("max-warnings")
+                  .value_parser(clap::value_parser!(usize))
                   .required(false)
                   .help("This option allows you to specify a warning threshold, which can be used to force oxc_lint to exit with an error status if there are too many warning-level rule violations in your project.")
               )
@@ -143,6 +144,22 @@ mod test {
     fn test_no_ignore() {
         let matches = get_lint_matches("oxc lint --no-ignore foo.js");
         assert!(matches.get_flag("no-ignore"));
+    }
+
+    #[test]
+    fn test_max_warnings_none() {
+        let arg = "oxc lint foo.js";
+        let matches = Command::new().build().try_get_matches_from(arg.split(' ')).unwrap();
+        let matches = matches.subcommand_matches("lint");
+        assert_eq!(matches.unwrap().get_one::<usize>("max-warnings"), None);
+    }
+
+    #[test]
+    fn test_max_warnings_some() {
+        let arg = "oxc lint --max-warnings 10 foo.js";
+        let matches = Command::new().build().try_get_matches_from(arg.split(' ')).unwrap();
+        let matches = matches.subcommand_matches("lint");
+        assert_eq!(matches.unwrap().get_one::<usize>("max-warnings"), Some(&10));
     }
 
     #[test]

--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -79,6 +79,17 @@ impl Cli {
             })
             .sum();
 
+        // https://eslint.org/docs/latest/use/command-line-interface#--max-warnings
+        if self.cli_options.max_warnings > -1 {
+            let max_warnings = self.cli_options.max_warnings as usize;
+            if number_of_diagnostics > max_warnings {
+                return CliRunResult::MaxWarningsExceeded {
+                    number_of_warnings: number_of_diagnostics,
+                    max_warnings,
+                };
+            }
+        }
+
         CliRunResult::LintResult { number_of_files: paths.len(), number_of_diagnostics }
     }
 

--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -59,7 +59,34 @@ impl Cli {
             })
             .collect::<Vec<_>>();
 
-        let number_of_diagnostics = paths
+        let mut number_of_warnings = 0;
+        let mut max_warnings_exceeded = false;
+        for path in paths {
+            let diagnostics = Self::lint_path(path);
+            let diagnostics_to_print = diagnostics
+                .iter()
+                .filter(|d| match d.severity() {
+                    // The --quiet flag follows ESLint's --quiet behavior as documented here: https://eslint.org/docs/latest/use/command-line-interface#--quiet
+                    // Note that it does not disable ALL diagnostics, only Warning diagnostics
+                    Some(Severity::Warning) => !self.cli_options.quiet,
+                    _ => true,
+                })
+                .collect::<Vec<_>>();
+
+            for diagnostic in diagnostics_to_print {
+                // https://eslint.org/docs/latest/use/command-line-interface#--max-warnings
+                if let Some(max_warnings) = self.cli_options.max_warnings {
+                    if number_of_warnings > max_warnings {
+                        max_warnings_exceeded = true;
+                        break;
+                    }
+                }
+                println!("{diagnostic:?}");
+                number_of_warnings += 1;
+            }
+        }
+
+        let number_of_warnings = paths
             .par_iter()
             .map(|path| {
                 let diagnostics = Self::lint_path(path);
@@ -79,18 +106,11 @@ impl Cli {
             })
             .sum();
 
-        // https://eslint.org/docs/latest/use/command-line-interface#--max-warnings
-        if self.cli_options.max_warnings > -1 {
-            let max_warnings = self.cli_options.max_warnings as usize;
-            if number_of_diagnostics > max_warnings {
-                return CliRunResult::MaxWarningsExceeded {
-                    number_of_warnings: number_of_diagnostics,
-                    max_warnings,
-                };
-            }
+        CliRunResult::LintResult {
+            number_of_files: paths.len(),
+            number_of_warnings,
+            max_warnings_exceeded,
         }
-
-        CliRunResult::LintResult { number_of_files: paths.len(), number_of_diagnostics }
     }
 
     fn lint_path(path: &Path) -> Vec<Error> {

--- a/crates/oxc_cli/src/options.rs
+++ b/crates/oxc_cli/src/options.rs
@@ -5,6 +5,7 @@ use glob::Pattern;
 
 pub struct CliOptions {
     pub quiet: bool,
+    pub max_warnings: isize,
     pub paths: Vec<PathBuf>,
     pub ignore_path: String,
     pub no_ignore: bool,
@@ -35,7 +36,14 @@ impl<'a> TryFrom<&'a ArgMatches> for CliOptions {
         let no_ignore = matches.get_flag("no-ignore");
         let ignore_pattern = get_ignore_pattern(matches);
 
-        Ok(Self { quiet: matches.get_flag("quiet"), paths, ignore_path, no_ignore, ignore_pattern })
+        Ok(Self {
+            quiet: matches.get_flag("quiet"),
+            max_warnings: matches.get_one::<isize>("max-warnings").copied().unwrap_or(-1),
+            paths,
+            ignore_path,
+            no_ignore,
+            ignore_pattern,
+        })
     }
 }
 

--- a/crates/oxc_cli/src/options.rs
+++ b/crates/oxc_cli/src/options.rs
@@ -5,7 +5,7 @@ use glob::Pattern;
 
 pub struct CliOptions {
     pub quiet: bool,
-    pub max_warnings: isize,
+    pub max_warnings: Option<usize>,
     pub paths: Vec<PathBuf>,
     pub ignore_path: String,
     pub no_ignore: bool,
@@ -38,7 +38,7 @@ impl<'a> TryFrom<&'a ArgMatches> for CliOptions {
 
         Ok(Self {
             quiet: matches.get_flag("quiet"),
-            max_warnings: matches.get_one::<isize>("max-warnings").copied().unwrap_or(-1),
+            max_warnings: matches.get_one("max-warnings").copied(),
             paths,
             ignore_path,
             no_ignore,

--- a/crates/oxc_cli/src/result.rs
+++ b/crates/oxc_cli/src/result.rs
@@ -7,6 +7,7 @@ use std::{
 pub enum CliRunResult {
     None,
     PathNotFound { paths: Vec<PathBuf> },
+    MaxWarningsExceeded { number_of_warnings: usize, max_warnings: usize },
     LintResult { number_of_files: usize, number_of_diagnostics: usize },
 }
 
@@ -16,6 +17,12 @@ impl Termination for CliRunResult {
             Self::None => ExitCode::from(0),
             Self::PathNotFound { paths } => {
                 println!("Path {paths:?} does not exist.");
+                ExitCode::from(1)
+            }
+            Self::MaxWarningsExceeded { number_of_warnings, max_warnings } => {
+                println!(
+                    "Exceeded --max-warnings value of {max_warnings}. Found {number_of_warnings} warning(s)."
+                );
                 ExitCode::from(1)
             }
             Self::LintResult { number_of_files, number_of_diagnostics } => {

--- a/crates/oxc_cli/src/result.rs
+++ b/crates/oxc_cli/src/result.rs
@@ -7,8 +7,7 @@ use std::{
 pub enum CliRunResult {
     None,
     PathNotFound { paths: Vec<PathBuf> },
-    MaxWarningsExceeded { number_of_warnings: usize, max_warnings: usize },
-    LintResult { number_of_files: usize, number_of_diagnostics: usize },
+    LintResult { number_of_files: usize, number_of_warnings: usize, max_warnings_exceeded: bool },
 }
 
 impl Termination for CliRunResult {
@@ -19,17 +18,16 @@ impl Termination for CliRunResult {
                 println!("Path {paths:?} does not exist.");
                 ExitCode::from(1)
             }
-            Self::MaxWarningsExceeded { number_of_warnings, max_warnings } => {
-                println!(
-                    "Exceeded --max-warnings value of {max_warnings}. Found {number_of_warnings} warning(s)."
-                );
-                ExitCode::from(1)
-            }
-            Self::LintResult { number_of_files, number_of_diagnostics } => {
+            Self::LintResult { number_of_files, number_of_warnings, max_warnings_exceeded } => {
                 println!("Checked {number_of_files} files.");
 
+                if max_warnings_exceeded {
+                    println!("Exceeded maximum number of warnings. Found {number_of_warnings}.");
+                    return ExitCode::from(1);
+                }
+
                 if number_of_files > 0 {
-                    println!("Found {number_of_diagnostics} diagnostics.");
+                    println!("Found {number_of_warnings} diagnostics.");
                     return ExitCode::from(1);
                 }
 


### PR DESCRIPTION
Closes #53

Adding a `--max-warnings` CLI option as outlined [here](https://eslint.org/docs/latest/use/command-line-interface#--max-warnings). If the option is not provided, the value defaults to `-1`, which indicates to ignore the flag. If the value is 0 or more, then we check against `number_of_diagnostics` and output accordingly with a failure exit code.