### PR TITLE
refactor(wasm): clean up options passing

### DIFF
--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -1,0 +1,135 @@
+use wasm_bindgen::prelude::*;
+
+#[allow(clippy::struct_excessive_bools)]
+#[wasm_bindgen]
+#[derive(Default, Clone, Copy)]
+pub struct OxcRunOptions {
+    syntax: bool,
+    lint: bool,
+    format: bool,
+    hir: bool,
+    minify: bool,
+}
+
+#[wasm_bindgen]
+impl OxcRunOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self { syntax: true, lint: true, ..Self::default() }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn syntax(self) -> bool {
+        self.format
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_syntax(&mut self, yes: bool) {
+        self.syntax = yes;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn lint(self) -> bool {
+        self.lint
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_lint(&mut self, yes: bool) {
+        self.lint = yes;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn format(self) -> bool {
+        self.format
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_format(&mut self, yes: bool) {
+        self.format = yes;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn hir(self) -> bool {
+        self.hir
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_hir(&mut self, yes: bool) {
+        self.hir = yes;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn minify(self) -> bool {
+        self.minify
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_minify(&mut self, yes: bool) {
+        self.minify = yes;
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Default, Clone, Copy)]
+pub struct OxcParserOptions {
+    #[wasm_bindgen(js_name = allowReturnOutsideFunction)]
+    pub allow_return_outside_function: bool,
+}
+
+#[wasm_bindgen]
+impl OxcParserOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Default, Clone, Copy)]
+pub struct OxcLinterOptions;
+
+#[wasm_bindgen]
+impl OxcLinterOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Default, Clone, Copy)]
+pub struct OxcFormatterOptions {
+    pub indentation: u8,
+}
+
+#[wasm_bindgen]
+impl OxcFormatterOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Default, Clone, Copy)]
+pub struct OxcMinifierOptions {
+    mangle: bool,
+}
+
+#[wasm_bindgen]
+impl OxcMinifierOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn mangle(self) -> bool {
+        self.mangle
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_mangle(&mut self, yes: bool) {
+        self.mangle = yes;
+    }
+}

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -13,10 +13,11 @@
       #editor { flex: 1; overflow-y: auto; }
       #panel { height: 300px; overflow-y: auto; padding: 1em; color: #d1d5da; background-color: #24292e; border-top: 1px solid #444!important; }
       #right { flex: 1; display:flex; flex-direction: column }
-      #tab { color: white; background: #24292e; padding: .5em; }
+      .controls { color: white; background: #24292e; padding: .5em; }
       #viewer { flex: 1; overflow-y: auto; }
       #mangle { display: inline-flex; align-items: center }
       #duration { float: right; }
+      label { display: inline-flex; align-items: center; cursor: pointer; user-select: none; }
     </style>
   </head>
   <body>
@@ -24,19 +25,20 @@
 
     <div id="container">
       <div id="left">
+        <div class="controls">
+          <label id="syntax">Check Syntax<input id="syntax-checkbox" type="checkbox" checked></label>
+          <label id="lint">Lint<input id="lint-checkbox" type="checkbox" checked></label>
+        </div>
         <div id="editor"></div>
         <div id="panel"></div>
       </div>
       <div id="right">
-        <div id="tab">
+        <div class="controls">
           <button id="ast">AST</button>
           <button id="hir">HIR</button>
           <button id="format">Format</button>
           <button id="minify">Minify</button>
-          <label id="mangle">
-            Mangle
-            <input id="mangle-checkbox" type="checkbox">
-          </label>
+          <label id="mangle">Mangle<input id="mangle-checkbox" type="checkbox"></label>
           <span id="duration"></span>
         </div>
         <div id="viewer"></div>


### PR DESCRIPTION
This enables fine grained control over the ast passes, which gives a more accurate number on the execution time.

See https://boshen.github.io/oxc/playground/

I'll do a few rounds of testings and tweaks before announcing.