### PR TITLE
feat(linter): add no-dupe-args rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -7,6 +7,7 @@ oxc_macros::declare_all_lint_rules! {
     eq_eq_eq,
     for_direction,
     no_debugger,
+    no_dupe_args,
     no_duplicate_case,
     no_array_constructor,
     no_caller,

--- a/crates/oxc_linter/src/rules/no_dupe_args.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_args.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::BindingPatternKind, AstKind, Span};
+use oxc_ast::{AstKind, Span};
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,

--- a/crates/oxc_linter/src/rules/no_dupe_args.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_args.rs
@@ -39,7 +39,6 @@ declare_oxc_lint!(
 impl Rule for NoDupeArgs {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::FormalParameters(params) = node.get().kind() {
-            println!("{:#?}", node.get());
             let mut map = FxHashMap::default();
             map.reserve(params.items.len());
             for formal_param in params.items.iter() {

--- a/crates/oxc_linter/src/rules/no_dupe_args.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_args.rs
@@ -1,0 +1,79 @@
+use oxc_ast::{ast::BindingPatternKind, AstKind, Span};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use rustc_hash::FxHashMap;
+
+use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint(no-dupe-args): Disallow duplicate arguments in function definitions")]
+#[diagnostic(severity(warning), help("Consider removing the duplicated argument"))]
+struct NoDupeArgsDiagnostic(#[label] pub Span, #[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDupeArgs;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow duplicate arguments in function definitions
+    ///
+    /// ### Why is this bad?
+    ///
+    /// If more than one parameter has the same name in a function definition,
+    /// the last occurrence “shadows” the preceding occurrences. A duplicated name might be a typing error.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// function foo(a, b, b) {
+    ///     console.log("value of the second a:", a);
+    /// }
+    /// ```
+    NoDupeArgs,
+    correctness
+);
+
+impl Rule for NoDupeArgs {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::FormalParameters(params) = node.get().kind() {
+            println!("{:#?}", node.get());
+            let mut map = FxHashMap::default();
+            map.reserve(params.items.len());
+            for formal_param in params.items.iter() {
+                let hash = calculate_hash(formal_param);
+                if let Some(prev_span) = map.insert(hash, formal_param.span) {
+                    ctx.diagnostic(NoDupeArgsDiagnostic(prev_span, formal_param.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("function a(a, b, c){}", None),
+        ("var a = function(a, b, c){}", None),
+        ("function a({a, b}, {c, d}){}", None),
+        ("function a([ , a]) {}", None),
+        ("function foo([[a, b], [c, d]]) {}", None),
+    ];
+
+    let fail = vec![
+        ("function a(a, b, b) {}", None),
+        ("function a(a, a, a) {}", None),
+        ("function a(a, b, a) {}", None),
+        ("function a(a, b, a, b) {}", None),
+        ("var a = function(a, b, b) {}", None),
+        ("var a = function(a, a, a) {}", None),
+        ("var a = function(a, b, a) {}", None),
+        ("var a = function(a, b, a, b) {}", None),
+    ];
+
+    Tester::new(NoDupeArgs::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/no_dupe_args.snap
+++ b/crates/oxc_linter/src/snapshots/no_dupe_args.snap
@@ -1,0 +1,186 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 53
+expression: no_dupe_args
+---
+
+  × Identifier `b` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, b) {}
+   ·               ┬  ┬
+   ·               │  ╰── It can not be redeclared here
+   ·               ╰── `b` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, b) {}
+   ·               ─  ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, a, a) {}
+   ·            ┬  ┬
+   ·            │  ╰── It can not be redeclared here
+   ·            ╰── `a` has already been declared here
+   ╰────
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, a, a) {}
+   ·               ┬  ┬
+   ·               │  ╰── It can not be redeclared here
+   ·               ╰── `a` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, a, a) {}
+   ·            ─  ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, a, a) {}
+   ·               ─  ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, a) {}
+   ·            ┬     ┬
+   ·            │     ╰── It can not be redeclared here
+   ·            ╰── `a` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, a) {}
+   ·            ─     ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, a, b) {}
+   ·            ┬     ┬
+   ·            │     ╰── It can not be redeclared here
+   ·            ╰── `a` has already been declared here
+   ╰────
+
+  × Identifier `b` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, a, b) {}
+   ·               ┬     ┬
+   ·               │     ╰── It can not be redeclared here
+   ·               ╰── `b` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, a, b) {}
+   ·            ─     ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ function a(a, b, a, b) {}
+   ·               ─     ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `b` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, b) {}
+   ·                     ┬  ┬
+   ·                     │  ╰── It can not be redeclared here
+   ·                     ╰── `b` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, b) {}
+   ·                     ─  ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, a, a) {}
+   ·                  ┬  ┬
+   ·                  │  ╰── It can not be redeclared here
+   ·                  ╰── `a` has already been declared here
+   ╰────
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, a, a) {}
+   ·                     ┬  ┬
+   ·                     │  ╰── It can not be redeclared here
+   ·                     ╰── `a` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, a, a) {}
+   ·                  ─  ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, a, a) {}
+   ·                     ─  ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, a) {}
+   ·                  ┬     ┬
+   ·                  │     ╰── It can not be redeclared here
+   ·                  ╰── `a` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, a) {}
+   ·                  ─     ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  × Identifier `a` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, a, b) {}
+   ·                  ┬     ┬
+   ·                  │     ╰── It can not be redeclared here
+   ·                  ╰── `a` has already been declared here
+   ╰────
+
+  × Identifier `b` has already been declared
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, a, b) {}
+   ·                     ┬     ┬
+   ·                     │     ╰── It can not be redeclared here
+   ·                     ╰── `b` has already been declared here
+   ╰────
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, a, b) {}
+   ·                  ─     ─
+   ╰────
+  help: Consider removing the duplicated argument
+
+  ⚠ eslint(no-dupe-args): Disallow duplicate arguments in function definitions
+   ╭─[no_dupe_args.tsx:1:1]
+ 1 │ var a = function(a, b, a, b) {}
+   ·                     ─     ─
+   ╰────
+  help: Consider removing the duplicated argument
+


### PR DESCRIPTION
## Description

Implement [`no-dupe-args`](https://eslint.org/docs/latest/rules/no-dupe-args) rule.

## Related issue

#123 