### PR TITLE
fix(macros): duplicate module declarations for nested modules

### DIFF
--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(iter_intersperse)]
+
 use syn::parse_macro_input;
 
 mod declare_all_lint_rules;


### PR DESCRIPTION
**Problem**
The `declare_all_lint_rules!` macro doesn't properly take care of having several modules within the same nested path.
The macro outputs duplicate module declarations, which is a build break.

For example
```rust
declare_all_lint_rules! {
    deepscan::module1,
    deepscan::module2
}
```

Will output
```rust
mod deepscan {
    pub mod module1;
}

mod deepscan {
    pub mod module2;
}
```

We need to group rules by module paths and output the module declarations together
```rust
mod deepscan {
    pub mod module1;
    pub mod module2;
}
```


**Solution**
This initial commit ugly, but it works.
I'm sure there's a rusty-er, terse, more readable way to do it.
I'm less bothered by that, I'm more bothered by having to have done many string copies and concats to use as keys.

Super late, will revisit tomorrow.

