### PR TITLE
feat(lexer/linter): configuration comments

### DIFF
--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -9,6 +9,8 @@ use crate::Span;
 pub struct Trivias {
     /// Keyed by span.start
     comments: BTreeMap<u32, Comment>,
+
+    configuration_comments: BTreeMap<u32, Comment>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -20,6 +22,7 @@ pub struct Comment {
 
 #[derive(Debug, Clone, Copy)]
 pub enum CommentKind {
+    ConfigurationSingleLine,
     SingleLine,
     MultiLine,
 }
@@ -35,10 +38,16 @@ impl Trivias {
     #[must_use]
     pub fn has_comments_between(&self, span: Span) -> bool {
         self.comments.range(span.start..span.end).count() > 0
+            || self.configuration_comments.range(span.start..span.end).count() > 0
     }
 
     pub fn add_comment(&mut self, span: Span, kind: CommentKind) {
         let comment = Comment::new(span.end, kind);
-        self.comments.insert(span.start, comment);
+        match kind {
+            CommentKind::ConfigurationSingleLine => {
+                self.configuration_comments.insert(span.start, comment)
+            }
+            _ => self.comments.insert(span.start, comment),
+        }
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -45,7 +45,7 @@ impl Trivias {
         let comment = Comment::new(span.end, kind);
         match kind {
             CommentKind::ConfigurationSingleLine => {
-                self.configuration_comments.insert(span.start, comment)
+                self.configuration_comments.insert(span.start, comment);
             }
             _ => self.comments.insert(span.start, comment),
         }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -47,7 +47,9 @@ impl Trivias {
             CommentKind::ConfigurationSingleLine => {
                 self.configuration_comments.insert(span.start, comment);
             }
-            _ => self.comments.insert(span.start, comment),
+            _ => {
+                self.comments.insert(span.start, comment);
+            }
         }
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -72,14 +72,8 @@ impl Trivias {
     /// Computes the associated line numbers given source text and starts/end offsets.
     #[must_use]
     pub fn line_numbers(&self, source_text: &str, start: u32, end: u32) -> BTreeSet<usize> {
-        let mut lines = BTreeSet::new();
-        let lines_to_start = &source_text[..start as usize].lines().collect::<Vec<_>>();
-        let lines_in_span = &source_text[start as usize..end as usize].lines().collect::<Vec<_>>();
-
-        lines.insert(lines_to_start.len());
-        for (offset, _) in lines_in_span.iter().enumerate() {
-            lines.insert(lines_to_start.len() + offset);
-        }
-        lines
+        let start_line = source_text[..start as usize].lines().count();
+        let end_line = source_text[..end as usize].lines().count();
+        (start_line..=end_line).collect()
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -23,7 +23,6 @@ pub struct Comment {
 #[derive(Debug, Clone, Copy)]
 pub enum CommentKind {
     ConfigurationSingleLine,
-    ConfigurationMultiLine,
     SingleLine,
     MultiLine,
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -13,6 +13,7 @@ mod rules;
 use std::{fs, rc::Rc};
 
 pub use fixer::{Fixer, Message};
+use oxc_ast::GetSpan;
 pub(crate) use oxc_semantic::AstNode;
 use oxc_semantic::Semantic;
 use rule::{Rule, RuleCategory};

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -13,7 +13,6 @@ mod rules;
 use std::{fs, rc::Rc};
 
 pub use fixer::{Fixer, Message};
-use oxc_ast::GetSpan;
 pub(crate) use oxc_semantic::AstNode;
 use oxc_semantic::Semantic;
 use rule::{Rule, RuleCategory};

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -30,7 +30,7 @@ use self::{
     },
     number::{parse_big_int, parse_float, parse_int},
     string_builder::AutoCow,
-    trivia_builder::TriviaBuilder,
+    trivia_builder::{is_eslint_configuration_comment, TriviaBuilder},
 };
 use crate::diagnostics;
 
@@ -510,7 +510,7 @@ impl<'a> Lexer<'a> {
         self.trivia_builder.add_single_line_comment(
             self.current.token.start,
             self.offset(),
-            comment.trim().starts_with("eslint-disable-next-line"),
+            is_eslint_configuration_comment(comment.trim()),
         );
         Kind::Comment
     }

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -499,7 +499,7 @@ impl<'a> Lexer<'a> {
     /// Section 12.4 Single Line Comment
     #[must_use]
     fn skip_single_line_comment(&mut self) -> Kind {
-        let mut comment = String::new_in(&self.allocator);
+        let mut comment = String::new_in(self.allocator);
         while let Some(c) = self.current.chars.next().as_ref() {
             comment.push(*c);
             if is_line_terminator(*c) {

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -499,13 +499,19 @@ impl<'a> Lexer<'a> {
     /// Section 12.4 Single Line Comment
     #[must_use]
     fn skip_single_line_comment(&mut self) -> Kind {
+        let mut comment = String::new_in(&self.allocator);
         while let Some(c) = self.current.chars.next().as_ref() {
+            comment.push(*c);
             if is_line_terminator(*c) {
                 break;
             }
         }
         self.current.token.is_on_new_line = true;
-        self.trivia_builder.add_single_line_comment(self.current.token.start, self.offset());
+        self.trivia_builder.add_single_line_comment(
+            self.current.token.start,
+            self.offset(),
+            comment.trim().starts_with("eslint-disable-next-line"),
+        );
         Kind::Comment
     }
 
@@ -530,7 +536,7 @@ impl<'a> Lexer<'a> {
             return Kind::Eof;
         }
 
-        self.trivia_builder.add_single_line_comment(self.current.token.start, self.offset());
+        self.trivia_builder.add_single_line_comment(self.current.token.start, self.offset(), false);
         Kind::MultiLineComment
     }
 

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -11,9 +11,16 @@ impl TriviaBuilder {
         self.trivias
     }
 
-    pub fn add_single_line_comment(&mut self, start: u32, end: u32) {
+    pub fn add_single_line_comment(&mut self, start: u32, end: u32, is_config_comment: bool) {
         // skip leading `//`
-        self.trivias.add_comment(Span::new(start + 2, end), CommentKind::SingleLine);
+        self.trivias.add_comment(
+            Span::new(start + 2, end),
+            if is_config_comment {
+                CommentKind::ConfigurationSingleLine
+            } else {
+                CommentKind::SingleLine
+            },
+        );
     }
 
     #[allow(unused)]

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -29,3 +29,8 @@ impl TriviaBuilder {
         self.trivias.add_comment(Span::new(start + 2, end - 2), CommentKind::MultiLine);
     }
 }
+
+pub fn is_eslint_configuration_comment(comment: &str) -> bool {
+    // TODO: extend to support other types of configuration comments
+    comment.starts_with("eslint-disable-next-line")
+}


### PR DESCRIPTION
I have no idea how this should work – ideally we could do everything in the lexer but the linter still needs some context of which nodes to skip applying rules to.

The PR just sets up basic structure for supporting configuration comments, and we can work through the implementation more here in this PR 👍🏼 

**Current question(s):**

1. We key the config comments by start offset, and we can utilise the `GetSpan` trait to get node offsets in the linter when applying rules, but how do we know they're immediately on the next line?

**Notes**

https://github.com/Boshen/oxc/pull/170/commits/fa443045ad53e65102ae5714c5d78dfaf1392e89 works against the following input:

```js
function foo() {
  const a = 1;

  // eslint-disable-next-line
  if (a == a) {
    console.log('foo!');
  }
}
```

The `no-self-compare` diagnostic is not reported with the above code. Removing the comment shows the diagnostic reported again.