### PR TITLE
fix: nullish coalescing operator precedence

### DIFF
--- a/crates/oxc_linter/src/rules/no_mixed_operators.rs
+++ b/crates/oxc_linter/src/rules/no_mixed_operators.rs
@@ -217,7 +217,7 @@ const PRECEDENCES: [u8; 27] = [
   4, 3,
   9, 9,
   2,
-  9,
+  3
 ];
 
 const ARITHMETIC: &[&str] = &OPERATORS[..6];
@@ -296,6 +296,7 @@ fn test() {
         ("x ? a && b : 0", Some(json!([{ "groups": [["&&", "||", "?:"]] }]))),
         ("x ? 0 : a && b", Some(json!([{ "groups": [["&&", "||", "?:"]] }]))),
         ("a + b ?? c", Some(json!([{ "groups": [["+", "??"]] }]))),
+        ("a in b ?? c", Some(json!([{ "groups": [["in", "??"]] }]))),
     ];
 
     Tester::new(NoMixedOperators::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_mixed_operators.snap
+++ b/crates/oxc_linter/src/snapshots/no_mixed_operators.snap
@@ -108,3 +108,10 @@ expression: no_mixed_operators
    ╰────
   help: Use parentheses to clarify the intended order of operations.
 
+  ⚠ eslint(no-mixed-operators): Unexpected mix of in with ??
+   ╭─[no_mixed_operators.tsx:1:1]
+ 1 │ a in b ?? c
+   ·   ──   ──
+   ╰────
+  help: Use parentheses to clarify the intended order of operations.
+


### PR DESCRIPTION
Fix one error copying operator precedence values from [MDN's table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table)

The mistake gave `in` and `??` the same precedence.  Add a test that should have failed (and with this PR it now does.)