### PR TITLE
test(oxc_linter): add testing for code fixer

### DIFF
--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 #[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, PartialOrd, Ord)]
 pub struct Span {
     pub start: u32,
     pub end: u32,

--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -31,6 +31,13 @@ impl Command {
             .about("Lint this repository.")
             .arg_required_else_help(true)
             .arg(
+                Arg::new("fix")
+                .long("fix")
+                .required(false)
+                .action(ArgAction::SetTrue)
+                .help("This option allows you to enable oxc to fix as many issues as possible. If enabled, only unfixed issues are reported in the output")
+            )
+            .arg(
               Arg::new("quiet")
                 .long("quiet")
                 .required(false)
@@ -132,6 +139,18 @@ mod test {
     fn test_quiet_false() {
         let matches = get_lint_matches("oxc lint foo.js");
         assert!(!matches.get_flag("quiet"));
+    }
+
+    #[test]
+    fn test_fix_true() {
+        let matches = get_lint_matches("oxc lint foo.js --fix");
+        assert!(matches.get_flag("fix"));
+    }
+
+    #[test]
+    fn test_fix_false() {
+        let matches = get_lint_matches("oxc lint foo.js");
+        assert!(!matches.get_flag("fix"));
     }
 
     #[test]

--- a/crates/oxc_cli/src/options.rs
+++ b/crates/oxc_cli/src/options.rs
@@ -5,6 +5,7 @@ use glob::Pattern;
 
 pub struct CliOptions {
     pub quiet: bool,
+    pub fix: bool,
     pub max_warnings: Option<usize>,
     pub paths: Vec<PathBuf>,
     pub ignore_path: String,
@@ -38,6 +39,7 @@ impl<'a> TryFrom<&'a ArgMatches> for CliOptions {
 
         Ok(Self {
             quiet: matches.get_flag("quiet"),
+            fix: matches.get_flag("fix"),
             max_warnings: matches.get_one("max-warnings").copied(),
             paths,
             ignore_path,

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -178,7 +178,9 @@ mod test {
 
     #[ignore]
     #[test]
-    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix() {}
+    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[test]
     fn apply_same_fix_when_span_overlap_regardless_of_order() {
@@ -189,118 +191,176 @@ mod test {
 
     #[ignore]
     #[test]
-    fn should_not_apply_fix_with_one_no_fix() {}
+    fn should_not_apply_fix_with_one_no_fix() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn sort_no_fix_messages_correctly() {}
+    fn sort_no_fix_messages_correctly() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_bom_at_0() {}
+    fn insert_bom_at_0() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_bom_with_text_at_0() {}
+    fn insert_bom_with_text_at_0() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn remove_bom_with_negative_range() {}
+    fn remove_bom_with_negative_range() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_bom_with_negative_range_and_foobar() {}
+    fn replace_bom_with_negative_range_and_foobar() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     // With BOM
     #[ignore]
     #[test]
-    fn insert_at_the_end_with_bom() {}
+    fn insert_at_the_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_at_the_start_with_bom() {}
+    fn insert_at_the_start_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_at_the_middle_with_bom() {}
+    fn insert_at_the_middle_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_at_the_start_middle_end_with_bom() {}
+    fn insert_at_the_start_middle_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn ignore_reverse_range_with_bom() {}
+    fn ignore_reverse_range_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_at_the_end_with_bom() {}
+    fn replace_at_the_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_at_the_start_with_bom() {}
+    fn replace_at_the_start_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_at_the_middle_with_bom() {}
+    fn replace_at_the_middle_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_at_the_start_middle_end_with_bom() {}
+    fn replace_at_the_start_middle_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn remove_at_the_end_with_bom() {}
+    fn remove_at_the_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn remove_at_the_start_with_bom() {}
+    fn remove_at_the_start_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn remove_at_the_middle_with_bom() {}
+    fn remove_at_the_middle_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn remove_at_the_start_middle_end_with_bom() {}
+    fn remove_at_the_start_middle_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_at_start_remove_at_middle_insert_at_end_with_bom() {}
+    fn replace_at_start_remove_at_middle_insert_at_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn apply_one_fix_when_spans_overlap_with_bom() {}
+    fn apply_one_fix_when_spans_overlap_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn apply_one_fix_when_the_start_the_same_as_the_previous_end_with_bom() {}
+    fn apply_one_fix_when_the_start_the_same_as_the_previous_end_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix_with_bom() {}
+    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn apply_same_fix_when_span_overlap_regardless_of_order_with_bom() {}
+    fn apply_same_fix_when_span_overlap_regardless_of_order_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn should_not_apply_fix_with_one_no_fix_with_bom() {}
+    fn should_not_apply_fix_with_one_no_fix_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_bom_at_0_with_bom() {}
+    fn insert_bom_at_0_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn insert_bom_with_text_at_0_with_bom() {}
+    fn insert_bom_with_text_at_0_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn remove_bom_with_negative_range_with_bom() {}
+    fn remove_bom_with_negative_range_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 
     #[ignore]
     #[test]
-    fn replace_bom_with_negative_range_and_foobar_with_bom() {}
+    fn replace_bom_with_negative_range_and_foobar_with_bom() {
+        let _fixer = create_fixer(vec![]);
+    }
 }

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -176,10 +176,131 @@ mod test {
         assert_eq!(fixer.fix(), TEST_CODE.replace("var ", ""));
     }
 
+    #[ignore]
+    #[test]
+    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix() {}
+
     #[test]
     fn apply_same_fix_when_span_overlap_regardless_of_order() {
         let fixer1 = create_fixer(vec![REMOVE_MIDDLE, REPLACE_ID]);
         let fixer2 = create_fixer(vec![REPLACE_ID, REMOVE_MIDDLE]);
         assert_eq!(fixer1.fix(), fixer2.fix());
     }
+
+    #[ignore]
+    #[test]
+    fn should_not_apply_fix_with_one_no_fix() {}
+
+    #[ignore]
+    #[test]
+    fn sort_no_fix_messages_correctly() {}
+
+    #[ignore]
+    #[test]
+    fn insert_bom_at_0() {}
+
+    #[ignore]
+    #[test]
+    fn insert_bom_with_text_at_0() {}
+
+    #[ignore]
+    #[test]
+    fn remove_bom_with_negative_range() {}
+
+    #[ignore]
+    #[test]
+    fn replace_bom_with_negative_range_and_foobar() {}
+
+    // With BOM
+    #[ignore]
+    #[test]
+    fn insert_at_the_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn insert_at_the_start_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn insert_at_the_middle_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn insert_at_the_start_middle_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn ignore_reverse_range_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn replace_at_the_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn replace_at_the_start_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn replace_at_the_middle_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn replace_at_the_start_middle_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn remove_at_the_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn remove_at_the_start_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn remove_at_the_middle_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn remove_at_the_start_middle_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn replace_at_start_remove_at_middle_insert_at_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn apply_one_fix_when_spans_overlap_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn apply_one_fix_when_the_start_the_same_as_the_previous_end_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn apply_same_fix_when_span_overlap_regardless_of_order_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn should_not_apply_fix_with_one_no_fix_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn insert_bom_at_0_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn insert_bom_with_text_at_0_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn remove_bom_with_negative_range_with_bom() {}
+
+    #[ignore]
+    #[test]
+    fn replace_bom_with_negative_range_and_foobar_with_bom() {}
 }

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -1,6 +1,4 @@
-use std::{borrow::Cow, cmp::Ordering};
-
-use oxc_ast::Span;
+use std::borrow::Cow;
 
 use super::Fix;
 
@@ -11,24 +9,7 @@ pub struct Fixer<'a> {
 
 impl<'a> Fixer<'a> {
     pub fn new(source_text: &'a str, mut fixes: Vec<Fix<'a>>) -> Self {
-        fixes.sort_by(
-            |Fix { span: Span { start: a_start, end: a_end }, .. },
-             Fix { span: Span { start: b_start, end: b_end }, .. }| {
-                if a_start < b_start {
-                    Ordering::Less
-                } else if a_start > b_start {
-                    Ordering::Greater
-                } else {
-                    if a_end < b_end {
-                        Ordering::Less
-                    } else if a_end > b_end {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Equal
-                    }
-                }
-            },
-        );
+        fixes.sort_by_key(|f| f.span);
         Self { source_text, fixes }
     }
 

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -4,11 +4,11 @@ use super::Fix;
 
 pub struct Fixer<'a> {
     source_text: &'a str,
-    fixes: Vec<Fix>,
+    fixes: Vec<Fix<'a>>,
 }
 
 impl<'a> Fixer<'a> {
-    pub fn new(source_text: &'a str, fixes: Vec<Fix>) -> Self {
+    pub fn new(source_text: &'a str, fixes: Vec<Fix<'a>>) -> Self {
         Self { source_text, fixes }
     }
 
@@ -16,11 +16,75 @@ impl<'a> Fixer<'a> {
         if self.fixes.is_empty() {
             Cow::Borrowed(self.source_text)
         } else {
-            let mut fixed_source = String::new();
-            for fix in &self.fixes {
-                fixed_source = fix.apply(self.source_text);
-            }
-            Cow::Owned(fixed_source)
+            let source_text = self.source_text;
+            let mut output = String::new();
+            // To record the position of the last fix.
+            let mut last_pos = 0;
+            self.fixes.iter().for_each(|Fix { content, span }| {
+                let start = span.start;
+                // Current fix may conflict with the last fix, so let's skip it.
+                if start < last_pos {
+                    return;
+                }
+
+                let offset = last_pos.max(0) as usize;
+                output.push_str(&source_text[offset..start as usize]);
+                output.push_str(content);
+                last_pos = span.end;
+            });
+
+            let offset = last_pos.max(0) as usize;
+            output.push_str(&source_text[offset..]);
+
+            return Cow::Owned(output);
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_ast::Span;
+
+    use super::Fixer;
+    use crate::autofix::Fix;
+
+    const TEST_CODE: &str = "var answer = 6 * 7";
+    const INSERT_AT_END: Fix = Fix { span: Span { start: 18, end: 18 }, content: "// end" };
+    const INSERT_AT_START: Fix = Fix { span: Span { start: 0, end: 0 }, content: "// start" };
+    const INSERT_AT_MIDDLE: Fix = Fix { span: Span { start: 13, end: 13 }, content: "5 *" };
+
+    #[test]
+    fn insert_at_the_end() {
+        let fixer = Fixer::new(TEST_CODE, vec![INSERT_AT_END]);
+        assert_eq!(fixer.fix(), TEST_CODE.to_string() + INSERT_AT_END.content);
+    }
+
+    #[test]
+    fn insert_at_the_beginning() {
+        let fixer = Fixer::new(TEST_CODE, vec![INSERT_AT_START]);
+        assert_eq!(fixer.fix(), INSERT_AT_START.content.to_string() + TEST_CODE);
+    }
+
+    #[test]
+    fn insert_at_the_middle() {
+        let fixer = Fixer::new(TEST_CODE, vec![INSERT_AT_MIDDLE]);
+        assert_eq!(
+            fixer.fix(),
+            TEST_CODE.replace("6 *", &format!("{}{}", INSERT_AT_MIDDLE.content, "6 *"))
+        );
+    }
+
+    #[test]
+    fn insert_at_the_beginning_middle_end() {
+        let fixer = Fixer::new(TEST_CODE, vec![INSERT_AT_START, INSERT_AT_MIDDLE, INSERT_AT_END]);
+        assert_eq!(
+            fixer.fix(),
+            format!(
+                "{}{}{}",
+                INSERT_AT_START.content,
+                TEST_CODE.replace("6 *", &format!("{}{}", INSERT_AT_MIDDLE.content, "6 *")),
+                INSERT_AT_END.content
+            )
+        );
     }
 }

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -84,6 +84,9 @@ mod test {
     const REPLACE_ID: Fix = Fix { span: Span { start: 4, end: 10 }, content: Cow::Borrowed("foo") };
     const REPLACE_VAR: Fix = Fix { span: Span { start: 0, end: 3 }, content: Cow::Borrowed("let") };
     const REPLACE_NUM: Fix = Fix { span: Span { start: 13, end: 14 }, content: Cow::Borrowed("5") };
+    const REMOVE_START: Fix = Fix::delete(Span { start: 0, end: 4 });
+    const REMOVE_MIDDLE: Fix = Fix::delete(Span { start: 5, end: 10 });
+    const REMOVE_END: Fix = Fix::delete(Span { start: 14, end: 18 });
     const REVERSE_RANGE: Fix = Fix { span: Span { start: 3, end: 0 }, content: Cow::Borrowed(" ") };
 
     fn create_fixer<'a>(fixes: Vec<Fix<'a>>) -> Fixer {
@@ -97,7 +100,7 @@ mod test {
     }
 
     #[test]
-    fn insert_at_the_beginning() {
+    fn insert_at_the_start() {
         let fixer = create_fixer(vec![INSERT_AT_START]);
         assert_eq!(fixer.fix(), INSERT_AT_START.content.to_string() + TEST_CODE);
     }
@@ -112,7 +115,7 @@ mod test {
     }
 
     #[test]
-    fn insert_at_the_beginning_middle_end() {
+    fn insert_at_the_start_middle_end() {
         let fixer = create_fixer(vec![INSERT_AT_MIDDLE, INSERT_AT_START, INSERT_AT_END]);
         assert_eq!(
             fixer.fix(),
@@ -132,7 +135,7 @@ mod test {
     }
 
     #[test]
-    fn replace_at_the_beginning() {
+    fn replace_at_the_start() {
         let fixer = create_fixer(vec![REPLACE_VAR]);
         assert_eq!(fixer.fix(), TEST_CODE.replace("var", "let"));
     }
@@ -150,8 +153,26 @@ mod test {
     }
 
     #[test]
-    fn replace_at_the_beginning_middle_end() {
+    fn replace_at_the_start_middle_end() {
         let fixer = create_fixer(vec![REPLACE_ID, REPLACE_VAR, REPLACE_NUM]);
         assert_eq!(fixer.fix(), "let foo = 5 * 7;");
+    }
+
+    #[test]
+    fn remove_at_the_start() {
+        let fixer = create_fixer(vec![REMOVE_START]);
+        assert_eq!(fixer.fix(), TEST_CODE.replace("var ", ""));
+    }
+
+    #[test]
+    fn remove_at_the_middle() {
+        let fixer = create_fixer(vec![REMOVE_MIDDLE]);
+        assert_eq!(fixer.fix(), TEST_CODE.replace("answer", "a"));
+    }
+
+    #[test]
+    fn remove_at_the_end() {
+        let fixer = create_fixer(vec![REMOVE_END]);
+        assert_eq!(fixer.fix(), TEST_CODE.replace(" * 7", ""));
     }
 }

--- a/crates/oxc_linter/src/autofix/mod.rs
+++ b/crates/oxc_linter/src/autofix/mod.rs
@@ -5,26 +5,13 @@ mod fixer;
 pub use fixer::Fixer;
 
 #[derive(Debug)]
-pub struct Fix {
-    pub content: String,
+pub struct Fix<'a> {
+    pub content: &'a str,
     pub span: Span,
 }
 
-impl<'a> Fix {
+impl<'a> Fix<'a> {
     pub const fn delete(span: Span) -> Self {
-        Self { content: String::new(), span }
-    }
-
-    pub fn apply(&self, source_text: &'a str) -> String {
-        let mut output = String::new();
-
-        let slice = &source_text[..self.span.start as usize];
-        let remainder = &source_text[self.span.end as usize..];
-
-        output.push_str(slice);
-        output.push_str(&self.content);
-        output.push_str(remainder);
-
-        output
+        Self { content: "", span }
     }
 }

--- a/crates/oxc_linter/src/autofix/mod.rs
+++ b/crates/oxc_linter/src/autofix/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use oxc_ast::Span;
 
 mod fixer;
@@ -6,12 +8,16 @@ pub use fixer::Fixer;
 
 #[derive(Debug)]
 pub struct Fix<'a> {
-    pub content: &'a str,
+    pub content: Cow<'a, str>,
     pub span: Span,
 }
 
 impl<'a> Fix<'a> {
     pub const fn delete(span: Span) -> Self {
-        Self { content: "", span }
+        Self { content: Cow::Borrowed(""), span }
+    }
+
+    pub fn new<T: Into<Cow<'a, str>>>(content: T, span: Span) -> Self {
+        Self { content: content.into(), span }
     }
 }

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -13,15 +13,20 @@ pub struct LintContext<'a> {
 
     diagnostics: RefCell<Vec<Error>>,
 
+    /// Whether or not to apply code fixes during linting.
+    fix: bool,
+
+    /// Collection of applicable fixes based on reported issues.
     fixes: RefCell<Vec<Fix<'a>>>,
 }
 
 impl<'a> LintContext<'a> {
-    pub fn new(source_text: &'a str, semantic: Rc<Semantic<'a>>) -> Self {
+    pub fn new(source_text: &'a str, semantic: Rc<Semantic<'a>>, fix: bool) -> Self {
         Self {
             source_text,
             semantic,
             diagnostics: RefCell::new(vec![]),
+            fix,
             fixes: RefCell::new(vec![]),
         }
     }
@@ -43,6 +48,9 @@ impl<'a> LintContext<'a> {
     }
 
     pub fn fix(&self, fix: Fix<'a>) {
+        if !self.fix {
+            return;
+        }
         self.fixes.borrow_mut().push(fix);
     }
 

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -54,10 +54,6 @@ impl<'a> LintContext<'a> {
         self.fixes.borrow_mut().push(fix);
     }
 
-    pub fn into_fixes(self) -> Vec<Fix<'a>> {
-        self.fixes.into_inner()
-    }
-
     pub fn parent_kind(&self, node: &AstNode<'a>) -> AstKind<'a> {
         self.semantic().nodes().parent_kind(node)
     }

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -13,7 +13,7 @@ pub struct LintContext<'a> {
 
     diagnostics: RefCell<Vec<Error>>,
 
-    fixes: RefCell<Vec<Fix>>,
+    fixes: RefCell<Vec<Fix<'a>>>,
 }
 
 impl<'a> LintContext<'a> {
@@ -30,7 +30,7 @@ impl<'a> LintContext<'a> {
         self.source_text
     }
 
-    pub fn into_diagnostics(self) -> (Vec<Fix>, Vec<Error>) {
+    pub fn into_diagnostics(self) -> (Vec<Fix<'a>>, Vec<Error>) {
         (self.fixes.into_inner(), self.diagnostics.into_inner())
     }
 
@@ -42,11 +42,11 @@ impl<'a> LintContext<'a> {
         self.diagnostics.borrow_mut().push(diagnostic.into());
     }
 
-    pub fn fix(&self, fix: Fix) {
+    pub fn fix(&self, fix: Fix<'a>) {
         self.fixes.borrow_mut().push(fix);
     }
 
-    pub fn into_fixes(self) -> Vec<Fix> {
+    pub fn into_fixes(self) -> Vec<Fix<'a>> {
         self.fixes.into_inner()
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -65,8 +65,13 @@ impl Linter {
     }
 
     #[must_use]
-    pub fn run<'a>(&self, semantic: &Rc<Semantic<'a>>, source_text: &'a str) -> LintRunResult<'a> {
-        let ctx = LintContext::new(source_text, semantic.clone());
+    pub fn run<'a>(
+        &self,
+        semantic: &Rc<Semantic<'a>>,
+        source_text: &'a str,
+        fix: bool,
+    ) -> LintRunResult<'a> {
+        let ctx = LintContext::new(source_text, semantic.clone(), fix);
 
         for node in semantic.nodes().iter() {
             for rule in &self.rules {

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -66,7 +66,7 @@ impl Tester {
         let semantic = std::rc::Rc::new(semantic);
         let rule = RULES.iter().find(|rule| rule.name() == self.rule_name).unwrap();
         let rule = rule.read_json(config);
-        let result = Linter::from_rules(vec![rule]).run(&semantic, source_text);
+        let result = Linter::from_rules(vec![rule]).run(&semantic, source_text, false);
         if result.diagnostics.is_empty() {
             return true;
         }


### PR DESCRIPTION
## Description

Add insertion testing for our code fixer, the test cases are copied from [eslint's test cases](https://github.com/eslint/eslint/blob/main/tests/lib/linter/source-code-fixer.js). The other test cases will be added in the other pr, otherwise this pr would be too big to review.

Store `&'a str` in `Fixer` instead of `String`.

To avoid overriding the previous fix, we need to record the position of the last fix. As a result, instead of using `Fix::apply`, I move the fixing code into the `Fixer::fix` method.

## Related issues

#68 