### PR TITLE
fix: add parens for unary expression

### DIFF
--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -880,14 +880,7 @@ impl<'a> Gen for ComputedMemberExpression<'a> {
 
 impl<'a> Gen for StaticMemberExpression<'a> {
     fn gen(&self, p: &mut Printer) {
-        let is_unary_expr = matches!(self.object, Expression::UnaryExpression(_));
-        if is_unary_expr {
-            p.print(b'(');
-        }
-        self.object.gen(p);
-        if is_unary_expr {
-            p.print(b')');
-        }
+        with_parens_if_unary_expr(&self.object, p);
         if self.optional {
             p.print(b'?');
         }
@@ -1402,9 +1395,22 @@ impl<'a> Gen for ChainExpression<'a> {
 impl<'a> Gen for NewExpression<'a> {
     fn gen(&self, p: &mut Printer) {
         p.print_str(b"new ");
-        self.callee.gen(p);
+        with_parens_if_unary_expr(&self.callee, p);
         p.print(b'(');
         p.print_list(&self.arguments);
+        p.print(b')');
+    }
+}
+
+fn with_parens_if_unary_expr(expr: &Expression, p: &mut Printer) {
+    let is_unary_expr = matches!(expr, Expression::UnaryExpression(_));
+
+    if is_unary_expr {
+        p.print(b'(');
+    }
+    expr.gen(p);
+
+    if is_unary_expr {
         p.print(b')');
     }
 }

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -1409,7 +1409,6 @@ fn with_parens_if_unary_expr(expr: &Expression, p: &mut Printer) {
         p.print(b'(');
     }
     expr.gen(p);
-
     if is_unary_expr {
         p.print(b')');
     }

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -1,5 +1,3 @@
-use std::matches;
-
 use oxc_allocator::{Box, Vec};
 #[allow(clippy::wildcard_imports)]
 use oxc_hir::hir::*;

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -1,3 +1,5 @@
+use std::matches;
+
 use oxc_allocator::{Box, Vec};
 #[allow(clippy::wildcard_imports)]
 use oxc_hir::hir::*;
@@ -878,7 +880,14 @@ impl<'a> Gen for ComputedMemberExpression<'a> {
 
 impl<'a> Gen for StaticMemberExpression<'a> {
     fn gen(&self, p: &mut Printer) {
+        let is_unary_expr = matches!(self.object, Expression::UnaryExpression(_));
+        if is_unary_expr {
+            p.print(b'(');
+        }
         self.object.gen(p);
+        if is_unary_expr {
+            p.print(b')');
+        }
         if self.optional {
             p.print(b'?');
         }

--- a/tasks/coverage/minifier_test262.snap
+++ b/tasks/coverage/minifier_test262.snap
@@ -1,5 +1,3 @@
 Minifier_Test262 Summary:
 AST Parsed     : 44676/44676 (100.00%)
-Positive Passed: 44674/44676 (100.00%)
-Expect to Parse: "language/expressions/new/S11.2.2_A3_T1.js"
-Expect to Parse: "language/expressions/new/S11.2.2_A3_T4.js"
+Positive Passed: 44676/44676 (100.00%)

--- a/tasks/coverage/minifier_test262.snap
+++ b/tasks/coverage/minifier_test262.snap
@@ -1,11 +1,5 @@
 Minifier_Test262 Summary:
 AST Parsed     : 44676/44676 (100.00%)
-Positive Passed: 44668/44676 (99.98%)
-Expect to Parse: "built-ins/Object/prototype/toLocaleString/primitive_this_value.js"
-Expect to Parse: "built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js"
+Positive Passed: 44674/44676 (100.00%)
 Expect to Parse: "language/expressions/new/S11.2.2_A3_T1.js"
 Expect to Parse: "language/expressions/new/S11.2.2_A3_T4.js"
-Expect to Parse: "language/expressions/property-accessors/S11.2.1_A3_T1.js"
-Expect to Parse: "language/expressions/property-accessors/S11.2.1_A3_T4.js"
-Expect to Parse: "language/types/reference/get-value-prop-base-primitive.js"
-Expect to Parse: "language/types/reference/put-value-prop-base-primitive.js"

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -9,6 +9,6 @@ Original   -> Minified   -> Gzip
 1.25 MB    -> 711.21 kB  -> 185.77 kB  three.js
 2.14 MB    -> 760.08 kB  -> 187.71 kB  victory.js
 3.20 MB    -> 1.15 MB    -> 399.07 kB  echarts.js
-6.69 MB    -> 2.42 MB    -> 501.33 kB  antd.js
+6.69 MB    -> 2.42 MB    -> 501.34 kB  antd.js
 8.11 MB    -> 3.52 MB    -> 1.04 MB    typescript.js
 4.44 MB    -> 4.62 MB    -> 1.05 MB    babylon.js


### PR DESCRIPTION
## What happened?

```js
true.toString();
```

The above code will be compressed to :
```js
!0.toString()
```
Which causes syntax error.

We should add parentheses for it:

```js
(!0).toString()
```

## Terser

[PARENS](https://github.com/terser/terser/blob/28bc97af0d7ef6606c0ed4a7a2403362b6c2a0e8/lib/output.js#L992)