### PR TITLE
feat(minifier): compress undefined variable declarations

### DIFF
--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -228,6 +228,19 @@ impl<'a> Compressor<'a> {
         }
     }
 
+    fn compress_variable_declarator<'b>(
+        &mut self,
+        decl: &'b mut VariableDeclarator<'a>,
+        is_const: bool,
+    ) {
+        if is_const {
+            return;
+        }
+        if let Some(init) = &decl.init && (init.is_undefined() || init.is_void_0()) {
+            decl.init = None;
+        }
+    }
+
     /// [Peephole Reorder Constant Expression](https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PeepholeReorderConstantExpression.java)
     ///
     /// Reorder constant expression hoping for a better compression.
@@ -277,6 +290,14 @@ impl<'a, 'b> VisitMut<'a, 'b> for Compressor<'a> {
         }
         // We may fold `void 1` to `void 0`, so compress it after visiting
         self.compress_return_statement(stmt);
+    }
+
+    fn visit_variable_declaration(&mut self, decl: &'b mut VariableDeclaration<'a>) {
+        let is_const = decl.kind.is_const(); // let, var
+        for declarator in decl.declarations.iter_mut() {
+            self.compress_variable_declarator(declarator, is_const);
+            self.visit_variable_declarator(declarator);
+        }
     }
 
     fn visit_expression(&mut self, expr: &'b mut Expression<'a>) {

--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -228,10 +228,7 @@ impl<'a> Compressor<'a> {
         }
     }
 
-    fn compress_variable_declarator<'b>(
-        &mut self,
-        decl: &'b mut VariableDeclarator<'a>,
-    ) {
+    fn compress_variable_declarator<'b>(&mut self, decl: &'b mut VariableDeclarator<'a>) {
         if decl.kind.is_const() {
             return;
         }

--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -231,9 +231,8 @@ impl<'a> Compressor<'a> {
     fn compress_variable_declarator<'b>(
         &mut self,
         decl: &'b mut VariableDeclarator<'a>,
-        is_const: bool,
     ) {
-        if is_const {
+        if decl.kind.is_const() {
             return;
         }
         if let Some(init) = &decl.init && (init.is_undefined() || init.is_void_0()) {
@@ -293,9 +292,8 @@ impl<'a, 'b> VisitMut<'a, 'b> for Compressor<'a> {
     }
 
     fn visit_variable_declaration(&mut self, decl: &'b mut VariableDeclaration<'a>) {
-        let is_const = decl.kind.is_const(); // let, var
         for declarator in decl.declarations.iter_mut() {
-            self.compress_variable_declarator(declarator, is_const);
+            self.compress_variable_declarator(declarator);
             self.visit_variable_declarator(declarator);
         }
     }

--- a/crates/oxc_minifier/tests/closure/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/closure/substitute_alternate_syntax.rs
@@ -14,10 +14,10 @@ fn fold_return_result() {
 
 #[test]
 fn undefined() {
-    test("var x = undefined", "var x=void 0");
+    test("var x = undefined", "var x");
     test(
-        "var undefined = 1;function f() {var undefined=2;var x = undefined;}",
-        "var undefined=1;function f(){var undefined=2,x=undefined}",
+        "var undefined = 1;function f() {var undefined=2;var x;}",
+        "var undefined=1;function f(){var undefined=2,x}",
     );
     test("function f(undefined) {}", "function f(undefined){}");
     test("try {} catch(undefined) {}", "try{}catch(undefined){}");

--- a/crates/oxc_minifier/tests/oxc/code_removal.rs
+++ b/crates/oxc_minifier/tests/oxc/code_removal.rs
@@ -1,0 +1,19 @@
+use crate::test;
+
+#[test]
+fn undefined_assignment() {
+    test("let x = undefined", "let x");
+    test("var x = undefined", "var x");
+    test("const x = undefined", "const x=void 0");
+    test("let x; x = undefined", "let x;x=void 0");
+    test("function foo(a = undefined) {}", "function foo(a=void 0){}");
+    test("let a = undefined; let b = 5; let c = undefined;", "let a,b=5,c");
+}
+
+#[test]
+fn undefined_return() {
+    test("function f(){return undefined;}", "function f(){return}");
+    test("function f(){return void 0;}", "function f(){return}");
+    test("function f(){return void foo();}", "function f(){return void foo()}");
+    test("function f(){if(a()){return undefined;}}", "function f(){if(a())return}");
+}

--- a/crates/oxc_minifier/tests/oxc/mod.rs
+++ b/crates/oxc_minifier/tests/oxc/mod.rs
@@ -1,1 +1,2 @@
+mod code_removal;
 mod precedence;

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,25 +1,25 @@
 Original   -> Minified   -> Gzip       Brotli    
-72.14 kB   -> 24.36 kB   -> 8.73 kB    7.64 kB    react.development.js
+72.14 kB   -> 24.35 kB   -> 8.73 kB    7.64 kB    react.development.js
 
 173.90 kB  -> 61.88 kB   -> 19.57 kB   17.75 kB   moment.js
 
 287.63 kB  -> 93.06 kB   -> 32.33 kB   29.24 kB   jquery.js
 
-342.15 kB  -> 123.09 kB  -> 44.99 kB   39.67 kB   vue.js
+342.15 kB  -> 123.05 kB  -> 44.98 kB   39.66 kB   vue.js
 
 544.10 kB  -> 74.51 kB   -> 26.02 kB   23.15 kB   lodash.js
 
 555.77 kB  -> 274.89 kB  -> 91.40 kB   76.86 kB   d3.js
 
-977.19 kB  -> 456.43 kB  -> 123.71 kB  107.19 kB  bundle.min.js
+977.19 kB  -> 456.42 kB  -> 123.70 kB  107.22 kB  bundle.min.js
 
-1.25 MB    -> 677.73 kB  -> 166.57 kB  134.53 kB  three.js
+1.25 MB    -> 677.66 kB  -> 166.54 kB  134.53 kB  three.js
 
-2.14 MB    -> 743.85 kB  -> 181.82 kB  138.77 kB  victory.js
+2.14 MB    -> 743.81 kB  -> 181.81 kB  138.77 kB  victory.js
 
-3.20 MB    -> 1.03 MB    -> 332.92 kB  268.96 kB  echarts.js
+3.20 MB    -> 1.03 MB    -> 332.69 kB  269.01 kB  echarts.js
 
-6.69 MB    -> 2.40 MB    -> 498.18 kB  390.19 kB  antd.js
+6.69 MB    -> 2.40 MB    -> 498.17 kB  390.18 kB  antd.js
 
-10.82 MB   -> 3.53 MB    -> 903.10 kB  693.09 kB  typescript.js
+10.82 MB   -> 3.53 MB    -> 902.84 kB  692.92 kB  typescript.js
 


### PR DESCRIPTION
> Splits #527 into the first of two parts

Compress variable declarations that are initialized to `undefined` by removing the initializer. Does not apply to constants.

## Example
```js
let x = undefined
```
will turn into
```js
let x
```

but 
```js
const x = undefined
```

will turn into
```js
const x=void 0
```