### PR TITLE
fix(minifier): break directive prologue

### DIFF
--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -502,9 +502,8 @@ impl<'a> Gen for FunctionBody<'a> {
         for directive in &self.directives {
             directive.gen(p);
         }
-        p.needs_semicolon =
-            if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0)
-            && let Expression::StringLiteral(_) = &expr_stmt.expression {
+        p.needs_semicolon = if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0)
+            && matches!(expr_stmt.expression, Expression::StringLiteral(_)) {
                 true
             } else {
                 false

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -503,7 +503,7 @@ impl<'a> Gen for FunctionBody<'a> {
             directive.gen(p);
         }
         p.needs_semicolon =
-            if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0) 
+            if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0)
             && let Expression::StringLiteral(_) = &expr_stmt.expression {
                 true
             } else {

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -502,7 +502,13 @@ impl<'a> Gen for FunctionBody<'a> {
         for directive in &self.directives {
             directive.gen(p);
         }
-        p.needs_semicolon = false;
+        p.needs_semicolon =
+            if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0) 
+            && let Expression::StringLiteral(_) = &expr_stmt.expression {
+                true
+            } else {
+                false
+            };
         for stmt in &self.statements {
             p.print_semicolon_if_needed();
             stmt.gen(p);

--- a/tasks/coverage/minifier_babel.snap
+++ b/tasks/coverage/minifier_babel.snap
@@ -1,4 +1,3 @@
 Minifier_Babel Summary:
 AST Parsed     : 1621/1621 (100.00%)
-Positive Passed: 1620/1621 (99.94%)
-Expect to Parse: "core/regression/use-strict-with-pre-semi/input.js"
+Positive Passed: 1621/1621 (100.00%)

--- a/tasks/coverage/minifier_test262.snap
+++ b/tasks/coverage/minifier_test262.snap
@@ -1,13 +1,11 @@
 Minifier_Test262 Summary:
 AST Parsed     : 44676/44676 (100.00%)
-Positive Passed: 44666/44676 (99.98%)
+Positive Passed: 44668/44676 (99.98%)
 Expect to Parse: "built-ins/Object/prototype/toLocaleString/primitive_this_value.js"
 Expect to Parse: "built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js"
-Expect to Parse: "language/directive-prologue/14.1-16-s.js"
 Expect to Parse: "language/expressions/new/S11.2.2_A3_T1.js"
 Expect to Parse: "language/expressions/new/S11.2.2_A3_T4.js"
 Expect to Parse: "language/expressions/property-accessors/S11.2.1_A3_T1.js"
 Expect to Parse: "language/expressions/property-accessors/S11.2.1_A3_T4.js"
-Expect to Parse: "language/statements/class/definition/this-access-restriction.js"
 Expect to Parse: "language/types/reference/get-value-prop-base-primitive.js"
 Expect to Parse: "language/types/reference/put-value-prop-base-primitive.js"


### PR DESCRIPTION
## What's happened?

`EmptyStatement` is not safety to drop when it is followed by a `StringLiteral`:

```js
function foo() {
	;'use strict'
}
```

Terser just stay it in place:

```js
function t(){;"use strict"}
```

## Terser

1. https://github.com/terser/terser/blob/28bc97af0d7ef6606c0ed4a7a2403362b6c2a0e8/lib/output.js#L1215
2. https://github.com/terser/terser/blob/28bc97af0d7ef6606c0ed4a7a2403362b6c2a0e8/lib/output.js#L845

## One more thing

It is not always keep `;`.

```js
function foo() {
  ;'use strict';
  console.log('hi')
}
```

It will be compressed to :

```js
function o(){"use strict",console.log("hi")};
```

Maybe I can continue to implement this condition when has test cases.


	

