### PR TITLE
refactor(ast): change `Option<Vec>` to `Vec` for decorators

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1249,8 +1249,8 @@ pub struct FormalParameter<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility: Option<TSAccessibility>,
     pub readonly: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub decorators: Option<Vec<'a, Decorator<'a>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1326,8 +1326,8 @@ pub struct Class<'a> {
     pub super_type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub implements: Option<Vec<'a, Box<'a, TSClassImplements<'a>>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub decorators: Option<Vec<'a, Decorator<'a>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub decorators: Vec<'a, Decorator<'a>>,
     /// Valid Modifiers: `export`, `abstract`
     #[serde(skip_serializing_if = "Modifiers::is_none")]
     pub modifiers: Modifiers<'a>,
@@ -1454,8 +1454,8 @@ pub struct MethodDefinition<'a> {
     pub optional: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility: Option<TSAccessibility>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub decorators: Option<Vec<'a, Decorator<'a>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Hash)]
@@ -1477,8 +1477,8 @@ pub struct PropertyDefinition<'a> {
     pub type_annotation: Option<TSTypeAnnotation<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility: Option<TSAccessibility>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub decorators: Option<Vec<'a, Decorator<'a>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq, Hash)]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -754,7 +754,7 @@ impl<'a> AstBuilder<'a> {
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
         super_type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
         implements: Option<Vec<'a, Box<'a, TSClassImplements<'a>>>>,
-        decorators: Option<Vec<'a, Decorator<'a>>>,
+        decorators: Vec<'a, Decorator<'a>>,
         modifiers: Modifiers<'a>,
     ) -> Box<'a, Class<'a>> {
         self.alloc(Class {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -692,7 +692,7 @@ impl<'a> AstBuilder<'a> {
         pattern: BindingPattern<'a>,
         accessibility: Option<TSAccessibility>,
         readonly: bool,
-        decorators: Option<Vec<'a, Decorator<'a>>>,
+        decorators: Vec<'a, Decorator<'a>>,
     ) -> FormalParameter<'a> {
         FormalParameter { span, pattern, accessibility, readonly, decorators }
     }

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -339,10 +339,8 @@ pub trait Visit<'a>: Sized {
     fn visit_formal_parameter(&mut self, param: &'a FormalParameter<'a>) {
         let kind = AstKind::FormalParameter(param);
         self.enter_node(kind);
-        if let Some(decorators) = &param.decorators {
-            for decorator in decorators {
-                self.visit_decorator(decorator);
-            }
+        for decorator in &param.decorators {
+            self.visit_decorator(decorator);
         }
         self.visit_pattern(&param.pattern);
         self.leave_node(kind);

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -358,10 +358,8 @@ pub trait Visit<'a>: Sized {
     fn visit_class(&mut self, class: &'a Class<'a>) {
         let kind = AstKind::Class(class);
         self.enter_node(kind);
-        if let Some(decorators) = &class.decorators {
-            for decorator in decorators {
-                self.visit_decorator(decorator);
-            }
+        for decorator in &class.decorators {
+            self.visit_decorator(decorator);
         }
         if let Some(id) = &class.id {
             self.visit_binding_identifier(id);
@@ -419,10 +417,8 @@ pub trait Visit<'a>: Sized {
     fn visit_method_definition(&mut self, def: &'a MethodDefinition<'a>) {
         let kind = AstKind::MethodDefinition(def);
         self.enter_node(kind);
-        if let Some(decorators) = &def.decorators {
-            for decorator in decorators {
-                self.visit_decorator(decorator);
-            }
+        for decorator in &def.decorators {
+            self.visit_decorator(decorator);
         }
         self.visit_property_key(&def.key);
         self.visit_function(&def.value);
@@ -432,10 +428,8 @@ pub trait Visit<'a>: Sized {
     fn visit_property_definition(&mut self, def: &'a PropertyDefinition<'a>) {
         let kind = AstKind::PropertyDefinition(def);
         self.enter_node(kind);
-        if let Some(decorators) = &def.decorators {
-            for decorator in decorators {
-                self.visit_decorator(decorator);
-            }
+        for decorator in &def.decorators {
+            self.visit_decorator(decorator);
         }
         self.visit_property_key(&def.key);
         if let Some(value) = &def.value {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -1,8 +1,8 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::Box;
 use oxc_ast::{
     ast::*,
     context::{Context, StatementContext},
-    GetSpan, Span,
+    AstBuilder, GetSpan, Span,
 };
 use oxc_diagnostics::Result;
 
@@ -240,7 +240,7 @@ impl<'a> Parser<'a> {
             pattern,
             None,
             false,
-            Vec::new_in(self.ast.allocator),
+            AstBuilder::new_vec(&self.ast),
         );
         let params = self.ast.formal_parameters(
             params_span,

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box;
+use oxc_allocator::{Box, Vec};
 use oxc_ast::{
     ast::*,
     context::{Context, StatementContext},
@@ -235,7 +235,13 @@ impl<'a> Parser<'a> {
         let ident = self.ast.binding_identifier(param);
         let pattern = self.ast.binding_pattern(ident, None, false);
         let params_span = self.end_span(params_span);
-        let formal_parameter = self.ast.formal_parameter(params_span, pattern, None, false, None);
+        let formal_parameter = self.ast.formal_parameter(
+            params_span,
+            pattern,
+            None,
+            false,
+            Vec::new_in(self.ast.allocator),
+        );
         let params = self.ast.formal_parameters(
             params_span,
             FormalParameterKind::ArrowFormalParameters,

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -255,7 +255,7 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
             _ => p.parse_binding_element()?,
         };
 
-        let decorators = p.state.consume_decorators();
+        let decorators = p.state.consume_decorators().unwrap_or(Vec::new_in(p.ast.allocator));
         let formal_parameter =
             p.ast.formal_parameter(p.end_span(span), pattern, accessibility, readonly, decorators);
         self.elements.push(formal_parameter);

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -255,8 +255,7 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
             _ => p.parse_binding_element()?,
         };
 
-        let decorators =
-            p.state.consume_decorators().unwrap_or_else(|| Vec::new_in(p.ast.allocator));
+        let decorators = p.state.consume_decorators();
         let formal_parameter =
             p.ast.formal_parameter(p.end_span(span), pattern, accessibility, readonly, decorators);
         self.elements.push(formal_parameter);

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -255,7 +255,8 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
             _ => p.parse_binding_element()?,
         };
 
-        let decorators = p.state.consume_decorators().unwrap_or(Vec::new_in(p.ast.allocator));
+        let decorators =
+            p.state.consume_decorators().unwrap_or_else(|| Vec::new_in(p.ast.allocator));
         let formal_parameter =
             p.ast.formal_parameter(p.end_span(span), pattern, accessibility, readonly, decorators);
         self.elements.push(formal_parameter);

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -71,7 +71,7 @@ impl<'a> Parser<'a> {
             errors,
             token: Token::default(),
             prev_token_end: 0,
-            state: ParserState::default(),
+            state: ParserState::new(oxc_allocator::Vec::new_in(allocator)),
             ctx: source_type.default_context(),
             ast: AstBuilder::new(allocator),
         }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -71,7 +71,7 @@ impl<'a> Parser<'a> {
             errors,
             token: Token::default(),
             prev_token_end: 0,
-            state: ParserState::new(oxc_allocator::Vec::new_in(allocator)),
+            state: ParserState::new(allocator),
             ctx: source_type.default_context(),
             ast: AstBuilder::new(allocator),
         }

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -1,20 +1,26 @@
 use std::collections::HashSet;
 
-use oxc_allocator::Vec;
+use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::Decorator;
 
 pub struct ParserState<'a> {
+    allocator: &'a Allocator,
+
     pub not_parenthesized_arrow: HashSet<u32>,
 
     pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 impl<'a> ParserState<'a> {
-    pub fn new(decorators: Vec<'a, Decorator<'a>>) -> Self {
-        Self { not_parenthesized_arrow: HashSet::new(), decorators }
+    pub fn new(allocator: &'a Allocator) -> Self {
+        Self {
+            allocator,
+            not_parenthesized_arrow: HashSet::new(),
+            decorators: Vec::new_in(allocator),
+        }
     }
 
     pub fn consume_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
-        todo!()
+        std::mem::replace(&mut self.decorators, Vec::new_in(self.allocator))
     }
 }

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -3,15 +3,18 @@ use std::collections::HashSet;
 use oxc_allocator::Vec;
 use oxc_ast::ast::Decorator;
 
-#[derive(Default)]
 pub struct ParserState<'a> {
     pub not_parenthesized_arrow: HashSet<u32>,
 
-    pub decorators: Option<Vec<'a, Decorator<'a>>>,
+    pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 impl<'a> ParserState<'a> {
-    pub fn consume_decorators(&mut self) -> Option<Vec<'a, Decorator<'a>>> {
-        self.decorators.take()
+    pub fn new(decorators: Vec<'a, Decorator<'a>>) -> Self {
+        Self { not_parenthesized_arrow: HashSet::new(), decorators }
+    }
+
+    pub fn consume_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
+        todo!()
     }
 }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -492,7 +492,7 @@ impl<'a> Parser<'a> {
 
         self.ctx = self.ctx.and_decorator(in_decorator);
 
-        self.state.decorators = Some(decorators);
+        self.state.decorators = decorators;
         Ok(())
     }
 


### PR DESCRIPTION
Closes #82 

Basically removing the surrounding `Option` from the `decorators` field on `FormalParameter` and chasing the compiler around 😄 