### PR TITLE
perf(semantic): use faster indextree building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "indextree"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497f036ac2fae75c34224648a77802e5dd4e9cfb56f4713ab6b12b7160a0523b"
+checksum = "c40411d0e5c63ef1323c3d09ce5ec6d84d71531e18daed0743fccea279d7deb6"
 
 [[package]]
 name = "insta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = "1.0.152"
 serde_json = "1.0.93"
 thiserror = "1.0.38"
 clap = "4.1.8"
-indextree = "4.5.0"
+indextree = "4.6.0"
 glob = "0.3.1"
 lazy_static = "1.4.0"
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -43,8 +43,8 @@ impl<'a> SemanticBuilder<'a> {
     fn create_ast_node(&mut self, kind: AstKind<'a>) {
         let ast_node =
             SemanticNode::new(kind, self.scope.current_scope_id, self.current_node_flags);
-        let node_id = self.nodes.new_node(ast_node);
-        self.current_node_id.append(node_id, &mut self.nodes);
+        let node_id = self.current_node_id.append_value(ast_node, &mut self.nodes);
+
         self.current_node_id = node_id.into();
     }
 

--- a/crates/oxc_semantic/src/scope/builder.rs
+++ b/crates/oxc_semantic/src/scope/builder.rs
@@ -36,8 +36,7 @@ impl ScopeBuilder {
         };
 
         let scope = Scope::new(flags, strict_mode);
-        let new_scope_id = self.scopes.new_node(scope);
-        self.current_scope_id.append(new_scope_id, &mut self.scopes);
+        let new_scope_id = self.current_scope_id.append_value(scope, &mut self.scopes);
         self.current_scope_id = new_scope_id.into();
     }
 


### PR DESCRIPTION
Related to issue #115, but not necessarily the final change.

Local profiling shows improvement as expected (see comment in the issue), which isn't large/significant.
I opened an [indextree PR](https://github.com/saschagrunert/indextree/pull/92), will need to wait for feedback.