### PR TITLE
feat(minifier): implement peephole reorder constant expression from closure compiler

### DIFF
--- a/crates/oxc_minifier/tests/closure/mod.rs
+++ b/crates/oxc_minifier/tests/closure/mod.rs
@@ -1,0 +1,1 @@
+mod reorder_constant_expression;

--- a/crates/oxc_minifier/tests/closure/reorder_constant_expression.rs
+++ b/crates/oxc_minifier/tests/closure/reorder_constant_expression.rs
@@ -1,0 +1,79 @@
+//! [PeepholeReorderConstantExpression](https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeReorderConstantExpressionTest.java)
+
+use crate::expect;
+
+#[test]
+fn symmetric_operations() {
+    set1_tests_same("==");
+    set2_tests("==");
+    set3_tests("==");
+
+    set1_tests_same("!=");
+    set2_tests("!=");
+    set3_tests("!=");
+
+    set1_tests_same("===");
+    set2_tests("===");
+    set3_tests("===");
+
+    set1_tests_same("!==");
+    set2_tests("!==");
+    set3_tests("!==");
+
+    // TODO: need to check operator precedence
+    set1_tests_same("*");
+    set2_tests("*");
+    set3_tests("*");
+}
+
+#[test]
+fn reorder_constant_doesnt_add_parens() {
+    expect("a % b * 4", "a%b*4");
+    expect("a * b * 4", "a*b*4");
+}
+
+fn set1_tests_same(op: &str) {
+    set1_tests(op, op);
+}
+
+// This set has a mutable on the right and an Immutable on the left.
+// Applies for relational and symmetric operations.
+fn set1_tests(op1: &str, op2: &str) {
+    expect(&format!("a {op1} 0"), &format!("0{op2}a"));
+    expect(&format!("a {op1} '0'"), &format!("'0'{op1}a"));
+    expect(&format!("a  {op1}  ''"), &format!("''{op2}a"));
+    expect(&format!("a {op1} -1.0"), &format!("-1.0{op2}a"));
+
+    expect(&format!("function f(a){{a {op1} 0}}"), &format!("function f(a){{0{op2}a}}"));
+    expect(&format!("f() {op1} 0"), &format!("0{op2}f()"));
+    expect(&format!("(a + b) {op1} 0"), &format!("0{op2}(a+b)"));
+    expect(&format!("(a + 1) {op1} 0"), &format!("0{op2}(a+1)"));
+
+    expect(&format!("x++ {op1} 0"), &format!("0{op2}x++"));
+    expect(
+        &format!("x = 0; function f(){{x++; return x}}; f() {op1} 0"),
+        &format!("x=0;function f(){{x++;return x}}0{op2}f()"),
+    );
+}
+
+// This set has a mutable on the right and an Immutable on the left.
+// Applies only for symmetric operations.
+fn set2_tests(op: &str) {
+    expect(&format!("a {op} NaN"), &format!("NaN{op}a"));
+    // expect(&format!("a {op} Infinity"), &format!("(1/0){op}a"));
+
+    expect(&format!("NaN {op} a"), &format!("NaN{op}a"));
+    // expect(&format!("Infinity {op} a"), &format!("(1/0){op}a"));
+}
+
+// This set has an the immutable on the left already, or both non-immutable.
+fn set3_tests(op: &str) {
+    expect(&format!("0 {op} a"), &format!("0{op}a"));
+    expect(&format!("'0' {op} a"), &format!("'0'{op}a"));
+    expect(&format!("'' {op} a"), &format!("''{op}a"));
+    expect(&format!("-1.0 {op} a"), &format!("-1.0{op}a"));
+
+    expect(&format!("0 {op} 1"), &format!("0{op}1"));
+
+    expect(&format!("a {op} b"), &format!("a{op}b"));
+}

--- a/crates/oxc_minifier/tests/esbuild/mod.rs
+++ b/crates/oxc_minifier/tests/esbuild/mod.rs
@@ -1,12 +1,4 @@
-use oxc_minifier::{Minifier, MinifierOptions};
-use oxc_span::SourceType;
-
-fn expect(source_text: &str, expected: &str) {
-    let source_type = SourceType::default();
-    let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
-    let minified = Minifier::new(source_text, source_type, options).build();
-    assert_eq!(expected, minified, "for source {source_text}");
-}
+use crate::expect;
 
 #[test]
 #[ignore]

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -1,4 +1,15 @@
 #![feature(let_chains)]
 
+mod closure;
 mod esbuild;
 mod terser;
+
+use oxc_minifier::{Minifier, MinifierOptions};
+use oxc_span::SourceType;
+
+pub(crate) fn expect(source_text: &str, expected: &str) {
+    let source_type = SourceType::default();
+    let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
+    let minified = Minifier::new(source_text, source_type, options).build();
+    assert_eq!(expected, minified, "for source {source_text}");
+}

--- a/crates/oxc_syntax/src/operator.rs
+++ b/crates/oxc_syntax/src/operator.rs
@@ -189,6 +189,16 @@ impl BinaryOperator {
         matches!(self, Self::In | Self::Instanceof)
     }
 
+    pub fn compare_inverse_operator(self) -> Option<Self> {
+        match self {
+            Self::LessThan => Some(Self::GreaterThan),
+            Self::LessEqualThan => Some(Self::GreaterEqualThan),
+            Self::GreaterThan => Some(Self::LessThan),
+            Self::GreaterEqualThan => Some(Self::LessEqualThan),
+            _ => None,
+        }
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Equality => "==",

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,13 +1,13 @@
 Original   -> Minified   -> Gzip
-72.14 kB   -> 24.61 kB   -> 8.71 kB    react.development.js
-173.90 kB  -> 62.53 kB   -> 19.66 kB   moment.js
-287.63 kB  -> 94.35 kB   -> 32.68 kB   jquery.js
-342.15 kB  -> 125.45 kB  -> 45.62 kB   vue.js
-544.10 kB  -> 75.44 kB   -> 26.35 kB   lodash.js
-555.77 kB  -> 276.48 kB  -> 91.61 kB   d3.js
-977.19 kB  -> 458.51 kB  -> 124.49 kB  bundle.min.js
-1.25 MB    -> 680.30 kB  -> 167.22 kB  three.js
-2.14 MB    -> 750.25 kB  -> 182.36 kB  victory.js
-3.20 MB    -> 1.04 MB    -> 335.12 kB  echarts.js
-6.69 MB    -> 2.42 MB    -> 499.91 kB  antd.js
-10.82 MB   -> 3.55 MB    -> 914.55 kB  typescript.js
+72.14 kB   -> 24.61 kB   -> 8.70 kB    react.development.js
+173.90 kB  -> 62.53 kB   -> 19.65 kB   moment.js
+287.63 kB  -> 94.35 kB   -> 32.65 kB   jquery.js
+342.15 kB  -> 125.45 kB  -> 45.63 kB   vue.js
+544.10 kB  -> 75.44 kB   -> 26.34 kB   lodash.js
+555.77 kB  -> 276.47 kB  -> 91.57 kB   d3.js
+977.19 kB  -> 458.51 kB  -> 124.58 kB  bundle.min.js
+1.25 MB    -> 680.30 kB  -> 167.10 kB  three.js
+2.14 MB    -> 750.25 kB  -> 182.39 kB  victory.js
+3.20 MB    -> 1.04 MB    -> 335.33 kB  echarts.js
+6.69 MB    -> 2.42 MB    -> 500.06 kB  antd.js
+10.82 MB   -> 3.55 MB    -> 916.42 kB  typescript.js


### PR DESCRIPTION
https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeReorderConstantExpression.java

```
/**
 * Reorder constant expression hoping for a better compression.
 * ex. x === 0 -> 0 === x
 * After reordering, expressions like 0 === x and 0 === y may have higher
 * compression together than their original counterparts.
 */
```

I must be doing something wrong