### PR TITLE
feat(ast): split `Property` into `ObjectProperty` and `BindingProperty`

### DIFF
--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -465,7 +465,7 @@ impl<'a> AstBuilder<'a> {
     pub fn object_expression(
         &self,
         span: Span,
-        properties: Vec<'a, ObjectProperty<'a>>,
+        properties: Vec<'a, ObjectPropertyKind<'a>>,
         trailing_comma: Option<Span>,
     ) -> Expression<'a> {
         Expression::ObjectExpression(self.alloc(ObjectExpression {
@@ -724,9 +724,10 @@ impl<'a> AstBuilder<'a> {
     pub fn object_pattern(
         &self,
         span: Span,
-        properties: Vec<'a, ObjectPatternProperty<'a>>,
+        properties: Vec<'a, BindingProperty<'a>>,
+        rest: Option<Box<'a, RestElement<'a>>>,
     ) -> BindingPatternKind<'a> {
-        BindingPatternKind::ObjectPattern(self.alloc(ObjectPattern { span, properties }))
+        BindingPatternKind::ObjectPattern(self.alloc(ObjectPattern { span, properties, rest }))
     }
 
     pub fn spread_element(
@@ -742,12 +743,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
-        value: PropertyValue<'a>,
+        value: Expression<'a>,
+        init: Option<Expression<'a>>,
         method: bool,
         shorthand: bool,
         computed: bool,
-    ) -> Box<'a, Property<'a>> {
-        self.alloc(Property { span, kind, key, value, method, shorthand, computed })
+    ) -> Box<'a, ObjectProperty<'a>> {
+        self.alloc(ObjectProperty { span, kind, key, value, init, method, shorthand, computed })
     }
 
     pub fn array_pattern(

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -74,9 +74,8 @@ pub enum AstKind<'a> {
     UpdateExpression(&'a UpdateExpression<'a>),
     YieldExpression(&'a YieldExpression<'a>),
 
-    Property(&'a Property<'a>),
+    ObjectProperty(&'a ObjectProperty<'a>),
     PropertyKey(&'a PropertyKey<'a>),
-    PropertyValue(&'a PropertyValue<'a>),
     Argument(&'a Argument<'a>),
     AssignmentTarget(&'a AssignmentTarget<'a>),
     SimpleAssignmentTarget(&'a SimpleAssignmentTarget<'a>),
@@ -298,9 +297,8 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::UpdateExpression(x) => x.span,
             Self::YieldExpression(x) => x.span,
 
-            Self::Property(x) => x.span,
+            Self::ObjectProperty(x) => x.span,
             Self::PropertyKey(x) => x.span(),
-            Self::PropertyValue(x) => x.span(),
             Self::Argument(x) => x.span(),
             Self::ArrayExpressionElement(x) => x.span(),
             Self::AssignmentTarget(x) => x.span(),

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -190,20 +190,11 @@ impl GetSpan for TSModuleDeclarationName {
     }
 }
 
-impl<'a> GetSpan for ObjectProperty<'a> {
+impl<'a> GetSpan for ObjectPropertyKind<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Property(p) => p.span,
+            Self::ObjectProperty(p) => p.span,
             Self::SpreadProperty(p) => p.span,
-        }
-    }
-}
-
-impl<'a> GetSpan for ObjectPatternProperty<'a> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Property(p) => p.span,
-            Self::RestElement(e) => e.span,
         }
     }
 }
@@ -218,15 +209,6 @@ impl<'a> GetSpan for AssignmentTarget<'a> {
             Self::AssignmentTargetPattern(AssignmentTargetPattern::ObjectAssignmentTarget(pat)) => {
                 pat.span
             }
-        }
-    }
-}
-
-impl<'a> GetSpan for PropertyValue<'a> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Pattern(pat) => pat.span(),
-            Self::Expression(expr) => expr.span(),
         }
     }
 }

--- a/crates/oxc_ast/src/syntax_directed_operations.rs
+++ b/crates/oxc_ast/src/syntax_directed_operations.rs
@@ -43,14 +43,10 @@ impl<'a> BoundNames for ArrayPattern<'a> {
 impl<'a> BoundNames for ObjectPattern<'a> {
     fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
         for p in &self.properties {
-            match p {
-                ObjectPatternProperty::Property(property) => {
-                    if let PropertyValue::Pattern(pattern) = &property.value {
-                        pattern.bound_names(f);
-                    }
-                }
-                ObjectPatternProperty::RestElement(rest) => rest.argument.bound_names(f),
-            }
+            p.value.bound_names(f);
+        }
+        if let Some(rest) = &self.rest {
+            rest.bound_names(f);
         }
     }
 }
@@ -172,16 +168,16 @@ pub trait PropName {
     fn prop_name(&self) -> Option<(&str, Span)>;
 }
 
-impl<'a> PropName for ObjectProperty<'a> {
+impl<'a> PropName for ObjectPropertyKind<'a> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         match self {
-            ObjectProperty::Property(prop) => prop.prop_name(),
-            ObjectProperty::SpreadProperty(_) => None,
+            ObjectPropertyKind::ObjectProperty(prop) => prop.prop_name(),
+            ObjectPropertyKind::SpreadProperty(_) => None,
         }
     }
 }
 
-impl<'a> PropName for Property<'a> {
+impl<'a> PropName for ObjectProperty<'a> {
     fn prop_name(&self) -> Option<(&str, Span)> {
         if self.kind != PropertyKind::Init || self.method || self.shorthand || self.computed {
             return None;

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -518,20 +518,20 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_object_expression(&mut self, expr: &'b mut ObjectExpression<'a>) {
         for prop in expr.properties.iter_mut() {
-            self.visit_object_property(prop);
+            self.visit_object_property_kind(prop);
+        }
+    }
+
+    fn visit_object_property_kind(&mut self, prop: &'b mut ObjectPropertyKind<'a>) {
+        match prop {
+            ObjectPropertyKind::ObjectProperty(prop) => self.visit_object_property(prop),
+            ObjectPropertyKind::SpreadProperty(elem) => self.visit_spread_element(elem),
         }
     }
 
     fn visit_object_property(&mut self, prop: &'b mut ObjectProperty<'a>) {
-        match prop {
-            ObjectProperty::Property(prop) => self.visit_property(prop),
-            ObjectProperty::SpreadProperty(elem) => self.visit_spread_element(elem),
-        }
-    }
-
-    fn visit_property(&mut self, prop: &'b mut Property<'a>) {
         self.visit_property_key(&mut prop.key);
-        self.visit_property_value(&mut prop.value);
+        self.visit_expression(&mut prop.value);
     }
 
     fn visit_property_key(&mut self, key: &'b mut PropertyKey<'a>) {
@@ -539,13 +539,6 @@ pub trait VisitMut<'a, 'b>: Sized {
             PropertyKey::Identifier(ident) => self.visit_identifier_name(ident),
             PropertyKey::PrivateIdentifier(ident) => self.visit_private_identifier(ident),
             PropertyKey::Expression(expr) => self.visit_expression(expr),
-        }
-    }
-
-    fn visit_property_value(&mut self, value: &'b mut PropertyValue<'a>) {
-        match value {
-            PropertyValue::Pattern(pat) => self.visit_binding_pattern(pat),
-            PropertyValue::Expression(expr) => self.visit_expression(expr),
         }
     }
 
@@ -801,15 +794,13 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_object_pattern(&mut self, pat: &'b mut ObjectPattern<'a>) {
         for prop in pat.properties.iter_mut() {
-            self.visit_object_pattern_property(prop);
+            self.visit_binding_property(prop);
         }
     }
 
-    fn visit_object_pattern_property(&mut self, prop: &'b mut ObjectPatternProperty<'a>) {
-        match prop {
-            ObjectPatternProperty::Property(prop) => self.visit_property(prop),
-            ObjectPatternProperty::RestElement(prop) => self.visit_rest_element(prop),
-        }
+    fn visit_binding_property(&mut self, prop: &'b mut BindingProperty<'a>) {
+        self.visit_property_key(&mut prop.key);
+        self.visit_binding_pattern(&mut prop.value);
     }
 
     fn visit_array_pattern(&mut self, pat: &'b mut ArrayPattern<'a>) {

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -428,25 +428,25 @@ pub enum ArrayExpressionElement<'a> {
 pub struct ObjectExpression<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub properties: Vec<'a, ObjectProperty<'a>>,
+    pub properties: Vec<'a, ObjectPropertyKind<'a>>,
     pub trailing_comma: Option<Span>,
 }
 
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
-pub enum ObjectProperty<'a> {
-    Property(Box<'a, Property<'a>>),
+pub enum ObjectPropertyKind<'a> {
+    ObjectProperty(Box<'a, ObjectProperty<'a>>),
     SpreadProperty(Box<'a, SpreadElement<'a>>),
 }
 
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
-pub struct Property<'a> {
+pub struct ObjectProperty<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub kind: PropertyKind,
     pub key: PropertyKey<'a>,
-    pub value: PropertyValue<'a>,
+    pub value: Expression<'a>,
     pub method: bool,
     pub shorthand: bool,
     pub computed: bool,
@@ -949,6 +949,7 @@ pub struct ParenthesizedExpression<'a> {
     pub span: Span,
     pub expression: Expression<'a>,
 }
+
 /// Statements
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
@@ -1302,14 +1303,21 @@ pub struct AssignmentPattern<'a> {
 pub struct ObjectPattern<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub properties: Vec<'a, ObjectPatternProperty<'a>>,
+    pub properties: Vec<'a, BindingProperty<'a>>,
+    pub rest: Option<Box<'a, RestElement<'a>>>,
 }
 
 #[derive(Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
-pub enum ObjectPatternProperty<'a> {
-    Property(Box<'a, Property<'a>>),
-    RestElement(Box<'a, RestElement<'a>>),
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+pub struct BindingProperty<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub span: Span,
+    pub kind: PropertyKind,
+    pub key: PropertyKey<'a>,
+    pub value: BindingPattern<'a>,
+    pub method: bool,
+    pub shorthand: bool,
+    pub computed: bool,
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_hir/src/hir_builder.rs
+++ b/crates/oxc_hir/src/hir_builder.rs
@@ -567,7 +567,7 @@ impl<'a> HirBuilder<'a> {
     pub fn object_expression(
         &mut self,
         span: Span,
-        properties: Vec<'a, ObjectProperty<'a>>,
+        properties: Vec<'a, ObjectPropertyKind<'a>>,
         trailing_comma: Option<Span>,
     ) -> Expression<'a> {
         Expression::ObjectExpression(self.alloc(ObjectExpression {
@@ -577,8 +577,17 @@ impl<'a> HirBuilder<'a> {
         }))
     }
 
-    pub fn object_property_property(&mut self, property: Property<'a>) -> ObjectProperty<'a> {
-        ObjectProperty::Property(self.alloc(property))
+    pub fn object_property(
+        &mut self,
+        span: Span,
+        kind: PropertyKind,
+        key: PropertyKey<'a>,
+        value: Expression<'a>,
+        method: bool,
+        shorthand: bool,
+        computed: bool,
+    ) -> Box<'a, ObjectProperty<'a>> {
+        self.alloc(ObjectProperty { span, kind, key, value, method, shorthand, computed })
     }
 
     pub fn parenthesized_expression(
@@ -907,9 +916,23 @@ impl<'a> HirBuilder<'a> {
     pub fn object_pattern(
         &mut self,
         span: Span,
-        properties: Vec<'a, ObjectPatternProperty<'a>>,
+        properties: Vec<'a, BindingProperty<'a>>,
+        rest: Option<Box<'a, RestElement<'a>>>,
     ) -> BindingPattern<'a> {
-        BindingPattern::ObjectPattern(self.alloc(ObjectPattern { span, properties }))
+        BindingPattern::ObjectPattern(self.alloc(ObjectPattern { span, properties, rest }))
+    }
+
+    pub fn binding_property(
+        &mut self,
+        span: Span,
+        kind: PropertyKind,
+        key: PropertyKey<'a>,
+        value: BindingPattern<'a>,
+        method: bool,
+        shorthand: bool,
+        computed: bool,
+    ) -> BindingProperty<'a> {
+        BindingProperty { span, kind, key, value, method, shorthand, computed }
     }
 
     pub fn spread_element(
@@ -918,19 +941,6 @@ impl<'a> HirBuilder<'a> {
         argument: Expression<'a>,
     ) -> Box<'a, SpreadElement<'a>> {
         self.alloc(SpreadElement { span, argument })
-    }
-
-    pub fn property(
-        &mut self,
-        span: Span,
-        kind: PropertyKind,
-        key: PropertyKey<'a>,
-        value: PropertyValue<'a>,
-        method: bool,
-        shorthand: bool,
-        computed: bool,
-    ) -> Box<'a, Property<'a>> {
-        self.alloc(Property { span, kind, key, value, method, shorthand, computed })
     }
 
     pub fn property_key_identifier(&mut self, ident: IdentifierName) -> PropertyKey<'a> {

--- a/crates/oxc_hir/src/visit_mut.rs
+++ b/crates/oxc_hir/src/visit_mut.rs
@@ -476,20 +476,20 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_object_expression(&mut self, expr: &'b mut ObjectExpression<'a>) {
         for prop in expr.properties.iter_mut() {
-            self.visit_object_property(prop);
+            self.visit_object_property_kind(prop);
+        }
+    }
+
+    fn visit_object_property_kind(&mut self, prop: &'b mut ObjectPropertyKind<'a>) {
+        match prop {
+            ObjectPropertyKind::ObjectProperty(prop) => self.visit_object_property(prop),
+            ObjectPropertyKind::SpreadProperty(elem) => self.visit_spread_element(elem),
         }
     }
 
     fn visit_object_property(&mut self, prop: &'b mut ObjectProperty<'a>) {
-        match prop {
-            ObjectProperty::Property(prop) => self.visit_property(prop),
-            ObjectProperty::SpreadProperty(elem) => self.visit_spread_element(elem),
-        }
-    }
-
-    fn visit_property(&mut self, prop: &'b mut Property<'a>) {
         self.visit_property_key(&mut prop.key);
-        self.visit_property_value(&mut prop.value);
+        self.visit_expression(&mut prop.value);
     }
 
     fn visit_property_key(&mut self, key: &'b mut PropertyKey<'a>) {
@@ -497,13 +497,6 @@ pub trait VisitMut<'a, 'b>: Sized {
             PropertyKey::Identifier(ident) => self.visit_identifier_name(ident),
             PropertyKey::PrivateIdentifier(ident) => self.visit_private_identifier(ident),
             PropertyKey::Expression(expr) => self.visit_expression(expr),
-        }
-    }
-
-    fn visit_property_value(&mut self, value: &'b mut PropertyValue<'a>) {
-        match value {
-            PropertyValue::Pattern(pat) => self.visit_binding_pattern(pat),
-            PropertyValue::Expression(expr) => self.visit_expression(expr),
         }
     }
 
@@ -744,15 +737,13 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_object_pattern(&mut self, pat: &'b mut ObjectPattern<'a>) {
         for prop in pat.properties.iter_mut() {
-            self.visit_object_pattern_property(prop);
+            self.visit_binding_property(prop);
         }
     }
 
-    fn visit_object_pattern_property(&mut self, prop: &'b mut ObjectPatternProperty<'a>) {
-        match prop {
-            ObjectPatternProperty::Property(prop) => self.visit_property(prop),
-            ObjectPatternProperty::RestElement(prop) => self.visit_rest_element(prop),
-        }
+    fn visit_binding_property(&mut self, prop: &'b mut BindingProperty<'a>) {
+        self.visit_property_key(&mut prop.key);
+        self.visit_binding_pattern(&mut prop.value);
     }
 
     fn visit_array_pattern(&mut self, pat: &'b mut ArrayPattern<'a>) {

--- a/crates/oxc_linter/src/rules/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/no_dupe_keys.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{
-    ast::{ObjectProperty, PropertyKind},
+    ast::{ObjectPropertyKind, PropertyKind},
     AstKind,
 };
 use oxc_diagnostics::{
@@ -45,7 +45,7 @@ impl Rule for NoDupeKeys {
         if let AstKind::ObjectExpression(obj_expr) = node.get().kind() {
             let mut map = FxHashMap::default();
             for prop in obj_expr.properties.iter() {
-                if let ObjectProperty::Property(prop) = prop
+                if let ObjectPropertyKind::ObjectProperty(prop) = prop
                     && let Some(key_name) = prop.key.static_name().as_ref() {
                     let hash = calculate_hash(key_name);
                     if let Some((prev_kind, prev_span)) = map.insert(hash, (prop.kind, prop.key.span())) {

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -960,18 +960,18 @@ impl<'a> Gen for ObjectExpression<'a> {
     }
 }
 
-impl<'a> Gen for ObjectProperty<'a> {
+impl<'a> Gen for ObjectPropertyKind<'a> {
     fn gen(&self, p: &mut Printer) {
         match self {
-            Self::Property(prop) => prop.gen(p),
+            Self::ObjectProperty(prop) => prop.gen(p),
             Self::SpreadProperty(elem) => elem.gen(p),
         }
     }
 }
 
-impl<'a> Gen for Property<'a> {
+impl<'a> Gen for ObjectProperty<'a> {
     fn gen(&self, p: &mut Printer) {
-        if let PropertyValue::Expression(Expression::FunctionExpression(func)) = &self.value {
+        if let Expression::FunctionExpression(func) = &self.value {
             let is_accessor = match &self.kind {
                 PropertyKind::Init => false,
                 PropertyKind::Get => {
@@ -1007,7 +1007,6 @@ impl<'a> Gen for Property<'a> {
                 return;
             }
         }
-
         if self.computed {
             p.print(b'[');
         }
@@ -1760,17 +1759,29 @@ impl<'a> Gen for ObjectPattern<'a> {
         p.print(b'{');
         p.print_space();
         p.print_list(&self.properties);
+        if let Some(rest) = &self.rest {
+            if !self.properties.is_empty() {
+                p.print(b',');
+            }
+            rest.gen(p);
+        }
         p.print_space();
         p.print(b'}');
     }
 }
 
-impl<'a> Gen for ObjectPatternProperty<'a> {
+impl<'a> Gen for BindingProperty<'a> {
     fn gen(&self, p: &mut Printer) {
-        match self {
-            Self::Property(prop) => prop.gen(p),
-            Self::RestElement(elem) => elem.gen(p),
+        if self.computed {
+            p.print(b'[');
         }
+        self.key.gen(p);
+        if self.computed {
+            p.print(b']');
+        }
+        p.print(b':');
+        p.print_space();
+        self.value.gen(p);
     }
 }
 

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -126,12 +126,11 @@ impl TestCase {
     fn parse_options<'a>(object_expr: &'a ObjectExpression<'a>) -> CompressOptions {
         let mut options = CompressOptions::default();
         for object_property in &object_expr.properties {
-            if let ObjectProperty::Property(property) = object_property
-                && let PropertyValue::Expression(value_expr) = &property.value
+            if let ObjectPropertyKind::ObjectProperty(property) = object_property
                 && let Some(name) = property.key.static_name() {
                 match name.as_str() {
                     "drop_debugger" => {
-                        options.drop_debugger = Self::get_boolean(value_expr);
+                        options.drop_debugger = Self::get_boolean(&property.value);
                     }
                     _ => {}
                 }

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -134,9 +134,9 @@ pub struct SpreadLastElement(#[label] pub Span);
 pub struct RestElementTrailingComma(#[label] pub Span);
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Invalid rest argument")]
-#[diagnostic(help("Expected identifier in rest argument"))]
-pub struct InvalidRestArgument(#[label] pub Span);
+#[error("Invalid rest element")]
+#[diagnostic(help("Expected identifier in rest element"))]
+pub struct InvalidRestElement(#[label] pub Span);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Cannot assign to this expression")]

--- a/tasks/coverage/babel.snap
+++ b/tasks/coverage/babel.snap
@@ -5206,33 +5206,33 @@ Expect to Parse: "typescript/types/const-type-parameters/input.ts"
    ·                                ╰── It cannot be redeclared here
    ╰────
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/16/input.js:1:1]
  1 │ var {...{z}} = { z: 1};
-   ·      ──────
+   ·         ───
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/17/input.js:1:1]
  1 │ var { ...{ x = 5 } } = {x : 1};
-   ·       ────────────
+   ·          ─────────
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/19/input.js:1:1]
  1 │ function test({...{}}) {}
-   ·                ─────
+   ·                   ──
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/20/input.js:1:1]
  1 │ function test({...{a}}) {}
-   ·                ──────
+   ·                   ───
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
   × Cannot assign to this expression
    ╭─[es2018/object-rest-spread/21/input.js:1:1]
@@ -5240,33 +5240,33 @@ Expect to Parse: "typescript/types/const-type-parameters/input.ts"
    ·      ─────
    ╰────
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/22/input.js:1:1]
  1 │ var {...x = 1} = {}
-   ·      ────────
+   ·         ─────
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/23/input.js:1:1]
  1 │ function test({...x = 1}) {}
-   ·                ────────
+   ·                   ─────
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/25/input.js:1:1]
  1 │ var {...[]} = {}
-   ·      ─────
+   ·         ──
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
-  × Invalid rest argument
+  × Invalid rest element
    ╭─[es2018/object-rest-spread/26/input.js:1:1]
  1 │ function test({...[]}) {}
-   ·                ─────
+   ·                   ──
    ╰────
-  help: Expected identifier in rest argument
+  help: Expected identifier in rest element
 
   × Rest element must be last element
    ╭─[es2018/object-rest-spread/7/input.js:1:1]
@@ -5278,6 +5278,12 @@ Expect to Parse: "typescript/types/const-type-parameters/input.ts"
    ╭─[es2018/object-rest-spread/8/input.js:1:1]
  1 │ let { x, y, ...z, } = obj;
    ·             ────
+   ╰────
+
+  × Rest element must be last element
+   ╭─[es2018/object-rest-spread/9/input.js:1:1]
+ 1 │ let { x, ...y, ...z } = obj;
+   ·          ────
    ╰────
 
   × Rest element must be last element

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,14 +1,14 @@
 Original   -> Minified   -> Gzip
-72.14 kB   -> 24.93 kB   -> 9.40 kB    react.development.js
-173.90 kB  -> 66.04 kB   -> 23.15 kB   moment.js
-287.63 kB  -> 97.61 kB   -> 35.10 kB   jquery.js
-342.15 kB  -> 136.68 kB  -> 53.06 kB   vue.js
-544.10 kB  -> 86.48 kB   -> 34.98 kB   lodash.js
-555.77 kB  -> 305.80 kB  -> 112.23 kB  d3.js
-905.11 kB  -> 444.04 kB  -> 127.11 kB  bundle.min.js
-1.25 MB    -> 711.21 kB  -> 185.77 kB  three.js
-2.14 MB    -> 760.08 kB  -> 187.71 kB  victory.js
-3.20 MB    -> 1.15 MB    -> 399.07 kB  echarts.js
-6.69 MB    -> 2.42 MB    -> 501.33 kB  antd.js
+72.14 kB   -> 25.02 kB   -> 9.42 kB    react.development.js
+173.90 kB  -> 66.07 kB   -> 23.16 kB   moment.js
+287.63 kB  -> 98.18 kB   -> 35.21 kB   jquery.js
+342.15 kB  -> 136.89 kB  -> 53.13 kB   vue.js
+544.10 kB  -> 86.47 kB   -> 34.98 kB   lodash.js
+555.77 kB  -> 305.93 kB  -> 112.28 kB  d3.js
+905.11 kB  -> 444.54 kB  -> 127.19 kB  bundle.min.js
+1.25 MB    -> 714.65 kB  -> 186.22 kB  three.js
+2.14 MB    -> 779.36 kB  -> 189.01 kB  victory.js
+3.20 MB    -> 1.15 MB    -> 399.67 kB  echarts.js
+6.69 MB    -> 2.48 MB    -> 504.90 kB  antd.js
 8.11 MB    -> 3.52 MB    -> 1.04 MB    typescript.js
 4.44 MB    -> 4.62 MB    -> 1.05 MB    babylon.js


### PR DESCRIPTION
`Property` is used in multiple places with confusing ast context, this was copied from estree. This deviates from estree and aligns to jsparagus.