### PR TITLE
refactor(lexer): avoid copying of self in SIMD functions

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -483,7 +483,8 @@ impl<'a> Lexer<'a> {
         }
 
         let remaining = self.remaining().as_bytes();
-        let state = SkipWhitespace::new(self.current.token.is_on_new_line).simd(remaining);
+        let mut state = SkipWhitespace::new(self.current.token.is_on_new_line);
+        state.simd(remaining);
 
         // SAFETY: offset is computed to the boundary
         self.current.chars =
@@ -512,7 +513,8 @@ impl<'a> Lexer<'a> {
     fn skip_multi_line_comment(&mut self) -> Kind {
         let remaining = self.remaining().as_bytes();
         let newline = self.current.token.is_on_new_line;
-        let state = SkipMultilineComment::new(newline, remaining).simd();
+        let mut state = SkipMultilineComment::new(newline, remaining);
+        state.simd();
 
         // SAFETY: offset is computed to the boundary
         self.current.chars =

--- a/crates/oxc_parser/src/lexer/simd.rs
+++ b/crates/oxc_parser/src/lexer/simd.rs
@@ -38,7 +38,7 @@ impl SkipWhitespace {
         }
     }
 
-    pub fn simd(mut self, bytes: &[u8]) -> Self {
+    pub fn simd(&mut self, bytes: &[u8]) -> &Self {
         let (chunks, remainder) = bytes.as_chunks::<ELEMENTS>();
 
         for chunk in chunks {
@@ -119,7 +119,7 @@ impl<'a> SkipMultilineComment<'a> {
         }
     }
 
-    pub fn simd(mut self) -> Self {
+    pub fn simd(&mut self) -> &Self {
         let (chunks, remainder) = self.remaining.as_chunks::<ELEMENTS>();
 
         for chunk in chunks {


### PR DESCRIPTION
Avoids copying self when returning from the SIMD functions.
See the assembly at [this comment](https://github.com/Boshen/oxc/pull/90#discussion_r1123780817).

With this PR, the struct is no longer copied.
The copying instructions before returning are removed:
```asm
 mov     rcx, qword, ptr, [rdx, +, 64]
 mov     qword, ptr, [rax, +, 64], rcx
 movzx   ecx, byte, ptr, [rdx, +, 72]
 mov     byte, ptr, [rax, +, 72], cl
 mov     ecx, dword, ptr, [rdx, +, 73]
 mov     dword, ptr, [rax, +, 73], ecx
 movzx   ecx, word, ptr, [rdx, +, 77]
 mov     word, ptr, [rax, +, 77], cx
 movzx   ecx, byte, ptr, [rdx, +, 79]
 mov     byte, ptr, [rax, +, 79], cl
 movaps  xmm0, xmmword, ptr, [rdx]
 movaps  xmm1, xmmword, ptr, [rdx, +, 16]
 movaps  xmm2, xmmword, ptr, [rdx, +, 32]
 movaps  xmm3, xmmword, ptr, [rdx, +, 48]
 movaps  xmmword, ptr, [rax, +, 48], xmm3
 movaps  xmmword, ptr, [rax, +, 32], xmm2
 movaps  xmmword, ptr, [rax, +, 16], xmm1
 movaps  xmmword, ptr, [rax], xmm0
```