### PR TITLE
fix(linter): skip abstract methods for dupe member check

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1497,6 +1497,19 @@ impl<'a> ClassElement<'a> {
             Self::TSAbstractPropertyDefinition(_def) => None,
         }
     }
+
+    #[must_use]
+    pub fn is_ts_empty_body_function(&self) -> bool {
+        match self {
+            Self::PropertyDefinition(_)
+            | Self::StaticBlock(_)
+            | Self::AccessorProperty(_)
+            | Self::TSAbstractPropertyDefinition(_)
+            | Self::TSIndexSignature(_) => false,
+            Self::MethodDefinition(method) => method.value.body.is_none(),
+            Self::TSAbstractMethodDefinition(_) => true,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, Hash)]

--- a/crates/oxc_linter/src/rules/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_class_members.rs
@@ -58,13 +58,9 @@ impl Rule for NoDupeClassMembers {
         let num_element = class.body.body.len();
         let mut property_table = PropertyTable::with_capacity(num_element);
         for element in &class.body.body {
-            if ctx.source_type().is_typescript() {
+            if ctx.source_type().is_typescript() && element.is_ts_empty_body_function() {
                 // Skip functions with no function bodies, which are Typescript's overload signatures
-                if let ClassElement::MethodDefinition(method) = element {
-                    if method.value.body.is_none() {
-                        continue;
-                    }
-                }
+                continue;
             }
 
             if let Some(dup_span) = property_table.insert(element) {
@@ -165,6 +161,13 @@ fn test() {
           foo(a: string): string;
           foo(a: number): number;
           foo(a: any): any {}
+        }",
+            None,
+        ),
+        (
+            "abstract class X {
+          abstract foo(): number;
+          abstract foo(): string;
         }",
             None,
         ),


### PR DESCRIPTION
Closes #197 