### PR TITLE
feat(minifer): distinguish-op-lessthan

### DIFF
--- a/crates/oxc_minifier/src/printer/mod.rs
+++ b/crates/oxc_minifier/src/printer/mod.rs
@@ -6,7 +6,7 @@
 mod gen;
 mod operator;
 
-use std::rc::Rc;
+use std::{rc::Rc, str::from_utf8_unchecked};
 
 #[allow(clippy::wildcard_imports)]
 use oxc_hir::hir::*;
@@ -130,10 +130,14 @@ impl Printer {
             || ((prev == bin_op_sub || prev == un_op_neg)
                 && (next == bin_op_sub || next == un_op_neg || next == un_op_pre_dec))
             || (prev == un_op_post_dec && next == bin_op_gt)
-            || (prev == un_op_not && next == un_op_pre_dec && self.code().len() > 1/*&& p.js[len(p.js)-2] == '<'*/)
+            || (prev == un_op_not && next == un_op_pre_dec && self.peek_nth(1) == Some('<'))
         {
             self.print(b' ');
         }
+    }
+
+    fn peek_nth(&self, n: usize) -> Option<char> {
+        unsafe{ from_utf8_unchecked(&self.code())}.chars().nth_back(n)
     }
 
     fn print_semicolon_after_statement(&mut self) {

--- a/crates/oxc_minifier/src/printer/mod.rs
+++ b/crates/oxc_minifier/src/printer/mod.rs
@@ -137,7 +137,7 @@ impl Printer {
     }
 
     fn peek_nth(&self, n: usize) -> Option<char> {
-        unsafe{ from_utf8_unchecked(&self.code())}.chars().nth_back(n)
+        unsafe { from_utf8_unchecked(self.code()) }.chars().nth_back(n)
     }
 
     fn print_semicolon_after_statement(&mut self) {

--- a/crates/oxc_minifier/tests/esbuild/mod.rs
+++ b/crates/oxc_minifier/tests/esbuild/mod.rs
@@ -562,7 +562,7 @@ fn whitespace() {
 
     test("x-- > y", "x-- >y");
     test("x < !--y", "x<! --y");
-    // test("x > !--y", "x>!--y");
+    test("x > !--y", "x>!--y");
     test("!--y", "!--y");
 
     test("1 + -0", "1+-0");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,7 +11,7 @@ Original   -> Minified   -> Gzip       Brotli
 
 555.77 kB  -> 275.56 kB  -> 91.51 kB   77.46 kB   d3.js
 
-977.19 kB  -> 456.99 kB  -> 124.12 kB  107.53 kB  bundle.min.js
+977.19 kB  -> 456.98 kB  -> 124.12 kB  107.47 kB  bundle.min.js
 
 1.25 MB    -> 678.15 kB  -> 166.78 kB  135.10 kB  three.js
 


### PR DESCRIPTION
patch `len(p.js) > 1 && p.js[len(p.js)-2] == '<'`

link: https://github.com/evanw/esbuild/blob/e6a8169c3a574f4c67d4cdd5f31a938b53eb7421/internal/js_printer/js_printer.go#L786)