### PR TITLE
chore(linter): remove extra spacing

### DIFF
--- a/crates/oxc_linter/src/rules/deepscan/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/deepscan/uninvoked_array_callback.rs
@@ -33,7 +33,6 @@ declare_oxc_lint!(
     /// When the Array constructor is called with a single number argument, an array with the specified number of empty slots (not actual undefined values) is constructed.
     /// If a callback function is passed to the function of this array, the callback function is never invoked because the array has no actual elements.
     ///
-    ///
     /// ### Example
     /// ```javascript
     ///   const list = new Array(5).map(_ => createElement());

--- a/crates/oxc_linter/src/rules/for_direction.rs
+++ b/crates/oxc_linter/src/rules/for_direction.rs
@@ -33,7 +33,6 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     /// A for loop that is known to run infinitely or never run is considered a bug.
     ///
-    ///
     /// ### Example
     /// ```javascript
     /// for (var i = 0; i < 10; i--) {}

--- a/crates/oxc_linter/src/rules/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/no_array_constructor.rs
@@ -23,7 +23,6 @@ declare_oxc_lint!(
     /// Use of the Array constructor to construct a new array is generally discouraged in favor of array literal notation because of the single-argument pitfall and because the Array global may be redefined.
     /// The exception is when the Array constructor is used to intentionally create sparse arrays of a specified size by giving the constructor a single numeric argument.
     ///
-    ///
     /// ### Example
     /// ```javascript
     /// let arr = new Array();

--- a/crates/oxc_linter/src/rules/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/no_debugger.rs
@@ -23,7 +23,6 @@ declare_oxc_lint!(
     /// `debugger` statements do not affect functionality when a debugger isn't attached.
     /// They're most commonly an accidental debugging leftover.
     ///
-    ///
     /// ### Example
     /// ```javascript
     /// const data = await getData();

--- a/crates/oxc_linter/src/rules/no_empty.rs
+++ b/crates/oxc_linter/src/rules/no_empty.rs
@@ -25,7 +25,6 @@ declare_oxc_lint!(
     /// Empty block statements, while not technically errors, usually occur due to refactoring that wasn’t completed.
     /// They can cause confusion when reading code.
     ///
-    ///
     /// ### Example
     /// ```javascript
     /// if (condition) {


### PR DESCRIPTION
Just some clean up, I noticed in most of the rules we have extra (unnecessary) spacing between some of the documentation sections and it seems like most people are copying existing rules and modifying them for new rules, which means the problem will persist.