### PR TITLE
feat(minifier): may add space before RegExpLiteral

### DIFF
--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -801,7 +801,11 @@ impl Gen for BigintLiteral {
 
 impl Gen for RegExpLiteral {
     fn gen(&self, p: &mut Printer) {
-        if let Some('/') = p.peek_nth(0) {
+        let last = p.peek_nth(0);
+        if Some('/') == last
+            || (Some('<') == last
+                && self.regex.pattern.as_str().to_lowercase().starts_with("script"))
+        {
             p.print(b' ');
         }
         p.print(b'/');

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -802,6 +802,7 @@ impl Gen for BigintLiteral {
 impl Gen for RegExpLiteral {
     fn gen(&self, p: &mut Printer) {
         let last = p.peek_nth(0);
+        // Avoid forming a single-line comment or "</script" sequence
         if Some('/') == last
             || (Some('<') == last
                 && self.regex.pattern.as_str().to_lowercase().starts_with("script"))

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -801,6 +801,9 @@ impl Gen for BigintLiteral {
 
 impl Gen for RegExpLiteral {
     fn gen(&self, p: &mut Printer) {
+        if let Some('/') = p.peek_nth(0) {
+            p.print(b' ');
+        }
         p.print(b'/');
         p.print_str(self.regex.pattern.as_bytes());
         p.print(b'/');

--- a/crates/oxc_minifier/tests/esbuild/mod.rs
+++ b/crates/oxc_minifier/tests/esbuild/mod.rs
@@ -570,7 +570,7 @@ fn whitespace() {
     // test("1 + -Infinity", "1+-1/0");
     // test("1 - -Infinity", "1- -1/0;");
 
-    // test("/x/ / /y/", "/x// /y/");
+    test("/x/ / /y/", "/x// /y/");
     test("/x/ + Foo", "/x/+Foo");
     test("/x/ instanceof Foo", "/x/ instanceof Foo");
     test("[x] instanceof Foo", "[x]instanceof Foo");

--- a/crates/oxc_minifier/tests/esbuild/mod.rs
+++ b/crates/oxc_minifier/tests/esbuild/mod.rs
@@ -693,8 +693,17 @@ fn jsx() {}
 fn jsx_single_line() {}
 
 #[test]
-#[ignore]
-fn avoid_slash_script() {}
+fn avoid_slash_script() {
+    // Positive cases
+    test("x = 1 < /script/.exec(y).length", "x=1< /script/.exec(y).length");
+    test("x = 1 < /SCRIPT/.exec(y).length", "x=1< /SCRIPT/.exec(y).length");
+    test("x = 1 < /ScRiPt/.exec(y).length", "x=1< /ScRiPt/.exec(y).length");
+    test("x = 1 << /script/.exec(y).length", "x=1<< /script/.exec(y).length");
+
+    // Negative cases
+    test("x = 1 < / script/.exec(y).length", "x=1</ script/.exec(y).length");
+    test("x = 1 << / script/.exec(y).length", "x=1<</ script/.exec(y).length");
+}
 
 #[test]
 fn binary_operator_visitor() {


### PR DESCRIPTION
ESBuild link: https://github.com/evanw/esbuild/blob/e6a8169c3a574f4c67d4cdd5f31a938b53eb7421/internal/js_printer/js_printer.go#L2777

<del>
Is there some good way to compare case-insensitive 'script'?

When I match case-insensitive 'script', I use:
```
if self.regex.pattern.as_str().to_lowercase().starts_with("script"))
{
    p.print(b' ');
}
```

The benchmark shows:
```
'./main/minifier tmp/react.js' ran
    1.02 ± 0.32 times faster than './this-pr/minifier tmp/react.js'
```

I though maybe something about [allocation of new `String`](https://doc.rust-lang.org/std/string/struct.String.html#method.to_lowercase), then I tried the following codes:

```rust
fn start_with_case_insensitive_script(s: &str) -> bool {
    // if not longer than 6, it can't be "script" 
    if s.len() < 6 {
        return false;
    }

    let lower_case = ['s', 'c', 'r', 'i', 'p', 't'];
    let upper_case = ['S', 'C', 'R', 'I', 'P', 'T'];

    let mut chars = s.chars();

    for i in 0..6 {
        let ch = chars.next().unwrap();

        if ch != lower_case[i] && ch != upper_case[i] {
            return false;
        }
    }

    return true
}
```

It is not good as well:

```
Summary
  './main/minifier tmp/react.js' ran
    1.02 ± 0.36 times faster than './this-pr/minifier tmp/react.js'
```
</del>

