### PR TITLE
feat(hir): concept of hir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_hir"
+version = "0.0.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "oxc_linter"
 version = "0.0.0"
 dependencies = [

--- a/crates/oxc_hir/Cargo.toml
+++ b/crates/oxc_hir/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name                  = "oxc_hir"
+version               = "0.0.0"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+
+serde      = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
+
+[features]
+default = []
+serde = [
+  "dep:serde",
+  "dep:serde_json",
+]

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1,0 +1,27 @@
+use oxc_allocator::Vec;
+use oxc_ast::{SourceType, Span};
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
+pub struct Program<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub span: Span,
+    pub source_type: SourceType,
+    pub directives: Vec<'a, Directive<'a>>,
+    // pub body: Vec<'a, Statement<'a>>,
+}
+
+/// Directive Prologue
+#[derive(Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+pub struct Directive<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub span: Span,
+    // pub expression: StringLiteral,
+    // directives should always use the unescaped raw string
+    pub directive: &'a str,
+}
+
+// ... All AST copied over

--- a/crates/oxc_hir/src/lib.rs
+++ b/crates/oxc_hir/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod hir;
+pub mod lower;

--- a/crates/oxc_hir/src/lower.rs
+++ b/crates/oxc_hir/src/lower.rs
@@ -1,0 +1,35 @@
+use oxc_allocator::{Allocator, Vec};
+use oxc_ast::ast;
+
+use crate::hir;
+
+pub struct LowerToHIR<'a> {
+    allocator: &'a Allocator,
+}
+
+impl<'a> LowerToHIR<'a> {
+    #[must_use]
+    pub fn build(self, program: ast::Program<'a>) -> hir::Program<'a> {
+        self.lower_program(program)
+    }
+
+    fn lower_program(&self, program: ast::Program<'a>) -> hir::Program<'a> {
+        hir::Program {
+            span: program.span,
+            source_type: program.source_type,
+            directives: self.lower_directives(program.directives),
+            // body: program.body,
+        }
+    }
+
+    fn lower_directives(
+        &self,
+        directives: Vec<'a, ast::Directive<'a>>,
+    ) -> Vec<'a, hir::Directive<'a>> {
+        let directives =
+            directives.into_iter().map(|d| hir::Directive { span: d.span, directive: d.directive });
+        Vec::from_iter_in(directives, self.allocator)
+    }
+
+    // manually type out everything ...
+}


### PR DESCRIPTION
This is the general direction for AST -> HIR lowering, copied from https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast_lowering/src/lib.rs

If this acceptable and reasonable, I am going to:

1. Copy over the entire AST
2. From top to bottom, lower the AST manually and "trim" out the parts we don't want. TypeScript definition should be the first layer to trim out.
3. During this process I'll add a HIR Id to each node for future back references
4. Modify the HIR so it includes scopes and symbols
5. At this stage @YangchenYe323 should be able to start constructing the CFG directly within this lowering process
6. Start desugaring syntax such JSX and many more

Everything will be done manually without macros and complicated generics, just plain vim foo ;-)

During the process we'll probably need to abstract the semantic builders into something much more general so it can be reused on the AST as well as this HIR.

----

I have no idea what I am doing but I'll boast this as ground breaking work for future javascript tools.
Compiler SDK can be achieved with this where semantic information can be queried through Node IDs. At this point I'll say we are ready for plugins.

The idea for compiler SDK comes from:
- [roslyn-sdk](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
- [cargo metadata](https://doc.rust-lang.org/cargo/reference/external-tools.html)
