### PR TITLE
Replace `[dev_dependencies]` with newer `[dev-dependencies]` syntax.

### DIFF
--- a/crates/oxc_ast_lower/Cargo.toml
+++ b/crates/oxc_ast_lower/Cargo.toml
@@ -20,7 +20,7 @@ oxc_semantic  = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 stacker = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 oxc_allocator = { workspace = true }
 oxc_parser    = { workspace = true }
 oxc_hir       = { workspace = true, features = ["serde"] }

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -15,6 +15,6 @@ oxc_ast       = { workspace = true }
 oxc_span      = { workspace = true }
 oxc_syntax    = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 oxc_parser = { workspace = true }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -27,7 +27,7 @@ num-traits  = { workspace = true }
 
 rust-lapper = "1.1.0"
 
-[dev_dependencies]
+[dev-dependencies]
 oxc_allocator = { workspace = true }
 oxc_parser    = { workspace = true }
 miette        = { workspace = true, features = ["fancy-no-backtrace"] }

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -21,6 +21,6 @@ rustc-hash = { workspace = true }
 phf        = { workspace = true, features = ["macros"] }
 indexmap   = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 oxc_parser    = { workspace = true }
 oxc_allocator = { workspace = true }

--- a/crates/oxc_type_synthesis/Cargo.toml
+++ b/crates/oxc_type_synthesis/Cargo.toml
@@ -19,5 +19,5 @@ serde_json    = { workspace = true }
 
 ezno-checker = { version = "0.0.4" }
 
-[dev_dependencies]
+[dev-dependencies]
 miette = { workspace = true, features = ["fancy-no-backtrace"] }


### PR DESCRIPTION
It seems that `dev_dependencies` is older syntax that has been deprecated in favor of the variant with the hyphen, and some newer cargo utilities don't support it:
```
$ cargo add once_cell
error: Deprecated dependency sections are unsupported: dev_dependencies
```

This PR replaces it everywhere in the repository.