### PR TITLE
linter: add texts for `eslint(no-cond-assign)` rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -15,8 +15,8 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("")]
-#[diagnostic(severity(warning), help(""))]
+#[error("eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment")]
+#[diagnostic(severity(warning), help("Consider wrapping the assignment in additional parentheses"))]
 struct NoCondAssignDiagnostic(#[label] pub Span);
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/no_cond_assign.snap
+++ b/crates/oxc_linter/src/snapshots/no_cond_assign.snap
@@ -1,201 +1,202 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 67
 expression: no_cond_assign
 ---
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x; if (x = 0) { var b = 1; }
    ·            ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x; while (x = 0) { var b = 1; }
    ·               ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x = 0, y; do { y = x; } while (x = x + 1);
    ·                                    ─────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x; for(; x+=1 ;){};
    ·              ────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x; if ((x) = (0));
    ·            ─────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ if (someNode || (someNode = parentNode)) { }
    ·     ───────────────────────────────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ while (someNode || (someNode = parentNode)) { }
    ·        ───────────────────────────────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ do { } while (someNode || (someNode = parentNode));
    ·               ───────────────────────────────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }
    ·         ────────────────────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ if (x = 0) { }
    ·     ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ if (x = 0) { }
    ·     ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ while (x = 0) { }
    ·        ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ while (x = 0) { }
    ·        ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ do { } while (x = x + 1);
    ·               ─────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ do { } while (x = x + 1);
    ·               ─────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ for(; x = y; ) { }
    ·       ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ for(; x = y; ) { }
    ·       ─────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ if ((x = 0)) { }
    ·     ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ if ((x = 0)) { }
    ·     ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ while ((x = 0)) { }
    ·        ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ while ((x = 0)) { }
    ·        ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ do { } while ((x = x + 1));
    ·               ───────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ do { } while ((x = x + 1));
    ·               ───────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ for(; (x = y); ) { }
    ·       ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ for(; (x = y); ) { }
    ·       ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x; var b = (x = 0) ? 1 : 0;
    ·                ───────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ var x; var b = x && (y = 0) ? 1 : 0;
    ·                ────────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
-  ⚠ 
+  ⚠ eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment
    ╭─[no_cond_assign.tsx:1:1]
  1 │ (((3496.29)).bkufyydt = 2e308) ? foo : bar;
    · ──────────────────────────────
    ╰────
-  help: 
+  help: Consider wrapping the assignment in additional parentheses
 
 


### PR DESCRIPTION
Closes #504 

PS i can't stand this rule