### PR TITLE
chore(rule_generator): preserve escaped string in test code

### DIFF
--- a/tasks/rule_generator/src/main.rs
+++ b/tasks/rule_generator/src/main.rs
@@ -93,7 +93,7 @@ fn parse_test_code<'a>(source_text: &'a str, expr: &'a Expression) -> Option<Cow
         let option_code = option_code.map_or(Cow::Borrowed("None"), |option_code| {
             Cow::Owned(format!("Some(serde_json::json!({option_code}))"))
         });
-        Cow::Owned(format!(r#"("{test_code}", {option_code})"#))
+        Cow::Owned(format!(r#"({test_code:?}, {option_code})"#))
     })
 }
 


### PR DESCRIPTION
Preserve escaped string literals in the test code by using a debug representation. E.g., `"i == \"bc\""` should be printed to the template verbatim rather than formatted as `i == "bc"`