### PR TITLE
fix(oxc_parser) correct span for decorators

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -12,8 +12,12 @@ type Implements<'a> = Vec<'a, Box<'a, TSClassImplements<'a>>>;
 
 /// Section 15.7 Class Definitions
 impl<'a> Parser<'a> {
-    pub fn parse_class_statement(&mut self, stmt_ctx: StatementContext) -> Result<Statement<'a>> {
-        let start_span = self.start_span();
+    // `start_span` points at the start of all decoractors and `class` keyword.
+    pub fn parse_class_statement(
+        &mut self,
+        stmt_ctx: StatementContext,
+        start_span: Span,
+    ) -> Result<Statement<'a>> {
         let decl = self.parse_class_declaration(start_span, Modifiers::empty())?;
 
         if stmt_ctx.is_single_statement() {
@@ -53,6 +57,7 @@ impl<'a> Parser<'a> {
         self.bump_any(); // advance `class`
 
         let decorators = self.state.consume_decorators();
+        let start_span = decorators.iter().next().map_or(start_span, |d| d.span);
 
         let id = if self.cur_kind().is_binding_identifier() && !self.at(Kind::Implements) {
             Some(self.parse_binding_identifier()?)

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -190,7 +190,7 @@ impl<'a> Parser<'a> {
     /// Exports
     /// `https://tc39.es/ecma262/#sec-exports`
     pub fn parse_export_declaration(&mut self) -> Result<Statement<'a>> {
-        let span = self.start_span();
+        let start_span = self.start_span();
         self.bump_any(); // advance `export`
 
         let kind = match self.cur_kind() {
@@ -219,7 +219,7 @@ impl<'a> Parser<'a> {
                 .parse_export_named_declaration()
                 .map(ModuleDeclarationKind::ExportNamedDeclaration),
         }?;
-        Ok(self.ast.module_declaration(self.end_span(span), kind))
+        Ok(self.ast.module_declaration(self.end_span(start_span), kind))
     }
 
     // export NamedExports ;
@@ -268,10 +268,10 @@ impl<'a> Parser<'a> {
 
     // export Declaration
     fn parse_export_named_declaration(&mut self) -> Result<Box<'a, ExportNamedDeclaration<'a>>> {
+        let start_span = self.start_span();
         // For tc39/proposal-decorators
         // For more information, please refer to https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport
         self.eat_decorators()?;
-        let start_span = self.start_span();
         let modifiers = if self.ts_enabled() {
             self.eat_modifiers_before_declaration().1
         } else {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -339,9 +339,9 @@ impl<'a> Parser<'a> {
         false
     }
 
-    pub fn parse_ts_declaration_statement(&mut self) -> Result<Statement<'a>> {
+    pub fn parse_ts_declaration_statement(&mut self, start_span: Span) -> Result<Statement<'a>> {
         let reserved_ctx = self.ctx;
-        let start_span = self.start_span();
+
         let (flags, modifiers) = self.eat_modifiers_before_declaration();
         let declare = flags.declare();
         let r#async = flags.r#async();
@@ -497,8 +497,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_decorator(&mut self) -> Result<Decorator<'a>> {
-        self.bump_any(); // bump @
         let span = self.start_span();
+        self.bump_any(); // bump @
         let expr = self.with_context(Context::Decorator, Self::parse_lhs_expression)?;
         Ok(self.ast.decorator(self.end_span(span), expr))
     }


### PR DESCRIPTION
Preserve span position when decorators are eaten. For example:
```javascript
@dec1 class A {}
```
should be parsed into a `ClassDeclaration` with `start = 0`(before `@dec1`) rather than `start = 6`(after `@dec1`).

It's not clear to me how to handle decorators before export. Tried to run it in ast explorer but their babel and swc don't support it now, I preserved the original behavior to the best degree. 

```javascript
@dec1 export class A {}
```
will have a `ModuleDeclaration` starting at 0 but the `ClassDeclaration` would start at the `class` keyword. It would contain a decorator that starts at `0` though.