### PR TITLE
feat(linter): implement rule categories

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -2,6 +2,11 @@ use std::fmt::Debug;
 
 use crate::{context::LintContext, AstNode};
 
+pub enum RuleCategory {
+    Correctness,
+    Nursery,
+}
+
 pub trait Rule: Sized + Default + Debug {
     /// Initialize from eslint json configuration
     #[must_use]
@@ -15,7 +20,7 @@ pub trait Rule: Sized + Default + Debug {
 pub trait RuleMeta {
     const NAME: &'static str;
 
-    const CATEGORY: &'static str;
+    const CATEGORY: RuleCategory;
 
     #[must_use]
     fn documentation() -> Option<&'static str> {

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -15,6 +15,8 @@ pub trait Rule: Sized + Default + Debug {
 pub trait RuleMeta {
     const NAME: &'static str;
 
+    const CATEGORY: &'static str;
+
     #[must_use]
     fn documentation() -> Option<&'static str> {
         None

--- a/crates/oxc_linter/src/rules/deepscan/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/deepscan/uninvoked_array_callback.rs
@@ -38,7 +38,8 @@ declare_oxc_lint!(
     /// ```javascript
     ///   const list = new Array(5).map(_ => createElement());
     /// ```
-    UninvokedArrayCallback
+    UninvokedArrayCallback,
+    correctness
 );
 
 impl Rule for UninvokedArrayCallback {

--- a/crates/oxc_linter/src/rules/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/no_array_constructor.rs
@@ -28,7 +28,8 @@ declare_oxc_lint!(
     /// ```javascript
     /// let arr = new Array();
     /// ```
-    NoArrayConstructor
+    NoArrayConstructor,
+    correctness
 );
 
 impl Rule for NoArrayConstructor {

--- a/crates/oxc_linter/src/rules/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/no_debugger.rs
@@ -30,7 +30,8 @@ declare_oxc_lint!(
     /// const result = complexCalculation(data);
     /// debugger;
     /// ```
-    NoDebugger
+    NoDebugger,
+    correctness
 );
 
 impl Rule for NoDebugger {

--- a/crates/oxc_linter/src/rules/no_empty.rs
+++ b/crates/oxc_linter/src/rules/no_empty.rs
@@ -32,7 +32,8 @@ declare_oxc_lint!(
     ///
     /// }
     /// ```
-    NoEmpty
+    NoEmpty,
+    correctness
 );
 
 impl Rule for NoEmpty {

--- a/crates/oxc_linter/src/rules/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/no_empty_pattern.rs
@@ -69,7 +69,8 @@ declare_oxc_lint!(
     /// function foo({a = []}) {}
     /// ```
     ///
-    NoEmptyPattern
+    NoEmptyPattern,
+    correctness
 );
 
 impl Rule for NoEmptyPattern {

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -1,3 +1,4 @@
+use oxc_linter::rule::RuleCategory;
 use oxc_linter::rule::RuleMeta;
 use oxc_macros::declare_oxc_lint_test;
 
@@ -7,7 +8,7 @@ declare_oxc_lint_test!(
     /// Dummy description
     /// # which is multiline
     TestRule,
-    test
+    correctness
 );
 
 struct TestRule2 {
@@ -18,7 +19,7 @@ struct TestRule2 {
 declare_oxc_lint_test!(
     /// Dummy description2
     TestRule2,
-    test
+    correctness
 );
 
 #[test]

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -7,7 +7,7 @@ declare_oxc_lint_test!(
     /// Dummy description
     /// # which is multiline
     TestRule,
-    "test"
+    test
 );
 
 struct TestRule2 {
@@ -18,7 +18,7 @@ struct TestRule2 {
 declare_oxc_lint_test!(
     /// Dummy description2
     TestRule2,
-    "test"
+    test
 );
 
 #[test]

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -66,6 +66,7 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
 
         impl RuleMeta for #name {
             const NAME: &'static str = #canonical_name;
+
             const CATEGORY: &'static str = #category;
 
             fn documentation() -> Option<&'static str> {


### PR DESCRIPTION
See #128 

Implementing basic lint rule categories via the `declare_oxc_lint!()` macro. This allows us to work on rules that might still be under active development.