### PR TITLE
refactor: pad raw content to parse with 16 empty bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "mimalloc",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_common",
  "oxc_parser",
  "pico-args",
  "ureq",
@@ -842,12 +843,17 @@ dependencies = [
  "mimalloc",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_common",
  "oxc_diagnostics",
  "oxc_linter",
  "oxc_parser",
  "oxc_semantic",
  "rayon",
 ]
+
+[[package]]
+name = "oxc_common"
+version = "0.0.0"
 
 [[package]]
 name = "oxc_coverage"
@@ -860,6 +866,7 @@ dependencies = [
  "miette",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_common",
  "oxc_diagnostics",
  "oxc_parser",
  "oxc_printer",
@@ -890,6 +897,7 @@ dependencies = [
  "miette",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_common",
  "oxc_diagnostics",
  "oxc_macros",
  "oxc_parser",
@@ -917,6 +925,7 @@ dependencies = [
  "num-bigint",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_common",
  "oxc_diagnostics",
  "rustc-hash",
  "serde_json",
@@ -930,6 +939,7 @@ dependencies = [
  "miette",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_common",
  "oxc_parser",
 ]
 

--- a/crates/oxc_cli/Cargo.toml
+++ b/crates/oxc_cli/Cargo.toml
@@ -19,6 +19,7 @@ mimalloc = { workspace = true }
 oxc_diagnostics = { path = "../oxc_diagnostics" }
 oxc_allocator = { path = "../oxc_allocator" }
 oxc_ast = { path  = "../oxc_ast" }
+oxc_common = { path = "../oxc_common" }
 oxc_parser = { path  = "../oxc_parser" }
 oxc_semantic = { path  = "../oxc_semantic" }
 oxc_linter = { path  = "../oxc_linter" }

--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -8,6 +8,7 @@ use std::{fs, path::Path, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_ast::SourceType;
+use oxc_common::PaddedStringView;
 use oxc_diagnostics::{Error, Severity};
 use oxc_linter::Linter;
 use oxc_parser::Parser;
@@ -113,7 +114,7 @@ impl Cli {
     }
 
     fn lint_path(path: &Path) -> Vec<Error> {
-        let source_text = fs::read_to_string(path).expect("{name} not found");
+        let source_text = PaddedStringView::read_from_file(path).expect("{name} not found");
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).expect("incorrect {path:?}");
         let ret = Parser::new(&allocator, &source_text, source_type).parse();
@@ -127,7 +128,7 @@ impl Cli {
 
         diagnostics
             .into_iter()
-            .map(|diagnostic| diagnostic.with_source_code(source_text.clone()))
+            .map(|diagnostic| diagnostic.with_source_code((*source_text).clone()))
             .collect()
     }
 }

--- a/crates/oxc_common/Cargo.toml
+++ b/crates/oxc_common/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "oxc_common"
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+

--- a/crates/oxc_common/src/lib.rs
+++ b/crates/oxc_common/src/lib.rs
@@ -1,0 +1,2 @@
+mod padded_string;
+pub use padded_string::PaddedStringView;

--- a/crates/oxc_common/src/padded_string.rs
+++ b/crates/oxc_common/src/padded_string.rs
@@ -1,0 +1,90 @@
+use core::fmt;
+use std::io::Read;
+use std::ops;
+use std::str;
+use std::str::FromStr;
+use std::{fs::File, io, path::Path};
+
+/// A simple read-only String wrapper that pads the string with 16 bytes
+/// This enables ignoring the last 16 bytes when parsing with SIMD
+#[derive(Clone, Debug)]
+pub struct PaddedStringView {
+    wrapped: String,
+}
+
+trait TestTrait: Sized {}
+
+impl TestTrait for PaddedStringView {}
+
+// 16 empty bytes - TODO better way to define this?
+const PADDING_BYTES: &'static str = match str::from_utf8(&[0; PaddedStringView::PADDING_SIZE])
+// const PADDING_BYTES: &'static str = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+// const PADDING_BYTES: [char; 16] = ['\0'; 16];
+
+{
+    Ok(res) => res,
+    Err(_) => unreachable!(),
+};
+
+impl PaddedStringView {
+    // Review note: this needs to be kept in sync with ELEMENTS in SIMD.
+    // Should ELEMENTS take from here?
+    pub const PADDING_SIZE: usize = 16;
+
+    pub fn read_from_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let mut file = File::open(path)?;
+        let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let mut string = String::with_capacity(size as usize + PaddedStringView::PADDING_SIZE);
+        file.read_to_string(&mut string)?;
+        string.push_str(PADDING_BYTES);
+        // string.extend(PADDING_BYTES);
+
+        Ok(Self { wrapped: string })
+    }
+
+    pub fn unpadded_str(&self) -> &str {
+        &(self.wrapped[0..self.wrapped.len() - 16])
+    }
+}
+
+impl FromStr for PaddedStringView {
+    type Err = core::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s))
+    }
+}
+
+impl From<&str> for PaddedStringView {
+    #[inline]
+    fn from(s: &str) -> PaddedStringView {
+        let mut string = String::with_capacity(s.len() + PaddedStringView::PADDING_SIZE);
+        string.push_str(s);
+        string.push_str(PADDING_BYTES);
+
+        Self { wrapped: string }
+    }
+}
+
+impl From<&String> for PaddedStringView {
+    #[inline]
+    fn from(s: &String) -> PaddedStringView {
+        Self::from(s.as_str())
+    }
+}
+
+impl ops::Deref for PaddedStringView {
+    type Target = String;
+
+    #[inline]
+    fn deref(&self) -> &String {
+        &self.wrapped
+    }
+}
+
+impl fmt::Display for PaddedStringView {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}

--- a/crates/oxc_common/src/padded_string.rs
+++ b/crates/oxc_common/src/padded_string.rs
@@ -16,19 +16,12 @@ trait TestTrait: Sized {}
 
 impl TestTrait for PaddedStringView {}
 
-// 16 empty bytes - TODO better way to define this?
-const PADDING_BYTES: &'static str = match str::from_utf8(&[0; PaddedStringView::PADDING_SIZE])
-// const PADDING_BYTES: &'static str = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-// const PADDING_BYTES: [char; 16] = ['\0'; 16];
-
-{
+const PADDING_BYTES: &'static str = match str::from_utf8(&[0; PaddedStringView::PADDING_SIZE]) {
     Ok(res) => res,
     Err(_) => unreachable!(),
 };
 
 impl PaddedStringView {
-    // Review note: this needs to be kept in sync with ELEMENTS in SIMD.
-    // Should ELEMENTS take from here?
     pub const PADDING_SIZE: usize = 16;
 
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
@@ -37,7 +30,6 @@ impl PaddedStringView {
         let mut string = String::with_capacity(size as usize + PaddedStringView::PADDING_SIZE);
         file.read_to_string(&mut string)?;
         string.push_str(PADDING_BYTES);
-        // string.extend(PADDING_BYTES);
 
         Ok(Self { wrapped: string })
     }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 
 [dependencies]
 oxc_ast = { path = "../oxc_ast" }
+oxc_common = { path = "../oxc_common" }
 oxc_diagnostics = { path = "../oxc_diagnostics" }
 oxc_macros = { path = "../oxc_macros" }
 oxc_semantic = { path = "../oxc_semantic" }

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -60,7 +60,7 @@ impl Tester {
         let allocator = Allocator::default();
         let path = PathBuf::from(name).with_extension("tsx");
         let source_type = SourceType::from_path(&path).expect("incorrect {path:?}");
-        let ret = Parser::new(&allocator, &source_text, source_type).parse();
+        let ret = Parser::new(&allocator, source_text, source_type).parse();
         assert!(ret.errors.is_empty(), "{:?}", &ret.errors);
         let program = allocator.alloc(ret.program);
         let semantic = SemanticBuilder::new().build(program, ret.trivias);

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [dependencies]
 oxc_allocator = { path = "../oxc_allocator" }
 oxc_ast = { path = "../oxc_ast" }
+oxc_common = { path = "../oxc_common" }
 oxc_diagnostics = { path = "../oxc_diagnostics" }
 
 bitflags = { workspace = true }

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -2,6 +2,7 @@ use std::{env, path::Path};
 
 use oxc_allocator::Allocator;
 use oxc_ast::SourceType;
+use oxc_common::PaddedStringView;
 use oxc_parser::Parser;
 
 // Instruction:
@@ -12,7 +13,8 @@ use oxc_parser::Parser;
 fn main() {
     let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
     let path = Path::new(&name);
-    let source_text = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("{name} not found"));
+    let source_text =
+        PaddedStringView::read_from_file(path).unwrap_or_else(|_| panic!("{name} not found"));
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
@@ -22,7 +24,7 @@ fn main() {
         println!("Parsed Successfully.");
     } else {
         for error in ret.errors {
-            let error = error.with_source_code(source_text.clone());
+            let error = error.with_source_code((*source_text).clone());
             println!("{error:?}");
         }
     }

--- a/crates/oxc_parser/src/lexer/constants.rs
+++ b/crates/oxc_parser/src/lexer/constants.rs
@@ -79,7 +79,7 @@ pub fn is_identifier_part(c: char) -> bool {
 }
 
 pub const SINGLE_CHAR_TOKENS: &[Kind; 128] = &[
-    /*   0 */ Kind::Undetermined,
+    /*   0 */ Kind::Eof,
     /*   1 */ Kind::Undetermined,
     /*   2 */ Kind::Undetermined,
     /*   3 */ Kind::Undetermined,

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -17,6 +17,7 @@ use std::{collections::VecDeque, str::Chars};
 
 use oxc_allocator::{Allocator, String};
 use oxc_ast::{ast::RegExpFlags, Atom, SourceType, Span};
+use oxc_common::PaddedStringView;
 use oxc_diagnostics::{Diagnostics, Error};
 use simd::{SkipMultilineComment, SkipWhitespace};
 pub use token::{RegExp, Token, TokenValue};
@@ -55,7 +56,7 @@ pub enum LexerContext {
 pub struct Lexer<'a> {
     allocator: &'a Allocator,
 
-    source: &'a str,
+    source: &'a PaddedStringView,
 
     source_type: SourceType,
 
@@ -75,7 +76,7 @@ impl<'a> Lexer<'a> {
     #[must_use]
     pub fn new(
         allocator: &'a Allocator,
-        source: &'a str,
+        source: &'a PaddedStringView,
         errors: Diagnostics,
         source_type: SourceType,
     ) -> Self {

--- a/crates/oxc_parser/src/lexer/simd.rs
+++ b/crates/oxc_parser/src/lexer/simd.rs
@@ -28,6 +28,7 @@ pub struct SkipWhitespace {
 }
 
 impl SkipWhitespace {
+    #[must_use]
     pub fn new(newline: bool) -> Self {
         Self {
             offset: 0,
@@ -40,7 +41,7 @@ impl SkipWhitespace {
         }
     }
 
-    pub fn simd(mut self, bytes: &[u8]) -> Self {
+    pub fn simd(&mut self, bytes: &[u8]) -> &Self {
         let (chunks, _remainder) = bytes.as_chunks::<ELEMENTS>();
 
         for chunk in chunks {
@@ -116,7 +117,7 @@ impl<'a> SkipMultilineComment<'a> {
         }
     }
 
-    pub fn simd(mut self) -> Self {
+    pub fn simd(&mut self) -> &Self {
         let (chunks, _remainder) = self.remaining.as_chunks::<ELEMENTS>();
 
         for chunk in chunks {

--- a/crates/oxc_parser/src/lexer/simd.rs
+++ b/crates/oxc_parser/src/lexer/simd.rs
@@ -6,7 +6,9 @@
 
 use std::simd::{Simd, SimdPartialEq, ToBitMask};
 
-const ELEMENTS: usize = 16;
+use oxc_common::PaddedStringView;
+
+const ELEMENTS: usize = PaddedStringView::PADDING_SIZE;
 type SimdVec = Simd<u8, ELEMENTS>;
 
 pub struct SkipWhitespace {

--- a/crates/oxc_parser/src/lexer/simd.rs
+++ b/crates/oxc_parser/src/lexer/simd.rs
@@ -39,7 +39,7 @@ impl SkipWhitespace {
     }
 
     pub fn simd(mut self, bytes: &[u8]) -> Self {
-        let (chunks, remainder) = bytes.as_chunks::<ELEMENTS>();
+        let (chunks, _remainder) = bytes.as_chunks::<ELEMENTS>();
 
         for chunk in chunks {
             self.check_chunk(chunk);
@@ -48,13 +48,8 @@ impl SkipWhitespace {
             }
         }
 
-        if !remainder.is_empty() {
-            // Align the last chunk for avoiding the use of a scalar version
-            let mut chunk = [0; ELEMENTS];
-            let len = remainder.len();
-            chunk[..len].copy_from_slice(remainder);
-            self.check_chunk(&chunk);
-        }
+        // We can safely ignore remainder since it is guaranteed to contain 16 empty bytes
+        // See `PaddedStringView` passed to lexer
 
         self
     }
@@ -120,7 +115,7 @@ impl<'a> SkipMultilineComment<'a> {
     }
 
     pub fn simd(mut self) -> Self {
-        let (chunks, remainder) = self.remaining.as_chunks::<ELEMENTS>();
+        let (chunks, _remainder) = self.remaining.as_chunks::<ELEMENTS>();
 
         for chunk in chunks {
             self.check(chunk, chunk.len());
@@ -129,13 +124,8 @@ impl<'a> SkipMultilineComment<'a> {
             }
         }
 
-        if !remainder.is_empty() {
-            // Align the last chunk for avoiding the use of a scalar version
-            let mut chunk = [0; ELEMENTS];
-            let len = remainder.len();
-            chunk[..len].copy_from_slice(remainder);
-            self.check(&chunk, len);
-        }
+        // We can safely ignore remainder since it is guaranteed to contain 16 empty bytes
+        // See `PaddedStringView` passed to lexer
 
         self
     }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -15,6 +15,7 @@ mod ts;
 mod diagnostics;
 mod lexer;
 
+pub use lexer::simd::SkipWhitespace;
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::Program, context::Context, AstBuilder, SourceType, Span, Trivias};
 use oxc_common::PaddedStringView;

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -17,6 +17,7 @@ mod lexer;
 
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::Program, context::Context, AstBuilder, SourceType, Span, Trivias};
+use oxc_common::PaddedStringView;
 use oxc_diagnostics::{Diagnostics, Error, Result};
 
 use crate::{
@@ -62,7 +63,11 @@ pub struct Parser<'a> {
 
 impl<'a> Parser<'a> {
     #[must_use]
-    pub fn new(allocator: &'a Allocator, source: &'a str, source_type: SourceType) -> Self {
+    pub fn new(
+        allocator: &'a Allocator,
+        source: &'a PaddedStringView,
+        source_type: SourceType,
+    ) -> Self {
         let errors = Diagnostics::default();
         Self {
             lexer: Lexer::new(allocator, source, errors.clone(), source_type),
@@ -161,8 +166,8 @@ mod test {
     fn smoke_test() {
         let allocator = Allocator::default();
         let source_type = SourceType::default();
-        let source = "";
-        let ret = Parser::new(&allocator, source, source_type).parse();
+        let source = PaddedStringView::from("");
+        let ret = Parser::new(&allocator, &source, source_type).parse();
         assert!(ret.program.is_empty());
         assert!(ret.errors.is_empty());
     }
@@ -171,13 +176,13 @@ mod test {
     fn flow_error() {
         let allocator = Allocator::default();
         let source_type = SourceType::default();
-        let source = "// @flow\nasdf adsf";
-        let ret = Parser::new(&allocator, source, source_type).parse();
+        let source = PaddedStringView::from("// @flow\nasdf adsf");
+        let ret = Parser::new(&allocator, &source, source_type).parse();
         assert!(ret.program.is_empty());
         assert_eq!(ret.errors.first().unwrap().to_string(), "Flow is not supported");
 
-        let source = "/* @flow */\n asdf asdf";
-        let ret = Parser::new(&allocator, source, source_type).parse();
+        let source = PaddedStringView::from("/* @flow */\n asdf asdf");
+        let ret = Parser::new(&allocator, &source, source_type).parse();
         assert!(ret.program.is_empty());
         assert_eq!(ret.errors.first().unwrap().to_string(), "Flow is not supported");
     }

--- a/crates/oxc_parser/src/ts/declaration.rs
+++ b/crates/oxc_parser/src/ts/declaration.rs
@@ -83,7 +83,9 @@ mod test_is_declaration {
 
     fn run_check(source: &str, expected: bool) {
         let alloc = Allocator::default();
-        let mut parser = Parser::new(&alloc, source, SourceType::builder().typescript().build());
+        let padded_source = &source.into();
+        let mut parser =
+            Parser::new(&alloc, padded_source, SourceType::builder().typescript().build());
         // Get the parser to the first token.
         parser.bump_any();
         assert_eq!(expected, parser.at_start_of_ts_declaration());

--- a/crates/oxc_printer/Cargo.toml
+++ b/crates/oxc_printer/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [dependencies]
 oxc_allocator = { path = "../oxc_allocator" }
 oxc_ast = { path = "../oxc_ast" }
+oxc_common = { path = "../oxc_common" }
 
 [dev_dependencies]
 oxc_parser = { path = "../oxc_parser" }

--- a/crates/oxc_printer/examples/printer.rs
+++ b/crates/oxc_printer/examples/printer.rs
@@ -2,6 +2,7 @@ use std::{env, path::Path};
 
 use oxc_allocator::Allocator;
 use oxc_ast::SourceType;
+use oxc_common::PaddedStringView;
 use oxc_parser::Parser;
 use oxc_printer::{Printer, PrinterOptions};
 
@@ -13,14 +14,14 @@ use oxc_printer::{Printer, PrinterOptions};
 fn main() {
     let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
     let path = Path::new(&name);
-    let source_text = std::fs::read_to_string(path).expect("{name} not found");
+    let source_text = PaddedStringView::read_from_file(path).expect("{name} not found");
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
     if !ret.errors.is_empty() {
         for error in ret.errors {
-            let error = error.with_source_code(source_text.clone());
+            let error = error.with_source_code((*source_text).clone());
             println!("{error:?}");
         }
         return;

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -19,6 +19,7 @@ mimalloc = { workspace = true }
 [dependencies]
 oxc_ast = { path = "../../crates/oxc_ast" }
 oxc_allocator = { path = "../../crates/oxc_allocator" }
+oxc_common = { path = "../../crates/oxc_common" }
 oxc_parser = { path = "../../crates/oxc_parser" }
 
 pico-args = "0.5.0"

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -1,12 +1,14 @@
 use std::{path::PathBuf, str::FromStr};
 
+use oxc_common::PaddedStringView;
+
 fn err_to_string<E: std::fmt::Debug>(e: E) -> String {
     format!("{e:?}")
 }
 
 /// # Errors
 /// # Panics
-pub fn get_code(lib: &str) -> Result<(String, String), String> {
+pub fn get_code(lib: &str) -> Result<(String, PaddedStringView), String> {
     let url = url::Url::from_str(lib).map_err(err_to_string)?;
 
     let segments = url.path_segments().ok_or_else(|| "lib url has no segments".to_string())?;
@@ -16,7 +18,7 @@ pub fn get_code(lib: &str) -> Result<(String, String), String> {
     let mut file = PathBuf::from_str("target").map_err(err_to_string)?;
     file.push(filename);
 
-    if let Ok(code) = std::fs::read_to_string(&file) {
+    if let Ok(code) = PaddedStringView::read_from_file(&file) {
         println!("[{filename}] - using [{}]", file.display());
         Ok((filename.to_string(), code))
     } else {
@@ -29,7 +31,7 @@ pub fn get_code(lib: &str) -> Result<(String, String), String> {
                 let mut writer = std::fs::File::create(&file).map_err(err_to_string)?;
                 let _drop = std::io::copy(&mut reader, &mut writer);
 
-                std::fs::read_to_string(&file)
+                PaddedStringView::read_from_file(&file)
                     .map_err(err_to_string)
                     .map(|code| (filename.to_string(), code))
             }

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 oxc_allocator = { path = "../../crates/oxc_allocator" }
 oxc_parser = { path = "../../crates/oxc_parser" }
 oxc_ast = { path = "../../crates/oxc_ast" }
+oxc_common = { path = "../../crates/oxc_common" }
 oxc_printer = { path = "../../crates/oxc_printer" }
 oxc_diagnostics = { path = "../../crates/oxc_diagnostics" }
 

--- a/tasks/coverage/src/babel.rs
+++ b/tasks/coverage/src/babel.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use oxc_ast::SourceType;
+use oxc_common::PaddedStringView;
 use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::project_root;
@@ -82,7 +83,7 @@ impl<T: Case> Suite<T> for BabelSuite<T> {
 
 pub struct BabelCase {
     path: PathBuf,
-    code: String,
+    code: PaddedStringView,
     options: Option<BabelOptions>,
     should_fail: bool,
     result: TestResult,
@@ -174,13 +175,13 @@ impl BabelCase {
 }
 
 impl Case for BabelCase {
-    fn new(path: PathBuf, code: String) -> Self {
+    fn new(path: PathBuf, code: PaddedStringView) -> Self {
         let options = Self::read_options_json(&path);
         let should_fail = Self::determine_should_fail(&path, &options);
         Self { path, code, options, should_fail, result: TestResult::ToBeRun }
     }
 
-    fn code(&self) -> &str {
+    fn code(&self) -> &PaddedStringView {
         &self.code
     }
 

--- a/tasks/coverage/src/printer.rs
+++ b/tasks/coverage/src/printer.rs
@@ -63,7 +63,7 @@ impl PrinterTest262Case {
             }
             builder.build()
         };
-        let program1 = Parser::new(&allocator, &source_text, source_type).parse().program;
+        let program1 = Parser::new(&allocator, source_text, source_type).parse().program;
         let printed_text1 = Printer::new(source_text.len(), options).build(&program1);
         let source_text1 = (&printed_text1).into();
         let program2 = Parser::new(&allocator, &source_text1, source_type).parse().program;
@@ -71,7 +71,7 @@ impl PrinterTest262Case {
         if printed_text1 == source_text2 {
             TestResult::Passed
         } else {
-            TestResult::Mismatch(printed_text1.to_string(), source_text2)
+            TestResult::Mismatch(printed_text1, source_text2)
         }
     }
 }

--- a/tasks/coverage/src/test262.rs
+++ b/tasks/coverage/src/test262.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use oxc_ast::SourceType;
+use oxc_common::PaddedStringView;
 use serde::Deserialize;
 
 use crate::project_root;
@@ -108,7 +109,7 @@ impl<T: Case> Suite<T> for Test262Suite<T> {
 
 pub struct Test262Case {
     path: PathBuf,
-    code: String,
+    code: PaddedStringView,
     meta: MetaData,
     should_fail: bool,
     result: TestResult,
@@ -138,13 +139,13 @@ impl Test262Case {
 }
 
 impl Case for Test262Case {
-    fn new(path: PathBuf, code: String) -> Self {
+    fn new(path: PathBuf, code: PaddedStringView) -> Self {
         let meta = Self::read_metadata(&code).expect("read test262 yaml meta");
         let should_fail = Self::should_fail(&meta);
         Self { path, code, meta, should_fail, result: TestResult::ToBeRun }
     }
 
-    fn code(&self) -> &str {
+    fn code(&self) -> &PaddedStringView {
         &self.code
     }
 

--- a/tasks/coverage/src/typescript.rs
+++ b/tasks/coverage/src/typescript.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use oxc_ast::SourceType;
+use oxc_common::PaddedStringView;
 use regex::Regex;
 
 use crate::{
@@ -65,18 +66,18 @@ impl<T: Case> Suite<T> for TypeScriptSuite<T> {
 
 pub struct TypeScriptCase {
     path: PathBuf,
-    code: String,
+    code: PaddedStringView,
     result: TestResult,
     meta: TypeScriptTestMeta,
 }
 
 impl Case for TypeScriptCase {
-    fn new(path: PathBuf, code: String) -> Self {
+    fn new(path: PathBuf, code: PaddedStringView) -> Self {
         let meta = TypeScriptTestMeta::from_source(&path, &code);
         Self { path, code, result: TestResult::ToBeRun, meta }
     }
 
-    fn code(&self) -> &str {
+    fn code(&self) -> &PaddedStringView {
         &self.code
     }
 


### PR DESCRIPTION
Addresses #43 

Initial crude attempt.
Unlike in @strager's [padded-string](https://github.com/quick-lint/quick-lint-js/blob/master/src/quick-lint-js/container/padded-string.cpp) which actually manages the underlying memory, I just wrapped a `String`.

Issues/thoughts:

1. I had to alter `SINGLE_CHAR_TOKENS` so that an empty byte char (null terminator) is considered EOF. Without this modification we get an error in `asi()->can_insert_semicolon()` since our token is `Kind::Undetermined`. I'm not sure if this is a hack that can cause issues down the road, or completely fine.
2. The `Lexer`'s constructor receiving a `PaddedStringView` is what enforces we'll have the 16 byte padding. but perhaps the internals can be refactored so it's clearer that it's what allows making assumptions and/or so we can only work with it where needed (in the SIMD parsing).
3. File load performance shouldn't take a hit, but I haven't verified this. Need to validate `read_to_string` and `push_str` aren't a regression.
4. Is there an easy way to benchmark E2E before/after?