### PR TITLE
auto convert the rule name

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -222,10 +222,11 @@ fn main() {
     let mut args = std::env::args();
     args.next();
 
-    let rule_name = args.next().expect("expected rule name");
+    let rule_name = args.next().expect("expected rule name").to_case(Case::Snake);
     let upper_rule_name = rule_name.to_case(Case::UpperCamel);
+    let kebab_rule_name = rule_name.to_case(Case::Kebab);
 
-    let rule_test_path = format!("{ESLINT_TEST_PATH}/{rule_name}.js");
+    let rule_test_path = format!("{ESLINT_TEST_PATH}/{kebab_rule_name}.js");
     let body = ureq::get(&rule_test_path)
         .call()
         .expect("failed to fetch source")


### PR DESCRIPTION
## Description

When I use `cargo rule no_const_assign`, the tool will panic because it is going to fetch with `no_const_assign` instead of `no-const-assign`. However, if we use `cargo rule no-const-assign`, it will generate a `no-const-assign.rs` file instead of a `no_const_assign.rs` file. I think it would be nice if we convert it in the rule generator tool.