### PR TITLE
feat(minifier): separate mangler pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_lower",
  "oxc_hir",
+ "oxc_index",
  "oxc_parser",
  "oxc_semantic2",
  "oxc_span",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -19,6 +19,7 @@ oxc_ast_lower = { workspace = true }
 oxc_hir       = { workspace = true }
 oxc_semantic2 = { workspace = true }
 oxc_syntax    = { workspace = true }
+oxc_index     = { workspace = true }
 bitflags      = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -764,8 +764,9 @@ impl<'a> GenExpr for Expression<'a> {
 
 impl Gen for IdentifierReference {
     fn gen(&self, p: &mut Printer, ctx: Context) {
-        if p.mangle && let Some(symbol_id) = p.symbol_table.get_reference(self.reference_id).symbol_id {
-            p.print_symbol(symbol_id, &self.name);
+        if let Some(mangler) = &p.mangler
+            && let Some(name) = mangler.get_reference_name(self.span) {
+            p.print_str(name.clone().as_bytes());
         } else {
             p.print_str(self.name.as_bytes());
         }
@@ -780,7 +781,7 @@ impl Gen for IdentifierName {
 
 impl Gen for BindingIdentifier {
     fn gen(&self, p: &mut Printer, ctx: Context) {
-        p.print_symbol(self.symbol_id, &self.name);
+        p.print_symbol(self.span, &self.name);
     }
 }
 

--- a/crates/oxc_semantic2/src/builder.rs
+++ b/crates/oxc_semantic2/src/builder.rs
@@ -30,7 +30,7 @@ impl SemanticBuilder {
         Semantic { scope_tree: self.scope_tree, symbol_table: self.symbol_table }
     }
 
-    fn enter_scope(&mut self, flags: ScopeFlags) {
+    pub fn enter_scope(&mut self, flags: ScopeFlags) {
         let mut flags = flags;
         // Inherit strict mode for functions
         // https://tc39.es/ecma262/#sec-strict-mode-code
@@ -67,7 +67,7 @@ impl SemanticBuilder {
     /// excludes: the flags which node cannot be declared alongside in a symbol table. Used to report forbidden declarations.
     ///
     /// Reports errors for conflicting identifier names.
-    fn declare_symbol(
+    pub fn declare_symbol(
         &mut self,
         span: Span,
         name: &Atom,
@@ -120,7 +120,7 @@ impl SemanticBuilder {
         // }
     }
 
-    fn declare_reference(&mut self, span: Span, name: &Atom) -> ReferenceId {
+    pub fn declare_reference(&mut self, span: Span, name: &Atom) -> ReferenceId {
         let reference_id = self.symbol_table.create_reference(span, name.clone());
         self.scope_tree.add_unresolved_reference(self.current_scope_id, name.clone(), reference_id);
         reference_id

--- a/crates/oxc_semantic2/src/lib.rs
+++ b/crates/oxc_semantic2/src/lib.rs
@@ -1,19 +1,12 @@
 mod builder;
-mod mangler;
 pub mod reference;
 pub mod scope;
 pub mod symbol;
 
 pub use crate::builder::SemanticBuilder;
-use crate::{mangler::Mangler, scope::ScopeTree, symbol::SymbolTable};
+use crate::{scope::ScopeTree, symbol::SymbolTable};
 
 pub struct Semantic {
     pub scope_tree: ScopeTree,
     pub symbol_table: SymbolTable,
-}
-
-impl Semantic {
-    pub fn mangle(&mut self) {
-        Mangler::mangle(self);
-    }
 }

--- a/crates/oxc_semantic2/src/symbol.rs
+++ b/crates/oxc_semantic2/src/symbol.rs
@@ -40,8 +40,16 @@ impl SymbolTable {
         self.len() == 0
     }
 
+    pub fn get_span(&self, symbol_id: SymbolId) -> Span {
+        self.spans[symbol_id]
+    }
+
     pub fn get_name(&self, symbol_id: SymbolId) -> &Atom {
         &self.names[symbol_id]
+    }
+
+    pub fn set_name(&mut self, symbol_id: SymbolId, name: Atom) {
+        self.names[symbol_id] = name;
     }
 
     pub fn get_flag(&self, symbol_id: SymbolId) -> SymbolFlags {

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -19,7 +19,7 @@ Original   -> Minified   -> Gzip       Brotli
 
 3.20 MB    -> 1.04 MB    -> 333.06 kB  270.14 kB  echarts.js
 
-6.69 MB    -> 2.40 MB    -> 498.57 kB  390.29 kB  antd.js
+6.69 MB    -> 2.40 MB    -> 498.53 kB  390.37 kB  antd.js
 
 10.82 MB   -> 3.52 MB    -> 909.47 kB  701.20 kB  typescript.js
 


### PR DESCRIPTION
The mangler is separated into another AST pass. Please note this will impact performance.

The benefit of doing this is that, we can now safely move functions around, drop unused identifiers and inline functions.

After this is merged, we can look into how google closure compiler optimizes this further by ordering the symbols to maximize gzip compression. https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/RenameVars.java

Once the feature is complete, we shall go back and improve the performance by optimizing memory usage.