### PR TITLE
feat(linter): add no-dupe-keys rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -7,6 +7,7 @@ oxc_macros::declare_all_lint_rules! {
     eq_eq_eq,
     for_direction,
     no_debugger,
+    no_dupe_keys,
     no_duplicate_case,
     no_array_constructor,
     no_async_promise_executor,

--- a/crates/oxc_linter/src/rules/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_keys.rs
@@ -77,7 +77,7 @@ fn test() {
         ("var x = { a: 1, b: { a: 2 } };", None),
         ("var x = ({ null: 1, [/(?<zero>0)/]: 2 })", None),
         ("var {a, a} = obj", None),
-        // Our parser doesn't allow the '0' prefixed octal literals.
+        // Syntax:error: the '0' prefixed octal literals is not allowed.
         // ("var x = { 012: 1, 12: 2 };", None),
         ("var x = { 1_0: 1, 1: 2 };", None),
     ];

--- a/crates/oxc_linter/src/rules/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_keys.rs
@@ -1,0 +1,110 @@
+use oxc_ast::{
+    ast::{ObjectProperty, PropertyKind},
+    AstKind, GetSpan, Span,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use rustc_hash::FxHashMap;
+
+use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint(no-dupe_keys): Disallow duplicate keys in object literals")]
+#[diagnostic(severity(warning), help("Consider removing the duplicated key"))]
+struct NoDupeKeysDiagnostic(#[label] pub Span, #[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDupeKeys;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow duplicate keys in object literals
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Multiple properties with the same key in object literals can cause unexpected behavior in your application.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// var foo = {
+    ///     bar: "baz",
+    ///     bar: "qux"
+    /// }
+    /// ```
+    NoDupeKeys,
+    correctness
+);
+
+impl Rule for NoDupeKeys {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::ObjectExpression(obj_expr) = node.get().kind() {
+            let mut map = FxHashMap::default();
+            for prop in obj_expr.properties.iter() {
+                if let ObjectProperty::Property(prop) = prop && let Some(key_name) = prop.key.static_name().as_ref() {
+                    let hash = calculate_hash(key_name);
+                    if map.contains_key(&hash) {
+                        let (kind, span) = map.get(&hash).unwrap();
+                        if kind == &PropertyKind::Init {
+                            ctx.diagnostic(NoDupeKeysDiagnostic(*span, prop.key.span()));
+                        } else if prop.kind == PropertyKind::Init {
+                            ctx.diagnostic(NoDupeKeysDiagnostic(*span, prop.key.span()));
+                            map.insert(hash, (prop.kind, prop.key.span()));
+                        }
+                    } else {
+                        map.insert(hash, (prop.kind, prop.key.span()));
+
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var foo = { __proto__: 1, two: 2};", None),
+        ("var x = { foo: 1, bar: 2 };", None),
+        ("var x = { '': 1, bar: 2 };", None),
+        ("var x = { '': 1, ' ': 2 };", None),
+        ("var x = { '': 1, [null]: 2 };", None),
+        ("var x = { '': 1, [a]: 2 };", None),
+        ("var x = { [a]: 1, [a]: 2 };", None),
+        ("+{ get a() { }, set a(b) { } };", None),
+        ("var x = { a: b, [a]: b };", None),
+        ("var x = { a: b, ...c }", None),
+        ("var x = { get a() {}, set a (value) {} };", None),
+        ("var x = { a: 1, b: { a: 2 } };", None),
+        ("var x = ({ null: 1, [/(?<zero>0)/]: 2 })", None),
+        ("var {a, a} = obj", None),
+        // ("var x = { 012: 1, 12: 2 };", None),
+        ("var x = { 1_0: 1, 1: 2 };", None),
+    ];
+
+    let fail = vec![
+        ("var x = { a: b, ['a']: b };", None),
+        ("var x = { y: 1, y: 2 };", None),
+        ("var x = { '': 1, '': 2 };", None),
+        ("var x = { '': 1, [``]: 2 };", None),
+        ("var foo = { 0x1: 1, 1: 2};", None),
+        ("var x = { 012: 1, 10: 2 };", None),
+        ("var x = { 0b1: 1, 1: 2 };", None),
+        ("var x = { 0o1: 1, 1: 2 };", None),
+        ("var x = { 1n: 1, 1: 2 };", None),
+        ("var x = { 1_0: 1, 10: 2 };", None),
+        ("var x = { \"z\": 1, z: 2 };", None),
+        ("var foo = {\n  bar: 1,\n  bar: 1,\n}", None),
+        ("var x = { a: 1, get a() {} };", None),
+        ("var x = { a: 1, set a(value) {} };", None),
+        ("var x = { a: 1, b: { a: 2 }, get b() {} };", None),
+        ("var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })", None),
+    ];
+
+    Tester::new(NoDupeKeys::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/no_dupe_keys.snap
@@ -1,0 +1,129 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 53
+expression: no_dupe_keys
+---
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { a: b, ['a']: b };
+   ·           ─      ───
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { y: 1, y: 2 };
+   ·           ─     ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { '': 1, '': 2 };
+   ·           ──     ──
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { '': 1, [``]: 2 };
+   ·           ──      ──
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var foo = { 0x1: 1, 1: 2};
+   ·             ───     ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { 012: 1, 10: 2 };
+   ·           ───     ──
+   ╰────
+  help: Consider removing the duplicated key
+
+  × '0'-prefixed octal literals and octal escape sequences are deprecated
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { 012: 1, 10: 2 };
+   ·           ───
+   ╰────
+  help: for octal literals use the '0o' prefix instead
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { 0b1: 1, 1: 2 };
+   ·           ───     ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { 0o1: 1, 1: 2 };
+   ·           ───     ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { 1n: 1, 1: 2 };
+   ·           ──     ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { 1_0: 1, 10: 2 };
+   ·           ───     ──
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { "z": 1, z: 2 };
+   ·           ───     ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var foo = {
+ 2 │   bar: 1,
+   ·   ───
+ 3 │   bar: 1,
+   ·   ───
+ 4 │ }
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { a: 1, get a() {} };
+   ·           ─         ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { a: 1, set a(value) {} };
+   ·           ─         ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = { a: 1, b: { a: 2 }, get b() {} };
+   ·                 ─                ─
+   ╰────
+  help: Consider removing the duplicated key
+
+  ⚠ eslint(no-dupe_keys): Disallow duplicate keys in object literals
+   ╭─[no_dupe_keys.tsx:1:1]
+ 1 │ var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })
+   ·            ──────────────      ────────────
+   ╰────
+  help: Consider removing the duplicated key
+


### PR DESCRIPTION
## Description

Add [`no-dupe-keys`](https://eslint.org/docs/latest/rules/no-dupe-keys) rule.

The test case : `"var x = { 012: 1, 12: 2 };"` would fail since the parser doesn't allow '0' prefixed octal literals.

```
thread 'rules::no_dupe_keys::test' panicked at 'expect test to pass: var x = { 012: 1, 12: 2 };
  × '0'-prefixed octal literals and octal escape sequences are deprecated
   ╭─[no_dupe_keys.tsx:1:1]
 1 │ var x = { 012: 1, 12: 2 };
   ·           ───
   ╰────
  help: for octal literals use the '0o' prefix instead
', crates/oxc_linter/src/tester.rs:39:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test rules::no_dupe_keys::test ... FAILED
```

Is it ok to delete the case?

## Related issue

#123 
