### PR TITLE
ci: use sccache

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -16,6 +16,18 @@ inputs:
     default: false
     required: false
     type: boolean
+  cache:
+    default: true
+    required: false
+    type: boolean
+  shared-key:
+    default: ''
+    required: false
+    type: string
+  sccache:
+    default: true
+    required: false
+    type: boolean
 
 runs:
   using: composite
@@ -52,3 +64,13 @@ runs:
     - name: Install
       shell: bash
       run: rustup show
+
+    - name: sccache-cache
+      if: ${{ inputs.sccache == 'true' }}
+      uses: mozilla-actions/sccache-action@v0.0.3
+
+    - name: Swatinem/rust-cache
+      if: ${{ inputs.cache == 'true' }}
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ${{ inputs.shared_key }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,21 +3,23 @@ name: Benchmark
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - './github/workflow/benchmark.yml'
-      - 'crates/oxc_parser/**'
-      - 'crates/oxc_ast/**'
-      - 'crates/oxc_semantic/**'
-      - 'tasks/benchmark/**'
-      - 'rust-toolchain.toml'
-      - '!**/*.md'
+    # paths:
+      # - './github/workflow/benchmark.yml'
+      # - 'crates/oxc_parser/**'
+      # - 'crates/oxc_ast/**'
+      # - 'crates/oxc_semantic/**'
+      # - 'tasks/benchmark/**'
+      # - 'rust-toolchain.toml'
+      # - '!**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:
-  CARGO_TERM_QUIET: true
+  # CARGO_TERM_QUIET: true
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   benchmark:
@@ -32,11 +34,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install Rust Toolchain
+      - name: Install Rust on PR
         uses: ./.github/actions/rustup
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
         with:
           shared-key: benchmark
 
@@ -58,8 +57,11 @@ jobs:
           clean: false
           ref: main
 
-      - name: Install Rust Toolchain
+      - name: Install Rust on Main
         uses: ./.github/actions/rustup
+        with:
+          cache: false
+          sccache: false
 
       - name: Compile
         run: cargo build --release -p oxc_benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'crates/**'
-      - 'tasks/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - '!**/*.md'
+      - sccache
+    # paths:
+      # - 'crates/**'
+      # - 'tasks/**'
+      # - 'Cargo.toml'
+      # - 'Cargo.lock'
+      # - 'rust-toolchain.toml'
+      # - '!**/*.md'
 
 # cancel previous job runs for the same workflow + pr
 concurrency:
@@ -27,7 +28,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_TERM_QUIET: true
+  # CARGO_TERM_QUIET: true
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   format:
@@ -37,10 +40,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust Toolchain
+      - name: Install Rust
         uses: ./.github/actions/rustup
         with:
           fmt: true
+          shared-key: ci
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check
@@ -52,15 +56,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust Toolchain
+      - name: Install Rust
         uses: ./.github/actions/rustup
         with:
           clippy: true
-
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: check
+          shared-key: ci
 
       - name: Run cargo check
         run: cargo check --workspace --all-targets --all-features --release --locked
@@ -78,14 +78,20 @@ jobs:
           files: .
 
   check-dependencies:
-    name: Check Dependencies
+    name: Check Unused Dependencies
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: ""
+      RUSTC_WRAPPER: ""
     steps:
       - name: Checkout PR Branch
         uses: actions/checkout@v3
 
-      - name: Install Rust Toolchain
+      - name: Install Rust
         uses: ./.github/actions/rustup
+        with:
+          shared-key: ci
+          sccache: false
 
       - name: Install cargo-udeps
         uses: taiki-e/install-action@v2
@@ -109,18 +115,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust Toolchain
+      - name: Install Rust
         uses: ./.github/actions/rustup
+        with:
+          shared-key: ci
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: check
 
       - name: Build tests
         run: cargo nextest run --no-run --locked

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -137,6 +137,7 @@ impl<'a> Parser<'a> {
     /// Create a new parser
     #[must_use]
     pub fn new(allocator: &'a Allocator, source_text: &'a str, source_type: SourceType) -> Self {
+        println!("a");
         Self {
             lexer: Lexer::new(allocator, source_text, source_type),
             source_type,


### PR DESCRIPTION
Summary:
* No significant speed up for my tiny project
* 429 rate limit when run in parallel
* if `Swatinem/rust-cache` is not installed, then cargo will still have to download the crates, countering the performance improvement 
* too many caches, this may "push out" all the other larger caches created by Swatinem/rust-cache

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/1430279/230547372-05648b37-cb45-4220-8e6b-b664302f4dae.png">
