### PR TITLE
feat(parser): parse TypeScript `this` function parameter

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1337,6 +1337,16 @@ pub struct FormalParameters<'a> {
     pub rest: Option<Box<'a, RestElement<'a>>>,
 }
 
+impl<'a> FormalParameters<'a> {
+    pub fn parameters_count(&self) -> usize {
+        self.items.len() + self.rest.as_ref().map_or(0, |_| 1)
+    }
+
+    pub fn this_parameter(&self) -> Option<&FormalParameter<'a>> {
+        self.items.first().filter(|item| matches!(&item.pattern.kind, BindingPatternKind::BindingIdentifier(ident) if ident.name == "this"))
+    }
+}
+
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct FormalParameter<'a> {

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -356,11 +356,15 @@ impl<'a> Parser<'a> {
 
         let value = self.parse_method(r#async, generator)?;
 
-        if kind == MethodDefinitionKind::Get && !value.params.is_empty() {
+        if kind == MethodDefinitionKind::Get
+            && value.params.parameters_count() != value.params.this_parameter().map_or(0, |_| 1)
+        {
             self.error(diagnostics::GetterParameters(value.params.span));
         }
 
-        if kind == MethodDefinitionKind::Set && value.params.items.len() != 1 {
+        if kind == MethodDefinitionKind::Set
+            && value.params.parameters_count() != value.params.this_parameter().map_or(1, |_| 2)
+        {
             self.error(diagnostics::SetterParameters(value.params.span));
         }
 

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -260,9 +260,8 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
 
         match p.cur_kind() {
             Kind::This if p.ts_enabled() => {
-                p.parse_ts_this_parameter()?;
-                // don't add this to ast fow now, the ast span shouldn't be in BindingIdentifier
-                return Ok(());
+                let formal_parameter = p.parse_ts_this_parameter()?;
+                self.elements.push(formal_parameter);
             }
             Kind::Dot3 => {
                 let rest = p.parse_rest_element()?;

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -217,7 +217,7 @@ impl<'a> Parser<'a> {
         self.expect(Kind::Get)?;
         let (key, computed) = self.parse_property_name()?;
         let method = self.parse_method(false, false)?;
-        if !method.params.is_empty() {
+        if method.params.parameters_count() != method.params.this_parameter().map_or(0, |_| 1) {
             self.error(diagnostics::GetterParameters(method.params.span));
         }
         let value = self.ast.function_expression(method);
@@ -241,7 +241,7 @@ impl<'a> Parser<'a> {
         let (key, computed) = self.parse_property_name()?;
         let method = self.parse_method(false, false)?;
 
-        if method.params.items.len() != 1 {
+        if method.params.parameters_count() != method.params.this_parameter().map_or(1, |_| 2) {
             self.error(diagnostics::SetterParameters(method.params.span));
         }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -427,10 +427,19 @@ impl<'a> Parser<'a> {
         ))
     }
 
-    pub(crate) fn parse_ts_this_parameter(&mut self) -> Result<()> {
-        let _ident = self.parse_identifier_kind(Kind::Ident);
-        self.parse_ts_type_annotation()?;
-        Ok(())
+    pub(crate) fn parse_ts_this_parameter(&mut self) -> Result<FormalParameter<'a>> {
+        let span = self.start_span();
+        let (ident_span, name) = self.parse_identifier_kind(Kind::This);
+        let type_annotation = self.parse_ts_type_annotation()?;
+        let kind = self.ast.binding_identifier(BindingIdentifier { span: ident_span, name });
+        let binding = self.ast.binding_pattern(kind, type_annotation, /* optional */ false);
+        Ok(self.ast.formal_parameter(
+            self.end_span(span),
+            binding,
+            /* accessibility */ None,
+            /* readonly */ false,
+            /* decorators */ self.ast.new_vec(),
+        ))
     }
 
     pub(crate) fn eat_decorators(&mut self) -> Result<()> {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -937,9 +937,6 @@ impl<'a> Parser<'a> {
         let return_type = self.parse_ts_return_type_annotation()?;
         self.bump(Kind::Comma);
         self.bump(Kind::Semicolon);
-        if !params.is_empty() {
-            self.error(diagnostics::GetterParameters(params.span));
-        }
         Ok(self.ast.ts_method_signature(
             self.end_span(span),
             key,
@@ -960,9 +957,6 @@ impl<'a> Parser<'a> {
         let return_type = self.parse_ts_return_type_annotation()?;
         self.bump(Kind::Comma);
         self.bump(Kind::Semicolon);
-        if params.items.len() != 1 {
-            self.error(diagnostics::SetterParameters(params.span));
-        }
         if let Some(return_type) = return_type.as_ref() {
             self.error(diagnostics::ASetAccessorCannotHaveAReturnTypeAnnotation(return_type.span));
         }

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -1,7 +1,7 @@
 parser_babel Summary:
 AST Parsed     : 2072/2078 (99.71%)
 Positive Passed: 2069/2078 (99.57%)
-Negative Passed: 1330/1507 (88.25%)
+Negative Passed: 1323/1507 (87.79%)
 Expect Syntax Error: "annex-b/disabled/1.1-html-comments-close/input.js"
 Expect Syntax Error: "annex-b/disabled/3.1-sloppy-labeled-functions/input.js"
 Expect Syntax Error: "annex-b/disabled/3.1-sloppy-labeled-functions-if-body/input.js"
@@ -45,6 +45,7 @@ Expect Syntax Error: "esprima/expression-primary-literal-regular-expression/.u-f
 Expect Syntax Error: "esprima/invalid-syntax/.GH-1106-09/input.js"
 Expect Syntax Error: "esprima/invalid-syntax/.migrated_0035/input.js"
 Expect Syntax Error: "esprima/invalid-syntax/migrated_0101/input.js"
+Expect Syntax Error: "esprima/rest-parameter/invalid-setter-rest/input.js"
 Expect Syntax Error: "esprima/statement-if/.migrated_0003/input.js"
 Expect Syntax Error: "esprima/statement-iteration/.migrated_0021/input.js"
 Expect Syntax Error: "esprima/statement-iteration/.pattern-in-for-in/input.js"
@@ -116,6 +117,12 @@ Expect Syntax Error: "typescript/interface/abstract/input.ts"
 Expect Syntax Error: "typescript/interface/export-abstract-interface/input.ts"
 Expect Syntax Error: "typescript/interface/get-set-invalid-optional-parameter/input.ts"
 Expect Syntax Error: "typescript/interface/get-set-invalid-optional-parameter-babel-7/input.ts"
+Expect Syntax Error: "typescript/interface/get-set-invalid-parameters/input.ts"
+Expect Syntax Error: "typescript/interface/get-set-invalid-parameters-babel-7/input.ts"
+Expect Syntax Error: "typescript/interface/get-set-invalid-reset-parameter/input.ts"
+Expect Syntax Error: "typescript/interface/get-set-invalid-reset-parameter-babel-7/input.ts"
+Expect Syntax Error: "typescript/interface/get-set-invalid-this-parameters/input.ts"
+Expect Syntax Error: "typescript/interface/get-set-invalid-this-parameters-babel-7/input.ts"
 Expect Syntax Error: "typescript/interface/invalid-modifiers-method/input.ts"
 Expect Syntax Error: "typescript/interface/invalid-modifiers-method-babel-7/input.ts"
 Expect Syntax Error: "typescript/interface/invalid-modifiers-property/input.ts"
@@ -9409,12 +9416,6 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ·                  ──────
    ╰────
 
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[esprima/rest-parameter/invalid-setter-rest/input.js:1:1]
- 1 │ x = { set f(...y) {} }
-   ·            ──────
-   ╰────
-
   × Invalid Unicode escape sequence
    ╭─[esprima/statement-expression/migrated_0002/input.js:1:1]
  1 │ \\u0061
@@ -9798,54 +9799,6 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ·                          ─
    ╰────
 
-  × A 'get' accessor must not have any formal parameters.
-   ╭─[typescript/interface/get-set-invalid-parameters/input.ts:1:1]
- 1 │ interface Foo {
- 2 │   get foo(param): string;
-   ·          ───────
- 3 │   set foo();
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[typescript/interface/get-set-invalid-parameters/input.ts:2:1]
- 2 │   get foo(param): string;
- 3 │   set foo();
-   ·          ──
- 4 │ }
-   ╰────
-
-  × A 'get' accessor must not have any formal parameters.
-   ╭─[typescript/interface/get-set-invalid-parameters-babel-7/input.ts:1:1]
- 1 │ interface Foo {
- 2 │   get foo(param): string;
-   ·          ───────
- 3 │   set foo();
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[typescript/interface/get-set-invalid-parameters-babel-7/input.ts:2:1]
- 2 │   get foo(param): string;
- 3 │   set foo();
-   ·          ──
- 4 │ }
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[typescript/interface/get-set-invalid-reset-parameter/input.ts:1:1]
- 1 │ interface Foo {
- 2 │   set bar(...v);
-   ·          ──────
- 3 │ }
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[typescript/interface/get-set-invalid-reset-parameter-babel-7/input.ts:1:1]
- 1 │ interface Foo {
- 2 │   set bar(...v);
-   ·          ──────
- 3 │ }
-   ╰────
-
   × TS1095: A 'set' accessor cannot have a return type annotation
    ╭─[typescript/interface/get-set-invalid-return-types/input.ts:1:1]
  1 │ interface Foo {
@@ -9860,22 +9813,6 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
  2 │   set foo(param): string;
    ·                 ────────
  3 │ }
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[typescript/interface/get-set-invalid-this-parameters/input.ts:2:1]
- 2 │   get bar(this: Foo);
- 3 │   set bar(this: Foo);
-   ·          ───────────
- 4 │ }
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[typescript/interface/get-set-invalid-this-parameters-babel-7/input.ts:2:1]
- 2 │   get bar(this: Foo);
- 3 │   set bar(this: Foo);
-   ·          ───────────
- 4 │ }
    ╰────
 
   × Expected `(` but found `<`

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1,7 +1,7 @@
 parser_typescript Summary:
 AST Parsed     : 5060/5063 (99.94%)
 Positive Passed: 5051/5063 (99.76%)
-Negative Passed: 986/4761 (20.71%)
+Negative Passed: 984/4761 (20.67%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
 Expect Syntax Error: "compiler/ClassDeclaration13.ts"
@@ -36,6 +36,7 @@ Expect Syntax Error: "compiler/accessorAccidentalCallDiagnostic.ts"
 Expect Syntax Error: "compiler/accessorDeclarationEmitVisibilityErrors.ts"
 Expect Syntax Error: "compiler/accessorParameterAccessibilityModifier.ts"
 Expect Syntax Error: "compiler/accessorWithInitializer.ts"
+Expect Syntax Error: "compiler/accessorWithRestParam.ts"
 Expect Syntax Error: "compiler/accessorWithoutBody1.ts"
 Expect Syntax Error: "compiler/accessorWithoutBody2.ts"
 Expect Syntax Error: "compiler/accessorsInAmbientContext.ts"
@@ -3121,6 +3122,7 @@ Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/
 Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration15.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration16.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration17.ts"
+Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration18.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration2.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration3.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration7.ts"
@@ -4003,22 +4005,6 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  2 │     get foo() { return 0 }
    ·               ─
  3 │ };
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[compiler/accessorWithRestParam.ts:3:1]
- 3 │ class C {
- 4 │     set X(...v) { }
-   ·          ──────
- 5 │     static set X(...v2) { }
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[compiler/accessorWithRestParam.ts:4:1]
- 4 │     set X(...v) { }
- 5 │     static set X(...v2) { }
-   ·                 ───────
- 6 │ }
    ╰────
 
   × Unexpected token
@@ -16476,14 +16462,6 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  2 │ class C {
  3 │    set Foo(a: number, b: number) { }
    ·           ──────────────────────
- 4 │ }
-   ╰────
-
-  × A 'set' accessor must have exactly one parameter.
-   ╭─[conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration18.ts:2:1]
- 2 │ class C {
- 3 │    set Foo(...a) { }
-   ·           ──────
  4 │ }
    ╰────
 


### PR DESCRIPTION
closes #459

Grammar checking for `get` and `set` accessors are crazy so I went for the minimal implementation to get things working, adding more rules would conflict between js and ts.