### PR TITLE
fix(tasks/rulegen): use correct `Span` import

### DIFF
--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -1,9 +1,9 @@
-use oxc_span::Span;
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -1,4 +1,4 @@
-use oxc_ast::Span;
+use oxc_span::Span;
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,


### PR DESCRIPTION
It seems `Span` is now in `oxc_span` instead of `oxc_ast`.