### PR TITLE
perf(semantics): avoid hashing when resolving references

### DIFF
--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -143,6 +143,13 @@ impl<'a> LintContext<'a> {
 
     /* Symbols */
 
+    pub fn is_unresolved_reference(&self, node_id: NodeId) -> bool {
+        let AstKind::IdentifierReference(id) = self.kind(node_id) else { return false; };
+        let reference_node = &self.nodes()[node_id];
+        let scope = self.scope(reference_node);
+        scope.unresolved_references.contains_key(&id.name)
+    }
+
     #[allow(clippy::unused_self)]
     pub fn is_reference_to_global_variable(&self, _ident: &IdentifierReference) -> bool {
         true

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -143,13 +143,6 @@ impl<'a> LintContext<'a> {
 
     /* Symbols */
 
-    pub fn is_unresolved_reference(&self, node_id: NodeId) -> bool {
-        let AstKind::IdentifierReference(id) = self.kind(node_id) else { return false; };
-        let reference_node = &self.nodes()[node_id];
-        let scope = self.scope(reference_node);
-        scope.unresolved_references.contains_key(&id.name)
-    }
-
     #[allow(clippy::unused_self)]
     pub fn is_reference_to_global_variable(&self, _ident: &IdentifierReference) -> bool {
         true

--- a/crates/oxc_linter/src/rules/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/valid_typeof.rs
@@ -93,7 +93,7 @@ impl Rule for ValidTypeof {
             }
 
             if sibling.is_undefined()
-                && ctx.is_unresolved_reference(sibling_id)
+                && ctx.semantic().is_unresolved_reference(sibling_id.into())
             {
                 ctx.diagnostic_with_fix(
                     if self.require_string_literals {

--- a/crates/oxc_linter/src/rules/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/valid_typeof.rs
@@ -93,7 +93,7 @@ impl Rule for ValidTypeof {
             }
 
             if sibling.is_undefined()
-                && ctx.symbols().get_resolved_reference(sibling_id.into()).is_none()
+                && ctx.is_unresolved_reference(sibling_id)
             {
                 ctx.diagnostic_with_fix(
                     if self.require_string_literals {

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -11,8 +11,9 @@ mod symbol;
 use std::rc::Rc;
 
 pub use builder::SemanticBuilder;
+use node::AstNodeId;
 pub use node::{AstNode, AstNodes, SemanticNode};
-use oxc_ast::{module_record::ModuleRecord, SourceType, Trivias};
+use oxc_ast::{module_record::ModuleRecord, AstKind, SourceType, Trivias};
 pub use scope::{Scope, ScopeFlags, ScopeTree};
 pub use symbol::{Reference, ResolvedReference, Symbol, SymbolFlags, SymbolTable};
 
@@ -66,5 +67,13 @@ impl<'a> Semantic<'a> {
     #[must_use]
     pub fn symbols(&self) -> &SymbolTable {
         &self.symbols
+    }
+
+    #[must_use]
+    pub fn is_unresolved_reference(&self, node_id: AstNodeId) -> bool {
+        let reference_node = &self.nodes()[node_id];
+        let AstKind::IdentifierReference(id) = reference_node.kind() else { return false; };
+        let scope = &self.scopes()[reference_node.scope_id()];
+        scope.unresolved_references.contains_key(&id.name)
     }
 }

--- a/crates/oxc_semantic/src/scope/builder.rs
+++ b/crates/oxc_semantic/src/scope/builder.rs
@@ -73,9 +73,7 @@ impl ScopeBuilder {
                 let scope = &self.scopes[scope];
                 if let Some(symbol_id) = scope.get().get_variable_symbol_id(&variable) {
                     // We have resolved this reference.
-                    for r in reference {
-                        symbol_table.resolve_reference(r, symbol_id);
-                    }
+                    symbol_table.resolve_reference(reference, symbol_id);
                     continue 'outer;
                 }
             }

--- a/crates/oxc_semantic/src/scope/builder.rs
+++ b/crates/oxc_semantic/src/scope/builder.rs
@@ -73,10 +73,8 @@ impl ScopeBuilder {
                 let scope = &self.scopes[scope];
                 if let Some(symbol_id) = scope.get().get_variable_symbol_id(&variable) {
                     // We have resolved this reference.
-                    let symbol = &mut symbol_table[symbol_id];
-                    symbol.add_references(&reference);
                     for r in reference {
-                        symbol_table.resolve_reference(r.ast_node_id, r.resolve_to(symbol_id));
+                        symbol_table.resolve_reference(r, symbol_id);
                     }
                     continue 'outer;
                 }

--- a/crates/oxc_semantic/src/symbol/mod.rs
+++ b/crates/oxc_semantic/src/symbol/mod.rs
@@ -8,6 +8,7 @@ mod table;
 use bitflags::bitflags;
 use oxc_ast::{Atom, Span};
 
+use self::reference::ResolvedReferenceId;
 pub use self::{
     id::SymbolId,
     reference::{Reference, ReferenceFlag, ResolvedReference},
@@ -24,7 +25,7 @@ pub struct Symbol {
     span: Span,
     flags: SymbolFlags,
     /// Pointers to the AST Nodes that reference this symbol
-    references: Vec<AstNodeId>,
+    references: Vec<ResolvedReferenceId>,
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
@@ -119,12 +120,12 @@ impl Symbol {
         self.flags.contains(SymbolFlags::Export)
     }
 
-    pub fn add_references(&mut self, new_references: &[Reference]) {
-        self.references.extend(new_references.iter().map(|r| r.ast_node_id));
+    pub fn add_reference(&mut self, reference_id: ResolvedReferenceId) {
+        self.references.push(reference_id);
     }
 
     #[must_use]
-    pub fn references(&self) -> &[AstNodeId] {
+    pub fn references(&self) -> &[ResolvedReferenceId] {
         &self.references
     }
 

--- a/crates/oxc_semantic/src/symbol/mod.rs
+++ b/crates/oxc_semantic/src/symbol/mod.rs
@@ -120,10 +120,6 @@ impl Symbol {
         self.flags.contains(SymbolFlags::Export)
     }
 
-    pub fn add_reference(&mut self, reference_id: ResolvedReferenceId) {
-        self.references.push(reference_id);
-    }
-
     #[must_use]
     pub fn references(&self) -> &[ResolvedReferenceId] {
         &self.references

--- a/crates/oxc_semantic/src/symbol/reference.rs
+++ b/crates/oxc_semantic/src/symbol/reference.rs
@@ -1,5 +1,7 @@
 #![allow(non_upper_case_globals)]
 
+use std::num::NonZeroUsize;
+
 use bitflags::bitflags;
 use oxc_ast::Span;
 
@@ -81,5 +83,26 @@ impl ResolvedReference {
     #[must_use]
     pub fn span(&self) -> Span {
         self.reference.span
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ResolvedReferenceId(NonZeroUsize);
+
+impl Default for ResolvedReferenceId {
+    fn default() -> Self {
+        Self::new(1)
+    }
+}
+
+impl ResolvedReferenceId {
+    #[must_use]
+    pub fn new(n: usize) -> Self {
+        unsafe { Self(NonZeroUsize::new_unchecked(n)) }
+    }
+
+    #[must_use]
+    pub(crate) fn index0(self) -> usize {
+        self.0.get() - 1
     }
 }

--- a/crates/oxc_semantic/src/symbol/table.rs
+++ b/crates/oxc_semantic/src/symbol/table.rs
@@ -93,12 +93,19 @@ impl SymbolTable {
 
     /// Resolve all `references` to `symbol_id`
     pub(crate) fn resolve_reference(&mut self, references: Vec<Reference>, symbol_id: SymbolId) {
+        let additional_len = references.len();
+        let symbol = &mut self.symbols[symbol_id];
+
+        self.resolved_references.reserve(additional_len);
+        symbol.references.reserve(additional_len);
+
         for reference in references {
             let resolved_reference_id =
                 ResolvedReferenceId::new(self.resolved_references.len() + 1);
             let resolved_reference = reference.resolve_to(symbol_id);
             self.resolved_references.push(resolved_reference);
-            self.symbols[symbol_id].add_reference(resolved_reference_id);
+            // explicitly push to vector here in correspondence to the previous reserve call
+            symbol.references.push(resolved_reference_id);
         }
     }
 }

--- a/crates/oxc_semantic/src/symbol/table.rs
+++ b/crates/oxc_semantic/src/symbol/table.rs
@@ -10,7 +10,7 @@ use crate::{Reference, ResolvedReference};
 /// `SymbolTable` is a storage of all the symbols (related to `BindingIdentifiers`)
 /// and references (related to `IdentifierReferences`) of the program. It supports two
 /// kinds of queries: indexing by `SymbolId` retrieves the corresponding `Symbol` and
-/// indexing by `ResovledReferenceId` retrieves the correspodning `ResolvedReference`
+/// indexing by `ResolvedReferenceId` retrieves the correspodning `ResolvedReference`
 ///
 #[derive(Debug, Default)]
 pub struct SymbolTable {
@@ -91,11 +91,14 @@ impl SymbolTable {
         self.resolved_references.get(id.index0())
     }
 
-    /// Resolve `reference` to `symbol_id`
-    pub(crate) fn resolve_reference(&mut self, reference: Reference, symbol_id: SymbolId) {
-        let resolved_reference_id = ResolvedReferenceId::new(self.resolved_references.len() + 1);
-        let resolved_reference = reference.resolve_to(symbol_id);
-        self.resolved_references.push(resolved_reference);
-        self.symbols[symbol_id].add_reference(resolved_reference_id);
+    /// Resolve all `references` to `symbol_id`
+    pub(crate) fn resolve_reference(&mut self, references: Vec<Reference>, symbol_id: SymbolId) {
+        for reference in references {
+            let resolved_reference_id =
+                ResolvedReferenceId::new(self.resolved_references.len() + 1);
+            let resolved_reference = reference.resolve_to(symbol_id);
+            self.resolved_references.push(resolved_reference);
+            self.symbols[symbol_id].add_reference(resolved_reference_id);
+        }
     }
 }

--- a/crates/oxc_semantic/src/symbol/table.rs
+++ b/crates/oxc_semantic/src/symbol/table.rs
@@ -7,9 +7,16 @@ use super::{Symbol, SymbolFlags, SymbolId};
 use crate::node::AstNodeId;
 use crate::{Reference, ResolvedReference};
 
+/// `SymbolTable` is a storage of all the symbols (related to `BindingIdentifiers`)
+/// and references (related to `IdentifierReferences`) of the program. It supports two
+/// kinds of queries: indexing by `SymbolId` retrieves the corresponding `Symbol` and
+/// indexing by `ResovledReferenceId` retrieves the correspodning `ResolvedReference`
+///
 #[derive(Debug, Default)]
 pub struct SymbolTable {
+    /// Stores all the `Symbols` indexed by `SymbolId`
     symbols: Vec<Symbol>,
+    /// Stores all the resolved references indexed by `ResolvedReferenceId`
     resolved_references: Vec<ResolvedReference>,
 }
 
@@ -24,6 +31,20 @@ impl Index<SymbolId> for SymbolTable {
 impl IndexMut<SymbolId> for SymbolTable {
     fn index_mut(&mut self, index: SymbolId) -> &mut Self::Output {
         &mut self.symbols[index.index0()]
+    }
+}
+
+impl Index<ResolvedReferenceId> for SymbolTable {
+    type Output = ResolvedReference;
+
+    fn index(&self, index: ResolvedReferenceId) -> &Self::Output {
+        &self.resolved_references[index.index0()]
+    }
+}
+
+impl IndexMut<ResolvedReferenceId> for SymbolTable {
+    fn index_mut(&mut self, index: ResolvedReferenceId) -> &mut Self::Output {
+        &mut self.resolved_references[index.index0()]
     }
 }
 
@@ -42,12 +63,12 @@ impl SymbolTable {
     }
 
     #[must_use]
-    pub fn get(&self, id: SymbolId) -> Option<&Symbol> {
+    pub fn get_symbol(&self, id: SymbolId) -> Option<&Symbol> {
         self.symbols.get(id.index0())
     }
 
     #[must_use]
-    pub fn create(
+    pub(crate) fn create(
         &mut self,
         declaration: AstNodeId,
         name: Atom,
@@ -61,12 +82,17 @@ impl SymbolTable {
     }
 
     #[must_use]
+    pub fn resolved_references(&self) -> &Vec<ResolvedReference> {
+        &self.resolved_references
+    }
+
+    #[must_use]
     pub fn get_resolved_reference(&self, id: ResolvedReferenceId) -> Option<&ResolvedReference> {
         self.resolved_references.get(id.index0())
     }
 
     /// Resolve `reference` to `symbol_id`
-    pub fn resolve_reference(&mut self, reference: Reference, symbol_id: SymbolId) {
+    pub(crate) fn resolve_reference(&mut self, reference: Reference, symbol_id: SymbolId) {
         let resolved_reference_id = ResolvedReferenceId::new(self.resolved_references.len() + 1);
         let resolved_reference = reference.resolve_to(symbol_id);
         self.resolved_references.push(resolved_reference);


### PR DESCRIPTION
Avoid additional hashing step when building the resolved reference table. Related to discussion in #225 