### PR TITLE
Reimplement more of the closure var rename step

### DIFF
--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -1,6 +1,7 @@
 //! ECMAScript Minifier
 
 #![feature(let_chains)]
+#![feature(slice_group_by)]
 
 mod compressor;
 mod mangler;

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -186,22 +186,43 @@ impl ManglerBuilder {
 
         // Group similar symbols for smaller gzipped file
         // <https://github.com/google/closure-compiler/blob/c383a3a1d2fce33b6c778ef76b5a626e07abca41/src/com/google/javascript/jscomp/RenameVars.java#L475-L483>
-        let mut freq_iter = frequencies.iter();
+        // Original Comment:
+        // 1) The most frequent vars get the shorter names.
+        // 2) If N number of vars are going to be assigned names of the same
+        //    length, we assign the N names based on the order at which the vars
+        //    first appear in the source. This makes the output somewhat less
+        //    random, because symbols declared close together are assigned names
+        //    that are quite similar. With this heuristic, the output is more
+        //    compressible.
+        //    For instance, the output may look like:
+        //    var da = "..", ea = "..";
+        //    function fa() { .. } function ga() { .. }
 
+        let mut freq_iter = frequencies.iter();
+        // 2. "N number of vars are going to be assigned names of the same length"
         for slice_of_same_len_strings in names.group_by_mut(|a, b| a.len() == b.len()) {
+            // 1. "The most frequent vars get the shorter names"
+            // (freq_iter is sorted by frequency from highest to lowest,
+            //  so taking means take the N most frequent symbols remaining)
             let mut symbols_renamed_in_this_batch =
                 freq_iter.by_ref().take(slice_of_same_len_strings.len()).collect::<Vec<_>>();
 
             debug_assert!(symbols_renamed_in_this_batch.len() == slice_of_same_len_strings.len());
 
+            // 2. "we assign the N names based on the order at which the vars first appear in the source."
+            // sorting by slot enables us to sort by the order at which the vars first appear in the source
+            // (this is possible because the slots are discovered currently in a DFS method which is the same order
+            //  as variables appear in the source code)
             symbols_renamed_in_this_batch.sort_by(|a, b| a.slot.cmp(&b.slot.clone()));
 
-            let mut iter_of_new_names = slice_of_same_len_strings.iter_mut();
-            for symbol_to_rename in symbols_renamed_in_this_batch {
-                if let Some(name) = iter_of_new_names.next() {
-                    for symbol_id in &symbol_to_rename.symbol_ids {
-                        symbol_table.set_name(*symbol_id, name.clone());
-                    }
+            // here we just zip the iterator of symbols to rename with the iterator of new names for the next for loop
+            let symbols_to_rename_with_new_names =
+                symbols_renamed_in_this_batch.iter().zip(slice_of_same_len_strings.iter());
+
+            // rename the variables
+            for (symbol_to_rename, new_name) in symbols_to_rename_with_new_names {
+                for symbol_id in &symbol_to_rename.symbol_ids {
+                    symbol_table.set_name(*symbol_id, new_name.clone());
                 }
             }
         }

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -192,19 +192,14 @@ impl ManglerBuilder {
 
             debug_assert!(symbols_renamed_in_this_batch.len() == slice_of_same_len_strings.len());
 
-            let symbols_to_rename_grouped_by_freq =
-                symbols_renamed_in_this_batch.group_by_mut(|a, b| a.frequency == b.frequency);
-
             let mut iter_of_new_names = slice_of_same_len_strings.into_iter();
-            for slice_of_symbols_with_same_frequency in symbols_to_rename_grouped_by_freq {
-                slice_of_symbols_with_same_frequency.sort_by(|a, b| a.slot.cmp(&b.slot.clone()));
-                for symbol_to_rename in slice_of_symbols_with_same_frequency {
-                    let name = iter_of_new_names.next().unwrap().to_owned();
+            symbols_renamed_in_this_batch.sort_by(|a, b| a.slot.cmp(&b.slot.clone()));
+            for symbol_to_rename in symbols_renamed_in_this_batch {
+                let name = iter_of_new_names.next().unwrap().to_owned();
 
-                    symbol_to_rename.symbol_ids.iter().for_each(|symbol_id| {
-                        symbol_table.set_name(*symbol_id, name.to_owned());
-                    });
-                }
+                symbol_to_rename.symbol_ids.iter().for_each(|symbol_id| {
+                    symbol_table.set_name(*symbol_id, name.to_owned());
+                });
             }
         }
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,25 +1,25 @@
 Original   -> Minified   -> Gzip       Brotli    
-72.14 kB   -> 24.36 kB   -> 8.68 kB    7.64 kB    react.development.js
+72.14 kB   -> 24.36 kB   -> 8.73 kB    7.64 kB    react.development.js
 
-173.90 kB  -> 61.88 kB   -> 19.46 kB   17.72 kB   moment.js
+173.90 kB  -> 61.88 kB   -> 19.57 kB   17.81 kB   moment.js
 
-287.63 kB  -> 93.07 kB   -> 32.28 kB   29.30 kB   jquery.js
+287.63 kB  -> 93.07 kB   -> 32.33 kB   29.24 kB   jquery.js
 
-342.15 kB  -> 123.19 kB  -> 44.97 kB   39.79 kB   vue.js
+342.15 kB  -> 123.19 kB  -> 45.03 kB   39.70 kB   vue.js
 
-544.10 kB  -> 74.51 kB   -> 26.07 kB   23.37 kB   lodash.js
+544.10 kB  -> 74.51 kB   -> 26.02 kB   23.15 kB   lodash.js
 
-555.77 kB  -> 274.90 kB  -> 91.36 kB   77.41 kB   d3.js
+555.77 kB  -> 274.90 kB  -> 91.40 kB   76.95 kB   d3.js
 
-977.19 kB  -> 456.44 kB  -> 123.81 kB  107.51 kB  bundle.min.js
+977.19 kB  -> 456.44 kB  -> 123.71 kB  107.15 kB  bundle.min.js
 
-1.25 MB    -> 677.76 kB  -> 166.78 kB  135.09 kB  three.js
+1.25 MB    -> 677.76 kB  -> 166.58 kB  134.57 kB  three.js
 
-2.14 MB    -> 743.86 kB  -> 181.81 kB  138.95 kB  victory.js
+2.14 MB    -> 743.86 kB  -> 181.83 kB  138.83 kB  victory.js
 
-3.20 MB    -> 1.04 MB    -> 333.06 kB  270.14 kB  echarts.js
+3.20 MB    -> 1.04 MB    -> 333.32 kB  269.37 kB  echarts.js
 
-6.69 MB    -> 2.40 MB    -> 498.53 kB  390.37 kB  antd.js
+6.69 MB    -> 2.40 MB    -> 498.46 kB  390.71 kB  antd.js
 
-10.82 MB   -> 3.52 MB    -> 909.47 kB  701.20 kB  typescript.js
+10.82 MB   -> 3.52 MB    -> 902.66 kB  693.41 kB  typescript.js
 


### PR DESCRIPTION
https://github.com/google/closure-compiler/blob/c383a3a1d2fce33b6c778ef76b5a626e07abca41/src/com/google/javascript/jscomp/RenameVars.java#L475C10-L483

```diff
  Original   -> Minified   -> Gzip      
- 10.82 MB   -> 3.52 MB    -> 909.47 kB typescript.js
+ 10.82 MB   -> 3.52 MB    -> 902.66 kB typescript.js
```