### PR TITLE
chore(parser): move import specifier parsing to `list.rs`

### DIFF
--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -478,3 +478,28 @@ impl<'a> NormalList<'a> for SwitchCases<'a> {
         Ok(())
     }
 }
+
+pub struct ImportSpecifierList<'a> {
+    pub import_specifiers: Vec<'a, ImportDeclarationSpecifier>,
+}
+
+impl<'a> SeparatedList<'a> for ImportSpecifierList<'a> {
+    fn new(p: &Parser<'a>) -> Self {
+        Self { import_specifiers: p.ast.new_vec() }
+    }
+
+    fn open(&self) -> Kind {
+        Kind::LCurly
+    }
+
+    fn close(&self) -> Kind {
+        Kind::RCurly
+    }
+
+    fn parse_element(&mut self, p: &mut Parser<'a>) -> Result<()> {
+        let import_specifier = p.parse_import_specifier()?;
+        let specifier = ImportDeclarationSpecifier::ImportSpecifier(import_specifier);
+        self.import_specifiers.push(specifier);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Self explanatory, but moving the parsing of import declaration specifiers into `js/list.rs` as the TODO said 😛 