### PR TITLE
typescript-eslint/no this alias

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -59,7 +59,8 @@ oxc_macros::declare_all_lint_rules! {
     typescript::no_extra_non_null_assertion,
     typescript::no_non_null_asserted_optional_chain,
     typescript::no_unnecessary_type_constraint,
-    typescript::no_misused_new
+    typescript::no_misused_new,
+    typescript::no_this_alias
 }
 
 #[cfg(test)]

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -63,7 +63,7 @@ impl Rule for NoThisAlias {
             .unwrap_or(&vec![])
             .iter()
             .map(serde_json::Value::as_str)
-            .filter(|x| x.is_some())
+            .filter(std::option::Option::is_some)
             .map(|x| x.unwrap().to_string())
             .collect::<Vec<String>>();
 
@@ -137,7 +137,7 @@ impl Rule for NoThisAlias {
 }
 
 fn rhs_is_this_reference(rhs_expression: &Expression) -> bool {
-    return matches!(rhs_expression, Expression::ThisExpression(_));
+    matches!(rhs_expression, Expression::ThisExpression(_))
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -209,5 +209,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoThisAlias::NAME, pass, fail).test_and_snapshot()
+    Tester::new(NoThisAlias::NAME, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -1,0 +1,213 @@
+use oxc_ast::{
+    ast::{AssignmentTarget, BindingPatternKind, Expression, SimpleAssignmentTarget},
+    AstKind,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.")]
+#[diagnostic(severity(error), help("Unexpected aliasing of 'this' to local variable."))]
+struct NoThisAliasDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables."
+)]
+#[diagnostic(severity(error), help("Unexpected aliasing of members of 'this' to local variables."))]
+struct NoThisDestructureDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Clone)]
+pub struct NoThisAlias {
+    allow_destructuring: bool,
+    allow_names: Vec<String>,
+}
+
+impl Default for NoThisAlias {
+    fn default() -> Self {
+        Self { allow_destructuring: true, allow_names: vec![] }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow unnecessary constraints on generic types.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Generic type parameters (<T>) in TypeScript may be "constrained" with an extends keyword.
+    /// When no extends is provided, type parameters default a constraint to unknown. It is therefore redundant to extend from any or unknown.
+    ///
+    /// the rule doesn't allow const {allowedName} = this
+    /// this is to keep 1:1 with eslint implementation
+    /// sampe with obj.<allowedName> = this
+    /// ```
+    NoThisAlias,
+    correctness
+);
+
+impl Rule for NoThisAlias {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let obj = value.get(0);
+        let allowed_names = value
+            .get(0)
+            .and_then(|v| v.get("allow_names"))
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or(&vec![])
+            .iter()
+            .map(serde_json::Value::as_str)
+            .filter(|x| x.is_some())
+            .map(|x| x.unwrap().to_string())
+            .collect::<Vec<String>>();
+
+        Self {
+            allow_destructuring: obj
+                .and_then(|v| v.get("allow_destructuring"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or_default(),
+            allow_names: allowed_names,
+        }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::VariableDeclarator(decl) => {
+                if decl.init.is_none() {
+                    return;
+                }
+
+                if let Some(init) = &decl.init && !rhs_is_this_reference(init) {
+                    return;
+                }
+
+                if self.allow_destructuring
+                    && !matches!(decl.id.kind, BindingPatternKind::BindingIdentifier(_))
+                {
+                    return;
+                }
+
+                if let BindingPatternKind::BindingIdentifier(identifier) = &decl.id.kind {
+                    if !self.allow_names.contains(&identifier.name.to_string()) {
+                        ctx.diagnostic(NoThisAliasDiagnostic(identifier.span));
+                    }
+
+                    return;
+                }
+                ctx.diagnostic(NoThisDestructureDiagnostic(decl.id.kind.span()));
+            }
+            AstKind::AssignmentExpression(assignment) => {
+                if !rhs_is_this_reference(&assignment.right) {
+                    return;
+                }
+                match &assignment.left {
+                    AssignmentTarget::AssignmentTargetPattern(pat) => {
+                        if self.allow_destructuring {
+                            return;
+                        }
+                        ctx.diagnostic(NoThisDestructureDiagnostic(pat.span()));
+                    }
+                    AssignmentTarget::SimpleAssignmentTarget(pat) => match pat {
+                        SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
+                            if !self.allow_names.contains(&id.name.to_string()) {
+                                ctx.diagnostic(NoThisAliasDiagnostic(id.span));
+                            }
+                        }
+                        _ => {
+                            if let Some(expr) = pat.get_expression() {
+                                if let Some(id) = expr.get_identifier_reference() {
+                                    if !self.allow_names.contains(&id.name.to_string()) {
+                                        ctx.diagnostic(NoThisAliasDiagnostic(id.span));
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn rhs_is_this_reference(rhs_expression: &Expression) -> bool {
+    return matches!(rhs_expression, Expression::ThisExpression(_));
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // allow destructuring
+        (
+            "const { props, state } = this;",
+            Some(serde_json::json!([{ "allow_destructuring": true }])),
+        ),
+        ("const { length } = this;", Some(serde_json::json!([{ "allow_destructuring": true }]))),
+        (
+            "const { length, toString } = this;",
+            Some(serde_json::json!([{ "allow_destructuring": true }])),
+        ),
+        ("const [foo] = this;", Some(serde_json::json!([{ "allow_destructuring": true }]))),
+        ("const [foo, bar] = this;", Some(serde_json::json!([{ "allow_destructuring": true }]))),
+        // allow list
+        ("const self = this;", Some(serde_json::json!([{ "allow_names": vec!["self"] }]))),
+    ];
+
+    let fail = vec![
+        ("const self = this;", None),
+        (
+            "const { props, state } = this;",
+            Some(serde_json::json!([{ "allow_destructuring": false }])),
+        ),
+        (
+            "const [ props, state ] = this;",
+            Some(serde_json::json!([{ "allow_destructuring": false }])),
+        ),
+        ("let foo; \nconst other =3;\n\n\n\nfoo = this", None),
+        ("let foo; (foo as any) = this", None),
+        (
+            "function testFunction() {
+            let inFunction = this;
+          }",
+            None,
+        ),
+        (
+            "const testLambda = () => {
+            const inLambda = this;
+          };",
+            None,
+        ),
+        // this slightly modified because conflicting ID's wont compile
+        (
+            "class TestClass {
+            constructor() {
+              const inConstructor = this;
+              const asThis: this = this;
+          
+              const asString = 'this';
+              const asArray = [this];
+              const asArrayString = ['this'];
+            }
+          
+            public act(scope: this = this) {
+              const inMemberFunction = this;
+              const { act1 } = this;
+              const { act2, constructor } = this;
+              const [foo1] = this;
+              const [foo, bar] = this;
+            }
+          }",
+            Some(serde_json::json!([{ "allow_destructuring": false }])),
+        ),
+    ];
+
+    Tester::new(NoThisAlias::NAME, pass, fail).test_and_snapshot()
+}

--- a/crates/oxc_linter/src/snapshots/no_this_alias.snap
+++ b/crates/oxc_linter/src/snapshots/no_this_alias.snap
@@ -1,0 +1,122 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_this_alias
+---
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const self = this;
+   ·       ────
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const { props, state } = this;
+   ·       ────────────────
+   ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const [ props, state ] = this;
+   ·       ────────────────
+   ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:5:1]
+ 5 │ 
+ 6 │ foo = this
+   · ───
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ let foo; (foo as any) = this
+   ·           ───
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ function testFunction() {
+ 2 │             let inFunction = this;
+   ·                 ──────────
+ 3 │           }
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const testLambda = () => {
+ 2 │             const inLambda = this;
+   ·                   ────────
+ 3 │           };
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:2:1]
+ 2 │             constructor() {
+ 3 │               const inConstructor = this;
+   ·                     ─────────────
+ 4 │               const asThis: this = this;
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:3:1]
+ 3 │               const inConstructor = this;
+ 4 │               const asThis: this = this;
+   ·                     ──────
+ 5 │           
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+    ╭─[no_this_alias.tsx:11:1]
+ 11 │             public act(scope: this = this) {
+ 12 │               const inMemberFunction = this;
+    ·                     ────────────────
+ 13 │               const { act1 } = this;
+    ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:12:1]
+ 12 │               const inMemberFunction = this;
+ 13 │               const { act1 } = this;
+    ·                     ────────
+ 14 │               const { act2, constructor } = this;
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:13:1]
+ 13 │               const { act1 } = this;
+ 14 │               const { act2, constructor } = this;
+    ·                     ─────────────────────
+ 15 │               const [foo1] = this;
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:14:1]
+ 14 │               const { act2, constructor } = this;
+ 15 │               const [foo1] = this;
+    ·                     ──────
+ 16 │               const [foo, bar] = this;
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:15:1]
+ 15 │               const [foo1] = this;
+ 16 │               const [foo, bar] = this;
+    ·                     ──────────
+ 17 │             }
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+

--- a/crates/oxc_linter/src/snapshots/no_this_alias.snap
+++ b/crates/oxc_linter/src/snapshots/no_this_alias.snap
@@ -7,21 +7,21 @@ expression: no_this_alias
  1 │ const self = this;
    ·       ────
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
    ╭─[no_this_alias.tsx:1:1]
  1 │ const { props, state } = this;
    ·       ────────────────
    ╰────
-  help: Unexpected aliasing of members of 'this' to local variables.
+  help: Disabling destructuring of this is not a default, consider allowing destructuring
 
   × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
    ╭─[no_this_alias.tsx:1:1]
  1 │ const [ props, state ] = this;
    ·       ────────────────
    ╰────
-  help: Unexpected aliasing of members of 'this' to local variables.
+  help: Disabling destructuring of this is not a default, consider allowing destructuring
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:5:1]
@@ -29,14 +29,14 @@ expression: no_this_alias
  6 │ foo = this
    · ───
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:1:1]
  1 │ let foo; (foo as any) = this
    ·           ───
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:1:1]
@@ -45,7 +45,7 @@ expression: no_this_alias
    ·                 ──────────
  3 │           }
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:1:1]
@@ -54,7 +54,7 @@ expression: no_this_alias
    ·                   ────────
  3 │           };
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:2:1]
@@ -63,7 +63,7 @@ expression: no_this_alias
    ·                     ─────────────
  4 │               const asThis: this = this;
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
    ╭─[no_this_alias.tsx:3:1]
@@ -72,7 +72,7 @@ expression: no_this_alias
    ·                     ──────
  5 │           
    ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
     ╭─[no_this_alias.tsx:11:1]
@@ -81,7 +81,7 @@ expression: no_this_alias
     ·                     ────────────────
  13 │               const { act1 } = this;
     ╰────
-  help: Unexpected aliasing of 'this' to local variable.
+  help: Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.
 
   × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
     ╭─[no_this_alias.tsx:12:1]
@@ -90,7 +90,7 @@ expression: no_this_alias
     ·                     ────────
  14 │               const { act2, constructor } = this;
     ╰────
-  help: Unexpected aliasing of members of 'this' to local variables.
+  help: Disabling destructuring of this is not a default, consider allowing destructuring
 
   × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
     ╭─[no_this_alias.tsx:13:1]
@@ -99,7 +99,7 @@ expression: no_this_alias
     ·                     ─────────────────────
  15 │               const [foo1] = this;
     ╰────
-  help: Unexpected aliasing of members of 'this' to local variables.
+  help: Disabling destructuring of this is not a default, consider allowing destructuring
 
   × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
     ╭─[no_this_alias.tsx:14:1]
@@ -108,7 +108,7 @@ expression: no_this_alias
     ·                     ──────
  16 │               const [foo, bar] = this;
     ╰────
-  help: Unexpected aliasing of members of 'this' to local variables.
+  help: Disabling destructuring of this is not a default, consider allowing destructuring
 
   × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
     ╭─[no_this_alias.tsx:15:1]
@@ -117,6 +117,6 @@ expression: no_this_alias
     ·                     ──────────
  17 │             }
     ╰────
-  help: Unexpected aliasing of members of 'this' to local variables.
+  help: Disabling destructuring of this is not a default, consider allowing destructuring
 
 


### PR DESCRIPTION
Implementation of https://typescript-eslint.io/rules/no-this-alias/.

I write bad rust sorry.