### PR TITLE
feat(cli): introduce pretty errors

### DIFF
--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -12,7 +12,6 @@ use std::{
     sync::{mpsc, Arc},
 };
 
-// use git::{Git, GitResult};
 use miette::NamedSource;
 use oxc_allocator::Allocator;
 use oxc_ast::SourceType;
@@ -27,18 +26,15 @@ pub struct Cli {
     pub cli_options: CliOptions,
 }
 
-#[allow(clippy::missing_const_for_fn)]
 impl Cli {
     #[must_use]
-    pub fn new(cli_options: CliOptions) -> Self {
+    pub const fn new(cli_options: CliOptions) -> Self {
         Self { cli_options }
     }
 
-    /// Runs the linter on the specified paths and returns a `CliRunResult`.
-    ///
     /// # Panics
     ///
-    /// This function may panic if the `fs::read_to_string` function in `lint_path` fails to read a file.
+    /// * When `mpsc::channel` fails to send.
     #[must_use]
     pub fn lint(&self) -> CliRunResult {
         let now = std::time::Instant::now();

--- a/crates/oxc_cli/src/main.rs
+++ b/crates/oxc_cli/src/main.rs
@@ -15,6 +15,10 @@ fn main() -> CliRunResult {
         let (subcommand, matches) = command;
         let cli_options = CliOptions::try_from(matches);
         if let Ok(cli_options) = cli_options {
+            // if cli_options.fix {
+            //   Git::new().verify()?;
+            // }
+
             let cli = Cli::new(cli_options);
 
             if subcommand == "lint" {


### PR DESCRIPTION
Builds upon #110 and introduces errors similar to the parser/linter in the CLI. Currently, an error will only be returned if there are issues verifying status of the  Git repository (no repo, multiple repos, or uncommitted files)