### PR TITLE
feat(linter): typescript/consistent-type-exports

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1830,10 +1830,9 @@ pub struct ExportSpecifier {
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
     pub export_kind: ImportOrExportKind, // `export { type foo }`
-
 }
 
-#[derive(Debug, Hash)] 
+#[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 pub enum ExportDefaultDeclarationKind<'a> {
     Expression(Expression<'a>),

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1829,9 +1829,11 @@ pub struct ExportSpecifier {
     pub span: Span,
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
+    pub export_kind: ImportOrExportKind, // `export { type foo }`
+
 }
 
-#[derive(Debug, Hash)]
+#[derive(Debug, Hash)] 
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 pub enum ExportDefaultDeclarationKind<'a> {
     Expression(Expression<'a>),

--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -41,7 +41,7 @@ impl<'a> AstLower<'a> {
         includes: SymbolFlags,
         excludes: SymbolFlags,
     ) -> SymbolId {
-        self.semantic.declare_symbol(span, name, includes, excludes)
+        self.semantic.declare_symbol(span, name, includes, excludes, false /* this is so much leaked complexity omg */)
     }
 
     pub fn enter_identifier_reference(

--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -41,7 +41,9 @@ impl<'a> AstLower<'a> {
         includes: SymbolFlags,
         excludes: SymbolFlags,
     ) -> SymbolId {
-        self.semantic.declare_symbol(span, name, includes, excludes, false /* this is so much leaked complexity omg */)
+        self.semantic.declare_symbol(
+            span, name, includes, excludes, false, /* this is so much leaked complexity omg */
+        )
     }
 
     pub fn enter_identifier_reference(

--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -1253,12 +1253,17 @@ impl<'a> AstLower<'a> {
             }
         }
     }
-    fn lower_import_export_type_or_value(&mut self, import_export_kind: ast::ImportOrExportKind) -> hir::ImportOrExportKind{
+
+    fn lower_import_export_type_or_value(
+        &mut self,
+        import_export_kind: ast::ImportOrExportKind,
+    ) -> hir::ImportOrExportKind {
         match import_export_kind {
             ast::ImportOrExportKind::Value => hir::ImportOrExportKind::Value,
-            ast::ImportOrExportKind::Type => hir::ImportOrExportKind::Type
+            ast::ImportOrExportKind::Type => hir::ImportOrExportKind::Type,
         }
     }
+
     fn lower_module_export_name(&mut self, name: &ast::ModuleExportName) -> hir::ModuleExportName {
         match name {
             ast::ModuleExportName::Identifier(ident) => {

--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -1253,7 +1253,12 @@ impl<'a> AstLower<'a> {
             }
         }
     }
-
+    fn lower_import_export_type_or_value(&mut self, import_export_kind: ast::ImportOrExportKind) -> hir::ImportOrExportKind{
+        match import_export_kind {
+            ast::ImportOrExportKind::Value => hir::ImportOrExportKind::Value,
+            ast::ImportOrExportKind::Type => hir::ImportOrExportKind::Type
+        }
+    }
     fn lower_module_export_name(&mut self, name: &ast::ModuleExportName) -> hir::ModuleExportName {
         match name {
             ast::ModuleExportName::Identifier(ident) => {
@@ -1352,17 +1357,17 @@ impl<'a> AstLower<'a> {
         let declaration = decl.declaration.as_ref().and_then(|decl| self.lower_declaration(decl));
         let specifiers = self.lower_vec(&decl.specifiers, Self::lower_export_specifier);
         let source = decl.source.as_ref().map(|source| self.lower_string_literal(source));
-        let export_kind = match decl.export_kind {
-            ast::ImportOrExportKind::Value => hir::ImportOrExportKind::Value,
-            ast::ImportOrExportKind::Type => hir::ImportOrExportKind::Type,
-        };
+        let export_kind = self.lower_import_export_type_or_value(decl.export_kind);
+
         self.hir.export_named_declaration(decl.span, declaration, specifiers, source, export_kind)
     }
 
     fn lower_export_specifier(&mut self, specifier: &ast::ExportSpecifier) -> hir::ExportSpecifier {
         let local = self.lower_module_export_name(&specifier.local);
         let exported = self.lower_module_export_name(&specifier.exported);
-        self.hir.export_specifier(specifier.span, local, exported)
+        let export_kind = self.lower_import_export_type_or_value(specifier.export_kind);
+
+        self.hir.export_specifier(specifier.span, local, exported, export_kind)
     }
 
     fn lower_declaration(&mut self, decl: &ast::Declaration<'a>) -> Option<hir::Declaration<'a>> {

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1826,6 +1826,8 @@ pub struct ExportSpecifier {
     pub span: Span,
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
+    pub export_kind: ImportOrExportKind, // `export type { foo }`
+
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1827,7 +1827,6 @@ pub struct ExportSpecifier {
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
     pub export_kind: ImportOrExportKind, // `export type { foo }`
-
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_hir/src/hir_builder.rs
+++ b/crates/oxc_hir/src/hir_builder.rs
@@ -1055,8 +1055,10 @@ impl<'a> HirBuilder<'a> {
         span: Span,
         local: ModuleExportName,
         exported: ModuleExportName,
+        export_kind: ImportOrExportKind, // `export type { foo }`
+
     ) -> ExportSpecifier {
-        ExportSpecifier { span, local, exported }
+        ExportSpecifier { span, local, exported, export_kind}
     }
 
     /* ---------- JSX ----------------- */

--- a/crates/oxc_hir/src/hir_builder.rs
+++ b/crates/oxc_hir/src/hir_builder.rs
@@ -1056,9 +1056,8 @@ impl<'a> HirBuilder<'a> {
         local: ModuleExportName,
         exported: ModuleExportName,
         export_kind: ImportOrExportKind, // `export type { foo }`
-
     ) -> ExportSpecifier {
-        ExportSpecifier { span, local, exported, export_kind}
+        ExportSpecifier { span, local, exported, export_kind }
     }
 
     /* ---------- JSX ----------------- */

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -54,13 +54,13 @@ oxc_macros::declare_all_lint_rules! {
     eslint::require_yield,
     eslint::use_isnan,
     eslint::valid_typeof,
+    typescript::consistent_type_exports,
     typescript::isolated_declaration,
     typescript::no_empty_interface,
     typescript::no_extra_non_null_assertion,
     typescript::no_non_null_asserted_optional_chain,
     typescript::no_unnecessary_type_constraint,
-    typescript::no_misused_new,
-    typescript::no_this_alias
+    typescript::no_misused_new
 }
 
 #[cfg(test)]

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -59,7 +59,8 @@ oxc_macros::declare_all_lint_rules! {
     typescript::no_extra_non_null_assertion,
     typescript::no_non_null_asserted_optional_chain,
     typescript::no_unnecessary_type_constraint,
-    typescript::no_misused_new
+    typescript::no_misused_new,
+    typescript::no_this_alias
 }
 
 #[cfg(test)]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
@@ -1,0 +1,105 @@
+use oxc_ast::{
+    ast::{ExportNamedDeclaration, ModuleDeclaration},
+    AstKind,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{AstNode, ScopeId};
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("typescript-eslint(consistent-type-export): Consistent type exports")]
+#[diagnostic(severity(error), help("Consistent type export"))]
+struct ConsistentTypeExportDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct ConsistentTypeExports;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// This rule enforces a set of restrictions on typescript files to enable "isolated declaration",
+    /// i.e., .d.ts files can be generated from a single .ts file without resolving its dependencies.
+    /// The typescript implementation is at `https://github.com/microsoft/TypeScript/pull/53463`
+    /// The thread on isolated declaration is at `https://github.com/microsoft/TypeScript/issues/47947`
+    ///
+    /// ### Why is this bad?
+    /// The restrictions allow .d.ts files to be generated based on one single .ts file, which improves the
+    /// efficiency and possible parallelism of the declaration emitting process. Furthermore, it prevents syntax
+    /// errors in one file from propagating to other dependent files.
+    ///
+    /// ### Example
+    /// ```typescript
+    /// export class Test {
+    ///   x // error under isolated declarations
+    ///   private y = 0; // no error, private field types are not serialized in declarations
+    ///   #z = 1;// no error, fields is not present in declarations
+    ///   constructor(x: number) {
+    ///     this.x = 1;
+    ///   }
+    ///   get a() { // error under isolated declarations
+    ///     return 1;
+    ///   }
+    ///   set a(value) { // error under isolated declarations
+    ///     this.x = 1;
+    ///   }
+    /// }
+    /// ```
+    ConsistentTypeExports,
+    nursery,
+);
+
+impl Rule for ConsistentTypeExports {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ModuleDeclaration(module_declaration) = node.kind() else { return };
+        //let symbol_table = ctx.semantic().symbols()
+        if let ModuleDeclaration::ExportNamedDeclaration(export_named_declaration) =
+            module_declaration
+        {
+            check_export_named_declaration(node.scope_id(), export_named_declaration, ctx);
+        }
+    }
+}
+
+fn check_export_named_declaration(
+    scope_id: ScopeId,
+    export_named_declaration: &ExportNamedDeclaration,
+    ctx: &LintContext,
+) {
+    let symbol_table = ctx.semantic().symbols();
+    let scopes = ctx.scopes();
+    for specifier in export_named_declaration.specifiers.iter() {
+        // {export {foo} }
+        let Some(symbol_id) = scopes.get_binding(scope_id, specifier.local.name()) else {
+            continue;
+        };
+        // Symbol resolution should not be done in a rule it should be a global function...
+        // Pretend this was TS equivalent check.getAliasedSymbol
+        let symbol_is_type = symbol_table.get_flag(symbol_id).is_type();
+        if symbol_is_type {
+            ctx.diagnostic(ConsistentTypeExportDiagnostic(specifier.span));
+        }
+
+        match specifier.export_kind {
+            oxc_ast::ast::ImportOrExportKind::Value => println!("Value"),
+            oxc_ast::ast::ImportOrExportKind::Type => println!("Type"),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass: Vec<(&str, Option<serde_json::Value>)> = vec![
+        //("export function foo(a: number): number { return a; }", None),
+    ];
+
+    let fail = vec![("type foo = number; export {foo}", None)];
+
+    Tester::new(ConsistentTypeExports::NAME, pass, fail).test();
+}

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
@@ -72,7 +72,6 @@ fn check_export_named_declaration(
 ) {
     let symbol_table = ctx.semantic().symbols();
     let scopes = ctx.scopes();
-    println!("{:?}", symbol_table);
     for specifier in export_named_declaration.specifiers.iter() {
         if matches!(specifier.export_kind, ImportOrExportKind::Type) {
             continue;

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
@@ -72,12 +72,13 @@ fn check_export_named_declaration(
 ) {
     let symbol_table = ctx.semantic().symbols();
     let scopes = ctx.scopes();
+    println!("{:?}", symbol_table);
     for specifier in export_named_declaration.specifiers.iter() {
         if matches!(specifier.export_kind, ImportOrExportKind::Type) {
             continue;
         }
         // {export {foo} }
-        let Some(symbol_id) = scopes.get_binding(scope_id, specifier.local.name()) else {
+        let Some(symbol_id) = scopes.get_type_binding(scope_id, specifier.local.name()) else {
             continue;
         };
         // Symbol resolution should not be done in a rule it should be a global function...

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -63,7 +63,7 @@ impl Rule for NoThisAlias {
             .unwrap_or(&vec![])
             .iter()
             .map(serde_json::Value::as_str)
-            .filter(|x| x.is_some())
+            .filter(std::option::Option::is_some)
             .map(|x| x.unwrap().to_string())
             .collect::<Vec<String>>();
 
@@ -137,7 +137,7 @@ impl Rule for NoThisAlias {
 }
 
 fn rhs_is_this_reference(rhs_expression: &Expression) -> bool {
-    return matches!(rhs_expression, Expression::ThisExpression(_));
+    matches!(rhs_expression, Expression::ThisExpression(_))
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -209,5 +209,5 @@ fn test() {
         ),
     ];
 
-    Tester::new(NoThisAlias::NAME, pass, fail).test_and_snapshot()
+    Tester::new(NoThisAlias::NAME, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -1,0 +1,213 @@
+use oxc_ast::{
+    ast::{AssignmentTarget, BindingPatternKind, Expression, SimpleAssignmentTarget},
+    AstKind,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.")]
+#[diagnostic(severity(error), help("Unexpected aliasing of 'this' to local variable."))]
+struct NoThisAliasDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables."
+)]
+#[diagnostic(severity(error), help("Unexpected aliasing of members of 'this' to local variables."))]
+struct NoThisDestructureDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Clone)]
+pub struct NoThisAlias {
+    allow_destructuring: bool,
+    allow_names: Vec<String>,
+}
+
+impl Default for NoThisAlias {
+    fn default() -> Self {
+        Self { allow_destructuring: true, allow_names: vec![] }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow unnecessary constraints on generic types.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Generic type parameters (<T>) in TypeScript may be "constrained" with an extends keyword.
+    /// When no extends is provided, type parameters default a constraint to unknown. It is therefore redundant to extend from any or unknown.
+    ///
+    /// the rule doesn't allow const {allowedName} = this
+    /// this is to keep 1:1 with eslint implementation
+    /// sampe with obj.<allowedName> = this
+    /// ```
+    NoThisAlias,
+    correctness
+);
+
+impl Rule for NoThisAlias {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let obj = value.get(0);
+        let allowed_names = value
+            .get(0)
+            .and_then(|v| v.get("allow_names"))
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or(&vec![])
+            .iter()
+            .map(serde_json::Value::as_str)
+            .filter(|x| x.is_some())
+            .map(|x| x.unwrap().to_string())
+            .collect::<Vec<String>>();
+
+        Self {
+            allow_destructuring: obj
+                .and_then(|v| v.get("allow_destructuring"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or_default(),
+            allow_names: allowed_names,
+        }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::VariableDeclarator(decl) => {
+                if decl.init.is_none() {
+                    return;
+                }
+
+                if let Some(init) = &decl.init && !rhs_is_this_reference(init) {
+                    return;
+                }
+
+                if self.allow_destructuring
+                    && !matches!(decl.id.kind, BindingPatternKind::BindingIdentifier(_))
+                {
+                    return;
+                }
+
+                if let BindingPatternKind::BindingIdentifier(identifier) = &decl.id.kind {
+                    if !self.allow_names.contains(&identifier.name.to_string()) {
+                        ctx.diagnostic(NoThisAliasDiagnostic(identifier.span));
+                    }
+
+                    return;
+                }
+                ctx.diagnostic(NoThisDestructureDiagnostic(decl.id.kind.span()));
+            }
+            AstKind::AssignmentExpression(assignment) => {
+                if !rhs_is_this_reference(&assignment.right) {
+                    return;
+                }
+                match &assignment.left {
+                    AssignmentTarget::AssignmentTargetPattern(pat) => {
+                        if self.allow_destructuring {
+                            return;
+                        }
+                        ctx.diagnostic(NoThisDestructureDiagnostic(pat.span()));
+                    }
+                    AssignmentTarget::SimpleAssignmentTarget(pat) => match pat {
+                        SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
+                            if !self.allow_names.contains(&id.name.to_string()) {
+                                ctx.diagnostic(NoThisAliasDiagnostic(id.span));
+                            }
+                        }
+                        _ => {
+                            if let Some(expr) = pat.get_expression() {
+                                if let Some(id) = expr.get_identifier_reference() {
+                                    if !self.allow_names.contains(&id.name.to_string()) {
+                                        ctx.diagnostic(NoThisAliasDiagnostic(id.span));
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn rhs_is_this_reference(rhs_expression: &Expression) -> bool {
+    return matches!(rhs_expression, Expression::ThisExpression(_));
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // allow destructuring
+        (
+            "const { props, state } = this;",
+            Some(serde_json::json!([{ "allow_destructuring": true }])),
+        ),
+        ("const { length } = this;", Some(serde_json::json!([{ "allow_destructuring": true }]))),
+        (
+            "const { length, toString } = this;",
+            Some(serde_json::json!([{ "allow_destructuring": true }])),
+        ),
+        ("const [foo] = this;", Some(serde_json::json!([{ "allow_destructuring": true }]))),
+        ("const [foo, bar] = this;", Some(serde_json::json!([{ "allow_destructuring": true }]))),
+        // allow list
+        ("const self = this;", Some(serde_json::json!([{ "allow_names": vec!["self"] }]))),
+    ];
+
+    let fail = vec![
+        ("const self = this;", None),
+        (
+            "const { props, state } = this;",
+            Some(serde_json::json!([{ "allow_destructuring": false }])),
+        ),
+        (
+            "const [ props, state ] = this;",
+            Some(serde_json::json!([{ "allow_destructuring": false }])),
+        ),
+        ("let foo; \nconst other =3;\n\n\n\nfoo = this", None),
+        ("let foo; (foo as any) = this", None),
+        (
+            "function testFunction() {
+            let inFunction = this;
+          }",
+            None,
+        ),
+        (
+            "const testLambda = () => {
+            const inLambda = this;
+          };",
+            None,
+        ),
+        // this slightly modified because conflicting ID's wont compile
+        (
+            "class TestClass {
+            constructor() {
+              const inConstructor = this;
+              const asThis: this = this;
+          
+              const asString = 'this';
+              const asArray = [this];
+              const asArrayString = ['this'];
+            }
+          
+            public act(scope: this = this) {
+              const inMemberFunction = this;
+              const { act1 } = this;
+              const { act2, constructor } = this;
+              const [foo1] = this;
+              const [foo, bar] = this;
+            }
+          }",
+            Some(serde_json::json!([{ "allow_destructuring": false }])),
+        ),
+    ];
+
+    Tester::new(NoThisAlias::NAME, pass, fail).test_and_snapshot()
+}

--- a/crates/oxc_linter/src/snapshots/no_this_alias.snap
+++ b/crates/oxc_linter/src/snapshots/no_this_alias.snap
@@ -1,0 +1,122 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_this_alias
+---
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const self = this;
+   ·       ────
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const { props, state } = this;
+   ·       ────────────────
+   ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const [ props, state ] = this;
+   ·       ────────────────
+   ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:5:1]
+ 5 │ 
+ 6 │ foo = this
+   · ───
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ let foo; (foo as any) = this
+   ·           ───
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ function testFunction() {
+ 2 │             let inFunction = this;
+   ·                 ──────────
+ 3 │           }
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:1:1]
+ 1 │ const testLambda = () => {
+ 2 │             const inLambda = this;
+   ·                   ────────
+ 3 │           };
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:2:1]
+ 2 │             constructor() {
+ 3 │               const inConstructor = this;
+   ·                     ─────────────
+ 4 │               const asThis: this = this;
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+   ╭─[no_this_alias.tsx:3:1]
+ 3 │               const inConstructor = this;
+ 4 │               const asThis: this = this;
+   ·                     ──────
+ 5 │           
+   ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of 'this' to local variable.
+    ╭─[no_this_alias.tsx:11:1]
+ 11 │             public act(scope: this = this) {
+ 12 │               const inMemberFunction = this;
+    ·                     ────────────────
+ 13 │               const { act1 } = this;
+    ╰────
+  help: Unexpected aliasing of 'this' to local variable.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:12:1]
+ 12 │               const inMemberFunction = this;
+ 13 │               const { act1 } = this;
+    ·                     ────────
+ 14 │               const { act2, constructor } = this;
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:13:1]
+ 13 │               const { act1 } = this;
+ 14 │               const { act2, constructor } = this;
+    ·                     ─────────────────────
+ 15 │               const [foo1] = this;
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:14:1]
+ 14 │               const { act2, constructor } = this;
+ 15 │               const [foo1] = this;
+    ·                     ──────
+ 16 │               const [foo, bar] = this;
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+  × typescript-eslint(no-this alias): Unexpected aliasing of members of 'this' to local variables.
+    ╭─[no_this_alias.tsx:15:1]
+ 15 │               const [foo1] = this;
+ 16 │               const [foo, bar] = this;
+    ·                     ──────────
+ 17 │             }
+    ╰────
+  help: Unexpected aliasing of members of 'this' to local variables.
+
+

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -374,7 +374,7 @@ impl<'a> SeparatedList<'a> for ExportNamedSpecifiers<'a> {
 
         let local = p.parse_module_export_name()?;
         let exported = if p.eat(Kind::As) { p.parse_module_export_name()? } else { local.clone() };
-        let element = ExportSpecifier { span: p.end_span(specifier_span), local, exported };
+        let element = ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
         self.elements.push(element);
         Ok(())
     }

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -374,7 +374,8 @@ impl<'a> SeparatedList<'a> for ExportNamedSpecifiers<'a> {
 
         let local = p.parse_module_export_name()?;
         let exported = if p.eat(Kind::As) { p.parse_module_export_name()? } else { local.clone() };
-        let element = ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
+        let element =
+            ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
         self.elements.push(element);
         Ok(())
     }

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -70,8 +70,7 @@ impl<'a> Binder for Class<'a> {
 
 impl<'a> Binder for TSTypeAliasDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
-        println!("Binder for TSTypeAliasDeclaration");
-        builder.declare_symbol(self.span, &self.id.name, SymbolFlags::Type, SymbolFlags::Value);
+        builder.declare_symbol(self.id.span, &self.id.name, SymbolFlags::Type, SymbolFlags::Value);
     }
 }
 

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -68,6 +68,14 @@ impl<'a> Binder for Class<'a> {
     }
 }
 
+impl<'a> Binder for TSTypeAliasDeclaration<'a> {
+    fn bind(&self, builder: &mut SemanticBuilder) {
+        println!("Binder for TSTypeAliasDeclaration");
+        builder.declare_symbol(self.span, &self.id.name, SymbolFlags::Type, SymbolFlags::Value);
+    }
+}
+
+
 // It is a Syntax Error if the LexicallyDeclaredNames of StatementList contains any duplicate entries,
 // unless the source text matched by this production is not strict mode code
 // and the duplicate entries are only bound by FunctionDeclarations.

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -75,7 +75,6 @@ impl<'a> Binder for TSTypeAliasDeclaration<'a> {
     }
 }
 
-
 // It is a Syntax Error if the LexicallyDeclaredNames of StatementList contains any duplicate entries,
 // unless the source text matched by this production is not strict mode code
 // and the duplicate entries are only bound by FunctionDeclarations.

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -27,7 +27,8 @@ impl<'a> Binder for VariableDeclarator<'a> {
             }
         };
         self.id.bound_names(&mut |ident| {
-            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes, false);
+            let symbol_id =
+                builder.declare_symbol(ident.span, &ident.name, includes, excludes, false);
             if self.kind == VariableDeclarationKind::Var
                 && !builder.scope.get_flags(current_scope_id).is_var()
             {
@@ -41,7 +42,14 @@ impl<'a> Binder for VariableDeclarator<'a> {
                 }
                 for scope_id in scope_ids {
                     if builder
-                        .check_redeclaration(scope_id, ident.span, &ident.name, excludes, true, false)
+                        .check_redeclaration(
+                            scope_id,
+                            ident.span,
+                            &ident.name,
+                            excludes,
+                            true,
+                            false,
+                        )
                         .is_none()
                     {
                         builder
@@ -71,7 +79,13 @@ impl<'a> Binder for Class<'a> {
 
 impl<'a> Binder for TSTypeAliasDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
-        builder.declare_symbol(self.id.span, &self.id.name, SymbolFlags::Type, SymbolFlags::Value, true);
+        builder.declare_symbol(
+            self.id.span,
+            &self.id.name,
+            SymbolFlags::Type,
+            SymbolFlags::Value,
+            true,
+        );
     }
 }
 
@@ -120,7 +134,7 @@ impl<'a> Binder for Function<'a> {
                     parent_scope_id,
                     includes,
                     excludes,
-                    false
+                    false,
                 );
             }
         }

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -27,7 +27,7 @@ impl<'a> Binder for VariableDeclarator<'a> {
             }
         };
         self.id.bound_names(&mut |ident| {
-            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+            let symbol_id = builder.declare_symbol(ident.span, &ident.name, includes, excludes, false);
             if self.kind == VariableDeclarationKind::Var
                 && !builder.scope.get_flags(current_scope_id).is_var()
             {
@@ -41,7 +41,7 @@ impl<'a> Binder for VariableDeclarator<'a> {
                 }
                 for scope_id in scope_ids {
                     if builder
-                        .check_redeclaration(scope_id, ident.span, &ident.name, excludes, true)
+                        .check_redeclaration(scope_id, ident.span, &ident.name, excludes, true, false)
                         .is_none()
                     {
                         builder
@@ -63,6 +63,7 @@ impl<'a> Binder for Class<'a> {
                 &ident.name,
                 SymbolFlags::Class,
                 SymbolFlags::ClassExcludes,
+                false /* Could be true idk tyeps are fun - does this redeclar */
             );
         }
     }
@@ -70,7 +71,7 @@ impl<'a> Binder for Class<'a> {
 
 impl<'a> Binder for TSTypeAliasDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
-        builder.declare_symbol(self.id.span, &self.id.name, SymbolFlags::Type, SymbolFlags::Value);
+        builder.declare_symbol(self.id.span, &self.id.name, SymbolFlags::Type, SymbolFlags::Value, true);
     }
 }
 
@@ -119,6 +120,7 @@ impl<'a> Binder for Function<'a> {
                     parent_scope_id,
                     includes,
                     excludes,
+                    false
                 );
             }
         }
@@ -157,7 +159,7 @@ impl<'a> Binder for FormalParameters<'a> {
         let is_signature = self.kind == FormalParameterKind::Signature;
         self.bound_names(&mut |ident| {
             if !is_signature {
-                builder.declare_symbol(ident.span, &ident.name, includes, excludes);
+                builder.declare_symbol(ident.span, &ident.name, includes, excludes, false);
             }
         });
     }
@@ -180,6 +182,7 @@ impl<'a> Binder for CatchClause<'a> {
                         &ident.name,
                         SymbolFlags::BlockScopedVariable | SymbolFlags::CatchVariable,
                         SymbolFlags::BlockScopedVariableExcludes,
+                        false,
                     );
                 });
             }
@@ -195,6 +198,7 @@ impl<'a> Binder for ModuleDeclaration<'a> {
                 &ident.name,
                 SymbolFlags::ImportBinding,
                 SymbolFlags::ImportBindingExcludes,
+                false,
             );
         });
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -237,9 +237,11 @@ impl<'a> SemanticBuilder<'a> {
         scope_id: ScopeId,
         includes: SymbolFlags,
         excludes: SymbolFlags,
-        is_type: bool
+        is_type: bool,
     ) -> SymbolId {
-        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true, is_type) {
+        if let Some(symbol_id) =
+            self.check_redeclaration(scope_id, span, name, excludes, true, is_type)
+        {
             return symbol_id;
         }
 
@@ -257,7 +259,7 @@ impl<'a> SemanticBuilder<'a> {
         name: &Atom,
         includes: SymbolFlags,
         excludes: SymbolFlags,
-        is_type: bool
+        is_type: bool,
     ) -> SymbolId {
         self.declare_symbol_on_scope(span, name, self.current_scope_id, includes, excludes, is_type)
     }
@@ -278,7 +280,9 @@ impl<'a> SemanticBuilder<'a> {
             self.current_scope_id
         };
 
-        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, false, false /* todo: eli u broke it */) {
+        if let Some(symbol_id) = self.check_redeclaration(
+            scope_id, span, name, excludes, false, false, /* todo: eli u broke it */
+        ) {
             return symbol_id;
         }
 
@@ -310,7 +314,7 @@ impl<'a> SemanticBuilder<'a> {
         name: &Atom,
         excludes: SymbolFlags,
         report_error: bool,
-        is_type: bool
+        is_type: bool,
     ) -> Option<SymbolId> {
         let symbol_id = self.scope.get_binding_generic(scope_id, name, is_type)?;
         if report_error && self.symbols.get_flag(symbol_id).intersects(excludes) {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -237,8 +237,9 @@ impl<'a> SemanticBuilder<'a> {
         scope_id: ScopeId,
         includes: SymbolFlags,
         excludes: SymbolFlags,
+        is_type: bool
     ) -> SymbolId {
-        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
+        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true, is_type) {
             return symbol_id;
         }
 
@@ -246,7 +247,7 @@ impl<'a> SemanticBuilder<'a> {
         let symbol_id =
             self.symbols.create_symbol(span, name.clone(), includes, self.current_scope_id);
         self.symbols.add_declaration(self.current_node_id);
-        self.scope.add_binding(scope_id, name.clone(), symbol_id);
+        self.scope.add_biding_generic(scope_id, name.clone(), symbol_id, is_type);
         symbol_id
     }
 
@@ -256,8 +257,9 @@ impl<'a> SemanticBuilder<'a> {
         name: &Atom,
         includes: SymbolFlags,
         excludes: SymbolFlags,
+        is_type: bool
     ) -> SymbolId {
-        self.declare_symbol_on_scope(span, name, self.current_scope_id, includes, excludes)
+        self.declare_symbol_on_scope(span, name, self.current_scope_id, includes, excludes, is_type)
     }
 
     pub fn declare_symbol_for_mangler(
@@ -276,7 +278,7 @@ impl<'a> SemanticBuilder<'a> {
             self.current_scope_id
         };
 
-        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, false) {
+        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, false, false /* todo: eli u broke it */) {
             return symbol_id;
         }
 
@@ -308,8 +310,9 @@ impl<'a> SemanticBuilder<'a> {
         name: &Atom,
         excludes: SymbolFlags,
         report_error: bool,
+        is_type: bool
     ) -> Option<SymbolId> {
-        let symbol_id = self.scope.get_binding(scope_id, name)?;
+        let symbol_id = self.scope.get_binding_generic(scope_id, name, is_type)?;
         if report_error && self.symbols.get_flag(symbol_id).intersects(excludes) {
             let symbol_span = self.symbols.get_span(symbol_id);
             self.error(Redeclaration(name.clone(), symbol_span, span));

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -457,6 +457,9 @@ impl<'a> SemanticBuilder<'a> {
             AstKind::CatchClause(clause) => {
                 clause.bind(self);
             }
+            AstKind::TSTypeAliasDeclaration(type_alias_declaration) => {
+                type_alias_declaration.bind(self);
+            }
             AstKind::IdentifierReference(ident) => {
                 self.reference_identifier(ident);
             }

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -22,8 +22,10 @@ pub struct ScopeTree {
     parent_ids: IndexVec<ScopeId, Option<ScopeId>>,
     flags: IndexVec<ScopeId, ScopeFlags>,
     bindings: IndexVec<ScopeId, Bindings>,
+    type_bindings: IndexVec<ScopeId, Bindings>,
     unresolved_references: IndexVec<ScopeId, UnresolvedReferences>,
 }
+
 
 impl ScopeTree {
     pub fn new(source_type: SourceType) -> Self {
@@ -77,6 +79,17 @@ impl ScopeTree {
     pub fn get_binding(&self, scope_id: ScopeId, name: &Atom) -> Option<SymbolId> {
         self.bindings[scope_id].get(name).copied()
     }
+    
+    pub fn get_binding_generic(&self, scope_id: ScopeId, name: &Atom, is_type: bool) -> Option<SymbolId> {
+        if is_type {
+            return self.get_type_binding(scope_id, name)
+        }
+        self.get_binding(scope_id, name)
+    }
+
+    pub fn get_type_binding(&self, scope_id: ScopeId, name: &Atom) -> Option<SymbolId> {
+        self.type_bindings[scope_id].get(name).copied()
+    }
 
     pub fn get_bindings(&self, scope_id: ScopeId) -> &Bindings {
         &self.bindings[scope_id]
@@ -90,12 +103,23 @@ impl ScopeTree {
         let scope_id = self.parent_ids.push(parent_id);
         _ = self.flags.push(flags);
         _ = self.bindings.push(Bindings::default());
+        _ = self.type_bindings.push(Bindings::default());
         _ = self.unresolved_references.push(UnresolvedReferences::default());
         scope_id
     }
 
     pub(crate) fn add_binding(&mut self, scope_id: ScopeId, name: Atom, symbol_id: SymbolId) {
         self.bindings[scope_id].insert(name, symbol_id);
+    }
+    pub(crate) fn add_type_biding(&mut self, scope_id: ScopeId, name: Atom, symbol_id: SymbolId) {
+        self.type_bindings[scope_id].insert(name, symbol_id);
+    }
+    pub(crate) fn add_biding_generic(&mut self, scope_id: ScopeId, name: Atom, symbol_id: SymbolId, is_type: bool) {
+        if is_type {
+            self.add_type_biding(scope_id, name, symbol_id)
+        } else {
+            self.add_binding(scope_id, name, symbol_id)
+        }
     }
 
     pub(crate) fn add_unresolved_reference(

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -26,7 +26,6 @@ pub struct ScopeTree {
     unresolved_references: IndexVec<ScopeId, UnresolvedReferences>,
 }
 
-
 impl ScopeTree {
     pub fn new(source_type: SourceType) -> Self {
         let mut scope_tree = Self::default();
@@ -79,10 +78,15 @@ impl ScopeTree {
     pub fn get_binding(&self, scope_id: ScopeId, name: &Atom) -> Option<SymbolId> {
         self.bindings[scope_id].get(name).copied()
     }
-    
-    pub fn get_binding_generic(&self, scope_id: ScopeId, name: &Atom, is_type: bool) -> Option<SymbolId> {
+
+    pub fn get_binding_generic(
+        &self,
+        scope_id: ScopeId,
+        name: &Atom,
+        is_type: bool,
+    ) -> Option<SymbolId> {
         if is_type {
-            return self.get_type_binding(scope_id, name)
+            return self.get_type_binding(scope_id, name);
         }
         self.get_binding(scope_id, name)
     }
@@ -111,14 +115,22 @@ impl ScopeTree {
     pub(crate) fn add_binding(&mut self, scope_id: ScopeId, name: Atom, symbol_id: SymbolId) {
         self.bindings[scope_id].insert(name, symbol_id);
     }
+
     pub(crate) fn add_type_biding(&mut self, scope_id: ScopeId, name: Atom, symbol_id: SymbolId) {
         self.type_bindings[scope_id].insert(name, symbol_id);
     }
-    pub(crate) fn add_biding_generic(&mut self, scope_id: ScopeId, name: Atom, symbol_id: SymbolId, is_type: bool) {
+
+    pub(crate) fn add_biding_generic(
+        &mut self,
+        scope_id: ScopeId,
+        name: Atom,
+        symbol_id: SymbolId,
+        is_type: bool,
+    ) {
         if is_type {
-            self.add_type_biding(scope_id, name, symbol_id)
+            self.add_type_biding(scope_id, name, symbol_id);
         } else {
-            self.add_binding(scope_id, name, symbol_id)
+            self.add_binding(scope_id, name, symbol_id);
         }
     }
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -48,6 +48,7 @@ impl SymbolFlags {
     pub fn is_type(&self) -> bool {
         self.intersects(Self::Type)
     }
+
     pub fn is_variable(&self) -> bool {
         self.intersects(Self::Variable)
     }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -25,8 +25,11 @@ bitflags! {
         const Function                = 1 << 7;
         const ImportBinding           = 1 << 8; // Imported ESM binding
 
+        const Type                    = 1 << 9; // WIP: prolly worth copying TS but this structure seems sufficienlty different unsure what to do
+
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();
         const Value = Self::Variable.bits() | Self::Class.bits();
+
 
         /// Variables can be redeclared, but can not redeclare a block-scoped declaration with the
         /// same name, or any other value that is not a variable, e.g. ValueModule or Class
@@ -42,6 +45,9 @@ bitflags! {
 }
 
 impl SymbolFlags {
+    pub fn is_type(&self) -> bool {
+        self.intersects(Self::Type)
+    }
     pub fn is_variable(&self) -> bool {
         self.intersects(Self::Variable)
     }


### PR DESCRIPTION
Sorry this includes my other PR, I totally borked this and honestly made a fork from a camp I was a part of in HS. 
But this adds types to the symbol tables, this will cause name conflicts so thats a todo, also I'm not really sure what I'm doing here, but I had to add types to implement at least a skeleton of consistent type imports. Which bans not annotating an export symbol as type when it is a type.

I.E: "type foo = number; export {foo}" is an error. 

This is mostly a wip and I'm largely looking for feedback before continuing.