### PR TITLE
feat(minifier): print [-In] Context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
 name = "oxc_minifier"
 version = "0.0.0"
 dependencies = [
+ "bitflags 2.3.1",
  "jemallocator",
  "mimalloc",
  "oxc_allocator",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -19,6 +19,7 @@ oxc_ast_lower = { workspace = true }
 oxc_hir       = { workspace = true }
 oxc_semantic2 = { workspace = true }
 oxc_syntax    = { workspace = true }
+bitflags      = { workspace = true }
 
 [dev-dependencies]
 walkdir   = { workspace = true }

--- a/crates/oxc_minifier/src/printer/context.rs
+++ b/crates/oxc_minifier/src/printer/context.rs
@@ -1,0 +1,44 @@
+#![allow(non_upper_case_globals)]
+
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct Context: u8 {
+        /// [In]
+        const In = 1 << 0;
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::In
+    }
+}
+
+impl Context {
+    #[inline]
+    pub fn has_in(self) -> bool {
+        self.contains(Self::In)
+    }
+
+    #[inline]
+    pub fn and_in(self, include: bool) -> Self {
+        self.and(Self::In, include)
+    }
+
+    #[inline]
+    fn and(self, flag: Self, set: bool) -> Self {
+        if set { self | flag } else { self - flag }
+    }
+
+    #[inline]
+    pub(crate) fn union_in_if(self, include: bool) -> Self {
+        self.union_if(Self::In, include)
+    }
+
+    #[inline]
+    fn union_if(self, other: Self, include: bool) -> Self {
+        if include { self.union(other) } else { self }
+    }
+}

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -10,22 +10,22 @@ use oxc_syntax::{
     NumberBase,
 };
 
-use super::{Operator, Printer, Separator};
+use super::{Context, Operator, Printer, Separator};
 
 pub trait Gen {
-    fn gen(&self, p: &mut Printer) {}
+    fn gen(&self, p: &mut Printer, ctx: Context) {}
 }
 
 pub trait GenExpr {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {}
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {}
 }
 
 impl<'a, T> Gen for Box<'a, T>
 where
     T: Gen,
 {
-    fn gen(&self, p: &mut Printer) {
-        (**self).gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        (**self).gen(p, ctx);
     }
 }
 
@@ -33,25 +33,25 @@ impl<'a, T> GenExpr for Box<'a, T>
 where
     T: GenExpr,
 {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
-        (**self).gen_expr(p, precedence);
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
+        (**self).gen_expr(p, precedence, ctx);
     }
 }
 
 impl<'a> Gen for Program<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         for directive in &self.directives {
-            directive.gen(p);
+            directive.gen(p, ctx);
         }
         for stmt in &self.body {
             p.print_semicolon_if_needed();
-            stmt.gen(p);
+            stmt.gen(p, ctx);
         }
     }
 }
 
 impl<'a> Gen for Directive<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'"');
         p.print_str(self.directive.as_bytes());
         p.print(b'"');
@@ -60,44 +60,44 @@ impl<'a> Gen for Directive<'a> {
 }
 
 impl<'a> Gen for Statement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::BlockStatement(stmt) => stmt.gen(p),
-            Self::BreakStatement(stmt) => stmt.gen(p),
-            Self::ContinueStatement(stmt) => stmt.gen(p),
-            Self::DebuggerStatement(stmt) => stmt.gen(p),
-            Self::DoWhileStatement(stmt) => stmt.gen(p),
-            Self::ExpressionStatement(stmt) => stmt.gen(p),
-            Self::ForInStatement(stmt) => stmt.gen(p),
-            Self::ForOfStatement(stmt) => stmt.gen(p),
-            Self::ForStatement(stmt) => stmt.gen(p),
-            Self::IfStatement(stmt) => stmt.gen(p),
-            Self::LabeledStatement(stmt) => stmt.gen(p),
-            Self::ModuleDeclaration(decl) => decl.gen(p),
-            Self::ReturnStatement(stmt) => stmt.gen(p),
-            Self::SwitchStatement(stmt) => stmt.gen(p),
-            Self::ThrowStatement(stmt) => stmt.gen(p),
-            Self::TryStatement(stmt) => stmt.gen(p),
-            Self::WhileStatement(stmt) => stmt.gen(p),
-            Self::WithStatement(stmt) => stmt.gen(p),
-            Self::Declaration(decl) => decl.gen(p),
+            Self::BlockStatement(stmt) => stmt.gen(p, ctx),
+            Self::BreakStatement(stmt) => stmt.gen(p, ctx),
+            Self::ContinueStatement(stmt) => stmt.gen(p, ctx),
+            Self::DebuggerStatement(stmt) => stmt.gen(p, ctx),
+            Self::DoWhileStatement(stmt) => stmt.gen(p, ctx),
+            Self::ExpressionStatement(stmt) => stmt.gen(p, ctx),
+            Self::ForInStatement(stmt) => stmt.gen(p, ctx),
+            Self::ForOfStatement(stmt) => stmt.gen(p, ctx),
+            Self::ForStatement(stmt) => stmt.gen(p, ctx),
+            Self::IfStatement(stmt) => stmt.gen(p, ctx),
+            Self::LabeledStatement(stmt) => stmt.gen(p, ctx),
+            Self::ModuleDeclaration(decl) => decl.gen(p, ctx),
+            Self::ReturnStatement(stmt) => stmt.gen(p, ctx),
+            Self::SwitchStatement(stmt) => stmt.gen(p, ctx),
+            Self::ThrowStatement(stmt) => stmt.gen(p, ctx),
+            Self::TryStatement(stmt) => stmt.gen(p, ctx),
+            Self::WhileStatement(stmt) => stmt.gen(p, ctx),
+            Self::WithStatement(stmt) => stmt.gen(p, ctx),
+            Self::Declaration(decl) => decl.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for Option<Statement<'a>> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Some(stmt) => stmt.gen(p),
+            Some(stmt) => stmt.gen(p, ctx),
             None => p.print(b';'),
         }
     }
 }
 
 impl<'a> Gen for ExpressionStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.start_of_stmt = p.code_len();
-        self.expression.gen_expr(p, Precedence::lowest());
+        self.expression.gen_expr(p, Precedence::lowest(), Context::default());
         if let Expression::Identifier(ident) = &self.expression
         && ident.name == "let" {
             p.print_semicolon();
@@ -108,29 +108,29 @@ impl<'a> Gen for ExpressionStatement<'a> {
 }
 
 impl<'a> Gen for IfStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
-        print_if(self, p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        print_if(self, p, ctx);
     }
 }
 
-fn print_if(if_stmt: &IfStatement<'_>, p: &mut Printer) {
+fn print_if(if_stmt: &IfStatement<'_>, p: &mut Printer, ctx: Context) {
     p.print_str(b"if");
     p.print(b'(');
-    if_stmt.test.gen_expr(p, Precedence::lowest());
+    if_stmt.test.gen_expr(p, Precedence::lowest(), Context::default());
     p.print(b')');
 
     match &if_stmt.consequent {
         Some(Statement::BlockStatement(block)) => {
-            p.print_block1(block);
+            p.print_block1(block, ctx);
         }
         Some(stmt) if wrap_to_avoid_ambiguous_else(stmt) => {
             p.print(b'{');
-            stmt.gen(p);
+            stmt.gen(p, ctx);
             p.print(b'}');
             p.needs_semicolon = false;
         }
         Some(stmt) => {
-            stmt.gen(p);
+            stmt.gen(p, ctx);
         }
         None => {
             p.print(b';');
@@ -144,13 +144,13 @@ fn print_if(if_stmt: &IfStatement<'_>, p: &mut Printer) {
         p.print(b' ');
         match alternate {
             Statement::BlockStatement(block) => {
-                p.print_block1(block);
+                p.print_block1(block, ctx);
             }
             Statement::IfStatement(if_stmt) => {
-                print_if(if_stmt, p);
+                print_if(if_stmt, p, ctx);
             }
             _ => {
-                alternate.gen(p);
+                alternate.gen(p, ctx);
             }
         }
     }
@@ -187,139 +187,142 @@ fn wrap_to_avoid_ambiguous_else(stmt: &Statement) -> bool {
 }
 
 impl<'a> Gen for BlockStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
-        p.print_block1(self);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        p.print_block1(self, ctx);
     }
 }
 
 impl<'a> Gen for ForStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"for");
         p.print(b'(');
 
         if let Some(init) = self.init.as_ref() {
+            let ctx = Context::empty();
             match init {
-                ForStatementInit::Expression(expr) => expr.gen_expr(p, Precedence::lowest()),
-                ForStatementInit::VariableDeclaration(var) => var.gen(p),
+                ForStatementInit::Expression(expr) => {
+                    expr.gen_expr(p, Precedence::lowest(), ctx);
+                }
+                ForStatementInit::VariableDeclaration(var) => var.gen(p, ctx),
             }
         }
 
         p.print_semicolon();
 
         if let Some(test) = self.test.as_ref() {
-            test.gen_expr(p, Precedence::lowest());
+            test.gen_expr(p, Precedence::lowest(), Context::default());
         }
 
         p.print_semicolon();
 
         if let Some(update) = self.update.as_ref() {
-            update.gen_expr(p, Precedence::lowest());
+            update.gen_expr(p, Precedence::lowest(), Context::default());
         }
 
         p.print(b')');
-        self.body.gen(p);
+        self.body.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for ForInStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"for");
         p.print(b'(');
-        self.left.gen(p);
+        self.left.gen(p, ctx);
         p.print(b' ');
         p.print_str(b"in");
         p.print(b' ');
-        self.right.gen_expr(p, Precedence::lowest());
+        self.right.gen_expr(p, Precedence::lowest(), Context::default());
         p.print(b')');
-        self.body.gen(p);
+        self.body.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for ForOfStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"for");
         if self.r#await {
             p.print_str(b" await");
         }
         p.print(b'(');
-        self.left.gen(p);
+        self.left.gen(p, ctx);
         p.print(b' ');
         p.print_str(b"of");
         p.print(b' ');
-        self.right.gen_expr(p, Precedence::Assign);
+        self.right.gen_expr(p, Precedence::Assign, Context::default());
         p.print(b')');
-        self.body.gen(p);
+        self.body.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for ForStatementLeft<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match &self {
-            ForStatementLeft::VariableDeclaration(var) => var.gen(p),
-            ForStatementLeft::AssignmentTarget(target) => target.gen(p),
+            ForStatementLeft::VariableDeclaration(var) => var.gen(p, ctx),
+            ForStatementLeft::AssignmentTarget(target) => target.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for WhileStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"while");
         p.print(b'(');
-        self.test.gen_expr(p, Precedence::lowest());
+        self.test.gen_expr(p, Precedence::lowest(), Context::default());
         p.print(b')');
-        self.body.gen(p);
+        self.body.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for DoWhileStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"do");
         p.print(b' ');
         if let Some(Statement::BlockStatement(block)) = &self.body {
-            p.print_block1(block);
+            p.print_block1(block, ctx);
         } else {
-            self.body.gen(p);
+            self.body.gen(p, ctx);
             p.print_semicolon_if_needed();
         }
         p.print_str(b"while");
         p.print(b'(');
-        self.test.gen_expr(p, Precedence::lowest());
+        self.test.gen_expr(p, Precedence::lowest(), Context::default());
         p.print(b')');
         p.print_semicolon_after_statement();
     }
 }
 
 impl Gen for ContinueStatement {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"continue");
         if let Some(label) = &self.label {
             p.print(b' ');
-            label.gen(p);
+            label.gen(p, ctx);
         }
         p.print_semicolon_after_statement();
     }
 }
 
 impl Gen for BreakStatement {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"break");
         if let Some(label) = &self.label {
             p.print(b' ');
-            label.gen(p);
+            label.gen(p, ctx);
         }
         p.print_semicolon_after_statement();
     }
 }
 
 impl<'a> Gen for SwitchStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"switch");
         p.print(b'(');
-        self.discriminant.gen_expr(p, Precedence::lowest());
+        self.discriminant.gen_expr(p, Precedence::lowest(), Context::default());
         p.print(b')');
         p.print(b'{');
         for case in &self.cases {
-            case.gen(p);
+            case.gen(p, ctx);
         }
         p.print(b'}');
         p.needs_semicolon = false;
@@ -327,112 +330,112 @@ impl<'a> Gen for SwitchStatement<'a> {
 }
 
 impl<'a> Gen for SwitchCase<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_semicolon_if_needed();
         match &self.test {
             Some(test) => {
                 p.print_str(b"case");
                 p.print(b' ');
-                test.gen_expr(p, Precedence::lowest());
+                test.gen_expr(p, Precedence::lowest(), Context::default());
             }
             None => p.print_str(b"default"),
         }
         p.print_colon();
         for item in &self.consequent {
             p.print_semicolon_if_needed();
-            item.gen(p);
+            item.gen(p, ctx);
         }
     }
 }
 
 impl<'a> Gen for ReturnStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"return");
         if let Some(arg) = &self.argument {
             p.print(b' ');
-            arg.gen_expr(p, Precedence::lowest());
+            arg.gen_expr(p, Precedence::lowest(), Context::default());
         }
         p.print_semicolon_after_statement();
     }
 }
 
 impl<'a> Gen for LabeledStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.label.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.label.gen(p, ctx);
         p.print_colon();
-        self.body.gen(p);
+        self.body.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for TryStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"try");
-        p.print_block1(&self.block);
+        p.print_block1(&self.block, ctx);
         if let Some(handler) = &self.handler {
             p.print_str(b"catch");
             if let Some(param) = &handler.param {
                 p.print_str(b"(");
-                param.gen(p);
+                param.gen(p, ctx);
                 p.print_str(b")");
             }
-            p.print_block1(&handler.body);
+            p.print_block1(&handler.body, ctx);
         }
         if let Some(finalizer) = &self.finalizer {
             p.print_str(b"finally");
-            p.print_block1(finalizer);
+            p.print_block1(finalizer, ctx);
         }
     }
 }
 
 impl<'a> Gen for ThrowStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"throw");
         p.print(b' ');
-        self.argument.gen_expr(p, Precedence::lowest());
+        self.argument.gen_expr(p, Precedence::lowest(), Context::default());
         p.print_semicolon_after_statement();
     }
 }
 
 impl<'a> Gen for WithStatement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"with");
         p.print(b'(');
-        self.object.gen_expr(p, Precedence::lowest());
+        self.object.gen_expr(p, Precedence::lowest(), Context::default());
         p.print(b')');
-        self.body.gen(p);
+        self.body.gen(p, ctx);
     }
 }
 
 impl Gen for DebuggerStatement {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"debugger");
         p.print_semicolon_after_statement();
     }
 }
 
 impl<'a> Gen for ModuleDeclaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::ImportDeclaration(decl) => decl.gen(p),
-            Self::ExportAllDeclaration(decl) => decl.gen(p),
-            Self::ExportDefaultDeclaration(decl) => decl.gen(p),
-            Self::ExportNamedDeclaration(decl) => decl.gen(p),
+            Self::ImportDeclaration(decl) => decl.gen(p, ctx),
+            Self::ExportAllDeclaration(decl) => decl.gen(p, ctx),
+            Self::ExportDefaultDeclaration(decl) => decl.gen(p, ctx),
+            Self::ExportNamedDeclaration(decl) => decl.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for Declaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
             Self::VariableDeclaration(stmt) => {
-                stmt.gen(p);
+                stmt.gen(p, ctx);
                 p.print_semicolon_after_statement();
             }
             Self::FunctionDeclaration(stmt) => {
-                stmt.gen(p);
+                stmt.gen(p, ctx);
             }
             Self::ClassDeclaration(declaration) => {
-                declaration.gen(p);
+                declaration.gen(p, ctx);
             }
             Self::TSEnumDeclaration(_) => {}
         }
@@ -440,29 +443,29 @@ impl<'a> Gen for Declaration<'a> {
 }
 
 impl<'a> Gen for VariableDeclaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(match self.kind {
             VariableDeclarationKind::Const => b"const",
             VariableDeclarationKind::Let => b"let",
             VariableDeclarationKind::Var => b"var",
         });
         p.print(b' ');
-        p.print_list(&self.declarations);
+        p.print_list(&self.declarations, ctx);
     }
 }
 
 impl<'a> Gen for VariableDeclarator<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.id.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.id.gen(p, ctx);
         if let Some(init) = &self.init {
             p.print_equal();
-            init.gen_expr(p, Precedence::Assign);
+            init.gen_expr(p, Precedence::Assign, ctx);
         }
     }
 }
 
 impl<'a> Gen for Function<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         let n = p.code_len();
         let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
         p.wrap(wrap, |p| {
@@ -478,23 +481,23 @@ impl<'a> Gen for Function<'a> {
                 if !self.generator {
                     p.print(b' ');
                 }
-                id.gen(p);
+                id.gen(p, ctx);
             }
             p.print(b'(');
-            self.params.gen(p);
+            self.params.gen(p, ctx);
             p.print(b')');
             if let Some(body) = &self.body {
-                body.gen(p);
+                body.gen(p, ctx);
             }
         });
     }
 }
 
 impl<'a> Gen for FunctionBody<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'{');
         for directive in &self.directives {
-            directive.gen(p);
+            directive.gen(p, ctx);
         }
         p.needs_semicolon = if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0)
             && matches!(expr_stmt.expression, Expression::StringLiteral(_)) {
@@ -504,7 +507,7 @@ impl<'a> Gen for FunctionBody<'a> {
             };
         for stmt in &self.statements {
             p.print_semicolon_if_needed();
-            stmt.gen(p);
+            stmt.gen(p, ctx);
         }
         p.print(b'}');
         p.needs_semicolon = false;
@@ -512,32 +515,32 @@ impl<'a> Gen for FunctionBody<'a> {
 }
 
 impl<'a> Gen for FormalParameter<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.decorators.gen(p);
-        self.pattern.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.decorators.gen(p, ctx);
+        self.pattern.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for FormalParameters<'a> {
-    fn gen(&self, p: &mut Printer) {
-        p.print_list(&self.items);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        p.print_list(&self.items, ctx);
         if let Some(rest) = &self.rest {
             if !self.items.is_empty() {
                 p.print_comma();
             }
-            rest.gen(p);
+            rest.gen(p, ctx);
         }
     }
 }
 
 impl<'a> Gen for ImportDeclaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"import ");
         if self.specifiers.is_empty() {
             p.print(b'\'');
             p.print_str(self.source.value.as_bytes());
             p.print(b'\'');
-            self.assertions.gen(p);
+            self.assertions.gen(p, ctx);
             p.print_semicolon_after_statement();
             return;
         }
@@ -552,7 +555,7 @@ impl<'a> Gen for ImportDeclaration<'a> {
                     } else if index != 0 {
                         p.print_comma();
                     }
-                    spec.local.gen(p);
+                    spec.local.gen(p, ctx);
                 }
                 ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
                     if in_block {
@@ -562,7 +565,7 @@ impl<'a> Gen for ImportDeclaration<'a> {
                         p.print_comma();
                     }
                     p.print_str(b"* as ");
-                    spec.local.gen(p);
+                    spec.local.gen(p, ctx);
                 }
                 ImportDeclarationSpecifier::ImportSpecifier(spec) => {
                     if in_block {
@@ -577,11 +580,11 @@ impl<'a> Gen for ImportDeclaration<'a> {
 
                     let imported_name = match &spec.imported {
                         ModuleExportName::Identifier(identifier) => {
-                            identifier.gen(p);
+                            identifier.gen(p, ctx);
                             identifier.name.as_bytes()
                         }
                         ModuleExportName::StringLiteral(literal) => {
-                            literal.gen(p);
+                            literal.gen(p, ctx);
                             literal.value.as_bytes()
                         }
                     };
@@ -590,7 +593,7 @@ impl<'a> Gen for ImportDeclaration<'a> {
 
                     if imported_name != local_name {
                         p.print_str(b" as ");
-                        spec.local.gen(p);
+                        spec.local.gen(p, ctx);
                     }
                 }
             }
@@ -599,48 +602,48 @@ impl<'a> Gen for ImportDeclaration<'a> {
             p.print(b'}');
         }
         p.print_str(b" from ");
-        self.source.gen(p);
-        self.assertions.gen(p);
+        self.source.gen(p, ctx);
+        self.assertions.gen(p, ctx);
         p.print_semicolon_after_statement();
     }
 }
 
 impl<'a> Gen for Option<Vec<'a, ImportAttribute>> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         if let Some(assertions) = &self {
             p.print_str(b"assert");
-            p.print_block(assertions, Separator::Comma);
+            p.print_block(assertions, Separator::Comma, ctx);
         };
     }
 }
 
 impl Gen for ImportAttribute {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match &self.key {
             ImportAttributeKey::Identifier(identifier) => {
                 p.print_str(identifier.name.as_bytes());
             }
-            ImportAttributeKey::StringLiteral(literal) => literal.gen(p),
+            ImportAttributeKey::StringLiteral(literal) => literal.gen(p, ctx),
         };
         p.print_colon();
-        self.value.gen(p);
+        self.value.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for ExportNamedDeclaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"export ");
         match &self.declaration {
-            Some(decl) => decl.gen(p),
+            Some(decl) => decl.gen(p, ctx),
             None => {
                 p.print(b'{');
                 if !self.specifiers.is_empty() {
-                    p.print_list(&self.specifiers);
+                    p.print_list(&self.specifiers, ctx);
                 }
                 p.print(b'}');
                 if let Some(source) = &self.source {
                     p.print_str(b"from");
-                    source.gen(p);
+                    source.gen(p, ctx);
                 }
                 p.print_semicolon_after_statement();
             }
@@ -649,108 +652,108 @@ impl<'a> Gen for ExportNamedDeclaration<'a> {
 }
 
 impl Gen for ExportSpecifier {
-    fn gen(&self, p: &mut Printer) {
-        self.local.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.local.gen(p, ctx);
         if self.local.name() != self.exported.name() {
             p.print_str(b" as ");
-            self.exported.gen(p);
+            self.exported.gen(p, ctx);
         }
     }
 }
 
 impl Gen for ModuleExportName {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
             Self::Identifier(identifier) => {
                 p.print_str(identifier.name.as_bytes());
             }
-            Self::StringLiteral(literal) => literal.gen(p),
+            Self::StringLiteral(literal) => literal.gen(p, ctx),
         };
     }
 }
 
 impl<'a> Gen for ExportAllDeclaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"export");
         p.print(b'*');
 
         if let Some(exported) = &self.exported {
             p.print_str(b"as ");
-            exported.gen(p);
+            exported.gen(p, ctx);
         }
 
         p.print_str(b" from");
-        self.source.gen(p);
-        self.assertions.gen(p);
+        self.source.gen(p, ctx);
+        self.assertions.gen(p, ctx);
 
         p.print_semicolon_after_statement();
     }
 }
 
 impl<'a> Gen for ExportDefaultDeclaration<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"export default ");
-        self.declaration.gen(p);
+        self.declaration.gen(p, ctx);
     }
 }
 impl<'a> Gen for ExportDefaultDeclarationKind<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
             Self::Expression(expr) => {
                 p.start_of_default_export = p.code_len();
-                expr.gen_expr(p, Precedence::Assign);
+                expr.gen_expr(p, Precedence::Assign, Context::default());
                 p.print_semicolon_after_statement();
             }
-            Self::FunctionDeclaration(fun) => fun.gen(p),
-            Self::ClassDeclaration(value) => value.gen(p),
+            Self::FunctionDeclaration(fun) => fun.gen(p, ctx),
+            Self::ClassDeclaration(value) => value.gen(p, ctx),
             Self::TSEnumDeclaration(_) => {}
         }
     }
 }
 
 impl<'a> GenExpr for Expression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         match self {
-            Self::BooleanLiteral(lit) => lit.gen(p),
-            Self::NullLiteral(lit) => lit.gen(p),
-            Self::NumberLiteral(lit) => lit.gen(p),
-            Self::BigintLiteral(lit) => lit.gen(p),
-            Self::RegExpLiteral(lit) => lit.gen(p),
-            Self::StringLiteral(lit) => lit.gen(p),
-            Self::Identifier(ident) => ident.gen(p),
-            Self::ThisExpression(expr) => expr.gen(p),
-            Self::MemberExpression(expr) => expr.gen_expr(p, precedence),
-            Self::CallExpression(expr) => expr.gen_expr(p, precedence),
-            Self::ArrayExpression(expr) => expr.gen(p),
-            Self::ObjectExpression(expr) => expr.gen_expr(p, precedence),
-            Self::FunctionExpression(expr) => expr.gen(p),
-            Self::ArrowExpression(expr) => expr.gen_expr(p, precedence),
-            Self::YieldExpression(expr) => expr.gen_expr(p, precedence),
-            Self::UpdateExpression(expr) => expr.gen_expr(p, precedence),
-            Self::UnaryExpression(expr) => expr.gen_expr(p, precedence),
-            Self::BinaryExpression(expr) => expr.gen_expr(p, precedence),
-            Self::PrivateInExpression(expr) => expr.gen(p),
-            Self::LogicalExpression(expr) => expr.gen_expr(p, precedence),
-            Self::ConditionalExpression(expr) => expr.gen_expr(p, precedence),
-            Self::AssignmentExpression(expr) => expr.gen_expr(p, precedence),
-            Self::SequenceExpression(expr) => expr.gen_expr(p, precedence),
-            Self::ImportExpression(expr) => expr.gen(p),
-            Self::TemplateLiteral(literal) => literal.gen(p),
-            Self::TaggedTemplateExpression(expr) => expr.gen(p),
-            Self::Super(sup) => sup.gen(p),
-            Self::AwaitExpression(expr) => expr.gen_expr(p, precedence),
-            Self::ChainExpression(expr) => expr.gen_expr(p, precedence),
-            Self::NewExpression(expr) => expr.gen_expr(p, precedence),
-            Self::MetaProperty(expr) => expr.gen(p),
-            Self::ClassExpression(expr) => expr.gen(p),
-            Self::JSXElement(el) => el.gen(p),
-            Self::JSXFragment(fragment) => fragment.gen(p),
+            Self::BooleanLiteral(lit) => lit.gen(p, ctx),
+            Self::NullLiteral(lit) => lit.gen(p, ctx),
+            Self::NumberLiteral(lit) => lit.gen(p, ctx),
+            Self::BigintLiteral(lit) => lit.gen(p, ctx),
+            Self::RegExpLiteral(lit) => lit.gen(p, ctx),
+            Self::StringLiteral(lit) => lit.gen(p, ctx),
+            Self::Identifier(ident) => ident.gen(p, ctx),
+            Self::ThisExpression(expr) => expr.gen(p, ctx),
+            Self::MemberExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::CallExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::ArrayExpression(expr) => expr.gen(p, ctx),
+            Self::ObjectExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::FunctionExpression(expr) => expr.gen(p, ctx),
+            Self::ArrowExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::YieldExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::UpdateExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::UnaryExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::BinaryExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::PrivateInExpression(expr) => expr.gen(p, ctx),
+            Self::LogicalExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::ConditionalExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::AssignmentExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::SequenceExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::ImportExpression(expr) => expr.gen(p, ctx),
+            Self::TemplateLiteral(literal) => literal.gen(p, ctx),
+            Self::TaggedTemplateExpression(expr) => expr.gen(p, ctx),
+            Self::Super(sup) => sup.gen(p, ctx),
+            Self::AwaitExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::ChainExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::NewExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            Self::MetaProperty(expr) => expr.gen(p, ctx),
+            Self::ClassExpression(expr) => expr.gen(p, ctx),
+            Self::JSXElement(el) => el.gen(p, ctx),
+            Self::JSXFragment(fragment) => fragment.gen(p, ctx),
         }
     }
 }
 
 impl Gen for IdentifierReference {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         if p.mangle && let Some(symbol_id) = p.symbol_table.get_reference(self.reference_id).symbol_id {
             p.print_symbol(symbol_id, &self.name);
         } else {
@@ -760,31 +763,31 @@ impl Gen for IdentifierReference {
 }
 
 impl Gen for IdentifierName {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(self.name.as_bytes());
     }
 }
 
 impl Gen for BindingIdentifier {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_symbol(self.symbol_id, &self.name);
     }
 }
 
 impl Gen for LabelIdentifier {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(self.name.as_bytes());
     }
 }
 
 impl Gen for BooleanLiteral {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(self.as_str().as_bytes());
     }
 }
 
 impl Gen for NullLiteral {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_space_before_identifier();
         p.print_str(b"null");
     }
@@ -792,7 +795,7 @@ impl Gen for NullLiteral {
 
 impl<'a> Gen for NumberLiteral<'a> {
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_space_before_identifier();
 
         let result = if self.base == NumberBase::Float {
@@ -877,14 +880,14 @@ fn print_non_negative_float(value: f64, p: &mut Printer) -> String {
 }
 
 impl Gen for BigintLiteral {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(self.value.to_string().as_bytes());
         p.print(b'n');
     }
 }
 
 impl Gen for RegExpLiteral {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         let last = p.peek_nth(0);
         // Avoid forming a single-line comment or "</script" sequence
         if Some('/') == last
@@ -902,7 +905,7 @@ impl Gen for RegExpLiteral {
 }
 
 impl Gen for StringLiteral {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'\'');
         for c in self.value.chars() {
             p.print_str(c.escape_default().to_string().as_bytes());
@@ -912,37 +915,39 @@ impl Gen for StringLiteral {
 }
 
 impl Gen for ThisExpression {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_space_before_identifier();
         p.print_str(b"this");
     }
 }
 
 impl<'a> GenExpr for MemberExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > self.precedence(), |p| match self {
-            Self::ComputedMemberExpression(expr) => expr.gen_expr(p, self.precedence()),
-            Self::StaticMemberExpression(expr) => expr.gen_expr(p, self.precedence()),
-            Self::PrivateFieldExpression(expr) => expr.gen_expr(p, self.precedence()),
+            Self::ComputedMemberExpression(expr) => {
+                expr.gen_expr(p, self.precedence(), ctx.and_in(true));
+            }
+            Self::StaticMemberExpression(expr) => expr.gen_expr(p, self.precedence(), ctx),
+            Self::PrivateFieldExpression(expr) => expr.gen_expr(p, self.precedence(), ctx),
         });
     }
 }
 
 impl<'a> GenExpr for ComputedMemberExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
-        self.object.gen_expr(p, Precedence::Postfix);
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
+        self.object.gen_expr(p, Precedence::Postfix, ctx);
         if self.optional {
             p.print_str(b"?.");
         }
         p.print(b'[');
-        self.expression.gen_expr(p, Precedence::lowest());
+        self.expression.gen_expr(p, Precedence::lowest(), ctx);
         p.print(b']');
     }
 }
 
 impl<'a> GenExpr for StaticMemberExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
-        self.object.gen_expr(p, Precedence::Postfix);
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
+        self.object.gen_expr(p, Precedence::Postfix, ctx);
         if self.optional {
             p.print(b'?');
         } else if p.need_space_before_dot == p.code_len() {
@@ -950,65 +955,65 @@ impl<'a> GenExpr for StaticMemberExpression<'a> {
             p.print(b' ');
         }
         p.print(b'.');
-        self.property.gen(p);
+        self.property.gen(p, ctx);
     }
 }
 
 impl<'a> GenExpr for PrivateFieldExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
-        self.object.gen_expr(p, Precedence::Postfix);
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
+        self.object.gen_expr(p, Precedence::Postfix, ctx);
         if self.optional {
             p.print_str(b"?");
         }
         p.print(b'.');
-        self.field.gen(p);
+        self.field.gen(p, ctx);
     }
 }
 
 impl<'a> GenExpr for CallExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > self.precedence(), |p| {
-            self.callee.gen_expr(p, self.precedence());
+            self.callee.gen_expr(p, self.precedence(), ctx);
             if self.optional {
                 p.print_str(b"?.");
             }
             p.print(b'(');
-            p.print_list(&self.arguments);
+            p.print_list(&self.arguments, ctx);
             p.print(b')');
         });
     }
 }
 
 impl<'a> Gen for Argument<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::SpreadElement(elem) => elem.gen(p),
-            Self::Expression(elem) => elem.gen_expr(p, Precedence::Assign),
+            Self::SpreadElement(elem) => elem.gen(p, ctx),
+            Self::Expression(elem) => elem.gen_expr(p, Precedence::Assign, Context::default()),
         }
     }
 }
 
 impl<'a> Gen for ArrayExpressionElement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Expression(expr) => expr.gen_expr(p, Precedence::Assign),
-            Self::SpreadElement(elem) => elem.gen(p),
+            Self::Expression(expr) => expr.gen_expr(p, Precedence::Assign, Context::default()),
+            Self::SpreadElement(elem) => elem.gen(p, ctx),
             Self::Elision(_span) => {}
         }
     }
 }
 
 impl<'a> Gen for SpreadElement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_ellipsis();
-        self.argument.gen_expr(p, Precedence::Assign);
+        self.argument.gen_expr(p, Precedence::Assign, Context::default());
     }
 }
 
 impl<'a> Gen for ArrayExpression<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'[');
-        p.print_list(&self.elements);
+        p.print_list(&self.elements, ctx);
         if self.trailing_comma.is_some() {
             p.print_comma();
         }
@@ -1017,7 +1022,7 @@ impl<'a> Gen for ArrayExpression<'a> {
 }
 
 impl<'a> GenExpr for ObjectExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         let n = p.code_len();
         p.wrap(p.start_of_stmt == n || p.start_of_arrow_expr == n, |p| {
             p.print(b'{');
@@ -1025,7 +1030,7 @@ impl<'a> GenExpr for ObjectExpression<'a> {
                 if i != 0 {
                     p.print_comma();
                 }
-                item.gen(p);
+                item.gen(p, ctx);
             }
             p.print(b'}');
         });
@@ -1033,16 +1038,16 @@ impl<'a> GenExpr for ObjectExpression<'a> {
 }
 
 impl<'a> Gen for ObjectPropertyKind<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::ObjectProperty(prop) => prop.gen(p),
-            Self::SpreadProperty(elem) => elem.gen(p),
+            Self::ObjectProperty(prop) => prop.gen(p, ctx),
+            Self::SpreadProperty(elem) => elem.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for ObjectProperty<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         if let Expression::FunctionExpression(func) = &self.value {
             let is_accessor = match &self.kind {
                 PropertyKind::Init => false,
@@ -1065,15 +1070,15 @@ impl<'a> Gen for ObjectProperty<'a> {
                 if self.computed {
                     p.print(b'[');
                 }
-                self.key.gen(p);
+                self.key.gen(p, ctx);
                 if self.computed {
                     p.print(b']');
                 }
                 p.print(b'(');
-                func.params.gen(p);
+                func.params.gen(p, ctx);
                 p.print(b')');
                 if let Some(body) = &func.body {
-                    body.gen(p);
+                    body.gen(p, ctx);
                 }
                 return;
             }
@@ -1081,36 +1086,36 @@ impl<'a> Gen for ObjectProperty<'a> {
         if self.computed {
             p.print(b'[');
         }
-        self.key.gen(p);
+        self.key.gen(p, ctx);
         if self.computed {
             p.print(b']');
         }
         p.print_colon();
-        self.value.gen_expr(p, Precedence::Assign);
+        self.value.gen_expr(p, Precedence::Assign, Context::default());
     }
 }
 
 impl<'a> Gen for PropertyKey<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Identifier(ident) => ident.gen(p),
-            Self::PrivateIdentifier(ident) => ident.gen(p),
-            Self::Expression(expr) => expr.gen_expr(p, Precedence::Assign),
+            Self::Identifier(ident) => ident.gen(p, ctx),
+            Self::PrivateIdentifier(ident) => ident.gen(p, ctx),
+            Self::Expression(expr) => expr.gen_expr(p, Precedence::Assign, Context::default()),
         }
     }
 }
 
 impl<'a> Gen for PropertyValue<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Pattern(pattern) => pattern.gen(p),
-            Self::Expression(expr) => expr.gen_expr(p, Precedence::Assign),
+            Self::Pattern(pattern) => pattern.gen(p, ctx),
+            Self::Expression(expr) => expr.gen_expr(p, Precedence::Assign, Context::default()),
         }
     }
 }
 
 impl<'a> GenExpr for ArrowExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > Precedence::Assign, |p| {
             if self.r#async {
                 p.print_str(b"async");
@@ -1123,23 +1128,23 @@ impl<'a> GenExpr for ArrowExpression<'a> {
                 p.print(b' ');
             }
             p.wrap(!nowrap, |p| {
-                self.params.gen(p);
+                self.params.gen(p, ctx);
             });
             p.print_str(b"=>");
             if self.expression {
                 if let Statement::ExpressionStatement(stmt) = &self.body.statements[0] {
                     p.start_of_arrow_expr = p.code_len();
-                    stmt.expression.gen_expr(p, Precedence::Assign);
+                    stmt.expression.gen_expr(p, Precedence::Assign, ctx);
                 }
             } else {
-                self.body.gen(p);
+                self.body.gen(p, ctx);
             }
         });
     }
 }
 
 impl<'a> GenExpr for YieldExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
             p.print_str(b"yield");
             if self.delegate {
@@ -1150,14 +1155,14 @@ impl<'a> GenExpr for YieldExpression<'a> {
                 if !self.delegate {
                     p.print(b' ');
                 }
-                argument.gen_expr(p, Precedence::Assign);
+                argument.gen_expr(p, Precedence::Assign, ctx);
             }
         });
     }
 }
 
 impl<'a> GenExpr for UpdateExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         let operator = self.operator.as_str().as_bytes();
         p.wrap(precedence > self.precedence(), |p| {
             if self.prefix {
@@ -1165,9 +1170,9 @@ impl<'a> GenExpr for UpdateExpression<'a> {
                 p.print_str(operator);
                 p.prev_op = Some(self.operator.into());
                 p.prev_op_end = p.code().len();
-                self.argument.gen_expr(p, Precedence::Prefix);
+                self.argument.gen_expr(p, Precedence::Prefix, ctx);
             } else {
-                self.argument.gen_expr(p, Precedence::Postfix);
+                self.argument.gen_expr(p, Precedence::Postfix, ctx);
                 p.print_str(operator);
                 p.prev_op = Some(self.operator.into());
                 p.prev_op_end = p.code().len();
@@ -1177,7 +1182,7 @@ impl<'a> GenExpr for UpdateExpression<'a> {
 }
 
 impl<'a> GenExpr for UnaryExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > self.precedence() || precedence == Precedence::Exponential, |p| {
             let operator = self.operator.as_str().as_bytes();
             if self.operator.is_keyword() {
@@ -1189,26 +1194,28 @@ impl<'a> GenExpr for UnaryExpression<'a> {
                 p.prev_op = Some(self.operator.into());
                 p.prev_op_end = p.code().len();
             }
-            self.argument.gen_expr(p, Precedence::Prefix);
+            self.argument.gen_expr(p, Precedence::Prefix, ctx);
         });
     }
 }
 
 impl<'a> GenExpr for BinaryExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
-        p.wrap(precedence > self.precedence() || self.operator == BinaryOperator::In, |p| {
-            self.left.gen_expr(p, self.precedence());
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
+        let wrap_in = self.operator == BinaryOperator::In && !ctx.has_in();
+        let wrap = precedence > self.precedence() || wrap_in;
+        p.wrap(wrap, |p| {
+            self.left.gen_expr(p, self.precedence(), ctx);
             if self.operator.is_keyword() {
                 p.print_space_before_identifier();
             }
-            self.operator.gen(p);
-            self.right.gen_expr(p, self.precedence());
+            self.operator.gen(p, ctx);
+            self.right.gen_expr(p, self.precedence(), ctx.union_in_if(wrap));
         });
     }
 }
 
 impl Gen for BinaryOperator {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         let operator = self.as_str().as_bytes();
         if self.is_keyword() {
             p.print_str(operator);
@@ -1224,48 +1231,49 @@ impl Gen for BinaryOperator {
 }
 
 impl<'a> Gen for PrivateInExpression<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.left.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.left.gen(p, ctx);
         p.print(b' ');
         p.print_str(b"in");
         p.print(b' ');
-        self.right.gen_expr(p, Precedence::Shift);
+        self.right.gen_expr(p, Precedence::Shift, Context::default());
     }
 }
 
 impl<'a> GenExpr for LogicalExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         // Logical expressions and coalesce expressions cannot be mixed (Syntax Error).
         let mixed = matches!(
             (precedence, self.precedence()),
             (Precedence::Coalesce, Precedence::LogicalAnd | Precedence::LogicalOr)
         );
         p.wrap(mixed || (precedence > self.precedence()), |p| {
-            self.left.gen_expr(p, self.precedence());
+            self.left.gen_expr(p, self.precedence(), ctx);
             p.print_str(self.operator.as_str().as_bytes());
             let precedence = match self.operator {
                 LogicalOperator::And | LogicalOperator::Coalesce => Precedence::BitwiseOr,
                 LogicalOperator::Or => Precedence::LogicalAnd,
             };
-            self.right.gen_expr(p, self.precedence());
+            self.right.gen_expr(p, self.precedence(), ctx);
         });
     }
 }
 
 impl<'a> GenExpr for ConditionalExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
-        p.wrap(precedence > self.precedence(), |p| {
-            self.test.gen_expr(p, self.precedence());
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
+        let wrap = precedence > self.precedence();
+        p.wrap(wrap, |p| {
+            self.test.gen_expr(p, self.precedence(), ctx);
             p.print(b'?');
-            self.consequent.gen_expr(p, Precedence::Assign);
+            self.consequent.gen_expr(p, Precedence::Assign, ctx.and_in(true));
             p.print(b':');
-            self.alternate.gen_expr(p, Precedence::Assign);
+            self.alternate.gen_expr(p, Precedence::Assign, ctx.union_in_if(wrap));
         });
     }
 }
 
 impl<'a> GenExpr for AssignmentExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         // Destructuring assignment
         let n = p.code_len();
         let wrap = (p.start_of_stmt == n || p.start_of_arrow_expr == n)
@@ -1276,50 +1284,52 @@ impl<'a> GenExpr for AssignmentExpression<'a> {
                 )
             );
         p.wrap(wrap || precedence > self.precedence(), |p| {
-            self.left.gen(p);
+            self.left.gen(p, ctx);
             p.print_str(self.operator.as_str().as_bytes());
-            self.right.gen_expr(p, Precedence::Assign);
+            self.right.gen_expr(p, Precedence::Assign, ctx);
         });
     }
 }
 
 impl<'a> Gen for AssignmentTarget<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::SimpleAssignmentTarget(target) => target.gen_expr(p, Precedence::Assign),
-            Self::AssignmentTargetPattern(pat) => pat.gen(p),
+            Self::SimpleAssignmentTarget(target) => {
+                target.gen_expr(p, Precedence::Assign, Context::default());
+            }
+            Self::AssignmentTargetPattern(pat) => pat.gen(p, ctx),
         }
     }
 }
 
 impl<'a> GenExpr for SimpleAssignmentTarget<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         match self {
-            Self::AssignmentTargetIdentifier(ident) => ident.gen(p),
+            Self::AssignmentTargetIdentifier(ident) => ident.gen(p, ctx),
             Self::MemberAssignmentTarget(member_expr) => {
-                member_expr.gen_expr(p, precedence);
+                member_expr.gen_expr(p, precedence, ctx);
             }
         }
     }
 }
 
 impl<'a> Gen for AssignmentTargetPattern<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::ArrayAssignmentTarget(target) => target.gen(p),
-            Self::ObjectAssignmentTarget(target) => target.gen(p),
+            Self::ArrayAssignmentTarget(target) => target.gen(p, ctx),
+            Self::ObjectAssignmentTarget(target) => target.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for ArrayAssignmentTarget<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'[');
-        p.print_list(&self.elements);
+        p.print_list(&self.elements, ctx);
         if let Some(target) = &self.rest {
             p.print_comma();
             p.print_ellipsis();
-            target.gen(p);
+            target.gen(p, ctx);
         }
         if self.trailing_comma.is_some() {
             p.print_comma();
@@ -1329,106 +1339,106 @@ impl<'a> Gen for ArrayAssignmentTarget<'a> {
 }
 
 impl<'a> Gen for Option<AssignmentTargetMaybeDefault<'a>> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         if let Some(arg) = self {
-            arg.gen(p);
+            arg.gen(p, ctx);
         }
     }
 }
 
 impl<'a> Gen for ObjectAssignmentTarget<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'{');
-        p.print_list(&self.properties);
+        p.print_list(&self.properties, ctx);
         if let Some(target) = &self.rest {
             if !self.properties.is_empty() {
                 p.print_comma();
             }
             p.print_ellipsis();
-            target.gen(p);
+            target.gen(p, ctx);
         }
         p.print(b'}');
     }
 }
 
 impl<'a> Gen for AssignmentTargetMaybeDefault<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::AssignmentTarget(target) => target.gen(p),
-            Self::AssignmentTargetWithDefault(target) => target.gen(p),
+            Self::AssignmentTarget(target) => target.gen(p, ctx),
+            Self::AssignmentTargetWithDefault(target) => target.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for AssignmentTargetWithDefault<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.binding.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.binding.gen(p, ctx);
         p.print_equal();
-        self.init.gen_expr(p, Precedence::Assign);
+        self.init.gen_expr(p, Precedence::Assign, Context::default());
     }
 }
 
 impl<'a> Gen for AssignmentTargetProperty<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::AssignmentTargetPropertyIdentifier(ident) => ident.gen(p),
-            Self::AssignmentTargetPropertyProperty(prop) => prop.gen(p),
+            Self::AssignmentTargetPropertyIdentifier(ident) => ident.gen(p, ctx),
+            Self::AssignmentTargetPropertyProperty(prop) => prop.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for AssignmentTargetPropertyIdentifier<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.binding.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.binding.gen(p, ctx);
         if let Some(expr) = &self.init {
             p.print_equal();
-            expr.gen_expr(p, Precedence::Assign);
+            expr.gen_expr(p, Precedence::Assign, Context::default());
         }
     }
 }
 
 impl<'a> Gen for AssignmentTargetPropertyProperty<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match &self.name {
             PropertyKey::Identifier(ident) => {
-                ident.gen(p);
+                ident.gen(p, ctx);
             }
             PropertyKey::PrivateIdentifier(ident) => {
-                ident.gen(p);
+                ident.gen(p, ctx);
             }
             PropertyKey::Expression(expr) => {
                 p.print(b'[');
-                expr.gen_expr(p, Precedence::Assign);
+                expr.gen_expr(p, Precedence::Assign, Context::default());
                 p.print(b']');
             }
         }
         p.print_colon();
-        self.binding.gen(p);
+        self.binding.gen(p, ctx);
     }
 }
 
 impl<'a> GenExpr for SequenceExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > self.precedence(), |p| {
-            p.print_expressions(&self.expressions, Precedence::Assign);
+            p.print_expressions(&self.expressions, Precedence::Assign, Context::default());
         });
     }
 }
 
 impl<'a> Gen for ImportExpression<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"import(");
-        self.source.gen_expr(p, Precedence::Assign);
+        self.source.gen_expr(p, Precedence::Assign, Context::default());
         if !self.arguments.is_empty() {
             p.print_comma();
-            p.print_expressions(&self.arguments, Precedence::Assign);
+            p.print_expressions(&self.arguments, Precedence::Assign, Context::default());
         }
         p.print(b')');
     }
 }
 
 impl<'a> Gen for TemplateLiteral<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'`');
         let mut expressions = self.expressions.iter();
 
@@ -1437,7 +1447,7 @@ impl<'a> Gen for TemplateLiteral<'a> {
 
             if let Some(expr) = expressions.next() {
                 p.print_str(b"${");
-                expr.gen_expr(p, Precedence::lowest());
+                expr.gen_expr(p, Precedence::lowest(), Context::default());
                 p.print(b'}');
             }
         }
@@ -1447,75 +1457,75 @@ impl<'a> Gen for TemplateLiteral<'a> {
 }
 
 impl<'a> Gen for TaggedTemplateExpression<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.tag.gen_expr(p, Precedence::Call);
-        self.quasi.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.tag.gen_expr(p, Precedence::Call, Context::default());
+        self.quasi.gen(p, ctx);
     }
 }
 
 impl Gen for Super {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"super");
     }
 }
 
 impl<'a> GenExpr for AwaitExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > self.precedence(), |p| {
             p.print_str(b"await ");
-            self.argument.gen_expr(p, self.precedence());
+            self.argument.gen_expr(p, self.precedence(), ctx);
         });
     }
 }
 
 impl<'a> GenExpr for ChainExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         match &self.expression {
-            ChainElement::CallExpression(expr) => expr.gen_expr(p, precedence),
-            ChainElement::MemberExpression(expr) => expr.gen_expr(p, precedence),
+            ChainElement::CallExpression(expr) => expr.gen_expr(p, precedence, ctx),
+            ChainElement::MemberExpression(expr) => expr.gen_expr(p, precedence, ctx),
         }
     }
 }
 
 impl<'a> GenExpr for NewExpression<'a> {
-    fn gen_expr(&self, p: &mut Printer, precedence: Precedence) {
+    fn gen_expr(&self, p: &mut Printer, precedence: Precedence, ctx: Context) {
         p.wrap(precedence > self.precedence(), |p| {
             p.print_str(b"new ");
-            self.callee.gen_expr(p, self.precedence());
+            self.callee.gen_expr(p, self.precedence(), ctx);
             p.wrap(true, |p| {
-                p.print_list(&self.arguments);
+                p.print_list(&self.arguments, ctx);
             });
         });
     }
 }
 
 impl Gen for MetaProperty {
-    fn gen(&self, p: &mut Printer) {
-        self.meta.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.meta.gen(p, ctx);
         p.print(b'.');
-        self.property.gen(p);
+        self.property.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for Class<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         let n = p.code_len();
         let wrap = self.is_expression() && (p.start_of_stmt == n || p.start_of_default_export == n);
         p.wrap(wrap, |p| {
-            self.decorators.gen(p);
+            self.decorators.gen(p, ctx);
             p.print_str(b"class");
             if let Some(id) = &self.id {
                 p.print(b' ');
-                id.gen(p);
+                id.gen(p, ctx);
             }
             if let Some(super_class) = self.super_class.as_ref() {
                 p.print_str(b" extends ");
-                super_class.gen_expr(p, Precedence::Call);
+                super_class.gen_expr(p, Precedence::Call, Context::default());
             }
             p.print(b'{');
             for item in &self.body.body {
                 p.print_semicolon_if_needed();
-                item.gen(p);
+                item.gen(p, ctx);
                 if matches!(
                     item,
                     ClassElement::PropertyDefinition(_) | ClassElement::AccessorProperty(_)
@@ -1531,129 +1541,129 @@ impl<'a> Gen for Class<'a> {
 }
 
 impl<'a> Gen for ClassElement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::StaticBlock(elem) => elem.gen(p),
-            Self::MethodDefinition(elem) => elem.gen(p),
-            Self::PropertyDefinition(elem) => elem.gen(p),
-            Self::AccessorProperty(elem) => elem.gen(p),
+            Self::StaticBlock(elem) => elem.gen(p, ctx),
+            Self::MethodDefinition(elem) => elem.gen(p, ctx),
+            Self::PropertyDefinition(elem) => elem.gen(p, ctx),
+            Self::AccessorProperty(elem) => elem.gen(p, ctx),
         }
     }
 }
 
 impl Gen for JSXIdentifier {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(self.name.as_bytes());
     }
 }
 
 impl<'a> Gen for JSXMemberExpressionObject<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Identifier(ident) => ident.gen(p),
-            Self::MemberExpression(member_expr) => member_expr.gen(p),
+            Self::Identifier(ident) => ident.gen(p, ctx),
+            Self::MemberExpression(member_expr) => member_expr.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for JSXMemberExpression<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.object.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.object.gen(p, ctx);
         p.print(b'.');
-        self.property.gen(p);
+        self.property.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for JSXElementName<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Identifier(identifier) => identifier.gen(p),
-            Self::NamespacedName(namespaced_name) => namespaced_name.gen(p),
-            Self::MemberExpression(member_expr) => member_expr.gen(p),
+            Self::Identifier(identifier) => identifier.gen(p, ctx),
+            Self::NamespacedName(namespaced_name) => namespaced_name.gen(p, ctx),
+            Self::MemberExpression(member_expr) => member_expr.gen(p, ctx),
         }
     }
 }
 
 impl Gen for JSXNamespacedName {
-    fn gen(&self, p: &mut Printer) {
-        self.namespace.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.namespace.gen(p, ctx);
         p.print(b'.');
-        self.property.gen(p);
+        self.property.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for JSXAttributeName<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Identifier(ident) => ident.gen(p),
-            Self::NamespacedName(namespaced_name) => namespaced_name.gen(p),
+            Self::Identifier(ident) => ident.gen(p, ctx),
+            Self::NamespacedName(namespaced_name) => namespaced_name.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for JSXAttribute<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.name.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.name.gen(p, ctx);
         p.print(b'=');
         if let Some(value) = &self.value {
-            value.gen(p);
+            value.gen(p, ctx);
         }
     }
 }
 
 impl Gen for JSXEmptyExpression {
-    fn gen(&self, _: &mut Printer) {}
+    fn gen(&self, _: &mut Printer, ctx: Context) {}
 }
 
 impl<'a> Gen for JSXExpression<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Expression(expr) => expr.gen_expr(p, Precedence::lowest()),
-            Self::EmptyExpression(expr) => expr.gen(p),
+            Self::Expression(expr) => expr.gen_expr(p, Precedence::lowest(), Context::default()),
+            Self::EmptyExpression(expr) => expr.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for JSXExpressionContainer<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'{');
-        self.expression.gen(p);
+        self.expression.gen(p, ctx);
         p.print(b'}');
     }
 }
 
 impl<'a> Gen for JSXAttributeValue<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Fragment(fragment) => fragment.gen(p),
-            Self::Element(el) => el.gen(p),
-            Self::StringLiteral(lit) => lit.gen(p),
-            Self::ExpressionContainer(expr_container) => expr_container.gen(p),
+            Self::Fragment(fragment) => fragment.gen(p, ctx),
+            Self::Element(el) => el.gen(p, ctx),
+            Self::StringLiteral(lit) => lit.gen(p, ctx),
+            Self::ExpressionContainer(expr_container) => expr_container.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for JSXSpreadAttribute<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.argument.gen_expr(p, Precedence::lowest());
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.argument.gen_expr(p, Precedence::lowest(), Context::default());
     }
 }
 
 impl<'a> Gen for JSXAttributeItem<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Attribute(attr) => attr.gen(p),
-            Self::SpreadAttribute(spread_attr) => spread_attr.gen(p),
+            Self::Attribute(attr) => attr.gen(p, ctx),
+            Self::SpreadAttribute(spread_attr) => spread_attr.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for JSXOpeningElement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"<");
-        self.name.gen(p);
+        self.name.gen(p, ctx);
         for attr in &self.attributes {
-            attr.gen(p);
+            attr.gen(p, ctx);
         }
         if self.self_closing {
             p.print_str(b"/>");
@@ -1664,79 +1674,81 @@ impl<'a> Gen for JSXOpeningElement<'a> {
 }
 
 impl<'a> Gen for JSXClosingElement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"</");
-        self.name.gen(p);
+        self.name.gen(p, ctx);
         p.print(b'>');
     }
 }
 
 impl<'a> Gen for JSXElement<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.opening_element.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.opening_element.gen(p, ctx);
         for child in &self.children {
-            child.gen(p);
+            child.gen(p, ctx);
         }
         if let Some(closing_element) = &self.closing_element {
-            closing_element.gen(p);
+            closing_element.gen(p, ctx);
         }
     }
 }
 
 impl Gen for JSXOpeningFragment {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"<>");
     }
 }
 
 impl Gen for JSXClosingFragment {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"</>");
     }
 }
 
 impl Gen for JSXText {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(self.value.as_bytes());
     }
 }
 
 impl<'a> Gen for JSXSpreadChild<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"...");
-        self.expression.gen_expr(p, Precedence::lowest());
+        self.expression.gen_expr(p, Precedence::lowest(), Context::default());
     }
 }
 
 impl<'a> Gen for JSXChild<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match self {
-            Self::Fragment(fragment) => fragment.gen(p),
-            Self::Element(el) => el.gen(p),
-            Self::Spread(spread) => spread.expression.gen_expr(p, Precedence::lowest()),
-            Self::ExpressionContainer(expr_container) => expr_container.gen(p),
-            Self::Text(text) => text.gen(p),
+            Self::Fragment(fragment) => fragment.gen(p, ctx),
+            Self::Element(el) => el.gen(p, ctx),
+            Self::Spread(spread) => {
+                spread.expression.gen_expr(p, Precedence::lowest(), Context::default());
+            }
+            Self::ExpressionContainer(expr_container) => expr_container.gen(p, ctx),
+            Self::Text(text) => text.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for JSXFragment<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.opening_fragment.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.opening_fragment.gen(p, ctx);
         for child in &self.children {
-            child.gen(p);
+            child.gen(p, ctx);
         }
-        self.closing_fragment.gen(p);
+        self.closing_fragment.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for StaticBlock<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_str(b"static");
         p.print(b'{');
         for stmt in &self.body {
             p.print_semicolon_if_needed();
-            stmt.gen(p);
+            stmt.gen(p, ctx);
         }
         p.needs_semicolon = false;
         p.print(b'}');
@@ -1744,8 +1756,8 @@ impl<'a> Gen for StaticBlock<'a> {
 }
 
 impl<'a> Gen for MethodDefinition<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.decorators.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.decorators.gen(p, ctx);
 
         if self.r#static {
             p.print_str(b"static ");
@@ -1768,41 +1780,41 @@ impl<'a> Gen for MethodDefinition<'a> {
         if self.computed {
             p.print(b'[');
         }
-        self.key.gen(p);
+        self.key.gen(p, ctx);
         if self.computed {
             p.print(b']');
         }
         p.print(b'(');
-        self.value.params.gen(p);
+        self.value.params.gen(p, ctx);
         p.print(b')');
         if let Some(body) = &self.value.body {
-            body.gen(p);
+            body.gen(p, ctx);
         }
     }
 }
 
 impl<'a> Gen for PropertyDefinition<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.decorators.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.decorators.gen(p, ctx);
         if self.r#static {
             p.print_str(b"static ");
         }
         if self.computed {
             p.print(b'[');
         }
-        self.key.gen(p);
+        self.key.gen(p, ctx);
         if self.computed {
             p.print(b']');
         }
         if let Some(value) = &self.value {
             p.print_equal();
-            value.gen_expr(p, Precedence::Assign);
+            value.gen_expr(p, Precedence::Assign, Context::default());
         }
     }
 }
 
 impl<'a> Gen for AccessorProperty<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         if self.r#static {
             p.print_str(b"static ");
         }
@@ -1810,112 +1822,112 @@ impl<'a> Gen for AccessorProperty<'a> {
         if self.computed {
             p.print(b'[');
         }
-        self.key.gen(p);
+        self.key.gen(p, ctx);
         if self.computed {
             p.print(b']');
         }
         if let Some(value) = &self.value {
             p.print_equal();
-            value.gen_expr(p, Precedence::Assign);
+            value.gen_expr(p, Precedence::Assign, Context::default());
         }
     }
 }
 
 impl Gen for PrivateIdentifier {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'#');
         p.print_str(self.name.as_bytes());
     }
 }
 
 impl<'a> Gen for BindingPattern<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         match &self {
-            BindingPattern::BindingIdentifier(ident) => ident.gen(p),
-            BindingPattern::ObjectPattern(pattern) => pattern.gen(p),
-            BindingPattern::RestElement(elem) => elem.gen(p),
-            BindingPattern::ArrayPattern(pattern) => pattern.gen(p),
-            BindingPattern::AssignmentPattern(pattern) => pattern.gen(p),
+            BindingPattern::BindingIdentifier(ident) => ident.gen(p, ctx),
+            BindingPattern::ObjectPattern(pattern) => pattern.gen(p, ctx),
+            BindingPattern::RestElement(elem) => elem.gen(p, ctx),
+            BindingPattern::ArrayPattern(pattern) => pattern.gen(p, ctx),
+            BindingPattern::AssignmentPattern(pattern) => pattern.gen(p, ctx),
         }
     }
 }
 
 impl<'a> Gen for ObjectPattern<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'{');
-        p.print_list(&self.properties);
+        p.print_list(&self.properties, ctx);
         if let Some(rest) = &self.rest {
             if !self.properties.is_empty() {
                 p.print_comma();
             }
-            rest.gen(p);
+            rest.gen(p, ctx);
         }
         p.print(b'}');
     }
 }
 
 impl<'a> Gen for BindingProperty<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         if self.computed {
             p.print(b'[');
         }
-        self.key.gen(p);
+        self.key.gen(p, ctx);
         if self.computed {
             p.print(b']');
         }
         p.print(b':');
-        self.value.gen(p);
+        self.value.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for RestElement<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print_ellipsis();
-        self.argument.gen(p);
+        self.argument.gen(p, ctx);
     }
 }
 
 impl<'a> Gen for ArrayPattern<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'[');
         for (index, item) in self.elements.iter().enumerate() {
             if index != 0 {
                 p.print_comma();
             }
             if let Some(item) = item {
-                item.gen(p);
+                item.gen(p, ctx);
             }
             if index == self.elements.len() - 1 && (item.is_none() || self.rest.is_some()) {
                 p.print_comma();
             }
         }
         if let Some(rest) = &self.rest {
-            rest.gen(p);
+            rest.gen(p, ctx);
         }
         p.print(b']');
     }
 }
 
 impl<'a> Gen for AssignmentPattern<'a> {
-    fn gen(&self, p: &mut Printer) {
-        self.left.gen(p);
+    fn gen(&self, p: &mut Printer, ctx: Context) {
+        self.left.gen(p, ctx);
         p.print_equal();
-        self.right.gen_expr(p, Precedence::Assign);
+        self.right.gen_expr(p, Precedence::Assign, Context::default());
     }
 }
 
 impl<'a> Gen for Vec<'a, Decorator<'a>> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         for decorator in self {
-            decorator.gen(p);
+            decorator.gen(p, ctx);
             p.print(b' ');
         }
     }
 }
 
 impl<'a> Gen for Decorator<'a> {
-    fn gen(&self, p: &mut Printer) {
+    fn gen(&self, p: &mut Printer, ctx: Context) {
         p.print(b'@');
-        self.expression.gen_expr(p, Precedence::Assign);
+        self.expression.gen_expr(p, Precedence::Assign, Context::default());
     }
 }

--- a/crates/oxc_minifier/tests/esbuild/mod.rs
+++ b/crates/oxc_minifier/tests/esbuild/mod.rs
@@ -287,27 +287,26 @@ fn object() {
 }
 
 #[test]
-#[ignore]
 fn r#for() {
     // Make sure "in" expressions are forbidden in the right places
-    test("for ((a in b);;);", "for ((a in b); ; )");
-    test("for (a ? b : (c in d);;);", "for (a ? b : (c in d); ; )");
-    test("for ((a ? b : c in d).foo;;);", "for ((a ? b : c in d).foo; ; )");
-    test("for (var x = (a in b);;);", "for (var x = (a in b); ; )");
-    test("for (x = (a in b);;);", "for (x = (a in b); ; )");
-    test("for (x == (a in b);;);", "for (x == (a in b); ; )");
-    test("for (1 * (x == a in b);;);", "for (1 * (x == a in b); ; )");
-    test("for (a ? b : x = (c in d);;);", "for (a ? b : x = (c in d); ; )");
-    test("for (var x = y = (a in b);;);", "for (var x = y = (a in b); ; )");
-    test("for ([a in b];;);", "for ([a in b]; ; )");
-    test("for (x(a in b);;);", "for (x(a in b); ; )");
-    test("for (x[a in b];;);", "for (x[a in b]; ; )");
-    test("for (x?.[a in b];;);", "for (x?.[a in b]; ; )");
-    test("for ((x => a in b);;);", "for ((x) => (a in b); ; )");
+    test("for ((a in b);;);", "for((a in b);;);");
+    test("for (a ? b : (c in d);;);", "for(a?b:(c in d);;);");
+    test("for ((a ? b : c in d).foo;;);", "for((a?b:c in d).foo;;);");
+    test("for (var x = (a in b);;);", "for(var x=(a in b);;);");
+    test("for (x = (a in b);;);", "for(x=(a in b);;);");
+    test("for (x == (a in b);;);", "for(x==(a in b);;);");
+    test("for (1 * (x == a in b);;);", "for(1*(x==a in b);;);");
+    test("for (a ? b : x = (c in d);;);", "for(a?b:x=(c in d);;);");
+    test("for (var x = y = (a in b);;);", "for(var x=y=(a in b);;);");
+    test("for ([a in b];;);", "for([a in b];;);");
+    test("for (x(a in b);;);", "for(x(a in b);;);");
+    test("for (x[a in b];;);", "for(x[a in b];;);");
+    test("for (x?.[a in b];;);", "for(x?.[a in b];;);");
+    test("for ((x => a in b);;);", "for(x=>(a in b);;);");
 
     // Make sure for-of loops with commas are wrapped in parentheses
-    test("for (let a in b, c);", "for (let a in b, c)");
-    test("for (let a of (b, c));", "for (let a of (b, c))");
+    test("for (let a in b, c);", "for(let a in b,c);");
+    test("for (let a of (b, c));", "for(let a of (b,c));");
 }
 
 #[test]
@@ -576,10 +575,10 @@ fn whitespace() {
     test("throw delete x", "throw delete x");
     test("throw function(){}", "throw function(){}");
 
-    // test("x in function(){}", "x in function(){}");
-    // test("x instanceof function(){}", "x instanceof function(){}");
-    // test("π in function(){}", "π in function(){}");
-    // test("π instanceof function(){}", "π instanceof function(){}");
+    test("x in function(){}", "x in function(){}");
+    test("x instanceof function(){}", "x instanceof function(){}");
+    test("π in function(){}", "π in function(){}");
+    test("π instanceof function(){}", "π instanceof function(){}");
 
     test("()=>({})", "()=>({})");
     test("()=>({}[1])", "()=>({})[1]");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,25 +1,25 @@
 Original   -> Minified   -> Gzip       Brotli    
 72.14 kB   -> 24.36 kB   -> 8.68 kB    7.64 kB    react.development.js
 
-173.90 kB  -> 61.89 kB   -> 19.47 kB   17.70 kB   moment.js
+173.90 kB  -> 61.88 kB   -> 19.46 kB   17.72 kB   moment.js
 
-287.63 kB  -> 93.12 kB   -> 32.30 kB   29.32 kB   jquery.js
+287.63 kB  -> 93.07 kB   -> 32.28 kB   29.30 kB   jquery.js
 
-342.15 kB  -> 123.22 kB  -> 44.98 kB   39.90 kB   vue.js
+342.15 kB  -> 123.19 kB  -> 44.97 kB   39.79 kB   vue.js
 
-544.10 kB  -> 74.54 kB   -> 26.08 kB   23.39 kB   lodash.js
+544.10 kB  -> 74.51 kB   -> 26.07 kB   23.37 kB   lodash.js
 
-555.77 kB  -> 274.97 kB  -> 91.38 kB   77.41 kB   d3.js
+555.77 kB  -> 274.90 kB  -> 91.36 kB   77.41 kB   d3.js
 
-977.19 kB  -> 456.45 kB  -> 123.82 kB  107.40 kB  bundle.min.js
+977.19 kB  -> 456.44 kB  -> 123.81 kB  107.51 kB  bundle.min.js
 
-1.25 MB    -> 677.77 kB  -> 166.79 kB  135.23 kB  three.js
+1.25 MB    -> 677.76 kB  -> 166.78 kB  135.09 kB  three.js
 
-2.14 MB    -> 744.16 kB  -> 181.91 kB  139.10 kB  victory.js
+2.14 MB    -> 743.86 kB  -> 181.81 kB  138.95 kB  victory.js
 
-3.20 MB    -> 1.04 MB    -> 333.07 kB  270.27 kB  echarts.js
+3.20 MB    -> 1.04 MB    -> 333.06 kB  270.14 kB  echarts.js
 
-6.69 MB    -> 2.40 MB    -> 498.68 kB  390.89 kB  antd.js
+6.69 MB    -> 2.40 MB    -> 498.57 kB  390.29 kB  antd.js
 
-10.82 MB   -> 3.52 MB    -> 909.48 kB  700.95 kB  typescript.js
+10.82 MB   -> 3.52 MB    -> 909.47 kB  701.20 kB  typescript.js
 


### PR DESCRIPTION
closes #402

This prints the correct parens for `a in b` expression according to the grammar. Which currently is inside the for loop head.

![image](https://github.com/Boshen/oxc/assets/1430279/ecfd1c91-a370-4c71-afd0-1741c4262012)
