### PR TITLE
Update to latest Ezno checker and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "ezno-checker"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e5c8dfbd90b19744169af6bc83e3b7b8dd0e359d8e39db9c959cdde8378aba"
+checksum = "ce89c36282d2e7e84de91cca6c2c32ba11f4839ae8c73fb7cc0024411ab28521"
 dependencies = [
  "bimap",
  "binary-serialize-derive",
@@ -1435,6 +1435,7 @@ dependencies = [
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_type_synthesis",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",

--- a/crates/oxc_cli/src/type_check/mod.rs
+++ b/crates/oxc_cli/src/type_check/mod.rs
@@ -172,16 +172,16 @@ mod type_check_output {
             // Conversion from Ezno -> codespan
             let diagnostic = match diagnostic {
                 TypeCheckDiagnostic::Global { reason, kind } => Diagnostic {
-                    severity: ezno_diagnostic_to_severity(kind),
+                    severity: ezno_diagnostic_to_severity(&kind),
                     code: None,
                     message: reason,
                     labels: Vec::new(),
                     notes: Vec::default(),
                 },
                 TypeCheckDiagnostic::Position { reason, position, kind } => Diagnostic {
-                    severity: ezno_diagnostic_to_severity(kind),
+                    severity: ezno_diagnostic_to_severity(&kind),
                     code: None,
-                    message: Default::default(),
+                    message: String::default(),
                     labels: vec![Label::primary((), position).with_message(reason)],
                     notes: Vec::default(),
                 },
@@ -195,9 +195,9 @@ mod type_check_output {
                         labels.into_iter().partition::<Vec<_>, _>(|(_, value)| value.is_some());
 
                     Diagnostic {
-                        severity: ezno_diagnostic_to_severity(kind),
+                        severity: ezno_diagnostic_to_severity(&kind),
                         code: None,
-                        message: Default::default(),
+                        message: String::default(),
                         labels: iter::once(Label::primary((), position).with_message(reason))
                             .chain(labels.into_iter().map(|(message, position)| {
                                 let position = position.unwrap();
@@ -213,7 +213,7 @@ mod type_check_output {
                 .unwrap();
         }
 
-        fn ezno_diagnostic_to_severity(kind: DiagnosticKind) -> Severity {
+        fn ezno_diagnostic_to_severity(kind: &DiagnosticKind) -> Severity {
             match kind {
                 DiagnosticKind::Error => Severity::Error,
                 DiagnosticKind::Warning => Severity::Warning,

--- a/crates/oxc_cli/src/type_check/mod.rs
+++ b/crates/oxc_cli/src/type_check/mod.rs
@@ -40,12 +40,20 @@ declare var console: Console;
 #[allow(clippy::struct_excessive_bools)]
 pub struct TypeCheckOptions {
     pub path: PathBuf,
+    // TODO temp, for exhibition
+    pub print_expression_mappings: bool,
+    // TODO temp, for exhibition
+    pub print_called_functions: bool,
 }
 
 #[allow(clippy::fallible_impl_from)]
 impl<'a> From<&'a ArgMatches> for TypeCheckOptions {
     fn from(matches: &'a ArgMatches) -> Self {
-        Self { path: PathBuf::from(matches.get_one::<String>("path").unwrap()) }
+        Self {
+            path: PathBuf::from(matches.get_one::<String>("path").unwrap()),
+            print_called_functions: matches.contains_id("print_called_functions"),
+            print_expression_mappings: matches.contains_id("print_expression_mappings"),
+        }
     }
 }
 
@@ -54,7 +62,13 @@ pub fn type_check_command() -> Command {
         .about(
             "NOTE: Experimental / work in progress. Check source code for type errors using Ezno",
         )
-        .arg(Arg::new("path").value_name("PATH").num_args(1..).help("File to type check"))
+        .arg(Arg::new("path").value_name("PATH").num_args(1).help("File to type check"))
+        .arg(
+            Arg::new("print_expression_mappings")
+                .required(false)
+                .help("Print types of expressions"),
+        )
+        .arg(Arg::new("print_called_functions").required(false).help("Print called functions"))
 }
 
 pub struct TypeCheckRunner {
@@ -80,23 +94,23 @@ impl TypeCheckRunner {
         let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
         if ret.errors.is_empty() {
-            let (diagnostics, _events, _types) =
+            let (diagnostics, _events, types, mappings, root_env) =
                 synthesize_program(&ret.program, |_: &std::path::Path| None);
 
             let duration = now.elapsed();
 
-            // if args.iter().any(|arg| arg == "--types") {
-            //     eprintln!("Types:");
-            //     for item in types {
-            //         eprintln!("\t{:?}", item);
-            //     }
-            // }
-            // if args.iter().any(|arg| arg == "--events") {
-            //     eprintln!("Events:");
-            //     for item in events {
-            //         eprintln!("\t{:?}", item);
-            //     }
-            // }
+            if self.options.print_expression_mappings {
+                let mappings = mappings.print_type_mappings(
+                    &source_text,
+                    &root_env.into_general_environment(),
+                    &types,
+                );
+                eprintln!("{mappings}");
+            }
+            if self.options.print_called_functions {
+                let called_functions = mappings.print_called_functions(&source_text);
+                eprintln!("{called_functions}");
+            }
 
             // TODO
             let number_of_diagnostics = 0;
@@ -122,7 +136,7 @@ mod type_check_output {
     use std::iter;
 
     use codespan_reporting::{
-        diagnostic::{Diagnostic, Label},
+        diagnostic::{Diagnostic, Label, Severity},
         files::SimpleFile,
         term::{
             termcolor::{ColorChoice, StandardStream},
@@ -130,12 +144,12 @@ mod type_check_output {
         },
     };
     use oxc_type_synthesis::{
-        Diagnostic as TypeCheckDiagnostic, DiagnosticsContainer, ErrorWarningInfo,
+        Diagnostic as TypeCheckDiagnostic, DiagnosticKind, DiagnosticsContainer,
     };
 
     #[allow(clippy::items_after_statements)]
     pub(super) fn print_diagnostics_container(
-        error_handler: DiagnosticsContainer,
+        diagnostic_container: DiagnosticsContainer,
         path: String,
         content: String,
     ) {
@@ -151,72 +165,59 @@ mod type_check_output {
         //     file_id_to_source_id.insert(source_id, file_id);
         // }
 
-        for item in error_handler.into_iter().rev() {
-            // TODO tidy this up:
-            let (diagnostic, info) = match item {
-                ErrorWarningInfo::Error(error) => (Diagnostic::error(), error),
-                ErrorWarningInfo::Warning(warning) => (Diagnostic::warning(), warning),
-                ErrorWarningInfo::Info(info) => (Diagnostic::note(), info),
-                ErrorWarningInfo::Data(_) => {
-                    continue;
+        let writer = StandardStream::stderr(ColorChoice::Always);
+        let mut lock = writer.lock();
+
+        for diagnostic in diagnostic_container.into_iter().rev() {
+            // Conversion from Ezno -> codespan
+            let diagnostic = match diagnostic {
+                TypeCheckDiagnostic::Global { reason, kind } => Diagnostic {
+                    severity: ezno_diagnostic_to_severity(kind),
+                    code: None,
+                    message: reason,
+                    labels: Vec::new(),
+                    notes: Vec::default(),
+                },
+                TypeCheckDiagnostic::Position { reason, position, kind } => Diagnostic {
+                    severity: ezno_diagnostic_to_severity(kind),
+                    code: None,
+                    message: Default::default(),
+                    labels: vec![Label::primary((), position).with_message(reason)],
+                    notes: Vec::default(),
+                },
+                TypeCheckDiagnostic::PositionWithAdditionLabels {
+                    reason,
+                    position,
+                    labels,
+                    kind,
+                } => {
+                    let (labels, notes) =
+                        labels.into_iter().partition::<Vec<_>, _>(|(_, value)| value.is_some());
+
+                    Diagnostic {
+                        severity: ezno_diagnostic_to_severity(kind),
+                        code: None,
+                        message: Default::default(),
+                        labels: iter::once(Label::primary((), position).with_message(reason))
+                            .chain(labels.into_iter().map(|(message, position)| {
+                                let position = position.unwrap();
+                                Label::secondary((), position).with_message(message)
+                            }))
+                            .collect(),
+                        notes: notes.into_iter().map(|(message, _)| message).collect(),
+                    }
                 }
             };
 
-            let diagnostic = checker_diagnostic_to_code_span_diagnostic(diagnostic, info);
-
-            emit(&files, &diagnostic);
-
-            #[cfg(target_arch = "wasm")]
-            fn emit<'a, F: codespan_reporting::files::Files<'a>>(
-                files: &F,
-                diagnostic: &Diagnostic<F::FileId>,
-            ) {
-                todo!("buffer then print")
-            }
-
-            #[cfg(not(target_arch = "wasm"))]
-            fn emit<'a, F: codespan_reporting::files::Files<'a>>(
-                files: &'a F,
-                diagnostic: &Diagnostic<F::FileId>,
-            ) {
-                let writer = StandardStream::stderr(ColorChoice::Always);
-
-                // TODO lines in diagnostic could be different
-                codespan_reporting::term::emit(
-                    &mut writer.lock(),
-                    &Config::default(),
-                    files,
-                    diagnostic,
-                )
+            codespan_reporting::term::emit(&mut lock, &Config::default(), &files, &diagnostic)
                 .unwrap();
-            }
         }
-    }
 
-    fn checker_diagnostic_to_code_span_diagnostic(
-        diagnostic: Diagnostic<()>,
-        information: TypeCheckDiagnostic,
-        // source_map: &HashMap<EznoSourceId, usize>,
-    ) -> Diagnostic<()> {
-        match information {
-            TypeCheckDiagnostic::Global(message) => diagnostic.with_message(message),
-            TypeCheckDiagnostic::Position { reason: message, pos } => {
-                diagnostic.with_labels(vec![Label::primary((), pos).with_message(message)])
-            }
-            TypeCheckDiagnostic::PositionWithAdditionLabels { reason, pos, labels } => {
-                let (labels, notes) =
-                    labels.into_iter().partition::<Vec<_>, _>(|(_, value)| value.is_some());
-
-                diagnostic
-                    .with_labels(
-                        iter::once(Label::primary((), pos).with_message(reason))
-                            .chain(labels.into_iter().map(|(message, pos)| {
-                                let pos = pos.unwrap();
-                                Label::secondary((), pos).with_message(message)
-                            }))
-                            .collect(),
-                    )
-                    .with_notes(notes.into_iter().map(|(message, _)| message).collect())
+        fn ezno_diagnostic_to_severity(kind: DiagnosticKind) -> Severity {
+            match kind {
+                DiagnosticKind::Error => Severity::Error,
+                DiagnosticKind::Warning => Severity::Warning,
+                DiagnosticKind::Info => Severity::Note,
             }
         }
     }

--- a/crates/oxc_type_synthesis/Cargo.toml
+++ b/crates/oxc_type_synthesis/Cargo.toml
@@ -17,7 +17,7 @@ oxc_syntax    = { workspace = true }
 oxc_allocator = { workspace = true }
 serde_json    = { workspace = true }
 
-ezno-checker = { version = "0.0.2" }
+ezno-checker = { version = "0.0.4" }
 
 [dev_dependencies]
 miette = { workspace = true, features = ["fancy-no-backtrace"] }

--- a/crates/oxc_type_synthesis/examples/check.rs
+++ b/crates/oxc_type_synthesis/examples/check.rs
@@ -45,14 +45,14 @@ fn main() {
         println!("Program parsed");
         // println!("{}", serde_json::to_string_pretty(&ret.program).unwrap());
 
-        let (diagnostics, events, types) =
+        let (diagnostics, events, types, ..) =
             synthesize_program(&ret.program, |_: &std::path::Path| None);
 
         let args: Vec<_> = env::args().collect();
 
         if args.iter().any(|arg| arg == "--types") {
             eprintln!("Types:");
-            for item in types {
+            for item in types.into_vec_temp() {
                 eprintln!("\t{item:?}");
             }
         }
@@ -65,7 +65,7 @@ fn main() {
 
         eprintln!("Diagnostics:");
         for diag in diagnostics.into_iter() {
-            eprintln!("\t{}", diag.get_diagnostic().unwrap().reason());
+            eprintln!("\t{}", diag.reason());
         }
     } else {
         for error in ret.errors {

--- a/crates/oxc_type_synthesis/src/functions.rs
+++ b/crates/oxc_type_synthesis/src/functions.rs
@@ -1,7 +1,7 @@
 use ezno_checker::{
     context::VariableRegisterBehavior,
-    structures::parameters::{SynthesizedParameter, SynthesizedParameters},
-    GenericFunctionTypeParameters, SynthesizableFunction, TypeId,
+    types::functions::{SynthesizedParameter, SynthesizedParameters},
+    GenericTypeParameters, SynthesizableFunction, TypeId,
 };
 use oxc_ast::ast;
 
@@ -11,11 +11,42 @@ use crate::{
     types::synthesize_type_annotation,
 };
 
-pub(crate) struct OxcFunction<'a, 'b>(pub &'a ast::Function<'b>);
+pub(crate) struct OxcFunction<'a, 'b>(pub &'a ast::Function<'b>, pub Option<ast::PropertyKind>);
 
 impl<'a, 'b> SynthesizableFunction for OxcFunction<'a, 'b> {
     fn is_declare(&self) -> bool {
         self.0.is_ts_declare_function()
+    }
+
+    fn is_async(&self) -> bool {
+        self.0.modifiers.contains(ast::ModifierKind::Async)
+    }
+
+    fn get_set_generator_or_none(&self) -> ezno_checker::GetSetGeneratorOrNone {
+        if self.0.generator {
+            ezno_checker::GetSetGeneratorOrNone::Generator
+        } else if let Some(prop_kind) = self.1 {
+            match prop_kind {
+                ast::PropertyKind::Init => ezno_checker::GetSetGeneratorOrNone::None,
+                ast::PropertyKind::Get => ezno_checker::GetSetGeneratorOrNone::Get,
+                ast::PropertyKind::Set => ezno_checker::GetSetGeneratorOrNone::Set,
+            }
+        } else {
+            ezno_checker::GetSetGeneratorOrNone::None
+        }
+    }
+
+    fn id(&self) -> ezno_checker::context::FunctionId {
+        ezno_checker::context::FunctionId(oxc_span_to_source_map_span(self.0.span))
+    }
+
+    fn this_constraint<T: ezno_checker::FSResolver>(
+        &self,
+        _environment: &mut ezno_checker::Environment,
+        _checking_data: &mut ezno_checker::CheckingData<T>,
+    ) -> Option<TypeId> {
+        // TODO
+        None
     }
 
     fn parameters<T: ezno_checker::FSResolver>(
@@ -39,20 +70,22 @@ impl<'a, 'b> SynthesizableFunction for OxcFunction<'a, 'b> {
         &self,
         environment: &mut ezno_checker::Environment,
         checking_data: &mut ezno_checker::CheckingData<T>,
-    ) -> GenericFunctionTypeParameters {
+    ) -> Option<GenericTypeParameters> {
         let type_parameters = self.0.type_parameters.as_deref();
         synthesize_type_parameters(type_parameters, environment, checking_data)
     }
 
-    fn return_type<T: ezno_checker::FSResolver>(
+    fn return_type_annotation<T: ezno_checker::FSResolver>(
         &self,
         environment: &mut ezno_checker::Environment,
         checking_data: &mut ezno_checker::CheckingData<T>,
-    ) -> Option<TypeId> {
-        self.0
-            .return_type
-            .as_ref()
-            .map(|ta| synthesize_type_annotation(&ta.type_annotation, environment, checking_data))
+    ) -> Option<(TypeId, ezno_checker::Span)> {
+        self.0.return_type.as_ref().map(|ta| {
+            (
+                synthesize_type_annotation(&ta.type_annotation, environment, checking_data),
+                oxc_span_to_source_map_span(ta.span),
+            )
+        })
     }
 }
 
@@ -60,35 +93,30 @@ pub(crate) fn synthesize_type_parameters<T: ezno_checker::FSResolver>(
     type_parameters: Option<&oxc_ast::ast::TSTypeParameterDeclaration>,
     environment: &mut ezno_checker::Environment,
     checking_data: &mut ezno_checker::CheckingData<T>,
-) -> GenericFunctionTypeParameters {
-    match type_parameters {
-        Some(params) => {
-            GenericFunctionTypeParameters::TypedParameters(
-                params
-                    .params
-                    .iter()
-                    .map(|ta| {
-                        // TODO effects in a map :/
-                        let constraint_type = ta
-                            .constraint
-                            .as_ref()
-                            .map(|ta| synthesize_type_annotation(ta, environment, checking_data));
-                        let default_type = ta
-                            .default
-                            .as_ref()
-                            .map(|ta| synthesize_type_annotation(ta, environment, checking_data));
-                        environment.new_explicit_type_parameter(
-                            ta.name.name.as_str(),
-                            constraint_type,
-                            default_type,
-                            &mut checking_data.types,
-                        )
-                    })
-                    .collect(),
-            )
-        }
-        None => GenericFunctionTypeParameters::None,
-    }
+) -> Option<GenericTypeParameters> {
+    type_parameters.as_ref().map(|params| {
+        params
+            .params
+            .iter()
+            .map(|ta| {
+                // TODO effects in a map :/
+                let constraint_type = ta
+                    .constraint
+                    .as_ref()
+                    .map(|ta| synthesize_type_annotation(ta, environment, checking_data));
+                let default_type = ta
+                    .default
+                    .as_ref()
+                    .map(|ta| synthesize_type_annotation(ta, environment, checking_data));
+                environment.new_explicit_type_parameter(
+                    ta.name.name.as_str(),
+                    constraint_type,
+                    default_type,
+                    &mut checking_data.types,
+                )
+            })
+            .collect()
+    })
 }
 
 pub(crate) fn synthesize_parameters<T: ezno_checker::FSResolver>(
@@ -99,19 +127,17 @@ pub(crate) fn synthesize_parameters<T: ezno_checker::FSResolver>(
     let (mut parameters, optional_parameters, rest_parameter) = (Vec::new(), Vec::new(), None);
 
     for param in params.items.iter() {
-        let base = param
-            .pattern
-            .type_annotation
-            .as_ref()
-            .map(|ta| synthesize_type_annotation(&ta.type_annotation, environment, checking_data))
-            .unwrap_or(TypeId::ANY_TYPE);
+        let annotation =
+            param.pattern.type_annotation.as_ref().map(|ta| {
+                synthesize_type_annotation(&ta.type_annotation, environment, checking_data)
+            });
 
         let param_type = register_variable(
             &param.pattern.kind,
             &param.span,
             environment,
             checking_data,
-            VariableRegisterBehavior::FunctionParameter { base },
+            VariableRegisterBehavior::FunctionParameter { annotation },
         );
 
         match &param.pattern.kind {
@@ -145,5 +171,89 @@ fn param_to_string(binding: &ast::BindingPatternKind) -> String {
         ast::BindingPatternKind::ArrayPattern(_) => todo!(),
         // ast::BindingPatternKind::RestElement(_) => todo!(),
         ast::BindingPatternKind::AssignmentPattern(_) => todo!(),
+    }
+}
+
+pub(crate) struct OxcArrowFunction<'a, 'b>(pub &'a ast::ArrowExpression<'b>);
+
+impl<'a, 'b> SynthesizableFunction for OxcArrowFunction<'a, 'b> {
+    fn is_declare(&self) -> bool {
+        false
+    }
+
+    fn is_async(&self) -> bool {
+        self.0.r#async
+    }
+
+    fn parameters<T: ezno_checker::FSResolver>(
+        &self,
+        environment: &mut ezno_checker::Environment,
+        checking_data: &mut ezno_checker::CheckingData<T>,
+    ) -> SynthesizedParameters {
+        synthesize_parameters(&self.0.params, environment, checking_data)
+    }
+
+    fn body<T: ezno_checker::FSResolver>(
+        &self,
+        environment: &mut ezno_checker::Environment,
+        checking_data: &mut ezno_checker::CheckingData<T>,
+    ) {
+        if self.0.expression {
+            if let Some(ast::Statement::ExpressionStatement(expr)) = self.0.body.statements.get(0) {
+                let returned = crate::expressions::synthesize_expression(
+                    &expr.expression,
+                    environment,
+                    checking_data,
+                );
+                environment.return_value(returned)
+            } else {
+                unreachable!()
+            }
+        } else {
+            synthesize_statements(&self.0.body.statements, environment, checking_data)
+        }
+    }
+
+    fn type_parameters<T: ezno_checker::FSResolver>(
+        &self,
+        environment: &mut ezno_checker::Environment,
+        checking_data: &mut ezno_checker::CheckingData<T>,
+    ) -> Option<GenericTypeParameters> {
+        let type_parameters = self.0.type_parameters.as_deref();
+        synthesize_type_parameters(type_parameters, environment, checking_data)
+    }
+
+    fn return_type_annotation<T: ezno_checker::FSResolver>(
+        &self,
+        environment: &mut ezno_checker::Environment,
+        checking_data: &mut ezno_checker::CheckingData<T>,
+    ) -> Option<(TypeId, ezno_checker::Span)> {
+        self.0.return_type.as_ref().map(|ta| {
+            (
+                synthesize_type_annotation(&ta.type_annotation, environment, checking_data),
+                oxc_span_to_source_map_span(ta.span),
+            )
+        })
+    }
+
+    fn get_set_generator_or_none(&self) -> ezno_checker::GetSetGeneratorOrNone {
+        if self.0.generator {
+            ezno_checker::GetSetGeneratorOrNone::Generator
+        } else {
+            ezno_checker::GetSetGeneratorOrNone::None
+        }
+    }
+
+    fn id(&self) -> ezno_checker::context::FunctionId {
+        ezno_checker::context::FunctionId(oxc_span_to_source_map_span(self.0.span))
+    }
+
+    fn this_constraint<T: ezno_checker::FSResolver>(
+        &self,
+        _environment: &mut ezno_checker::Environment,
+        _checking_data: &mut ezno_checker::CheckingData<T>,
+    ) -> Option<TypeId> {
+        // TODO
+        None
     }
 }

--- a/crates/oxc_type_synthesis/src/interfaces.rs
+++ b/crates/oxc_type_synthesis/src/interfaces.rs
@@ -23,7 +23,6 @@ pub(crate) fn synthesize_signatures<T: ezno_checker::FSResolver>(
 ) {
     for declaration in signatures.iter() {
         match declaration {
-            ast::TSSignature::TSIndexSignature(_) => todo!(),
             ast::TSSignature::TSPropertySignature(property) => {
                 let key_ty = property_key_to_type(&property.key, environment, checking_data);
                 let value_ty = synthesize_type_annotation(
@@ -31,10 +30,21 @@ pub(crate) fn synthesize_signatures<T: ezno_checker::FSResolver>(
                     environment,
                     checking_data,
                 );
-                environment.register_property(onto, key_ty, value_ty);
+                environment.register_property(
+                    onto,
+                    key_ty,
+                    ezno_checker::Property::Value(value_ty),
+                );
             }
-            ast::TSSignature::TSCallSignatureDeclaration(_) => todo!(),
-            ast::TSSignature::TSConstructSignatureDeclaration(_) => todo!(),
+            ast::TSSignature::TSIndexSignature(item) => {
+				checking_data.raise_unimplemented_error("ts index signature", oxc_span_to_source_map_span(item.span));
+			}
+            ast::TSSignature::TSCallSignatureDeclaration(item) => {
+				checking_data.raise_unimplemented_error("ts call signature", oxc_span_to_source_map_span(item.span));
+			}
+            ast::TSSignature::TSConstructSignatureDeclaration(item) => {
+				checking_data.raise_unimplemented_error("ts construct signature", oxc_span_to_source_map_span(item.span));
+			}
             ast::TSSignature::TSMethodSignature(method) => {
                 // TODO reuse more functions
                 let key_ty = property_key_to_type(&method.key, environment, checking_data);
@@ -121,7 +131,7 @@ pub(crate) fn synthesize_signatures<T: ezno_checker::FSResolver>(
                     constant_fn,
                 );
 
-                environment.register_property(onto, key_ty, func_ty);
+                environment.register_property(onto, key_ty, ezno_checker::Property::Value(func_ty));
             }
         }
     }

--- a/crates/oxc_type_synthesis/src/interfaces.rs
+++ b/crates/oxc_type_synthesis/src/interfaces.rs
@@ -37,14 +37,23 @@ pub(crate) fn synthesize_signatures<T: ezno_checker::FSResolver>(
                 );
             }
             ast::TSSignature::TSIndexSignature(item) => {
-				checking_data.raise_unimplemented_error("ts index signature", oxc_span_to_source_map_span(item.span));
-			}
+                checking_data.raise_unimplemented_error(
+                    "ts index signature",
+                    oxc_span_to_source_map_span(item.span),
+                );
+            }
             ast::TSSignature::TSCallSignatureDeclaration(item) => {
-				checking_data.raise_unimplemented_error("ts call signature", oxc_span_to_source_map_span(item.span));
-			}
+                checking_data.raise_unimplemented_error(
+                    "ts call signature",
+                    oxc_span_to_source_map_span(item.span),
+                );
+            }
             ast::TSSignature::TSConstructSignatureDeclaration(item) => {
-				checking_data.raise_unimplemented_error("ts construct signature", oxc_span_to_source_map_span(item.span));
-			}
+                checking_data.raise_unimplemented_error(
+                    "ts construct signature",
+                    oxc_span_to_source_map_span(item.span),
+                );
+            }
             ast::TSSignature::TSMethodSignature(method) => {
                 // TODO reuse more functions
                 let key_ty = property_key_to_type(&method.key, environment, checking_data);

--- a/crates/oxc_type_synthesis/src/lib.rs
+++ b/crates/oxc_type_synthesis/src/lib.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::all, clippy::restriction, clippy::pedantic, clippy::nursery)]
 
 use ezno_checker::{
-    events::Event, CheckingData, Environment, FSResolver, Root, Scope, Span as SourceMapSpan,
-    TypeId,
+    events::Event, types::TypeStore, CheckingData, Environment, FSResolver, Root, Scope,
+    Span as SourceMapSpan, TypeId, TypeMappings,
 };
 pub use ezno_checker::{
-    Diagnostic, DiagnosticsContainer, ErrorWarningInfo, SourceId as EznoSourceId, Span as EznoSpan,
+    Diagnostic, DiagnosticKind, DiagnosticsContainer, SourceId as EznoSourceId, Span as EznoSpan,
 };
 use oxc_ast::ast;
 use oxc_span::Span;
@@ -20,7 +20,7 @@ mod types;
 pub fn synthesize_program<T: FSResolver>(
     program: &ast::Program,
     resolver: T,
-) -> (DiagnosticsContainer, Vec<Event>, Vec<(TypeId, ezno_checker::Type)>) {
+) -> (DiagnosticsContainer, Vec<Event>, TypeStore, TypeMappings, Root) {
     let default_settings = Default::default();
     let mut checking_data = CheckingData::new(default_settings, &resolver);
 
@@ -34,7 +34,13 @@ pub fn synthesize_program<T: FSResolver>(
         },
     );
 
-    (checking_data.diagnostics_container, stuff.unwrap().0, checking_data.types.into_vec_temp())
+    (
+        checking_data.diagnostics_container,
+        stuff.unwrap().0,
+        checking_data.types,
+        checking_data.type_mappings,
+        root,
+    )
 }
 
 fn oxc_span_to_source_map_span(span: Span) -> SourceMapSpan {

--- a/crates/oxc_type_synthesis/src/types.rs
+++ b/crates/oxc_type_synthesis/src/types.rs
@@ -35,13 +35,15 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
                 .raise_unimplemented_error("this type", oxc_span_to_source_map_span(item.span));
             TypeId::ERROR_TYPE
         }
-        ast::TSType::TSUndefinedKeyword(_) => TypeId::UNDEFINED_TYPE,
+        // 🔥
+        ast::TSType::TSVoidKeyword(_) | ast::TSType::TSUndefinedKeyword(_) => {
+            TypeId::UNDEFINED_TYPE
+        }
         ast::TSType::TSUnknownKeyword(item) => {
             checking_data
                 .raise_unimplemented_error("unknown type", oxc_span_to_source_map_span(item.span));
             TypeId::ERROR_TYPE
         }
-        ast::TSType::TSVoidKeyword(_) => TypeId::UNDEFINED_TYPE,
         ast::TSType::TSArrayType(item) => {
             checking_data
                 .raise_unimplemented_error("array type", oxc_span_to_source_map_span(item.span));
@@ -238,13 +240,17 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
             }
         }
         ast::TSType::JSDocNullableType(item) => {
-            checking_data
-                .raise_unimplemented_error("js doc nullable", oxc_span_to_source_map_span(item.span));
+            checking_data.raise_unimplemented_error(
+                "js doc nullable",
+                oxc_span_to_source_map_span(item.span),
+            );
             TypeId::ERROR_TYPE
         }
         ast::TSType::JSDocUnknownType(item) => {
-            checking_data
-                .raise_unimplemented_error("js doc unknown", oxc_span_to_source_map_span(item.span));
+            checking_data.raise_unimplemented_error(
+                "js doc unknown",
+                oxc_span_to_source_map_span(item.span),
+            );
             TypeId::ERROR_TYPE
         }
     }

--- a/crates/oxc_type_synthesis/src/types.rs
+++ b/crates/oxc_type_synthesis/src/types.rs
@@ -10,19 +10,43 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
 ) -> TypeId {
     match ta {
         ast::TSType::TSAnyKeyword(_) => TypeId::ANY_TYPE,
-        ast::TSType::TSBigIntKeyword(_) => todo!(),
+        ast::TSType::TSBigIntKeyword(item) => {
+            checking_data.raise_unimplemented_error(
+                "big int keyword",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSBooleanKeyword(_) => TypeId::BOOLEAN_TYPE,
         ast::TSType::TSNeverKeyword(_) => TypeId::NEVER_TYPE,
         ast::TSType::TSNullKeyword(_) => TypeId::NULL_TYPE,
         ast::TSType::TSNumberKeyword(_) => TypeId::NUMBER_TYPE,
         ast::TSType::TSObjectKeyword(_) => TypeId::OBJECT_TYPE,
         ast::TSType::TSStringKeyword(_) => TypeId::STRING_TYPE,
-        ast::TSType::TSSymbolKeyword(_) => todo!(),
-        ast::TSType::TSThisKeyword(_) => todo!(),
+        ast::TSType::TSSymbolKeyword(item) => {
+            checking_data.raise_unimplemented_error(
+                "symbol keyword",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSThisKeyword(item) => {
+            checking_data
+                .raise_unimplemented_error("this type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSUndefinedKeyword(_) => TypeId::UNDEFINED_TYPE,
-        ast::TSType::TSUnknownKeyword(_) => todo!(),
+        ast::TSType::TSUnknownKeyword(item) => {
+            checking_data
+                .raise_unimplemented_error("unknown type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSVoidKeyword(_) => TypeId::UNDEFINED_TYPE,
-        ast::TSType::TSArrayType(_) => todo!(),
+        ast::TSType::TSArrayType(item) => {
+            checking_data
+                .raise_unimplemented_error("array type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSConditionalType(condition) => {
             let check_type =
                 synthesize_type_annotation(&condition.check_type, environment, checking_data);
@@ -33,11 +57,35 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
 
             checking_data.types.new_conditional_extends_type(check_type, extends, lhs, rhs)
         }
-        ast::TSType::TSConstructorType(_) => todo!(),
-        ast::TSType::TSFunctionType(_) => todo!(),
-        ast::TSType::TSImportType(_) => todo!(),
-        ast::TSType::TSIndexedAccessType(_) => todo!(),
-        ast::TSType::TSInferType(_) => todo!(),
+        ast::TSType::TSConstructorType(item) => {
+            checking_data.raise_unimplemented_error(
+                "constructor type",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSFunctionType(item) => {
+            checking_data
+                .raise_unimplemented_error("function type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSImportType(item) => {
+            checking_data
+                .raise_unimplemented_error("import type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSIndexedAccessType(item) => {
+            checking_data.raise_unimplemented_error(
+                "index access type",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSInferType(item) => {
+            checking_data
+                .raise_unimplemented_error("infer type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSUnionType(r#union) => {
             // Borrow checker doesn't like :(
             // r#union
@@ -80,15 +128,61 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
             ast::TSLiteral::StringLiteral(string) => checking_data.types.new_constant_type(
                 ezno_checker::Constant::String(string.value.as_str().to_owned()),
             ),
-            ast::TSLiteral::BigintLiteral(_) => todo!(),
-            ast::TSLiteral::RegExpLiteral(_) => todo!(),
-            ast::TSLiteral::TemplateLiteral(_) => todo!(),
-            ast::TSLiteral::UnaryExpression(_) => todo!(),
+            ast::TSLiteral::BigintLiteral(item) => {
+                checking_data.raise_unimplemented_error(
+                    "big int literal type",
+                    oxc_span_to_source_map_span(item.span),
+                );
+                TypeId::ERROR_TYPE
+            }
+            ast::TSLiteral::RegExpLiteral(item) => {
+                checking_data.raise_unimplemented_error(
+                    "regexp literal type",
+                    oxc_span_to_source_map_span(item.span),
+                );
+                TypeId::ERROR_TYPE
+            }
+            ast::TSLiteral::TemplateLiteral(item) => {
+                checking_data.raise_unimplemented_error(
+                    "template literal type",
+                    oxc_span_to_source_map_span(item.span),
+                );
+                TypeId::ERROR_TYPE
+            }
+            ast::TSLiteral::UnaryExpression(item) => {
+                checking_data.raise_unimplemented_error(
+                    "unary expression type",
+                    oxc_span_to_source_map_span(item.span),
+                );
+                TypeId::ERROR_TYPE
+            }
         },
-        ast::TSType::TSMappedType(_) => todo!(),
-        ast::TSType::TSQualifiedName(_name) => todo!(),
-        ast::TSType::TSTemplateLiteralType(_) => todo!(),
-        ast::TSType::TSTupleType(_) => todo!(),
+        ast::TSType::TSMappedType(item) => {
+            checking_data.raise_unimplemented_error(
+                "ts mapped type",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSQualifiedName(item) => {
+            checking_data.raise_unimplemented_error(
+                "ts qualified name",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSTemplateLiteralType(item) => {
+            checking_data.raise_unimplemented_error(
+                "ts template literal type",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSTupleType(item) => {
+            checking_data
+                .raise_unimplemented_error("tuple type", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSTypeLiteral(anom_interface) => {
             let ty = checking_data.types.new_anonymous_interface_ty();
             crate::interfaces::synthesize_signatures(
@@ -99,12 +193,32 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
             );
             ty
         }
-        ast::TSType::TSTypeOperatorType(_) => todo!(),
-        ast::TSType::TSTypePredicate(_) => todo!(),
-        ast::TSType::TSTypeQuery(_) => todo!(),
+        ast::TSType::TSTypeOperatorType(item) => {
+            checking_data.raise_unimplemented_error(
+                "ts operator type",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSTypePredicate(item) => {
+            checking_data.raise_unimplemented_error(
+                "ts type predicate",
+                oxc_span_to_source_map_span(item.span),
+            );
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::TSTypeQuery(item) => {
+            checking_data
+                .raise_unimplemented_error("ts type query", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
         ast::TSType::TSTypeReference(reference) => {
             if let Some(ref _args) = reference.type_parameters {
-                todo!()
+                checking_data.raise_unimplemented_error(
+                    "reference with parameters",
+                    oxc_span_to_source_map_span(reference.span),
+                );
+                return TypeId::ERROR_TYPE;
             }
             let tn = &reference.type_name;
             match tn {
@@ -114,10 +228,24 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
                         oxc_span_to_source_map_span(name.span),
                         checking_data,
                     ),
-                ast::TSTypeName::QualifiedName(_) => todo!(),
+                ast::TSTypeName::QualifiedName(item) => {
+                    checking_data.raise_unimplemented_error(
+                        "qualified name",
+                        oxc_span_to_source_map_span(item.span),
+                    );
+                    TypeId::ERROR_TYPE
+                }
             }
         }
-        ast::TSType::JSDocNullableType(_) => todo!(),
-        ast::TSType::JSDocUnknownType(_) => todo!(),
+        ast::TSType::JSDocNullableType(item) => {
+            checking_data
+                .raise_unimplemented_error("js doc nullable", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
+        ast::TSType::JSDocUnknownType(item) => {
+            checking_data
+                .raise_unimplemented_error("js doc unknown", oxc_span_to_source_map_span(item.span));
+            TypeId::ERROR_TYPE
+        }
     }
 }

--- a/crates/oxc_wasm/Cargo.toml
+++ b/crates/oxc_wasm/Cargo.toml
@@ -14,17 +14,18 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-oxc_allocator   = { workspace = true }
-oxc_diagnostics = { workspace = true }
-oxc_ast         = { workspace = true, features = ["serde"] }
-oxc_parser      = { workspace = true }
-oxc_semantic    = { workspace = true }
-oxc_linter      = { workspace = true }
-oxc_formatter   = { workspace = true }
-oxc_ast_lower   = { workspace = true }
-oxc_hir         = { workspace = true, features = ["serde"] }
-oxc_minifier    = { workspace = true }
-oxc_span        = { workspace = true }
+oxc_allocator      = { workspace = true }
+oxc_diagnostics    = { workspace = true }
+oxc_ast            = { workspace = true, features = ["serde"] }
+oxc_parser         = { workspace = true }
+oxc_semantic       = { workspace = true }
+oxc_linter         = { workspace = true }
+oxc_formatter      = { workspace = true }
+oxc_ast_lower      = { workspace = true }
+oxc_hir            = { workspace = true, features = ["serde"] }
+oxc_type_synthesis = { workspace = true }
+oxc_minifier       = { workspace = true }
+oxc_span           = { workspace = true }
 
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
 serde  = { workspace = true }

--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -9,6 +9,7 @@ pub struct OxcRunOptions {
     format: bool,
     hir: bool,
     minify: bool,
+    type_check: bool
 }
 
 #[wasm_bindgen]
@@ -66,6 +67,16 @@ impl OxcRunOptions {
     #[wasm_bindgen(setter)]
     pub fn set_minify(&mut self, yes: bool) {
         self.minify = yes;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn type_check(self) -> bool {
+        self.type_check
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_type_check(&mut self, yes: bool) {
+        self.type_check = yes;
     }
 }
 
@@ -133,3 +144,7 @@ impl OxcMinifierOptions {
         self.mangle = yes;
     }
 }
+
+#[wasm_bindgen]
+#[derive(Default, Clone, Copy)]
+pub struct OxcTypeCheckingOptions;

--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -9,7 +9,7 @@ pub struct OxcRunOptions {
     format: bool,
     hir: bool,
     minify: bool,
-    type_check: bool
+    type_check: bool,
 }
 
 #[wasm_bindgen]
@@ -148,3 +148,11 @@ impl OxcMinifierOptions {
 #[wasm_bindgen]
 #[derive(Default, Clone, Copy)]
 pub struct OxcTypeCheckingOptions;
+
+#[wasm_bindgen]
+impl OxcTypeCheckingOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -153,6 +153,6 @@ pub struct OxcTypeCheckingOptions;
 impl OxcTypeCheckingOptions {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -20,6 +20,7 @@
       #panel { height: 20%; overflow-y: auto; padding: 1em; color: #d1d5da; background-color: #24292e; border-top: 1px solid #444!important; }
       #right { flex: 1; display:flex; flex-direction: column }
       .controls { color: white; background: #24292e; padding: .8em 1em; border-bottom: 1px solid #444; display: flex; align-items: center; justify-content: space-between; }
+      .controls label { font-size: 14px; }
       #viewer { flex: 1; overflow-y: auto; }
       #mangle { display: inline-flex; align-items: center }
     </style>
@@ -33,6 +34,7 @@
         <div class="controls">
           <div id="logo"><img height="100%" width="20" src="https://raw.githubusercontent.com/Boshen/oxc-assets/main/oxc.ico" alt="logo"></img><span>Oxc</span></div>
           <div>
+            <label id="type-check">Type Check (experimental)<input id="type-check-checkbox" type="checkbox"></label>
             <label id="syntax">Check Syntax<input id="syntax-checkbox" type="checkbox" checked></label>
             <label id="lint">Lint<input id="lint-checkbox" type="checkbox" checked></label>
           </div>

--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -23,6 +23,7 @@ import initWasm, {
   OxcLinterOptions,
   OxcMinifierOptions,
   OxcFormatterOptions,
+  OxcTypeCheckOptions
 } from "@oxc/wasm-web";
 
 const placeholderText = `
@@ -75,6 +76,7 @@ class Playground {
     this.formatterOptions = new OxcFormatterOptions();
     this.linterOptions = new OxcLinterOptions();
     this.minifierOptions = new OxcMinifierOptions();
+    this.typeCheckOptions = new OxcTypeCheckOptions();
     // This will trigger `stateListener`.
     this.updateEditorText(this.editor, this.urlParams.code || placeholderText);
   }
@@ -163,7 +165,8 @@ class Playground {
       this.parserOptions,
       this.linterOptions,
       this.formatterOptions,
-      this.minifierOptions
+      this.minifierOptions,
+      this.typeCheckOptions
     );
     const elapsed = new Date() - start;
     document.getElementById("duration").innerText = `${elapsed}ms`;

--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -23,7 +23,7 @@ import initWasm, {
   OxcLinterOptions,
   OxcMinifierOptions,
   OxcFormatterOptions,
-  OxcTypeCheckOptions
+  OxcTypeCheckingOptions
 } from "@oxc/wasm-web";
 
 const placeholderText = `
@@ -76,7 +76,7 @@ class Playground {
     this.formatterOptions = new OxcFormatterOptions();
     this.linterOptions = new OxcLinterOptions();
     this.minifierOptions = new OxcMinifierOptions();
-    this.typeCheckOptions = new OxcTypeCheckOptions();
+    this.typeCheckOptions = new OxcTypeCheckingOptions();
     // This will trigger `stateListener`.
     this.updateEditorText(this.editor, this.urlParams.code || placeholderText);
   }
@@ -459,6 +459,12 @@ async function main() {
     const checked = document.getElementById("mangle-checkbox").checked;
     playground.minifierOptions.mangle = checked;
     playground.updateView("minify");
+  };
+
+  document.getElementById("type-check").onchange = function () {
+    const checked = document.getElementById("type-check-checkbox").checked;
+    playground.runOptions.type_check = checked;
+    playground.updateView();
   };
 }
 


### PR DESCRIPTION
This PR updates to the latest Ezno checker:
- More assignments work using the `Reference` API
- Simpler function registration
- `satisfies` checking support 😉
- Basic closed over typed variables
- Objects reassignment restrictions
- Simplified diagnostics
- Add AST to instance mappings during synthesis
- Support getters
- Records called functions (temp WIP)

The synthesis crate now:
- Emits *unsupported* diagnostics for most (**but not all**) AST which means that there is less panics buy the synthesis crate. There are still some structures which can be done + ezno-checker still has a lot of `todo!` calls unfortuantly.
- Supports arrow function
- Adds AST -> [Instance](https://docs.rs/ezno-checker/latest/ezno_checker/enum.Instance.html) type mappings

The CLI:
- Now can print all the type mappings (in pretty form to show it is working and how eventually could be used for things)
- Can print called function (again in pretty form to show it is working and how eventually could be used for greater tree shaking 👀 )

The WASM bindings:
- Now can call the checker
- Now emits diagnostics in the similar way to the linter

Apologies that it is a bit messy and rushed, this stuff is all work in progress 😁
