### PR TITLE
feat(minifier): support drop_console

### DIFF
--- a/crates/oxc_minifier/src/compressor/drop.rs
+++ b/crates/oxc_minifier/src/compressor/drop.rs
@@ -18,7 +18,8 @@ impl<'a> Compressor<'a> {
     /// Drop `console.*` expressions.
     /// Enabled by `compress.drop_console
     fn drop_console<'b>(&mut self, stmt: &'b Statement<'a>) -> bool {
-        self.options.drop_console && matches!(stmt, Statement::ExpressionStatement(expr) if self.is_console(&expr.expression))
+        self.options.drop_console
+            && matches!(stmt, Statement::ExpressionStatement(expr) if self.is_console(&expr.expression))
     }
 
     pub(super) fn is_console<'b>(&self, expr: &'b Expression<'a>) -> bool {
@@ -29,5 +30,4 @@ impl<'a> Compressor<'a> {
         let Some(ident) = obj.get_identifier_reference() else { return false };
         ident.name == "console"
     }
-
 }

--- a/crates/oxc_minifier/src/compressor/drop.rs
+++ b/crates/oxc_minifier/src/compressor/drop.rs
@@ -1,0 +1,31 @@
+//! Expression and statement removal
+
+use oxc_hir::hir::{Expression, Statement};
+
+use super::Compressor;
+
+impl<'a> Compressor<'a> {
+    pub(super) fn should_drop<'b>(&mut self, stmt: &'b Statement<'a>) -> bool {
+        self.drop_debugger(stmt) || self.drop_console(stmt)
+    }
+
+    /// Drop `drop_debugger` statement.
+    /// Enabled by `compress.drop_debugger`
+    fn drop_debugger<'b>(&mut self, stmt: &'b Statement<'a>) -> bool {
+        matches!(stmt, Statement::DebuggerStatement(_)) && self.options.drop_debugger
+    }
+
+    /// Drop `console.*` expressions.
+    /// Enabled by `compress.drop_console
+    fn drop_console<'b>(&mut self, stmt: &'b Statement<'a>) -> bool {
+        if !self.options.drop_console {
+            return false;
+        }
+        let Statement::ExpressionStatement(expr) = stmt else { return false };
+        let Expression::CallExpression(call_expr) = &expr.expression else { return false };
+        let Expression::MemberExpression(member_expr) = &call_expr.callee else { return false };
+        let obj = member_expr.object();
+        let Some(ident) = obj.get_identifier_reference() else { return false };
+        ident.name == "console"
+    }
+}

--- a/crates/oxc_minifier/src/compressor/drop.rs
+++ b/crates/oxc_minifier/src/compressor/drop.rs
@@ -18,14 +18,16 @@ impl<'a> Compressor<'a> {
     /// Drop `console.*` expressions.
     /// Enabled by `compress.drop_console
     fn drop_console<'b>(&mut self, stmt: &'b Statement<'a>) -> bool {
-        if !self.options.drop_console {
-            return false;
-        }
-        let Statement::ExpressionStatement(expr) = stmt else { return false };
-        let Expression::CallExpression(call_expr) = &expr.expression else { return false };
+        self.options.drop_console && matches!(stmt, Statement::ExpressionStatement(expr) if self.is_console(&expr.expression))
+    }
+
+    pub(super) fn is_console<'b>(&self, expr: &'b Expression<'a>) -> bool {
+        // let Statement::ExpressionStatement(expr) = stmt else { return false };
+        let Expression::CallExpression(call_expr) = &expr else { return false };
         let Expression::MemberExpression(member_expr) = &call_expr.callee else { return false };
         let obj = member_expr.object();
         let Some(ident) = obj.get_identifier_reference() else { return false };
         ident.name == "console"
     }
+
 }

--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -18,27 +18,33 @@ use oxc_syntax::{
 #[derive(Debug, Clone, Copy)]
 pub struct CompressOptions {
     /// Various optimizations for boolean context, for example `!!a ? b : c` → `a ? b : c`
-    /// Default true
+    /// 
+    /// Default `true`
     pub booleans: bool,
 
     /// Remove `debugger;` statements
-    /// Default true
+    /// 
+    /// Default `true`
     pub drop_debugger: bool,
 
     /// Remove `console.*` statements
+    /// 
     /// Default `false`
     pub drop_console: bool,
 
     /// Join consecutive var statements
-    /// Default true
+    /// 
+    /// Default `true`
     pub join_vars: bool,
 
     /// Optimizations for do, while and for loops when we can statically determine the condition
-    /// Default: true
+    /// 
+    /// Default `true`
     pub loops: bool,
 
     /// Transforms `typeof foo == "undefined" into `foo === void 0`
-    /// Default true
+    /// 
+    /// Default `true`
     pub typeofs: bool,
 }
 

--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -18,32 +18,32 @@ use oxc_syntax::{
 #[derive(Debug, Clone, Copy)]
 pub struct CompressOptions {
     /// Various optimizations for boolean context, for example `!!a ? b : c` → `a ? b : c`
-    /// 
+    ///
     /// Default `true`
     pub booleans: bool,
 
     /// Remove `debugger;` statements
-    /// 
+    ///
     /// Default `true`
     pub drop_debugger: bool,
 
     /// Remove `console.*` statements
-    /// 
+    ///
     /// Default `false`
     pub drop_console: bool,
 
     /// Join consecutive var statements
-    /// 
+    ///
     /// Default `true`
     pub join_vars: bool,
 
     /// Optimizations for do, while and for loops when we can statically determine the condition
-    /// 
+    ///
     /// Default `true`
     pub loops: bool,
 
     /// Transforms `typeof foo == "undefined" into `foo === void 0`
-    /// 
+    ///
     /// Default `true`
     pub typeofs: bool,
 }

--- a/crates/oxc_minifier/tests/closure/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/closure/substitute_alternate_syntax.rs
@@ -1,6 +1,8 @@
 //! <https://github.com/google/closure-compiler/blob/master/test/com/google/javascript/jscomp/PeepholeSubstituteAlternateSyntaxTest.java>
 
-use crate::test;
+use oxc_minifier::CompressOptions;
+
+use crate::{test, test_with_options};
 
 #[test]
 fn fold_return_result() {
@@ -14,14 +16,27 @@ fn fold_return_result() {
 
 #[test]
 fn undefined() {
-    test("var x = undefined", "var x=void 0");
+    test("var x = undefined", "var x");
+    test("let a = 5, b = undefined, c = true", "let a=5,b,c=!0");
+    test("const x = undefined", "const x=void 0");
     test(
         "var undefined = 1;function f() {var undefined=2;var x = undefined;}",
-        "var undefined=1;function f(){var undefined=2,x=undefined}",
+        "var undefined=1;function f(){var undefined=2,x}",
     );
     test("function f(undefined) {}", "function f(undefined){}");
     test("try {} catch(undefined) {}", "try{}catch(undefined){}");
     test("for (undefined in {}) {}", "for(undefined in {}){}");
     test("undefined++", "undefined++");
     test("undefined += undefined;", "undefined+=void 0");
+}
+
+#[test]
+fn console() {
+    let opts = oxc_minifier::MinifierOptions {
+        mangle: false,
+        compress: CompressOptions { drop_console: true, ..Default::default() },
+        ..Default::default()
+    };
+    test_with_options("let x = 5; console.log(x);", "let x=5", opts);
+    test_with_options("let x = console.log('foo')", "let x", opts);
 }

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -10,11 +10,15 @@ mod terser;
 use oxc_minifier::{CompressOptions, Minifier, MinifierOptions, PrinterOptions};
 use oxc_span::SourceType;
 
-pub(crate) fn test(source_text: &str, expected: &str) {
+pub(crate) fn test_with_options(source_text: &str, expected: &str, options: MinifierOptions){
     let source_type = SourceType::default();
-    let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
     let minified = Minifier::new(source_text, source_type, options).build();
     assert_eq!(expected, minified, "for source {source_text}");
+}
+
+pub(crate) fn test(source_text: &str, expected: &str) {
+    let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
+    test_with_options(source_text, expected, options);
 }
 
 pub(crate) fn test_same(source_text: &str) {

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -10,7 +10,7 @@ mod terser;
 use oxc_minifier::{CompressOptions, Minifier, MinifierOptions, PrinterOptions};
 use oxc_span::SourceType;
 
-pub(crate) fn test_with_options(source_text: &str, expected: &str, options: MinifierOptions){
+pub(crate) fn test_with_options(source_text: &str, expected: &str, options: MinifierOptions) {
     let source_type = SourceType::default();
     let minified = Minifier::new(source_text, source_type, options).build();
     assert_eq!(expected, minified, "for source {source_text}");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,15 +11,15 @@ Original   -> Minified   -> Gzip       Brotli
 
 555.77 kB  -> 274.89 kB  -> 91.40 kB   76.86 kB   d3.js
 
-977.19 kB  -> 456.43 kB  -> 123.71 kB  107.19 kB  bundle.min.js
+977.19 kB  -> 456.42 kB  -> 123.70 kB  107.22 kB  bundle.min.js
 
-1.25 MB    -> 677.73 kB  -> 166.57 kB  134.53 kB  three.js
+1.25 MB    -> 677.71 kB  -> 166.56 kB  134.62 kB  three.js
 
-2.14 MB    -> 743.85 kB  -> 181.82 kB  138.77 kB  victory.js
+2.14 MB    -> 743.83 kB  -> 181.81 kB  138.96 kB  victory.js
 
 3.20 MB    -> 1.03 MB    -> 332.92 kB  268.96 kB  echarts.js
 
-6.69 MB    -> 2.40 MB    -> 498.18 kB  390.19 kB  antd.js
+6.69 MB    -> 2.40 MB    -> 498.18 kB  390.20 kB  antd.js
 
-10.82 MB   -> 3.53 MB    -> 903.10 kB  693.09 kB  typescript.js
+10.82 MB   -> 3.53 MB    -> 903.09 kB  693.35 kB  typescript.js
 


### PR DESCRIPTION
> WIP

Adds support for [`drop_console`](https://github.com/terser/terser#:~:text=drop_console%20(default%3A%20false)%20%2D%2D%20Pass%20true%20to%20discard%20calls%20to%20console.*%20functions.%20If%20you%20wish%20to%20drop%20a%20specific%20function%20call%20such%20as%20console.info%20and/or%20retain%20side%20effects%20from%20function%20arguments%20after%20dropping%20the%20function%20call%20then%20use%20pure_funcs%20instead.)

when `compress.drop_console` is set to `true`, console statements will be removed and expressions using `console.*` will have `void 0` swapped in.

Besides removing console statements, This PR also compresses variable declarations with `undefined` assignments. Terser compresses
```js
let x = undefined;
```
to
```js
let x;
```

## Todo
- [x] Drop console statements
- [x] Drop console expressions in assignments, comma exprs, etc
- [x] Add test cases (_note: may need more_)