### PR TITLE
feat(oxc_cli): support ignore-path

### DIFF
--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -39,7 +39,7 @@ impl Cli {
             .paths
             .iter()
             .flat_map(|path| {
-                Walk::new(path)
+                Walk::new(path, &self.cli_options)
                     .iter()
                     .filter(|path| {
                         let ignore_pattern = &self.cli_options.ignore_pattern;

--- a/crates/oxc_cli/src/options.rs
+++ b/crates/oxc_cli/src/options.rs
@@ -6,6 +6,7 @@ use glob::Pattern;
 pub struct CliOptions {
     pub quiet: bool,
     pub paths: Vec<PathBuf>,
+    pub ignore_path: String,
     pub ignore_pattern: Vec<Pattern>,
 }
 
@@ -29,10 +30,15 @@ impl<'a> TryFrom<&'a ArgMatches> for CliOptions {
             paths.extend(globbed);
         }
 
+        let ignore_path = get_ignore_path(matches);
         let ignore_pattern = get_ignore_pattern(matches);
 
-        Ok(Self { quiet: matches.get_flag("quiet"), paths, ignore_pattern })
+        Ok(Self { quiet: matches.get_flag("quiet"), paths, ignore_path, ignore_pattern })
     }
+}
+
+fn get_ignore_path(matches: &ArgMatches) -> String {
+    matches.get_one::<String>("ignore-path").map_or(".eslintignore".to_string(), ToOwned::to_owned)
 }
 
 fn get_ignore_pattern(matches: &ArgMatches) -> Vec<Pattern> {

--- a/crates/oxc_cli/src/walk.rs
+++ b/crates/oxc_cli/src/walk.rs
@@ -3,14 +3,16 @@ use std::path::Path;
 use ignore::{DirEntry, WalkBuilder};
 use oxc_ast::VALID_EXTENSIONS;
 
+use crate::CliOptions;
+
 pub struct Walk {
     inner: ignore::Walk,
 }
 
 impl Walk {
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+    pub fn new<P: AsRef<Path>>(path: P, options: &CliOptions) -> Self {
         let inner = WalkBuilder::new(path)
-            .add_custom_ignore_filename(".eslintignore")
+            .add_custom_ignore_filename(&options.ignore_path)
             .ignore(false)
             .git_global(false)
             .build();


### PR DESCRIPTION
## Description

- Support `ignore-path` option.
- Add `get_lint_matches` to reduce the boilerplate testing code.

## Additional information

As mentioned in #54, it seems that the `add_custom_ignore_filename` doesn't work.

## Related issue 

#54 