### PR TITLE
feat(semantic): parse jsdoc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsdoc"
+version = "0.1.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_semantic",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1065,7 @@ version = "0.0.4"
 dependencies = [
  "bitflags",
  "indextree",
+ "once_cell",
  "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
 	"crates/*",
+	"examples/*",
 	"tasks/*",
 ]
 
@@ -41,6 +42,7 @@ indextree = "4.6.0"
 glob = "0.3.1"
 lazy_static = "1.4.0"
 phf = "0.11"
+once_cell = "1.17.1"
 
 [workspace.metadata.workspaces]
 independent = true

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -161,11 +161,11 @@ impl<'a> AstKind<'a> {
     #[must_use]
     #[rustfmt::skip]
     pub fn is_declaration(self) -> bool {
-        matches!(
-            self,
-            Self::ModuleDeclaration(_) | Self::TSEnumDeclaration(_) | Self::TSModuleDeclaration(_)
-                | Self::VariableDeclaration(_) | Self::TSInterfaceDeclaration(_)
-                | Self::TSTypeAliasDeclaration(_) | Self::TSImportEqualsDeclaration(_)
+        matches!(self, Self::Function(func) if func.is_declaration())
+        || matches!(self, Self::Class(class) if class.is_declaration())
+        || matches!(self, Self::ModuleDeclaration(_) | Self::TSEnumDeclaration(_) | Self::TSModuleDeclaration(_)
+            | Self::VariableDeclaration(_) | Self::TSInterfaceDeclaration(_)
+            | Self::TSTypeAliasDeclaration(_) | Self::TSImportEqualsDeclaration(_)
         )
     }
 

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -151,7 +151,7 @@ impl<'a> LintContext<'a> {
         Printer::new(0, PrinterOptions::default())
     }
 
-    /* JsDoc */
+    /* JSDoc */
     pub fn jsdoc(&self, node: &AstNode<'a>) -> Option<JSDocComment<'a>> {
         self.semantic().jsdoc().get_by_node(node)
     }

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -4,7 +4,7 @@ use indextree::{Ancestors, NodeId};
 use oxc_ast::{ast::IdentifierReference, AstKind, SourceType};
 use oxc_diagnostics::Error;
 use oxc_printer::{Printer, PrinterOptions};
-use oxc_semantic::{AstNodes, Scope, ScopeTree, Semantic, SemanticNode, SymbolTable};
+use oxc_semantic::{AstNodes, JSDocComment, Scope, ScopeTree, Semantic, SemanticNode, SymbolTable};
 
 use crate::{
     disable_directives::{DisableDirectives, DisableDirectivesBuilder},
@@ -149,5 +149,10 @@ impl<'a> LintContext<'a> {
     #[allow(clippy::unused_self)]
     pub fn printer(&self) -> Printer {
         Printer::new(0, PrinterOptions::default())
+    }
+
+    /* JsDoc */
+    pub fn jsdoc(&self, node: &AstNode<'a>) -> Option<JSDocComment<'a>> {
+        self.semantic().jsdoc().get_by_node(node)
     }
 }

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -16,6 +16,7 @@ oxc_diagnostics = { workspace = true }
 indextree = { workspace = true }
 bitflags = { workspace = true }
 rustc-hash = { workspace = true }
+once_cell = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 
 [dev_dependencies]

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -145,7 +145,7 @@ impl<'a> SemanticBuilder<'a> {
     fn create_ast_node(&mut self, kind: AstKind<'a>) {
         let mut flags = self.current_node_flags;
         if self.jsdoc.retrieve_jsdoc_comment(kind) {
-            flags |= NodeFlags::JsDoc;
+            flags |= NodeFlags::JSDoc;
         }
         let ast_node = SemanticNode::new(kind, self.scope.current_scope_id, flags);
         let node_id = self.current_node_id.append_value(ast_node, &mut self.nodes);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -15,6 +15,7 @@ use crate::{
     binder::Binder,
     checker::EarlyErrorJavaScript,
     diagnostics::Redeclaration,
+    jsdoc::JSDocBuilder,
     module_record::ModuleRecordBuilder,
     node::{AstNodeId, AstNodes, NodeFlags, SemanticNode},
     scope::{ScopeBuilder, ScopeId},
@@ -45,6 +46,8 @@ pub struct SemanticBuilder<'a> {
     with_module_record_builder: bool,
     pub module_record_builder: ModuleRecordBuilder,
 
+    jsdoc: JSDocBuilder<'a>,
+
     check_syntax_error: bool,
 }
 
@@ -74,6 +77,7 @@ impl<'a> SemanticBuilder<'a> {
             symbols: SymbolTableBuilder::default(),
             with_module_record_builder: false,
             module_record_builder: ModuleRecordBuilder::default(),
+            jsdoc: JSDocBuilder::new(source_text, trivias),
             check_syntax_error: false,
         }
     }
@@ -118,6 +122,7 @@ impl<'a> SemanticBuilder<'a> {
             scopes: self.scope.scopes,
             symbols,
             module_record,
+            jsdoc: self.jsdoc.build(),
         };
         SemanticBuilderReturn { semantic, errors: self.errors.into_inner() }
     }
@@ -138,10 +143,12 @@ impl<'a> SemanticBuilder<'a> {
     }
 
     fn create_ast_node(&mut self, kind: AstKind<'a>) {
-        let ast_node =
-            SemanticNode::new(kind, self.scope.current_scope_id, self.current_node_flags);
+        let mut flags = self.current_node_flags;
+        if self.jsdoc.retrieve_jsdoc_comment(kind) {
+            flags |= NodeFlags::JsDoc;
+        }
+        let ast_node = SemanticNode::new(kind, self.scope.current_scope_id, flags);
         let node_id = self.current_node_id.append_value(ast_node, &mut self.nodes);
-
         self.current_node_id = node_id.into();
     }
 

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -54,9 +54,9 @@ impl<'a> JSDocBuilder<'a> {
         }
 
         // The comment is the leading comment of this span if there is nothing in between.
-        let end = comment.end() + if comment.is_multi_line() { 2 } else { 0 };
-        let text_between = Span::new(end, span.start).source_text(self.source_text);
-        if !text_between.chars().all(char::is_whitespace) {
+        // +2 to skip `*/` ending
+        let text_between = Span::new(comment.end() + 2, span.start).source_text(self.source_text);
+        if text_between.chars().any(|c| !c.is_whitespace()) {
             return None;
         }
 
@@ -108,9 +108,11 @@ mod test {
     #[test]
     fn not_found() {
         let source_texts = [
+            "function foo() {}",
             "/* test */function foo() {}",
             "/*** test */function foo() {}",
             "/** test */ ; function foo() {}",
+            "/** test */ function foo1() {} function foo() {}",
         ];
         for source_text in source_texts {
             test_jsdoc_not_found(source_text, "function foo() {}");

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -1,0 +1,140 @@
+use std::{collections::BTreeMap, rc::Rc};
+
+use oxc_ast::{AstKind, GetSpan, Span, Trivias};
+
+use super::{JSDoc, JSDocComment};
+
+pub struct JSDocBuilder<'a> {
+    source_text: &'a str,
+
+    trivias: Rc<Trivias>,
+
+    docs: BTreeMap<Span, JSDocComment<'a>>,
+}
+
+impl<'a> JSDocBuilder<'a> {
+    pub fn new(source_text: &'a str, trivias: &Rc<Trivias>) -> Self {
+        Self { source_text, trivias: Rc::clone(trivias), docs: BTreeMap::default() }
+    }
+
+    pub fn build(self) -> JSDoc<'a> {
+        JSDoc::new(self.docs)
+    }
+
+    /// Save the span if the given kind has a jsdoc comment attached
+    pub fn retrieve_jsdoc_comment(&mut self, kind: AstKind<'a>) -> bool {
+        if !kind.is_declaration() {
+            return false;
+        }
+        let span = kind.span();
+        let comment_text = self.find_jsdoc_comment(span);
+        if let Some(comment_text) = comment_text {
+            self.docs.insert(span, JSDocComment::new(comment_text));
+        }
+        comment_text.is_some()
+    }
+
+    /// Find the jsdoc doc in frontend this span, a.k.a leading comment
+    fn find_jsdoc_comment(&self, span: Span) -> Option<&'a str> {
+        let (start, comment) = self.trivias.comments().range(..span.start).next()?;
+
+        if comment.is_single_line() {
+            return None;
+        }
+
+        let comment_text = Span::new(*start, comment.end()).source_text(self.source_text);
+
+        // Comments beginning with /*, /***, or more than 3 stars will be ignored.
+        let mut chars = comment_text.chars();
+        if chars.next() != Some('*') {
+            return None;
+        }
+        if chars.next() == Some('*') {
+            return None;
+        }
+
+        // The comment is the leading comment of this span if there is nothing in between.
+        let end = comment.end() + if comment.is_multi_line() { 2 } else { 0 };
+        let text_between = Span::new(end, span.start).source_text(self.source_text);
+        if !text_between.chars().all(char::is_whitespace) {
+            return None;
+        }
+
+        Some(comment_text)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_allocator::Allocator;
+    use oxc_ast::{SourceType, Span};
+    use oxc_parser::Parser;
+
+    use crate::{jsdoc::JSDocComment, SemanticBuilder};
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn get_jsdoc<'a>(
+        allocator: &'a Allocator,
+        source_text: &'a str,
+        symbol: &'a str,
+    ) -> Option<JSDocComment<'a>> {
+        let source_type = SourceType::default();
+        let ret = Parser::new(allocator, source_text, source_type).parse();
+        let program = allocator.alloc(ret.program);
+        let semantic =
+            SemanticBuilder::new(source_text, source_type, &ret.trivias).build(program).semantic;
+        let jsdoc = semantic.jsdoc();
+        let start = source_text.find(symbol).unwrap() as u32;
+        let span = Span::new(start, start + symbol.len() as u32);
+        jsdoc.get_by_span(span)
+    }
+
+    fn test_jsdoc(source_text: &str, symbol: &str) {
+        let allocator = Allocator::default();
+        assert!(
+            get_jsdoc(&allocator, source_text, symbol).is_some(),
+            "{symbol} not found in {source_text}"
+        );
+    }
+
+    fn test_jsdoc_not_found(source_text: &str, symbol: &str) {
+        let allocator = Allocator::default();
+        assert!(
+            get_jsdoc(&allocator, source_text, symbol).is_none(),
+            "{symbol} found in {source_text}"
+        );
+    }
+
+    #[test]
+    fn not_found() {
+        let source_texts = [
+            "/* test */function foo() {}",
+            "/*** test */function foo() {}",
+            "/** test */ ; function foo() {}",
+        ];
+        for source_text in source_texts {
+            test_jsdoc_not_found(source_text, "function foo() {}");
+        }
+    }
+
+    #[test]
+    fn found() {
+        let source_texts = [
+            "/** test */function foo() {}",
+            "
+            /** test */
+        function foo() {}",
+            "/** test */
+                function foo() {}",
+            "/**
+             * test
+             * */
+            function foo() {}",
+            "/** test */
+            function foo() {}",
+        ];
+        for source_text in source_texts {
+            test_jsdoc(source_text, "function foo() {}");
+        }
+    }
+}

--- a/crates/oxc_semantic/src/jsdoc/mod.rs
+++ b/crates/oxc_semantic/src/jsdoc/mod.rs
@@ -1,0 +1,58 @@
+mod builder;
+
+use std::collections::BTreeMap;
+
+pub use builder::JSDocBuilder;
+use once_cell::unsync::OnceCell;
+use oxc_ast::{GetSpan, Span};
+
+pub use self::parser::JSDocTag;
+use self::parser::JsDocParser;
+use crate::AstNode;
+
+mod parser;
+
+#[derive(Debug)]
+pub struct JSDoc<'a> {
+    /// JSDocs by Span
+    docs: BTreeMap<Span, JSDocComment<'a>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct JSDocComment<'a> {
+    comment: &'a str,
+    /// Cached JSDocTags
+    tags: OnceCell<Vec<JSDocTag<'a>>>,
+}
+
+impl<'a> JSDoc<'a> {
+    #[must_use]
+    pub fn new(docs: BTreeMap<Span, JSDocComment<'a>>) -> Self {
+        Self { docs }
+    }
+
+    #[must_use]
+    pub fn get_by_node<'b>(&'b self, node: &AstNode<'a>) -> Option<JSDocComment<'a>> {
+        if !node.get().has_jsdoc() {
+            return None;
+        }
+        let span = node.get().kind().span();
+        self.get_by_span(span)
+    }
+
+    #[must_use]
+    pub fn get_by_span<'b>(&'b self, span: Span) -> Option<JSDocComment<'a>> {
+        self.docs.get(&span).cloned()
+    }
+}
+
+impl<'a> JSDocComment<'a> {
+    #[must_use]
+    pub fn new(comment: &'a str) -> JSDocComment<'a> {
+        Self { comment, tags: OnceCell::new() }
+    }
+
+    pub fn tags<'b>(&'b self) -> &'b Vec<JSDocTag<'a>> {
+        self.tags.get_or_init(|| JsDocParser::new(self.comment).parse())
+    }
+}

--- a/crates/oxc_semantic/src/jsdoc/mod.rs
+++ b/crates/oxc_semantic/src/jsdoc/mod.rs
@@ -6,8 +6,8 @@ pub use builder::JSDocBuilder;
 use once_cell::unsync::OnceCell;
 use oxc_ast::{GetSpan, Span};
 
-pub use self::parser::JSDocTag;
 use self::parser::JSDocParser;
+pub use self::parser::JSDocTag;
 use crate::AstNode;
 
 mod parser;

--- a/crates/oxc_semantic/src/jsdoc/mod.rs
+++ b/crates/oxc_semantic/src/jsdoc/mod.rs
@@ -7,7 +7,7 @@ use once_cell::unsync::OnceCell;
 use oxc_ast::{GetSpan, Span};
 
 pub use self::parser::JSDocTag;
-use self::parser::JsDocParser;
+use self::parser::JSDocParser;
 use crate::AstNode;
 
 mod parser;
@@ -53,6 +53,6 @@ impl<'a> JSDocComment<'a> {
     }
 
     pub fn tags<'b>(&'b self) -> &'b Vec<JSDocTag<'a>> {
-        self.tags.get_or_init(|| JsDocParser::new(self.comment).parse())
+        self.tags.get_or_init(|| JSDocParser::new(self.comment).parse())
     }
 }

--- a/crates/oxc_semantic/src/jsdoc/parser.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser.rs
@@ -1,0 +1,307 @@
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParamTypeKind {
+    Any,
+    Repeated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParamType<'a> {
+    value: &'a str,
+}
+
+impl<'a> ParamType<'a> {
+    #[allow(unused)]
+    pub fn kind(&self) -> Option<ParamTypeKind> {
+        ParamTypeKind::from_str(self.value).map(Option::Some).unwrap_or_default()
+    }
+}
+
+impl FromStr for ParamTypeKind {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO: This might be inaccurate if the type is listed as {....string} or some variant
+        if s.len() > 3 && &s[0..3] == "..." {
+            return Ok(Self::Repeated);
+        }
+
+        if s == "*" {
+            return Ok(Self::Any);
+        }
+
+        Err(())
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Param<'a> {
+    name: &'a str,
+    r#type: Option<ParamType<'a>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JSDocTagKind<'a> {
+    Deprecated,
+    Param(Param<'a>),
+}
+
+impl<'a> FromStr for JSDocTagKind<'a> {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "deprecated" => Ok(Self::Deprecated),
+            "param" => Ok(Self::Param(Param::default())),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JSDocTag<'a> {
+    pub kind: JSDocTagKind<'a>,
+    pub description: &'a str,
+}
+
+impl<'a> JSDocTag<'a> {
+    #[must_use]
+    pub fn is_deprecated(&self) -> bool {
+        matches!(self.kind, JSDocTagKind::Deprecated)
+    }
+}
+
+#[derive(Debug)]
+pub struct JsDocParser<'a> {
+    source_text: &'a str,
+    current: usize,
+}
+
+impl<'a> JsDocParser<'a> {
+    pub fn new(source_text: &'a str) -> Self {
+        Self { source_text, current: 0 }
+    }
+
+    pub fn parse(mut self) -> Vec<JSDocTag<'a>> {
+        self.parse_comment(self.source_text)
+    }
+
+    fn advance(&mut self) {
+        if self.current < self.source_text.len() {
+            self.current += 1;
+        }
+    }
+
+    fn at(&mut self, c: char) -> bool {
+        let Some(ch) = self.source_text.chars().nth(self.current) else { return false };
+        if ch == c {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn take_until(&mut self, s: &'a str, predicate: fn(char) -> bool) -> &'a str {
+        let start = self.current;
+        while let Some(c) = s.chars().nth(self.current) {
+            if predicate(c) {
+                break;
+            }
+            self.current += 1;
+        }
+        &s[start..self.current]
+    }
+
+    fn skip_whitespace(&mut self, s: &'a str) {
+        while let Some(c) = s.chars().nth(self.current) {
+            if c != ' ' {
+                break;
+            }
+            self.current += 1;
+        }
+    }
+
+    fn parse_comment(&mut self, comment: &'a str) -> Vec<JSDocTag<'a>> {
+        let mut tags = vec![];
+
+        while let Some(c) = comment.chars().nth(self.current) {
+            match c {
+                '@' => {
+                    self.current += 1;
+                    let Some(tag) = self.parse_tag(comment) else { break };
+                    self.current += tag.description.len();
+                    tags.push(tag);
+                }
+                _ => {
+                    self.current += 1;
+                }
+            }
+        }
+
+        tags
+    }
+
+    fn parse_tag(&mut self, comment: &'a str) -> Option<JSDocTag<'a>> {
+        let tag = self.take_until(comment, |c| c == ' ' || c == '\n');
+        JSDocTagKind::from_str(tag).map_or(None, |kind| match kind {
+            JSDocTagKind::Deprecated => Some(self.parse_deprecated_tag(comment)),
+            JSDocTagKind::Param { .. } => Some(self.parse_param_tag(comment)),
+        })
+    }
+
+    fn parse_deprecated_tag(&mut self, comment: &'a str) -> JSDocTag<'a> {
+        self.skip_whitespace(comment);
+        let description = self.take_until(comment, |c| c == '\n' || c == '*');
+        JSDocTag { kind: JSDocTagKind::Deprecated, description }
+    }
+
+    fn parse_param_tag(&mut self, comment: &'a str) -> JSDocTag<'a> {
+        self.skip_whitespace(comment);
+
+        let mut r#type = None;
+
+        if self.at('{') {
+            // If we hit a space, then treat it as the end of the type annotation.
+            let type_annotation = self.take_until(comment, |c| c == '}' || c == ' ');
+            r#type = Some(ParamType { value: type_annotation });
+            if self.at('}') {
+                self.skip_whitespace(comment);
+            }
+            self.skip_whitespace(comment);
+        }
+
+        let name = self.take_until(comment, |c| c == ' ' || c == '\n');
+
+        self.skip_whitespace(comment);
+        if self.at('-') {
+            self.skip_whitespace(comment);
+        }
+
+        let description = self.take_until(comment, |c| c == '\n' || c == '*');
+
+        JSDocTag { kind: JSDocTagKind::Param(Param { name, r#type }), description }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::JsDocParser;
+    use crate::jsdoc::parser::{JSDocTag, JSDocTagKind, Param, ParamType, ParamTypeKind};
+
+    #[test]
+    fn deduces_correct_param_kind() {
+        let param = Param { name: "a", r#type: Some(ParamType { value: "string" }) };
+        assert_eq!(param.r#type.and_then(|t| t.kind()), None);
+
+        let param = Param { name: "a", r#type: Some(ParamType { value: "...string" }) };
+        assert_eq!(param.r#type.and_then(|t| t.kind()), Some(ParamTypeKind::Repeated));
+
+        let param = Param { name: "a", r#type: Some(ParamType { value: "*" }) };
+        assert_eq!(param.r#type.and_then(|t| t.kind()), Some(ParamTypeKind::Any));
+    }
+
+    #[test]
+    fn parses_single_line_jsdoc() {
+        let source = "/** @deprecated */";
+
+        let tags = JsDocParser::new(source).parse();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags, vec![JSDocTag { kind: JSDocTagKind::Deprecated, description: "" }]);
+    }
+
+    #[test]
+    fn parses_multi_line_disjoint_jsdoc() {
+        let source = r#"/** @deprecated
+        */
+        "#;
+
+        let tags = JsDocParser::new(source).parse();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags, vec![JSDocTag { kind: JSDocTagKind::Deprecated, description: "" }]);
+    }
+
+    #[test]
+    fn parses_multiline_jsdoc() {
+        let source = r#"/**
+        * @param a
+        * @deprecated
+        */
+       "#;
+
+        let tags = JsDocParser::new(source).parse();
+        assert_eq!(tags.len(), 2);
+        assert_eq!(
+            tags,
+            vec![
+                JSDocTag {
+                    kind: JSDocTagKind::Param(Param { name: "a", r#type: None }),
+                    description: ""
+                },
+                JSDocTag { kind: JSDocTagKind::Deprecated, description: "" },
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_multiline_jsdoc_with_descriptions() {
+        let source = r#"/**
+        * @param a
+        * @deprecated since version 1.0
+        */
+       "#;
+
+        let tags = JsDocParser::new(source).parse();
+        assert_eq!(tags.len(), 2);
+        assert_eq!(
+            tags,
+            vec![
+                JSDocTag {
+                    kind: JSDocTagKind::Param(Param { name: "a", r#type: None }),
+                    description: ""
+                },
+                JSDocTag { kind: JSDocTagKind::Deprecated, description: "since version 1.0" },
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_param_type_annotation() {
+        let source = r#"/**
+        * @param {string} a
+        * @param {string b
+        * @param {string} c - description
+        */
+       "#;
+
+        let tags = JsDocParser::new(source).parse();
+        assert_eq!(tags.len(), 3);
+        assert_eq!(
+            tags,
+            vec![
+                JSDocTag {
+                    kind: JSDocTagKind::Param(Param {
+                        name: "a",
+                        r#type: Some(ParamType { value: "string" })
+                    }),
+                    description: ""
+                },
+                JSDocTag {
+                    kind: JSDocTagKind::Param(Param {
+                        name: "b",
+                        r#type: Some(ParamType { value: "string" })
+                    }),
+                    description: ""
+                },
+                JSDocTag {
+                    kind: JSDocTagKind::Param(Param {
+                        name: "c",
+                        r#type: Some(ParamType { value: "string" })
+                    }),
+                    description: "description"
+                },
+            ]
+        );
+    }
+}

--- a/crates/oxc_semantic/src/jsdoc/parser.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser.rs
@@ -73,12 +73,12 @@ impl<'a> JSDocTag<'a> {
 }
 
 #[derive(Debug)]
-pub struct JsDocParser<'a> {
+pub struct JSDocParser<'a> {
     source_text: &'a str,
     current: usize,
 }
 
-impl<'a> JsDocParser<'a> {
+impl<'a> JSDocParser<'a> {
     pub fn new(source_text: &'a str) -> Self {
         Self { source_text, current: 0 }
     }
@@ -187,7 +187,7 @@ impl<'a> JsDocParser<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::JsDocParser;
+    use super::JSDocParser;
     use crate::jsdoc::parser::{JSDocTag, JSDocTagKind, Param, ParamType, ParamTypeKind};
 
     #[test]
@@ -206,7 +206,7 @@ mod test {
     fn parses_single_line_jsdoc() {
         let source = "/** @deprecated */";
 
-        let tags = JsDocParser::new(source).parse();
+        let tags = JSDocParser::new(source).parse();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags, vec![JSDocTag { kind: JSDocTagKind::Deprecated, description: "" }]);
     }
@@ -217,7 +217,7 @@ mod test {
         */
         "#;
 
-        let tags = JsDocParser::new(source).parse();
+        let tags = JSDocParser::new(source).parse();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags, vec![JSDocTag { kind: JSDocTagKind::Deprecated, description: "" }]);
     }
@@ -230,7 +230,7 @@ mod test {
         */
        "#;
 
-        let tags = JsDocParser::new(source).parse();
+        let tags = JSDocParser::new(source).parse();
         assert_eq!(tags.len(), 2);
         assert_eq!(
             tags,
@@ -252,7 +252,7 @@ mod test {
         */
        "#;
 
-        let tags = JsDocParser::new(source).parse();
+        let tags = JSDocParser::new(source).parse();
         assert_eq!(tags.len(), 2);
         assert_eq!(
             tags,
@@ -275,7 +275,7 @@ mod test {
         */
        "#;
 
-        let tags = JsDocParser::new(source).parse();
+        let tags = JSDocParser::new(source).parse();
         assert_eq!(tags.len(), 3);
         assert_eq!(
             tags,

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -5,6 +5,7 @@ mod binder;
 mod builder;
 mod checker;
 mod diagnostics;
+mod jsdoc;
 mod module_record;
 mod node;
 mod scope;
@@ -13,6 +14,7 @@ mod symbol;
 use std::rc::Rc;
 
 pub use builder::SemanticBuilder;
+pub use jsdoc::{JSDoc, JSDocComment, JSDocTag};
 use node::AstNodeId;
 pub use node::{AstNode, AstNodes, SemanticNode};
 use oxc_ast::{
@@ -37,6 +39,8 @@ pub struct Semantic<'a> {
     trivias: Rc<Trivias>,
 
     module_record: ModuleRecord,
+
+    jsdoc: JSDoc<'a>,
 }
 
 impl<'a> Semantic<'a> {
@@ -63,6 +67,11 @@ impl<'a> Semantic<'a> {
     #[must_use]
     pub fn trivias(&self) -> &Trivias {
         &self.trivias
+    }
+
+    #[must_use]
+    pub fn jsdoc(&self) -> &JSDoc<'a> {
+        &self.jsdoc
     }
 
     #[must_use]

--- a/crates/oxc_semantic/src/node/mod.rs
+++ b/crates/oxc_semantic/src/node/mod.rs
@@ -27,7 +27,8 @@ pub struct SemanticNode<'a> {
 bitflags! {
     #[derive(Default)]
     pub struct NodeFlags: u8 {
-        const Class = 1 << 0; // If Node is inside a class
+        const JsDoc = 1 << 0; // If the Node has a JsDoc comment attached
+        const Class = 1 << 1; // If Node is inside a class
     }
 }
 
@@ -56,5 +57,10 @@ impl<'a> SemanticNode<'a> {
     #[must_use]
     pub fn in_class(self) -> bool {
         self.flags.contains(NodeFlags::Class)
+    }
+
+    #[must_use]
+    pub fn has_jsdoc(&self) -> bool {
+        self.flags.contains(NodeFlags::JsDoc)
     }
 }

--- a/crates/oxc_semantic/src/node/mod.rs
+++ b/crates/oxc_semantic/src/node/mod.rs
@@ -27,7 +27,7 @@ pub struct SemanticNode<'a> {
 bitflags! {
     #[derive(Default)]
     pub struct NodeFlags: u8 {
-        const JsDoc = 1 << 0; // If the Node has a JsDoc comment attached
+        const JSDoc = 1 << 0; // If the Node has a JSDoc comment attached
         const Class = 1 << 1; // If Node is inside a class
     }
 }
@@ -61,6 +61,6 @@ impl<'a> SemanticNode<'a> {
 
     #[must_use]
     pub fn has_jsdoc(&self) -> bool {
-        self.flags.contains(NodeFlags::JsDoc)
+        self.flags.contains(NodeFlags::JSDoc)
     }
 }

--- a/examples/jsdoc/Cargo.toml
+++ b/examples/jsdoc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "jsdoc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+oxc_allocator = { path = "../../crates/oxc_allocator" }
+oxc_ast = { path = "../../crates/oxc_ast" }
+oxc_parser = { path = "../../crates/oxc_parser" }
+oxc_semantic = { path = "../../crates/oxc_semantic" }

--- a/examples/jsdoc/src/main.rs
+++ b/examples/jsdoc/src/main.rs
@@ -1,0 +1,28 @@
+use std::rc::Rc;
+
+use oxc_allocator::Allocator;
+use oxc_ast::SourceType;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().unwrap();
+    let source = std::fs::read_to_string(&path).unwrap();
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(&path).unwrap();
+    let ret = Parser::new(&allocator, &source, source_type).parse();
+
+    let program = allocator.alloc(ret.program);
+    let trivias = Rc::new(ret.trivias);
+
+    let ctx = SemanticBuilder::new(&source, source_type, &trivias).build(program);
+    let jsdoc = ctx.semantic.jsdoc();
+
+    for node in ctx.semantic.nodes().iter() {
+        if let Some(jsdoc) = jsdoc.get_by_node(node) {
+            println!("{jsdoc:#?}");
+        }
+    }
+}


### PR DESCRIPTION
@Boshen I took a very naive first pass and it's not completely functional. I'd love to see your ideas around using `OnceCell` and how we can properly attribute a given comment span to a node span.

I attempted the lazy `OnceCell` approach in this commit (https://github.com/Boshen/oxc/pull/205/commits/9cefee43fc0bfc76436b6040de9efc9a708b2e02), but `OnceCell` is not `Copy` so it doesn't compile