### PR TITLE
fix(ast): properly serialize FormalParameter

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1175,9 +1175,8 @@ pub struct DebuggerStatement {
 
 /// Destructuring Binding Patterns
 #[derive(Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
 pub struct BindingPattern<'a> {
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub kind: BindingPatternKind<'a>,
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub optional: bool,
@@ -1309,11 +1308,10 @@ pub struct FormalParameters<'a> {
 }
 
 #[derive(Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct FormalParameter<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub pattern: BindingPattern<'a>,
     pub accessibility: Option<TSAccessibility>,
     pub readonly: bool,
@@ -1321,7 +1319,7 @@ pub struct FormalParameter<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum FormalParameterKind {
     /// <https://tc39.es/ecma262/#prod-FormalParameters>
     FormalParameter,

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1382,17 +1382,16 @@ pub struct FormalParameters<'a> {
 }
 
 #[derive(Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct FormalParameter<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub pattern: BindingPattern<'a>,
     pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 #[derive(Debug, Clone, Copy, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum FormalParameterKind {
     /// <https://tc39.es/ecma262/#prod-FormalParameters>
     FormalParameter,


### PR DESCRIPTION
Everything was being flattened to be closer to estree, but since we deviating from estree, we should aim for correctness.

closes #410

It is now serialized as
```
      "params": {
        "type": "FormalParameters",
        "start": 14,
        "end": 29,
        "kind": "FormalParameter",
        "items": [
          {
            "type": "FormalParameter",
            "start": 15,
            "end": 28,
            "pattern": {
              "type": "BindingPattern",
              "kind": {
                "type": "BindingIdentifier",
                "start": 15,
                "end": 19,
                "name": "name"
              },
              "typeAnnotation": {
                "type": "TSTypeAnnotation",
                "start": 20,
                "end": 28,
                "typeAnnotation": {
                  "type": "TSStringKeyword",
                  "start": 22,
                  "end": 28
                }
              },
              "optional": true
            },
            "accessibility": null,
            "readonly": false,
            "decorators": []
          }
        ],
        "rest": null
      },
```