### PR TITLE
feat(linter): wire up `--fix` CLI flag

### DIFF
--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -31,6 +31,13 @@ impl Command {
             .about("Lint this repository.")
             .arg_required_else_help(true)
             .arg(
+                Arg::new("fix")
+                .long("fix")
+                .required(false)
+                .action(ArgAction::SetTrue)
+                .help("This option allows you to enable oxc to fix as many issues as possible. If enabled, only unfixed issues are reported in the output")
+            )
+            .arg(
               Arg::new("quiet")
                 .long("quiet")
                 .required(false)
@@ -132,6 +139,18 @@ mod test {
     fn test_quiet_false() {
         let matches = get_lint_matches("oxc lint foo.js");
         assert!(!matches.get_flag("quiet"));
+    }
+
+    #[test]
+    fn test_fix_true() {
+        let matches = get_lint_matches("oxc lint foo.js --fix");
+        assert!(matches.get_flag("fix"));
+    }
+
+    #[test]
+    fn test_fix_false() {
+        let matches = get_lint_matches("oxc lint foo.js");
+        assert!(!matches.get_flag("fix"));
     }
 
     #[test]

--- a/crates/oxc_cli/src/options.rs
+++ b/crates/oxc_cli/src/options.rs
@@ -5,6 +5,7 @@ use glob::Pattern;
 
 pub struct CliOptions {
     pub quiet: bool,
+    pub fix: bool,
     pub max_warnings: Option<usize>,
     pub paths: Vec<PathBuf>,
     pub ignore_path: String,
@@ -38,6 +39,7 @@ impl<'a> TryFrom<&'a ArgMatches> for CliOptions {
 
         Ok(Self {
             quiet: matches.get_flag("quiet"),
+            fix: matches.get_flag("fix"),
             max_warnings: matches.get_one("max-warnings").copied(),
             paths,
             ignore_path,

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -13,15 +13,20 @@ pub struct LintContext<'a> {
 
     diagnostics: RefCell<Vec<Error>>,
 
+    /// Whether or not to apply code fixes during linting.
+    fix: bool,
+
+    /// Collection of applicable fixes based on reported issues.
     fixes: RefCell<Vec<Fix<'a>>>,
 }
 
 impl<'a> LintContext<'a> {
-    pub fn new(source_text: &'a str, semantic: Rc<Semantic<'a>>) -> Self {
+    pub fn new(source_text: &'a str, semantic: Rc<Semantic<'a>>, fix: bool) -> Self {
         Self {
             source_text,
             semantic,
             diagnostics: RefCell::new(vec![]),
+            fix,
             fixes: RefCell::new(vec![]),
         }
     }
@@ -43,6 +48,9 @@ impl<'a> LintContext<'a> {
     }
 
     pub fn fix(&self, fix: Fix<'a>) {
+        if !self.fix {
+            return;
+        }
         self.fixes.borrow_mut().push(fix);
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -65,8 +65,13 @@ impl Linter {
     }
 
     #[must_use]
-    pub fn run<'a>(&self, semantic: &Rc<Semantic<'a>>, source_text: &'a str) -> LintRunResult<'a> {
-        let ctx = LintContext::new(source_text, semantic.clone());
+    pub fn run<'a>(
+        &self,
+        semantic: &Rc<Semantic<'a>>,
+        source_text: &'a str,
+        fix: bool,
+    ) -> LintRunResult<'a> {
+        let ctx = LintContext::new(source_text, semantic.clone(), fix);
 
         for node in semantic.nodes().iter() {
             for rule in &self.rules {

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -66,7 +66,7 @@ impl Tester {
         let semantic = std::rc::Rc::new(semantic);
         let rule = RULES.iter().find(|rule| rule.name() == self.rule_name).unwrap();
         let rule = rule.read_json(config);
-        let result = Linter::from_rules(vec![rule]).run(&semantic, source_text);
+        let result = Linter::from_rules(vec![rule]).run(&semantic, source_text, false);
         if result.diagnostics.is_empty() {
             return true;
         }


### PR DESCRIPTION
Building off #101, wiring up the `--fix` CLI flag so we can indicate whether or not to apply auto-fixing to source code.