### PR TITLE
Add IR view to playground

### DIFF
--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -32,6 +32,7 @@ pub struct Oxc {
     source_text: String,
 
     ast: JsValue,
+    ir: JsValue,
     hir: JsValue,
 
     formatted_text: String,
@@ -74,6 +75,11 @@ impl Oxc {
     #[wasm_bindgen(getter)]
     pub fn ast(&self) -> JsValue {
         self.ast.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn ir(&self) -> JsValue {
+        self.ir.clone()
     }
 
     /// Returns HIR in JSON
@@ -164,6 +170,7 @@ impl Oxc {
         self.save_diagnostics(ret.errors);
 
         self.ast = ret.program.serialize(&self.serializer)?;
+        self.ir = format!("{:#?}", ret.program.body).into();
         let program = allocator.alloc(ret.program);
 
         if run_options.syntax() && !run_options.lint() {

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@codemirror/lang-javascript": "^6.1.8",
     "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-rust": "^6.0.1",
     "@codemirror/language": "^6.7.0",
     "@codemirror/lint": "^6.2.1",
     "@codemirror/state": "^6.2.1",

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -47,8 +47,10 @@
           <div>
             <button type="button" id="ast">AST</button>
             <button type="button" id="hir">HIR</button>
+            <button type="button" id="ir">IR</button>
             <!-- The formatter is WIP <button type="button" id="format">Format</button> -->
             <button type="button" id="minify">Minify</button>
+            <button type="button" id="ir-copy">Copy IR to clipboard</button>
             <label id="mangle">Mangle<input id="mangle-checkbox" type="checkbox"></label>
           </div>
           <span id="duration"></span>

--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -9,6 +9,7 @@ import {
   RangeSet,
 } from "@codemirror/state";
 import { javascript, javascriptLanguage } from "@codemirror/lang-javascript";
+import { rust, rustLanguage } from "@codemirror/lang-rust";
 import { json, jsonLanguage } from "@codemirror/lang-json";
 import { vscodeKeymap } from "@replit/codemirror-vscode-keymap";
 import { githubDark } from "@ddietr/codemirror-themes/github-dark";
@@ -58,7 +59,7 @@ class Playground {
 
   editor;
   viewer;
-  currentView = "ast"; // "ast" | "hir" | "format" | "minify"
+  currentView = "ast"; // "ast" | "hir" | "format" | "minify" | "ir"
   languageConf;
   urlParams;
 
@@ -145,6 +146,10 @@ class Playground {
               if (currentLanguage == javascriptLanguage) return null;
               newLanguage = javascript();
               break;
+            case "rust":
+              if (currentLanguage == rustLanguage) return null;
+              newLanguage = rust();
+              break;
           }
           return {
             effects: this.languageConf.reconfigure(newLanguage),
@@ -174,6 +179,8 @@ class Playground {
 
   currentLanguage() {
     switch (this.currentView) {
+      case "ir":
+        return "rust";
       case "ast":
       case "hir":
         return "json";
@@ -202,6 +209,7 @@ class Playground {
     this.currentView = view;
 
     document.getElementById("mangle").style.visibility = "hidden";
+    document.getElementById("ir-copy").style.visibility = "hidden";
     this.runOptions.format = false;
     this.runOptions.hir = false;
     this.runOptions.minify = false;
@@ -216,6 +224,12 @@ class Playground {
         this.runOptions.hir = true;
         this.run();
         text = JSON.stringify(this.oxc.hir, null, 2);
+        break;
+      case "ir":
+        document.getElementById("ir-copy").style.visibility = "visible";
+        this.runOptions.ir = true;
+        this.run();
+        text = this.oxc.ir;
         break;
       case "format":
         this.runOptions.format = true;
@@ -427,8 +441,16 @@ async function main() {
     playground.updateView("hir");
   };
 
+  document.getElementById("ir").onclick = () => {
+    playground.updateView("ir");
+  };
+
+  document.getElementById("ir-copy").onclick = () => {
+    navigator.clipboard.writeText(playground.oxc.ir);
+  };
+
   // document.getElementById("format").onclick = () => {
-    // playground.updateView("format");
+  // playground.updateView("format");
   // };
 
   document.getElementById("minify").onclick = function () {


### PR DESCRIPTION
Adds an ir view to playground, looks like this: 
![image](https://github.com/Boshen/oxc/assets/43508353/2a614878-3b03-4e39-9aa9-4e17d4d0b95c)

Very helpful for designing lints in which you need to know what certain things look like internally to rust.