### PR TITLE
perf(manger): use RefCell<SymbolId> instead of roundtrip with BTreeMap

### DIFF
--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     fmt,
     hash::{Hash, Hasher},
 };
@@ -399,25 +400,37 @@ pub struct IdentifierName {
 }
 
 /// Identifier Reference
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct IdentifierReference {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom,
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub reference_id: ReferenceId,
+    pub reference_id: RefCell<ReferenceId>,
+}
+
+impl Hash for IdentifierReference {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
 }
 
 /// Binding Identifier
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct BindingIdentifier {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom,
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub symbol_id: SymbolId,
+    pub symbol_id: RefCell<SymbolId>,
+}
+
+impl Hash for BindingIdentifier {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
 }
 
 /// Label Identifier

--- a/crates/oxc_hir/src/hir_builder.rs
+++ b/crates/oxc_hir/src/hir_builder.rs
@@ -182,7 +182,7 @@ impl<'a> HirBuilder<'a> {
         name: Atom,
         reference_id: ReferenceId,
     ) -> IdentifierReference {
-        IdentifierReference { span, name, reference_id }
+        IdentifierReference { span, name, reference_id: reference_id.into() }
     }
 
     pub fn binding_identifier(
@@ -191,7 +191,7 @@ impl<'a> HirBuilder<'a> {
         name: Atom,
         symbol_id: SymbolId,
     ) -> BindingIdentifier {
-        BindingIdentifier { span, name, symbol_id }
+        BindingIdentifier { span, name, symbol_id: symbol_id.into() }
     }
 
     pub fn label_identifier(&mut self, span: Span, name: Atom) -> LabelIdentifier {

--- a/crates/oxc_minifier/src/compressor/fold.rs
+++ b/crates/oxc_minifier/src/compressor/fold.rs
@@ -307,7 +307,7 @@ impl<'a> Compressor<'a> {
                 let ident = self.hir.identifier_reference(
                     unary_expr.span,
                     ident.name.clone(),
-                    ident.reference_id,
+                    ident.reference_id.clone().into_inner(),
                 );
                 return Some(self.hir.identifier_reference_expression(ident));
             }

--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -163,7 +163,7 @@ impl<'a> Compressor<'a> {
     fn compress_undefined<'b>(&mut self, expr: &'b mut Expression<'a>) -> bool {
         if let Expression::Identifier(ident) = expr
         && ident.name == "undefined"
-        && self.semantic.symbol_table.is_global_reference(ident.reference_id) {
+        && self.semantic.symbol_table.is_global_reference(ident.reference_id.clone().into_inner()) {
             *expr = self.create_void_0();
             return true;
         }
@@ -175,7 +175,7 @@ impl<'a> Compressor<'a> {
     fn compress_infinity<'b>(&mut self, expr: &'b mut Expression<'a>) -> bool {
         if let Expression::Identifier(ident) = expr
         && ident.name == "Infinity"
-        && self.semantic.symbol_table.is_global_reference(ident.reference_id) {
+        && self.semantic.symbol_table.is_global_reference(ident.reference_id.clone().into_inner()) {
             *expr = self.create_one_div_zero();
             return true;
         }

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -765,7 +765,7 @@ impl<'a> GenExpr for Expression<'a> {
 impl Gen for IdentifierReference {
     fn gen(&self, p: &mut Printer, ctx: Context) {
         if let Some(mangler) = &p.mangler
-            && let Some(name) = mangler.get_reference_name(self.span) {
+            && let Some(name) = mangler.get_reference_name(self.reference_id.clone().into_inner()) {
             p.print_str(name.clone().as_bytes());
         } else {
             p.print_str(self.name.as_bytes());
@@ -781,7 +781,7 @@ impl Gen for IdentifierName {
 
 impl Gen for BindingIdentifier {
     fn gen(&self, p: &mut Printer, ctx: Context) {
-        p.print_symbol(self.span, &self.name);
+        p.print_symbol(self.symbol_id.clone().into_inner(), &self.name);
     }
 }
 

--- a/crates/oxc_minifier/src/printer/mod.rs
+++ b/crates/oxc_minifier/src/printer/mod.rs
@@ -250,9 +250,9 @@ impl Printer {
         }
     }
 
-    fn print_symbol(&mut self, span: Span, fallback: &Atom) {
-        if let Some(mangler) = &self.mangler
-            && let Some(name) = mangler.get_symbol_name(span) {
+    fn print_symbol(&mut self, symbol_id: SymbolId, fallback: &Atom) {
+        if let Some(mangler) = &self.mangler {
+            let name = mangler.get_symbol_name(symbol_id);
             self.print_str(name.clone().as_bytes());
         } else {
             self.print_str(fallback.as_bytes());


### PR DESCRIPTION
Previously I was trying to be pure during the mangler visit, where we save the new symbol ids in a lookup table. This obviously kills performance due to the huge amount of memory inefficiency.

This PR changes the symbol id to a RefCell, where we can safely mutate the symbol id. I don't know what other impact this may introduce ... but it works.