### PR TITLE
Add Brotli size to minsize task output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotlic"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d5a350a871e06f5274bc1206bcd0da426522b4d0fbfad5fcec92806d854e5b"
+dependencies = [
+ "brotlic-sys",
+]
+
+[[package]]
+name = "brotlic-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdec5c62bc97b56349053cf66ba503af5c2448591be61c3ad70a5f11b57e574"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bstr"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1154,7 @@ dependencies = [
 name = "oxc_minsize"
 version = "0.0.0"
 dependencies = [
+ "brotlic",
  "flate2",
  "humansize",
  "oxc_minifier",

--- a/tasks/minsize/Cargo.toml
+++ b/tasks/minsize/Cargo.toml
@@ -13,3 +13,4 @@ oxc_tasks_common = { workspace = true }
 flate2           = { workspace = true }
 
 humansize = "2.1.3"
+brotlic          = "0.8.1"

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,13 +1,13 @@
-Original   -> Minified   -> Gzip
-72.14 kB   -> 24.61 kB   -> 8.70 kB    react.development.js
-173.90 kB  -> 62.53 kB   -> 19.65 kB   moment.js
-287.63 kB  -> 94.35 kB   -> 32.65 kB   jquery.js
-342.15 kB  -> 125.45 kB  -> 45.63 kB   vue.js
-544.10 kB  -> 75.44 kB   -> 26.34 kB   lodash.js
-555.77 kB  -> 276.47 kB  -> 91.57 kB   d3.js
-977.19 kB  -> 458.51 kB  -> 124.58 kB  bundle.min.js
-1.25 MB    -> 680.30 kB  -> 167.10 kB  three.js
-2.14 MB    -> 750.25 kB  -> 182.39 kB  victory.js
-3.20 MB    -> 1.04 MB    -> 335.33 kB  echarts.js
-6.69 MB    -> 2.42 MB    -> 500.06 kB  antd.js
-10.82 MB   -> 3.55 MB    -> 916.42 kB  typescript.js
+Original   -> Minified   -> Gzip       Brotli    
+72.14 kB   -> 24.61 kB   -> 8.70 kB    7.66 kB    react.development.js
+173.90 kB  -> 62.53 kB   -> 19.65 kB   17.82 kB   moment.js
+287.63 kB  -> 94.35 kB   -> 32.65 kB   29.57 kB   jquery.js
+342.15 kB  -> 125.45 kB  -> 45.63 kB   40.33 kB   vue.js
+544.10 kB  -> 75.44 kB   -> 26.34 kB   23.51 kB   lodash.js
+555.77 kB  -> 276.47 kB  -> 91.57 kB   77.68 kB   d3.js
+977.19 kB  -> 458.51 kB  -> 124.58 kB  107.89 kB  bundle.min.js
+1.25 MB    -> 680.30 kB  -> 167.10 kB  135.39 kB  three.js
+2.14 MB    -> 750.25 kB  -> 182.39 kB  139.62 kB  victory.js
+3.20 MB    -> 1.04 MB    -> 335.33 kB  271.70 kB  echarts.js
+6.69 MB    -> 2.42 MB    -> 500.06 kB  391.21 kB  antd.js
+10.82 MB   -> 3.55 MB    -> 916.42 kB  705.41 kB  typescript.js

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -3,6 +3,7 @@ use std::{
     io::{self, Write},
 };
 
+use brotlic::{BlockSize, BrotliEncoderOptions, CompressorWriter, Quality, WindowSize};
 use flate2::{write::GzEncoder, Compression};
 use humansize::{format_size, DECIMAL};
 use oxc_minifier::{Minifier, MinifierOptions};
@@ -23,14 +24,22 @@ pub fn run() -> Result<(), io::Error> {
     let path = project_root().join("tasks/minsize/minsize.snap");
 
     let mut out = String::new();
-    out.push_str(&format!("{:width$} -> {:width$} -> Gzip\n", "Original", "Minified", width = 10));
+    out.push_str(&format!(
+        "{:width$} -> {:width$} -> {:width$}",
+        "Original",
+        "Minified",
+        "Gzip",
+        width = 10
+    ));
+    out.push_str(&format!(" {:width$}\n", "Brotli", width = 10));
     for file in files.files() {
         let minified = minify(file);
         let s = format!(
-            "{:width$} -> {:width$} -> {:width$} {}\n",
+            "{:width$} -> {:width$} -> {:width$} {:width$} {}\n",
             format_size(file.source_text.len(), DECIMAL),
             format_size(minified.len(), DECIMAL),
             format_size(gzip_size(&minified), DECIMAL),
+            format_size(brotli_size(&minified), DECIMAL),
             &file.file_name,
             width = 10
         );
@@ -56,5 +65,19 @@ fn gzip_size(s: &str) -> usize {
     let mut e = GzEncoder::new(Vec::new(), Compression::best());
     e.write_all(s.as_bytes()).unwrap();
     let s = e.finish().unwrap();
+    s.len()
+}
+
+fn brotli_size(s: &str) -> usize {
+    let encoder = BrotliEncoderOptions::new()
+        .quality(Quality::best())
+        .window_size(WindowSize::best())
+        .block_size(BlockSize::best())
+        .build()
+        .unwrap();
+
+    let mut e = CompressorWriter::with_encoder(encoder, Vec::new());
+    e.write_all(s.as_bytes()).unwrap();
+    let s = e.into_inner().unwrap();
     s.len()
 }


### PR DESCRIPTION
I think it's worth adding Brotli to the output snapshot.
It can help validate minifier passes/changes are net positive, or dispel that they're net negative (#376 seems to be such a case).