### PR TITLE
feat(printer,semantic): mangler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_parser",
+ "oxc_semantic",
 ]
 
 [[package]]
@@ -1087,6 +1088,7 @@ name = "oxc_semantic"
 version = "0.0.4"
 dependencies = [
  "bitflags",
+ "compact_str",
  "indextree",
  "once_cell",
  "oxc_allocator",

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -130,8 +130,8 @@ impl<'a> LintContext<'a> {
     }
 
     #[must_use]
-    pub fn symbols(&self) -> &SymbolTable {
-        self.semantic().symbols()
+    pub fn symbols(&self) -> Rc<SymbolTable> {
+        Rc::clone(&self.semantic().symbols())
     }
 
     #[must_use]

--- a/crates/oxc_linter/src/rules/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/no_class_assign.rs
@@ -41,8 +41,9 @@ declare_oxc_lint!(
 impl Rule for NoClassAssign {
     fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
         if symbol.is_class() {
+            let symbols = ctx.symbols();
             for reference_id in symbol.references() {
-                let reference = ctx.symbols().get_resolved_reference(*reference_id).unwrap();
+                let reference = symbols.get_resolved_reference(*reference_id).unwrap();
                 if reference.is_write() {
                     ctx.diagnostic(NoClassAssignDiagnostic(
                         symbol.name().clone(),

--- a/crates/oxc_linter/src/rules/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/no_const_assign.rs
@@ -40,9 +40,9 @@ declare_oxc_lint!(
 impl Rule for NoConstAssign {
     fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
         if symbol.is_const() {
+            let symbols = ctx.symbols();
             for reference_id in symbol.references() {
-                let reference =
-                    ctx.semantic().symbols().get_resolved_reference(*reference_id).unwrap();
+                let reference = symbols.get_resolved_reference(*reference_id).unwrap();
                 if reference.is_write() {
                     ctx.diagnostic(NoConstAssignDiagnostic(
                         symbol.name().clone(),

--- a/crates/oxc_linter/src/rules/no_function_assign.rs
+++ b/crates/oxc_linter/src/rules/no_function_assign.rs
@@ -40,9 +40,9 @@ declare_oxc_lint!(
 impl Rule for NoFunctionAssign {
     fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
         if let AstKind::Function(_) = ctx.kind(symbol.declaration().into()) {
+            let symbols = ctx.symbols();
             for reference_id in symbol.references() {
-                let reference =
-                    ctx.semantic().symbols().get_resolved_reference(*reference_id).unwrap();
+                let reference = symbols.get_resolved_reference(*reference_id).unwrap();
                 if reference.is_write() {
                     ctx.diagnostic(NoFunctionAssignDiagnostic(
                         symbol.name().clone(),

--- a/crates/oxc_linter/src/rules/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/no_shadow_restricted_names.rs
@@ -40,8 +40,9 @@ static RESTRICTED: [&str; 5] = ["undefined", "NaN", "Infinity", "arguments", "ev
 fn safely_shadows_undefined(symbol: &Symbol, ctx: &LintContext<'_>) -> bool {
     if symbol.name().as_str() == "undefined" {
         let mut no_assign = true;
+        let symbols = ctx.symbols();
         for reference_id in symbol.references() {
-            let reference = ctx.semantic().symbols().get_resolved_reference(*reference_id).unwrap();
+            let reference = symbols.get_resolved_reference(*reference_id).unwrap();
             if reference.is_write() {
                 no_assign = false;
             }

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -33,10 +33,12 @@ fn main() {
     let minifier_options = MinifierOptions::default();
     Minifier::new(&allocator, minifier_options).build(program);
 
-    let _semantic = SemanticBuilder::new(&source_text, source_type, &ret.trivias).build(program);
+    let semantic_ret = SemanticBuilder::new(&source_text, source_type, &ret.trivias).build(program);
 
     let printer_options = PrinterOptions { minify_whitespace: true, ..PrinterOptions::default() };
-    let _printed = Printer::new(source_text.len(), printer_options).build(program);
+    let printed = Printer::new(source_text.len(), printer_options)
+        .with_symbol_table(&semantic_ret.semantic.symbols(), true)
+        .build(program);
 
-    // println!("{printed}");
+    println!("{printed}");
 }

--- a/crates/oxc_printer/Cargo.toml
+++ b/crates/oxc_printer/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_semantic = { workspace = true }
 
 [dev_dependencies]
 oxc_parser = { workspace = true }

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -17,6 +17,7 @@ indextree = { workspace = true }
 bitflags = { workspace = true }
 rustc-hash = { workspace = true }
 once_cell = { workspace = true }
+compact_str = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 
 [dev_dependencies]

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -125,15 +125,13 @@ impl<'a> SemanticBuilder<'a> {
             ModuleRecord::default()
         };
 
-        let symbols = self.symbols.build();
-
         let semantic = Semantic {
             source_text: self.source_text,
             source_type: self.source_type,
             trivias: self.trivias,
             nodes: self.nodes,
             scopes: self.scope.scopes,
-            symbols,
+            symbols: Rc::new(self.symbols.build()),
             module_record,
             jsdoc: self.jsdoc.build(),
             unused_labels: self.unused_labels.labels,
@@ -223,6 +221,9 @@ impl<'a> SemanticBuilder<'a> {
         let includes = includes | self.current_symbol_flags;
         let symbol_id = self.symbols.create(self.current_node_id, name.clone(), span, includes);
         self.scope.scopes[scope_id].variables.insert(name.clone(), symbol_id);
+        if !self.scope.current_scope().is_top() && includes.is_variable() {
+            self.symbols.update_slot(symbol_id);
+        }
         symbol_id
     }
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -23,7 +23,7 @@ use oxc_ast::{
 use scope::ScopeId;
 pub use scope::{Scope, ScopeFlags, ScopeTree};
 use symbol::SymbolId;
-pub use symbol::{Reference, ResolvedReference, Symbol, SymbolFlags, SymbolTable};
+pub use symbol::{Mangler, Reference, ResolvedReference, Symbol, SymbolFlags, SymbolTable};
 
 pub struct Semantic<'a> {
     source_text: &'a str,
@@ -34,7 +34,7 @@ pub struct Semantic<'a> {
 
     scopes: ScopeTree,
 
-    symbols: SymbolTable,
+    symbols: Rc<SymbolTable>,
 
     trivias: Rc<Trivias>,
 
@@ -82,8 +82,8 @@ impl<'a> Semantic<'a> {
     }
 
     #[must_use]
-    pub fn symbols(&self) -> &SymbolTable {
-        &self.symbols
+    pub fn symbols(&self) -> Rc<SymbolTable> {
+        Rc::clone(&self.symbols)
     }
 
     #[must_use]

--- a/crates/oxc_semantic/src/symbol/mangler.rs
+++ b/crates/oxc_semantic/src/symbol/mangler.rs
@@ -1,0 +1,156 @@
+use std::cell::RefCell;
+
+use compact_str::CompactString;
+
+use super::Symbol;
+
+/// # Name Mangler / Symbol Minification
+///
+/// See:
+///   * [esbuild](https://github.com/evanw/esbuild/blob/main/docs/architecture.md#symbol-minification)
+///
+/// This algorithm is targeted for better gzip compression.
+///
+/// Visually, a slot is the index position for binding identifiers:
+///
+/// ```javascript
+/// function x(slot0, slot1) {
+///     function y(slot2, slot3) {
+///         slot0 = 1;
+///     }
+/// }
+/// function z(slot0, slot1, slot3, slot4) {
+///     slot0 = 1;
+/// }
+/// ```
+///
+/// Occurrences of slots and their corresponding newly assigned short identifiers (mangled names) are:
+/// - slot0: 4 - a
+/// - slot1: 2 - b
+/// - slot3: 2 - c
+/// - slot2: 1 - d
+/// - slot4: 1 - e
+///
+/// After swapping out the mangled names, the functions become:
+///
+/// ```javascript
+/// function x(a, b) {
+///     function y(d, c) {
+///         a = 1;
+///     }
+/// }
+/// function z(a, b, c, e) {
+///     a = 1;
+/// }
+/// ```
+#[derive(Debug, Default)]
+pub struct Mangler {
+    /// The current slot used by semantic builder
+    current_slot: Slot,
+
+    /// The maximum slot of all scopes.
+    max_slot: Slot,
+
+    /// Mangled names, indexed by slot, length by `max_slot`.
+    mangled_names: RefCell<Vec<CompactString>>,
+}
+
+/// A slot is the occurrence index of a binding identifier inside a scope.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Slot(usize);
+
+impl Slot {
+    #[must_use]
+    #[inline]
+    pub fn index(self) -> usize {
+        self.0 - 1
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn is_some(self) -> bool {
+        self.0 != 0
+    }
+
+    #[inline]
+    pub fn increment(&mut self) {
+        self.0 += 1;
+    }
+}
+
+impl Mangler {
+    #[must_use]
+    pub fn next_slot(&mut self) -> Slot {
+        let slot = self.current_slot;
+        self.current_slot.increment();
+        if self.current_slot > self.max_slot {
+            self.max_slot = self.current_slot;
+        }
+        slot
+    }
+
+    pub fn reset_slot(&mut self) {
+        self.current_slot = Slot(1);
+    }
+
+    #[must_use]
+    pub fn mangled_name(&self, slot: Slot) -> CompactString {
+        self.mangled_names.borrow()[slot.index()].clone()
+    }
+
+    pub fn compute_slot_frequency(&self, symbols: &[Symbol]) {
+        // (index, frequency)
+        let mut frequencies = vec![(0usize, 0usize); self.max_slot.index()];
+        for symbol in symbols {
+            if symbol.slot.is_some() {
+                let index = symbol.slot.index();
+                frequencies[index].0 = index;
+                frequencies[index].1 += symbol.references.len() + 1;
+            }
+        }
+        frequencies.sort_by_key(|x| std::cmp::Reverse(x.1));
+        let mut mangled_names = vec![CompactString::default(); self.max_slot.index()];
+        let mut i = 0;
+        for freq in &frequencies {
+            let keyword = loop {
+                let keyword = Self::base54(i);
+                i += 1;
+                if !Self::is_keyword(keyword.as_str()) {
+                    break keyword;
+                }
+            };
+            mangled_names[freq.0] = keyword;
+        }
+        *self.mangled_names.borrow_mut() = mangled_names;
+    }
+
+    /// Get the shortest mangled name for a given slot.
+    /// Code adapted from [terser](https://github.com/terser/terser/blob/8b966d687395ab493d2c6286cc9dd38650324c11/lib/scope.js#L1041-L1051)
+    fn base54(slot: usize) -> CompactString {
+        let mut num = slot;
+        let chars = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
+        let base = 54usize;
+        let mut ret = CompactString::default();
+        ret.push(chars[num % base] as char);
+        num /= base;
+        let base = 64usize;
+        while num > 0 {
+            num -= 1;
+            ret.push(chars[num % base] as char);
+            num /= base;
+        }
+        ret
+    }
+
+    #[rustfmt::skip]
+    fn is_keyword(s: &str) -> bool {
+        let len = s.len();
+        if len == 1 {
+            return false;
+        }
+        matches!(s, "as" | "do" | "if" | "in" | "is" | "of" | "any" | "for" | "get"
+                | "let" | "new" | "out" | "set" | "try" | "var" | "case" | "else"
+                | "enum" | "from" | "meta" | "null" | "this" | "true" | "type"
+                | "void" | "with")
+    }
+}

--- a/crates/oxc_semantic/src/symbol/mod.rs
+++ b/crates/oxc_semantic/src/symbol/mod.rs
@@ -3,6 +3,7 @@
 
 mod builder;
 mod id;
+mod mangler;
 mod reference;
 mod table;
 
@@ -13,6 +14,7 @@ use self::reference::ResolvedReferenceId;
 pub use self::{
     builder::SymbolTableBuilder,
     id::SymbolId,
+    mangler::{Mangler, Slot},
     reference::{Reference, ReferenceFlag, ResolvedReference},
     table::SymbolTable,
 };
@@ -26,6 +28,7 @@ pub struct Symbol {
     name: Atom,
     span: Span,
     flags: SymbolFlags,
+    slot: Slot,
     /// Pointers to the AST Nodes that reference this symbol
     references: Vec<ResolvedReferenceId>,
 }
@@ -34,7 +37,7 @@ pub struct Symbol {
 #[test]
 fn symbol_size() {
     use std::mem::size_of;
-    assert_eq!(size_of::<Symbol>(), 88);
+    assert_eq!(size_of::<Symbol>(), 96);
 }
 
 bitflags! {
@@ -68,6 +71,13 @@ bitflags! {
     }
 }
 
+impl SymbolFlags {
+    #[must_use]
+    pub fn is_variable(&self) -> bool {
+        self.intersects(Self::Variable)
+    }
+}
+
 impl Symbol {
     #[must_use]
     pub fn new(
@@ -77,7 +87,7 @@ impl Symbol {
         span: Span,
         flags: SymbolFlags,
     ) -> Self {
-        Self { id, declaration, name, span, flags, references: vec![] }
+        Self { id, declaration, name, span, flags, slot: Slot::default(), references: vec![] }
     }
 
     #[must_use]
@@ -98,6 +108,11 @@ impl Symbol {
     #[must_use]
     pub fn flags(&self) -> SymbolFlags {
         self.flags
+    }
+
+    #[must_use]
+    pub fn slot(&self) -> Slot {
+        self.slot
     }
 
     #[must_use]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,14 +1,14 @@
 Original   -> Minified   -> Gzip
-72.14 kB   -> 40.45 kB   -> 10.91 kB   react.development.js
-173.90 kB  -> 96.53 kB   -> 24.57 kB   moment.js
-287.63 kB  -> 142.51 kB  -> 40.17 kB   jquery.js
-342.15 kB  -> 195.70 kB  -> 56.22 kB   vue.js
-544.10 kB  -> 147.16 kB  -> 35.74 kB   lodash.js
-555.77 kB  -> 395.65 kB  -> 103.48 kB  d3.js
-905.11 kB  -> 570.69 kB  -> 135.18 kB  bundle.min.js
-1.25 MB    -> 945.29 kB  -> 191.32 kB  three.js
-2.14 MB    -> 1.44 MB    -> 220.14 kB  victory.js
-3.20 MB    -> 1.78 MB    -> 432.67 kB  echarts.js
-6.69 MB    -> 4.44 MB    -> 624.83 kB  antd.js
-8.11 MB    -> 5.71 MB    -> 1.13 MB    typescript.js
-4.44 MB    -> 4.45 MB    -> 958.44 kB  babylon.js
+72.14 kB   -> 26.15 kB   -> 9.98 kB    react.development.js
+173.90 kB  -> 67.23 kB   -> 24.34 kB   moment.js
+287.63 kB  -> 102.90 kB  -> 40.34 kB   jquery.js
+342.15 kB  -> 141.47 kB  -> 56.86 kB   vue.js
+544.10 kB  -> 88.48 kB   -> 37.15 kB   lodash.js
+555.77 kB  -> 325.21 kB  -> 122.11 kB  d3.js
+905.11 kB  -> 456.75 kB  -> 138.98 kB  bundle.min.js
+1.25 MB    -> 748.60 kB  -> 206.07 kB  three.js
+2.14 MB    -> 867.04 kB  -> 249.66 kB  victory.js
+3.20 MB    -> 1.26 MB    -> 447.99 kB  echarts.js
+6.69 MB    -> 2.69 MB    -> 674.62 kB  antd.js
+8.11 MB    -> 3.69 MB    -> 1.12 MB    typescript.js
+4.44 MB    -> 4.73 MB    -> 1.16 MB    babylon.js

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -53,9 +53,11 @@ fn minify(file: &TestFile) -> String {
     let source_text = &file.source_text;
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = allocator.alloc(ret.program);
-    let _semantic = SemanticBuilder::new(source_text, source_type, &ret.trivias).build(program);
+    let semantic_ret = SemanticBuilder::new(source_text, source_type, &ret.trivias).build(program);
     let printer_options = PrinterOptions { minify_whitespace: true, ..PrinterOptions::default() };
-    Printer::new(source_text.len(), printer_options).build(program)
+    Printer::new(source_text.len(), printer_options)
+        .with_symbol_table(&semantic_ret.semantic.symbols(), true)
+        .build(program)
 }
 
 fn gzip_size(s: &str) -> usize {


### PR DESCRIPTION
* The mangler should be similar (almost the same) to the esbuild mangler, described in https://github.com/evanw/esbuild/blob/main/docs/architecture.md#symbol-minification
* crates/oxc_semantic/src/symbol/mangler.rs is the core algorithm, I hope its documentation makes sense
* The printer receives the symbol table and uses it to re-compute the mangled names
* Added a `Span -> SymbolId` index for looking up binding identifiers