### PR TITLE
test(fixer): cover more test cases

### DIFF
--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -4,8 +4,6 @@ use oxc_diagnostics::Error;
 
 use super::Fix;
 
-const BOM: char = '\u{FEFF}';
-
 pub struct FixResult<'a> {
     pub fixed: bool,
     pub fixed_code: Cow<'a, str>,
@@ -39,19 +37,14 @@ impl<'a> Fixer<'a> {
     #[must_use]
     /// # Panics
     pub fn fix(mut self) -> FixResult<'a> {
+        let source_text = self.source_text;
         if self.messages.iter().all(|m| matches!(m.fix, None)) {
             return FixResult {
                 fixed: false,
-                fixed_code: Cow::Borrowed(self.source_text),
+                fixed_code: Cow::Borrowed(source_text),
                 messages: self.messages,
             };
         }
-
-        let (source_text, mut prepend_bom) = if self.source_text.starts_with(BOM) {
-            (&self.source_text[3..], true)
-        } else {
-            (self.source_text, false)
-        };
 
         self.messages.sort_by_key(|m| m.fix.as_ref().unwrap_or(&Fix::default()).span);
         let mut fixed = false;
@@ -72,21 +65,12 @@ impl<'a> Fixer<'a> {
             fixed = true;
             let offset = usize::try_from(last_pos.max(0)).ok().unwrap();
             output.push_str(&source_text[offset..start as usize]);
-            if start == 0 && content.starts_with(BOM) {
-                prepend_bom = true;
-                output.push_str(&content[3..]);
-            } else {
-                output.push_str(content);
-            }
+            output.push_str(content);
             last_pos = i64::from(end);
         });
 
         let offset = usize::try_from(last_pos.max(0)).ok().unwrap();
         output.push_str(&source_text[offset..]);
-
-        if prepend_bom {
-            output.insert(0, BOM);
-        }
 
         let messages = self.messages.into_iter().filter(|m| !m.fixed).collect::<Vec<_>>();
 
@@ -103,10 +87,9 @@ mod test {
     use oxc_diagnostics::{thiserror::Error, Error};
 
     use super::{FixResult, Fixer, Message};
-    use crate::autofix::{fixer::BOM, Fix};
+    use crate::autofix::Fix;
 
     const TEST_CODE: &str = "var answer = 6 * 7;";
-    const TEST_CODE_WITH_BOM: &str = "\u{FEFF}var answer = 6 * 7;";
 
     #[derive(Debug, Error, Diagnostic)]
     #[error("End")]
@@ -163,18 +146,6 @@ mod test {
     #[derive(Debug, Error, Diagnostic)]
     #[error("nofix")]
     struct NoFix();
-
-    #[derive(Debug, Error, Diagnostic)]
-    #[error("insert-bom")]
-    struct InsertBOM();
-    const INSERT_BOM: Fix =
-        Fix { span: Span { start: 0, end: 0 }, content: Cow::Borrowed("\u{FEFF}") };
-
-    #[derive(Debug, Error, Diagnostic)]
-    #[error("insert-bom")]
-    struct InsertBOMWithText();
-    const INSERT_BOM_WITH_TEXT: Fix =
-        Fix { span: Span { start: 0, end: 0 }, content: Cow::Borrowed("\u{FEFF}// start\n") };
 
     #[derive(Debug, Error, Diagnostic)]
     #[error("nofix1")]
@@ -389,268 +360,5 @@ mod test {
         assert_eq!(result.messages[0].error.to_string(), "nofix1");
         assert_eq!(result.messages[0].error.to_string(), "nofix2");
         assert!(result.fixed);
-    }
-
-    #[test]
-    fn insert_bom_at_0() {
-        let result = get_fix_result(vec![create_message(InsertBOM(), Some(INSERT_BOM))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
-        assert!(result.fixed);
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[test]
-    fn insert_bom_with_text_at_0() {
-        let result =
-            get_fix_result(vec![create_message(InsertBOMWithText(), Some(INSERT_BOM_WITH_TEXT))]);
-        assert_eq!(result.fixed_code, format!("\u{FEFF}// start\n{TEST_CODE}"));
-        assert!(result.fixed);
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[ignore]
-    #[test]
-    fn remove_bom_with_negative_range() {
-        let _result = get_fix_result(vec![]);
-    }
-
-    #[ignore]
-    #[test]
-    fn replace_bom_with_negative_range_and_foobar() {
-        let _result = get_fix_result(vec![]);
-    }
-
-    fn get_fix_result_with_bom(messages: Vec<Message>) -> FixResult {
-        Fixer::new(TEST_CODE_WITH_BOM, messages).fix()
-    }
-
-    // With BOM
-    #[test]
-    fn insert_at_the_end_with_bom() {
-        let result =
-            get_fix_result_with_bom(vec![create_message(InsertAtEnd(), Some(INSERT_AT_END))]);
-        assert_eq!(result.fixed_code, format!("{}{}", TEST_CODE_WITH_BOM, INSERT_AT_END.content));
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[test]
-    fn insert_at_the_start_with_bom() {
-        let result =
-            get_fix_result_with_bom(vec![create_message(InsertAtStart(), Some(INSERT_AT_START))]);
-        assert_eq!(result.fixed_code, format!("{}{}{}", BOM, INSERT_AT_START.content, TEST_CODE));
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[test]
-    fn insert_at_the_middle_with_bom() {
-        let result =
-            get_fix_result_with_bom(vec![create_message(InsertAtMiddle(), Some(INSERT_AT_MIDDLE))]);
-        let insert_in_middle =
-            TEST_CODE.replace("6 *", &format!("{}6 *", INSERT_AT_MIDDLE.content));
-        assert_eq!(result.fixed_code, format!("{BOM}{insert_in_middle}"));
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[test]
-    fn insert_at_the_start_middle_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(InsertAtMiddle(), Some(INSERT_AT_MIDDLE)),
-            create_message(InsertAtStart(), Some(INSERT_AT_START)),
-            create_message(InsertAtEnd(), Some(INSERT_AT_END)),
-        ]);
-        let insert_in_middle =
-            TEST_CODE.replace("6 *", &format!("{}6 *", INSERT_AT_MIDDLE.content));
-        assert_eq!(
-            result.fixed_code,
-            format!(
-                "{}{}{}{}",
-                BOM, INSERT_AT_START.content, insert_in_middle, INSERT_AT_END.content
-            )
-        );
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[test]
-    fn ignore_reverse_range_with_bom() {
-        let result =
-            get_fix_result_with_bom(vec![create_message(ReverseRange(), Some(REVERSE_RANGE))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
-    }
-
-    #[test]
-    fn replace_at_the_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(ReplaceVar(), Some(REPLACE_VAR))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("var", "let"));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn replace_at_the_start_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(ReplaceId(), Some(REPLACE_ID))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("answer", "foo"));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn replace_at_the_middle_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(ReplaceNum(), Some(REPLACE_NUM))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace('6', "5"));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn replace_at_the_start_middle_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(ReplaceId(), Some(REPLACE_ID)),
-            create_message(ReplaceVar(), Some(REPLACE_VAR)),
-            create_message(ReplaceNum(), Some(REPLACE_NUM)),
-        ]);
-        assert_eq!(result.fixed_code, format!("{BOM}let foo = 5 * 7;"));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn remove_at_the_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(RemoveEnd(), Some(REMOVE_END))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace(" * 7", ""));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn remove_at_the_start_with_bom() {
-        let result =
-            get_fix_result_with_bom(vec![create_message(RemoveStart(), Some(REMOVE_START))]);
-        assert_eq!(result.fixed_code, format!("{}{}", BOM, TEST_CODE.replace("var ", "")));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn remove_at_the_middle_with_bom() {
-        let result =
-            get_fix_result_with_bom(vec![create_message(RemoveMiddle(), Some(REMOVE_MIDDLE))]);
-        assert_eq!(result.fixed_code, format!("{}{}", BOM, TEST_CODE.replace("answer", "a")));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn remove_at_the_start_middle_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(RemoveEnd(), Some(REMOVE_END)),
-            create_message(RemoveStart(), Some(REMOVE_START)),
-            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
-        ]);
-        assert_eq!(result.fixed_code, format!("{BOM}a = 6;"));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn replace_at_start_remove_at_middle_insert_at_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(InsertAtEnd(), Some(INSERT_AT_END)),
-            create_message(RemoveEnd(), Some(REMOVE_END)),
-            create_message(ReplaceVar(), Some(REPLACE_VAR)),
-        ]);
-        assert_eq!(result.fixed_code, format!("{BOM}let answer = 6;// end"));
-        assert_eq!(result.messages.len(), 0);
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn apply_one_fix_when_spans_overlap_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
-            create_message(ReplaceId(), Some(REPLACE_ID)),
-        ]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("answer", "foo"));
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].error.to_string(), "removemiddle");
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn apply_one_fix_when_the_start_the_same_as_the_previous_end_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(RemoveStart(), Some(REMOVE_START)),
-            create_message(ReplaceId(), Some(REPLACE_ID)),
-        ]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("var ", ""));
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].error.to_string(), "foo");
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix_with_bom() {
-        let result = get_fix_result_with_bom(vec![
-            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
-            create_message(ReplaceId(), Some(REPLACE_ID)),
-            create_message(NoFix(), None),
-        ]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("answer", "foo"));
-        assert_eq!(result.messages.len(), 2);
-        assert_eq!(result.messages[0].error.to_string(), "nofix");
-        assert_eq!(result.messages[1].error.to_string(), "removemiddle");
-        assert!(result.fixed);
-    }
-
-    #[test]
-    fn apply_same_fix_when_span_overlap_regardless_of_order_with_bom() {
-        let result1 = get_fix_result_with_bom(vec![
-            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
-            create_message(ReplaceId(), Some(REPLACE_ID)),
-        ]);
-        let result2 = get_fix_result_with_bom(vec![
-            create_message(ReplaceId(), Some(REPLACE_ID)),
-            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
-        ]);
-        assert_eq!(result1.fixed_code, result2.fixed_code);
-    }
-
-    #[test]
-    fn should_not_apply_fix_with_one_no_fix_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(NoFix(), None)]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].error.to_string(), "nofix");
-        assert!(!result.fixed);
-    }
-
-    #[test]
-    fn insert_bom_at_0_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(InsertBOM(), Some(INSERT_BOM))]);
-        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
-        assert!(result.fixed);
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[test]
-    fn insert_bom_with_text_at_0_with_bom() {
-        let result = get_fix_result_with_bom(vec![create_message(
-            InsertBOMWithText(),
-            Some(INSERT_BOM_WITH_TEXT),
-        )]);
-        assert_eq!(result.fixed_code, format!("\u{FEFF}// start\n{TEST_CODE}"));
-        assert!(result.fixed);
-        assert_eq!(result.messages.len(), 0);
-    }
-
-    #[ignore]
-    #[test]
-    fn remove_bom_with_negative_range_with_bom() {
-        let _result = get_fix_result(vec![]);
-    }
-
-    #[ignore]
-    #[test]
-    fn replace_bom_with_negative_range_and_foobar_with_bom() {
-        let _result = get_fix_result(vec![]);
     }
 }

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -4,6 +4,8 @@ use oxc_diagnostics::Error;
 
 use super::Fix;
 
+const BOM: char = '\u{FEFF}';
+
 pub struct FixResult<'a> {
     pub fixed: bool,
     pub fixed_code: Cow<'a, str>,
@@ -37,14 +39,19 @@ impl<'a> Fixer<'a> {
     #[must_use]
     /// # Panics
     pub fn fix(mut self) -> FixResult<'a> {
-        let source_text = self.source_text;
         if self.messages.iter().all(|m| matches!(m.fix, None)) {
             return FixResult {
                 fixed: false,
-                fixed_code: Cow::Borrowed(source_text),
+                fixed_code: Cow::Borrowed(self.source_text),
                 messages: self.messages,
             };
         }
+
+        let (source_text, mut prepend_bom) = if self.source_text.starts_with(BOM) {
+            (&self.source_text[3..], true)
+        } else {
+            (self.source_text, false)
+        };
 
         self.messages.sort_by_key(|m| m.fix.as_ref().unwrap_or(&Fix::default()).span);
         let mut fixed = false;
@@ -65,12 +72,21 @@ impl<'a> Fixer<'a> {
             fixed = true;
             let offset = usize::try_from(last_pos.max(0)).ok().unwrap();
             output.push_str(&source_text[offset..start as usize]);
-            output.push_str(content);
+            if start == 0 && content.starts_with(BOM) {
+                prepend_bom = true;
+                output.push_str(&content[3..]);
+            } else {
+                output.push_str(content);
+            }
             last_pos = i64::from(end);
         });
 
         let offset = usize::try_from(last_pos.max(0)).ok().unwrap();
         output.push_str(&source_text[offset..]);
+
+        if prepend_bom {
+            output.insert(0, BOM);
+        }
 
         let messages = self.messages.into_iter().filter(|m| !m.fixed).collect::<Vec<_>>();
 
@@ -87,9 +103,10 @@ mod test {
     use oxc_diagnostics::{thiserror::Error, Error};
 
     use super::{FixResult, Fixer, Message};
-    use crate::autofix::Fix;
+    use crate::autofix::{fixer::BOM, Fix};
 
     const TEST_CODE: &str = "var answer = 6 * 7;";
+    const TEST_CODE_WITH_BOM: &str = "\u{FEFF}var answer = 6 * 7;";
 
     #[derive(Debug, Error, Diagnostic)]
     #[error("End")]
@@ -146,6 +163,18 @@ mod test {
     #[derive(Debug, Error, Diagnostic)]
     #[error("nofix")]
     struct NoFix();
+
+    #[derive(Debug, Error, Diagnostic)]
+    #[error("insert-bom")]
+    struct InsertBOM();
+    const INSERT_BOM: Fix =
+        Fix { span: Span { start: 0, end: 0 }, content: Cow::Borrowed("\u{FEFF}") };
+
+    #[derive(Debug, Error, Diagnostic)]
+    #[error("insert-bom")]
+    struct InsertBOMWithText();
+    const INSERT_BOM_WITH_TEXT: Fix =
+        Fix { span: Span { start: 0, end: 0 }, content: Cow::Borrowed("\u{FEFF}// start\n") };
 
     #[derive(Debug, Error, Diagnostic)]
     #[error("nofix1")]
@@ -356,20 +385,27 @@ mod test {
         ]);
         assert_eq!(result.fixed_code, TEST_CODE.replace("answer", "foo"));
         assert_eq!(result.messages.len(), 2);
+        // We should sort the error to pass the following assertion.
         assert_eq!(result.messages[0].error.to_string(), "nofix1");
         assert_eq!(result.messages[0].error.to_string(), "nofix2");
         assert!(result.fixed);
     }
-    #[ignore]
+
     #[test]
     fn insert_bom_at_0() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result(vec![create_message(InsertBOM(), Some(INSERT_BOM))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
+        assert!(result.fixed);
+        assert_eq!(result.messages.len(), 0);
     }
 
-    #[ignore]
     #[test]
     fn insert_bom_with_text_at_0() {
-        let _result = get_fix_result(vec![]);
+        let result =
+            get_fix_result(vec![create_message(InsertBOMWithText(), Some(INSERT_BOM_WITH_TEXT))]);
+        assert_eq!(result.fixed_code, format!("\u{FEFF}// start\n{TEST_CODE}"));
+        assert!(result.fixed);
+        assert_eq!(result.messages.len(), 0);
     }
 
     #[ignore]
@@ -384,131 +420,226 @@ mod test {
         let _result = get_fix_result(vec![]);
     }
 
+    fn get_fix_result_with_bom(messages: Vec<Message>) -> FixResult {
+        Fixer::new(TEST_CODE_WITH_BOM, messages).fix()
+    }
+
     // With BOM
-    #[ignore]
     #[test]
     fn insert_at_the_end_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result =
+            get_fix_result_with_bom(vec![create_message(InsertAtEnd(), Some(INSERT_AT_END))]);
+        assert_eq!(result.fixed_code, format!("{}{}", TEST_CODE_WITH_BOM, INSERT_AT_END.content));
+        assert_eq!(result.messages.len(), 0);
     }
 
-    #[ignore]
     #[test]
     fn insert_at_the_start_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result =
+            get_fix_result_with_bom(vec![create_message(InsertAtStart(), Some(INSERT_AT_START))]);
+        assert_eq!(result.fixed_code, format!("{}{}{}", BOM, INSERT_AT_START.content, TEST_CODE));
+        assert_eq!(result.messages.len(), 0);
     }
 
-    #[ignore]
     #[test]
     fn insert_at_the_middle_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result =
+            get_fix_result_with_bom(vec![create_message(InsertAtMiddle(), Some(INSERT_AT_MIDDLE))]);
+        let insert_in_middle =
+            TEST_CODE.replace("6 *", &format!("{}6 *", INSERT_AT_MIDDLE.content));
+        assert_eq!(result.fixed_code, format!("{}{}", BOM, insert_in_middle));
+        assert_eq!(result.messages.len(), 0);
     }
 
-    #[ignore]
     #[test]
     fn insert_at_the_start_middle_end_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(InsertAtMiddle(), Some(INSERT_AT_MIDDLE)),
+            create_message(InsertAtStart(), Some(INSERT_AT_START)),
+            create_message(InsertAtEnd(), Some(INSERT_AT_END)),
+        ]);
+        let insert_in_middle =
+            TEST_CODE.replace("6 *", &format!("{}6 *", INSERT_AT_MIDDLE.content));
+        assert_eq!(
+            result.fixed_code,
+            format!(
+                "{}{}{}{}",
+                BOM, INSERT_AT_START.content, insert_in_middle, INSERT_AT_END.content
+            )
+        );
+        assert_eq!(result.messages.len(), 0);
     }
 
-    #[ignore]
     #[test]
     fn ignore_reverse_range_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result =
+            get_fix_result_with_bom(vec![create_message(ReverseRange(), Some(REVERSE_RANGE))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
     }
 
-    #[ignore]
     #[test]
     fn replace_at_the_end_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(ReplaceVar(), Some(REPLACE_VAR))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("var", "let"));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn replace_at_the_start_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(ReplaceId(), Some(REPLACE_ID))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("answer", "foo"));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn replace_at_the_middle_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(ReplaceNum(), Some(REPLACE_NUM))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace('6', "5"));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn replace_at_the_start_middle_end_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(ReplaceId(), Some(REPLACE_ID)),
+            create_message(ReplaceVar(), Some(REPLACE_VAR)),
+            create_message(ReplaceNum(), Some(REPLACE_NUM)),
+        ]);
+        assert_eq!(result.fixed_code, format!("{BOM}let foo = 5 * 7;"));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn remove_at_the_end_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(RemoveEnd(), Some(REMOVE_END))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace(" * 7", ""));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn remove_at_the_start_with_bom() {
-        let _fixer = get_fix_result(vec![]);
+        let result =
+            get_fix_result_with_bom(vec![create_message(RemoveStart(), Some(REMOVE_START))]);
+        assert_eq!(result.fixed_code, format!("{}{}", BOM, TEST_CODE.replace("var ", "")));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn remove_at_the_middle_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result =
+            get_fix_result_with_bom(vec![create_message(RemoveMiddle(), Some(REMOVE_MIDDLE))]);
+        assert_eq!(result.fixed_code, format!("{}{}", BOM, TEST_CODE.replace("answer", "a")));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn remove_at_the_start_middle_end_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(RemoveEnd(), Some(REMOVE_END)),
+            create_message(RemoveStart(), Some(REMOVE_START)),
+            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
+        ]);
+        assert_eq!(result.fixed_code, format!("{}a = 6;", BOM));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn replace_at_start_remove_at_middle_insert_at_end_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(InsertAtEnd(), Some(INSERT_AT_END)),
+            create_message(RemoveEnd(), Some(REMOVE_END)),
+            create_message(ReplaceVar(), Some(REPLACE_VAR)),
+        ]);
+        assert_eq!(result.fixed_code, format!("{}let answer = 6;// end", BOM));
+        assert_eq!(result.messages.len(), 0);
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn apply_one_fix_when_spans_overlap_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
+            create_message(ReplaceId(), Some(REPLACE_ID)),
+        ]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("answer", "foo"));
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].error.to_string(), "removemiddle");
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn apply_one_fix_when_the_start_the_same_as_the_previous_end_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(RemoveStart(), Some(REMOVE_START)),
+            create_message(ReplaceId(), Some(REPLACE_ID)),
+        ]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("var ", ""));
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].error.to_string(), "foo");
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn apply_one_fix_when_range_overlap_and_one_message_has_no_fix_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![
+            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
+            create_message(ReplaceId(), Some(REPLACE_ID)),
+            create_message(NoFix(), None),
+        ]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM.replace("answer", "foo"));
+        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result.messages[0].error.to_string(), "nofix");
+        assert_eq!(result.messages[1].error.to_string(), "removemiddle");
+        assert!(result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn apply_same_fix_when_span_overlap_regardless_of_order_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result1 = get_fix_result_with_bom(vec![
+            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
+            create_message(ReplaceId(), Some(REPLACE_ID)),
+        ]);
+        let result2 = get_fix_result_with_bom(vec![
+            create_message(ReplaceId(), Some(REPLACE_ID)),
+            create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
+        ]);
+        assert_eq!(result1.fixed_code, result2.fixed_code);
     }
 
-    #[ignore]
     #[test]
     fn should_not_apply_fix_with_one_no_fix_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(NoFix(), None)]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].error.to_string(), "nofix");
+        assert!(!result.fixed);
     }
 
-    #[ignore]
     #[test]
     fn insert_bom_at_0_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(InsertBOM(), Some(INSERT_BOM))]);
+        assert_eq!(result.fixed_code, TEST_CODE_WITH_BOM);
+        assert!(result.fixed);
+        assert_eq!(result.messages.len(), 0);
     }
 
-    #[ignore]
     #[test]
     fn insert_bom_with_text_at_0_with_bom() {
-        let _result = get_fix_result(vec![]);
+        let result = get_fix_result_with_bom(vec![create_message(
+            InsertBOMWithText(),
+            Some(INSERT_BOM_WITH_TEXT),
+        )]);
+        assert_eq!(result.fixed_code, format!("\u{FEFF}// start\n{TEST_CODE}"));
+        assert!(result.fixed);
+        assert_eq!(result.messages.len(), 0);
     }
 
     #[ignore]

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -447,7 +447,7 @@ mod test {
             get_fix_result_with_bom(vec![create_message(InsertAtMiddle(), Some(INSERT_AT_MIDDLE))]);
         let insert_in_middle =
             TEST_CODE.replace("6 *", &format!("{}6 *", INSERT_AT_MIDDLE.content));
-        assert_eq!(result.fixed_code, format!("{}{}", BOM, insert_in_middle));
+        assert_eq!(result.fixed_code, format!("{BOM}{insert_in_middle}"));
         assert_eq!(result.messages.len(), 0);
     }
 
@@ -546,7 +546,7 @@ mod test {
             create_message(RemoveStart(), Some(REMOVE_START)),
             create_message(RemoveMiddle(), Some(REMOVE_MIDDLE)),
         ]);
-        assert_eq!(result.fixed_code, format!("{}a = 6;", BOM));
+        assert_eq!(result.fixed_code, format!("{BOM}a = 6;"));
         assert_eq!(result.messages.len(), 0);
         assert!(result.fixed);
     }
@@ -558,7 +558,7 @@ mod test {
             create_message(RemoveEnd(), Some(REMOVE_END)),
             create_message(ReplaceVar(), Some(REPLACE_VAR)),
         ]);
-        assert_eq!(result.fixed_code, format!("{}let answer = 6;// end", BOM));
+        assert_eq!(result.fixed_code, format!("{BOM}let answer = 6;// end"));
         assert_eq!(result.messages.len(), 0);
         assert!(result.fixed);
     }

--- a/crates/oxc_linter/src/autofix/fixer.rs
+++ b/crates/oxc_linter/src/autofix/fixer.rs
@@ -23,6 +23,8 @@ impl<'a> Message<'a> {
     }
 }
 
+/// The fixer of the code.
+/// Note that our parser has handled the BOM, so we don't need to port the BOM test cases from ESLint.
 pub struct Fixer<'a> {
     source_text: &'a str,
     messages: Vec<Message<'a>>,


### PR DESCRIPTION
## Description

Almost all ESLint's test cases are ported. However, there are some test case cannot be satisfied:

1. BOM removal: ESLint use `range.start===-1` to determine whether to delete the starting BOM, but `Span` cannot accept negative number.
2. Messages sorting: If there are multiple nofix messages, eslint we sort them by there column and line.

## Related issue

#68 