### PR TITLE
refactor(cli): Runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "mimalloc",
  "oxc_allocator",
  "oxc_diagnostics",
+ "oxc_index",
  "oxc_linter",
  "oxc_parser",
  "oxc_semantic",

--- a/crates/oxc_cli/Cargo.toml
+++ b/crates/oxc_cli/Cargo.toml
@@ -21,13 +21,14 @@ jemallocator = { workspace = true }
 mimalloc = { workspace = true }
 
 [dependencies]
-oxc_diagnostics    = { workspace = true }
 oxc_allocator      = { workspace = true }
+oxc_diagnostics    = { workspace = true }
+oxc_index          = { workspace = true }
+oxc_linter         = { workspace = true }
 oxc_parser         = { workspace = true }
 oxc_semantic       = { workspace = true }
-oxc_linter         = { workspace = true }
-oxc_type_synthesis = { workspace = true }
 oxc_span           = { workspace = true }
+oxc_type_synthesis = { workspace = true }
 
 # TODO temp, for type check output, replace with Miette
 codespan-reporting = "0.11.1"
@@ -35,8 +36,8 @@ codespan-reporting = "0.11.1"
 clap              = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap           = { workspace = true }
-rayon             = { workspace = true }
-miette            = { workspace = true, features = ["fancy-no-backtrace"] }
-rustc-hash        = { workspace = true }
 ignore            = { workspace = true, features = ["simd-accel"] }
+miette            = { workspace = true, features = ["fancy-no-backtrace"] }
+rayon             = { workspace = true }
+rustc-hash        = { workspace = true }
 # git2 = { version = "0.16.1", default_features = false }

--- a/crates/oxc_cli/src/lib.rs
+++ b/crates/oxc_cli/src/lib.rs
@@ -1,15 +1,15 @@
 // mod git;
 mod lint;
-mod result;
+mod runner;
 mod type_check;
 mod walk;
 
 use clap::{Arg, Command};
 
 pub use crate::{
-    lint::{lint_command, LintOptions, LintRunner, LintRunnerWithModuleTree},
-    result::CliRunResult,
-    type_check::{type_check_command, TypeCheckOptions, TypeCheckRunner},
+    lint::{LintOptions, LintRunner},
+    runner::{CliRunResult, Runner, RunnerOptions},
+    type_check::{TypeCheckOptions, TypeCheckRunner},
     walk::Walk,
 };
 
@@ -21,8 +21,8 @@ pub fn command() -> Command {
         .about("The JavaScript Oxidation Compiler")
         .subcommand_required(true)
         .arg_required_else_help(true)
-        .subcommand(lint_command(Command::new("lint").about("Lint this repository.")))
-        .subcommand(type_check_command())
+        .subcommand(LintRunner::command())
+        .subcommand(TypeCheckRunner::command())
         .arg(
             Arg::new("threads")
                 .long("threads")

--- a/crates/oxc_cli/src/lint/command.rs
+++ b/crates/oxc_cli/src/lint/command.rs
@@ -1,6 +1,6 @@
 use clap::{builder::ValueParser, Arg, ArgAction, Command};
 
-pub fn lint_command(command: Command) -> Command {
+pub(super) fn lint_command(command: Command) -> Command {
     command
             .arg_required_else_help(true)
             .after_help(

--- a/crates/oxc_cli/src/lint/main.rs
+++ b/crates/oxc_cli/src/lint/main.rs
@@ -9,10 +9,10 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::{Arg, Command};
-use oxc_cli::{lint_command, CliRunResult, LintOptions, LintRunner};
+use oxc_cli::{CliRunResult, LintOptions, LintRunner, Runner, RunnerOptions};
 
 pub fn command() -> Command {
-    lint_command(
+    LintOptions::build_args(
         Command::new("oxlint")
             .bin_name("oxlint")
             .version("alpha")
@@ -36,11 +36,6 @@ fn main() -> CliRunResult {
     }
 
     let options = LintOptions::from(&matches);
-
-    if options.list_rules {
-        LintRunner::print_rules();
-        return CliRunResult::None;
-    }
 
     LintRunner::new(options).run()
 }

--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -1,202 +1,113 @@
 mod command;
 mod error;
-mod runner;
-mod runner_with_module_tree;
+mod isolated_handler;
+mod module_tree_handler;
+mod options;
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{io::BufWriter, sync::Arc};
 
-use clap::ArgMatches;
+use oxc_index::assert_impl_all;
+use oxc_linter::{Linter, RuleCategory, RuleEnum, RULES};
+use rustc_hash::FxHashSet;
 
-pub use self::{
-    command::lint_command, error::Error, runner::LintRunner,
-    runner_with_module_tree::LintRunnerWithModuleTree,
+pub use self::{error::Error, options::LintOptions};
+use self::{
+    isolated_handler::IsolatedLintHandler, module_tree_handler::ModuleTreeLintHandler,
+    options::AllowWarnDeny,
 };
+use crate::{CliRunResult, Runner};
 
-#[derive(Debug)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct LintOptions {
-    pub paths: Vec<PathBuf>,
-    /// Allow / Deny rules in order. [("allow" / "deny", rule name)]
-    /// Defaults to [("deny", "correctness")]
-    pub rules: Vec<(AllowWarnDeny, String)>,
-    pub list_rules: bool,
-    pub fix: bool,
-    pub quiet: bool,
-    pub ignore_path: PathBuf,
-    pub no_ignore: bool,
-    pub ignore_pattern: Vec<String>,
-    pub max_warnings: Option<usize>,
+pub struct LintRunner {
+    options: Arc<LintOptions>,
+    linter: Arc<Linter>,
+}
+assert_impl_all!(LintRunner: Send, Sync);
+
+impl Default for LintRunner {
+    fn default() -> Self {
+        Self::new(LintOptions::default())
+    }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum AllowWarnDeny {
-    Allow,
-    // Warn,
-    Deny,
-}
+impl Runner for LintRunner {
+    type Options = LintOptions;
 
-impl From<&'static str> for AllowWarnDeny {
-    fn from(s: &'static str) -> Self {
-        match s {
-            "allow" => Self::Allow,
-            "deny" => Self::Deny,
-            _ => unreachable!(),
+    const ABOUT: &'static str = "Lint this repository.";
+    const NAME: &'static str = "lint";
+
+    fn new(options: LintOptions) -> Self {
+        let linter = Linter::from_rules(Self::derive_rules(&options)).with_fix(options.fix);
+        Self { options: Arc::new(options), linter: Arc::new(linter) }
+    }
+
+    fn run(&self) -> CliRunResult {
+        if self.options.list_rules {
+            Self::print_rules();
+            return CliRunResult::None;
+        }
+
+        if Self::enable_module_tree() {
+            ModuleTreeLintHandler::new(Arc::clone(&self.options), Arc::clone(&self.linter)).run()
+        } else {
+            IsolatedLintHandler::new(Arc::clone(&self.options), Arc::clone(&self.linter)).run()
         }
     }
 }
 
-impl<'a> From<&'a ArgMatches> for LintOptions {
-    fn from(matches: &'a ArgMatches) -> Self {
-        let list_rules = matches.get_flag("rules");
-
-        Self {
-            paths: matches.get_many("path").map_or_else(
-                || if list_rules { vec![] } else { vec![PathBuf::from(".")] },
-                |paths| paths.into_iter().cloned().collect(),
-            ),
-            rules: Self::get_rules(matches),
-            fix: matches.get_flag("fix"),
-            quiet: matches.get_flag("quiet"),
-            ignore_path: matches
-                .get_one::<PathBuf>("ignore-path")
-                .map_or_else(|| PathBuf::from(".eslintignore"), Clone::clone),
-            no_ignore: matches.get_flag("no-ignore"),
-            ignore_pattern: matches
-                .get_many::<String>("ignore-pattern")
-                .map(|patterns| patterns.into_iter().cloned().collect())
-                .unwrap_or_default(),
-            max_warnings: matches.get_one("max-warnings").copied(),
-            list_rules,
-        }
+impl LintRunner {
+    /// check if the module tree should be provided when linting
+    fn enable_module_tree() -> bool {
+        matches!(std::env::var("OXC_MODULE_TREE"), Ok(x) if x == "true" || x == "1")
     }
-}
 
-impl LintOptions {
-    /// Get all rules in order, e.g.
-    /// `-A all -D no-var -D -eqeqeq` => [("allow", "all"), ("deny", "no-var"), ("deny", "eqeqeq")]
-    /// Defaults to [("deny", "correctness")];
-    fn get_rules(matches: &ArgMatches) -> Vec<(AllowWarnDeny, String)> {
-        let mut map: BTreeMap<usize, (AllowWarnDeny, String)> = BTreeMap::new();
-        for key in ["allow", "deny"] {
-            let allow_warn_deny = AllowWarnDeny::from(key);
-            if let Some(values) = matches.get_many::<String>(key) {
-                let indices = matches.indices_of(key).unwrap();
-                let zipped =
-                    values.zip(indices).map(|(value, i)| (i, (allow_warn_deny, value.clone())));
-                map.extend(zipped);
+    pub fn print_rules() {
+        let mut stdout = BufWriter::new(std::io::stdout());
+        Linter::print_rules(&mut stdout);
+    }
+
+    fn derive_rules(options: &LintOptions) -> Vec<RuleEnum> {
+        let mut rules: FxHashSet<RuleEnum> = FxHashSet::default();
+
+        for (allow_warn_deny, name_or_category) in &options.rules {
+            let maybe_category = RuleCategory::from(name_or_category.as_str());
+            match allow_warn_deny {
+                AllowWarnDeny::Deny => {
+                    match maybe_category {
+                        Some(category) => rules.extend(
+                            RULES.iter().filter(|rule| rule.category() == category).cloned(),
+                        ),
+                        None => {
+                            if name_or_category == "all" {
+                                rules.extend(RULES.iter().cloned());
+                            } else {
+                                rules.extend(
+                                    RULES
+                                        .iter()
+                                        .filter(|rule| rule.name() == name_or_category)
+                                        .cloned(),
+                                );
+                            }
+                        }
+                    };
+                }
+                AllowWarnDeny::Allow => {
+                    match maybe_category {
+                        Some(category) => rules.retain(|rule| rule.category() != category),
+                        None => {
+                            if name_or_category == "all" {
+                                rules.clear();
+                            } else {
+                                rules.retain(|rule| rule.name() == name_or_category);
+                            }
+                        }
+                    };
+                }
             }
         }
-        if map.is_empty() {
-            vec![(AllowWarnDeny::Deny, "correctness".into())]
-        } else {
-            map.into_values().collect()
-        }
-    }
-}
 
-#[cfg(test)]
-mod test {
-    use std::path::PathBuf;
-
-    use clap::Command;
-
-    use super::{lint_command, AllowWarnDeny, LintOptions};
-
-    #[test]
-    fn verify_command() {
-        lint_command(Command::new("oxc")).debug_assert();
-    }
-
-    fn get_lint_options(arg: &str) -> LintOptions {
-        let matches =
-            lint_command(Command::new("oxc")).try_get_matches_from(arg.split(' ')).unwrap();
-        LintOptions::from(&matches)
-    }
-
-    #[test]
-    fn default() {
-        let options = get_lint_options("lint .");
-        assert_eq!(options.paths, vec![PathBuf::from(".")]);
-        assert!(!options.fix);
-        assert!(!options.quiet);
-        assert_eq!(options.ignore_path, PathBuf::from(".eslintignore"));
-        assert!(!options.no_ignore);
-        assert!(options.ignore_pattern.is_empty());
-        assert_eq!(options.max_warnings, None);
-    }
-
-    #[test]
-    fn multiple_paths() {
-        let options = get_lint_options("lint foo bar baz");
-        assert_eq!(
-            options.paths,
-            [PathBuf::from("foo"), PathBuf::from("bar"), PathBuf::from("baz")]
-        );
-    }
-
-    #[test]
-    fn rules_with_deny_and_allow() {
-        let options = get_lint_options(
-            "lint src -D suspicious --deny pedantic -A no-debugger --allow no-var",
-        );
-        assert_eq!(
-            options.rules,
-            vec![
-                (AllowWarnDeny::Deny, "suspicious".into()),
-                (AllowWarnDeny::Deny, "pedantic".into()),
-                (AllowWarnDeny::Allow, "no-debugger".into()),
-                (AllowWarnDeny::Allow, "no-var".into())
-            ]
-        );
-    }
-
-    #[test]
-    fn quiet_true() {
-        let options = get_lint_options("lint foo.js --quiet");
-        assert!(options.quiet);
-    }
-
-    #[test]
-    fn fix_true() {
-        let options = get_lint_options("lint foo.js --fix");
-        assert!(options.fix);
-    }
-
-    #[test]
-    fn max_warnings() {
-        let options = get_lint_options("lint --max-warnings 10 foo.js");
-        assert_eq!(options.max_warnings, Some(10));
-    }
-
-    #[test]
-    fn ignore_path() {
-        let options = get_lint_options("lint --ignore-path .xxx foo.js");
-        assert_eq!(options.ignore_path, PathBuf::from(".xxx"));
-    }
-
-    #[test]
-    fn no_ignore() {
-        let options = get_lint_options("lint --no-ignore foo.js");
-        assert!(options.no_ignore);
-    }
-
-    #[test]
-    fn single_ignore_pattern() {
-        let options = get_lint_options("lint --ignore-pattern ./test foo.js");
-        assert_eq!(options.ignore_pattern, vec![String::from("./test")]);
-    }
-
-    #[test]
-    fn multiple_ignore_pattern() {
-        let options =
-            get_lint_options("lint --ignore-pattern ./test --ignore-pattern bar.js foo.js");
-        assert_eq!(options.ignore_pattern, vec![String::from("./test"), String::from("bar.js")]);
-    }
-
-    #[test]
-    fn list_rules_true() {
-        let options = get_lint_options("lint --rules");
-        assert!(options.paths.is_empty());
-        assert!(options.list_rules);
+        let mut rules = rules.into_iter().collect::<Vec<_>>();
+        // for stable diagnostics output ordering
+        rules.sort_unstable_by_key(|rule| rule.name());
+        rules
     }
 }

--- a/crates/oxc_cli/src/lint/options.rs
+++ b/crates/oxc_cli/src/lint/options.rs
@@ -1,0 +1,214 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use clap::ArgMatches;
+
+use super::command::lint_command;
+pub use super::{
+    error::Error, isolated_handler::IsolatedLintHandler, module_tree_handler::ModuleTreeLintHandler,
+};
+use crate::runner::RunnerOptions;
+
+#[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct LintOptions {
+    pub paths: Vec<PathBuf>,
+    /// Allow / Deny rules in order. [("allow" / "deny", rule name)]
+    /// Defaults to [("deny", "correctness")]
+    pub rules: Vec<(AllowWarnDeny, String)>,
+    pub list_rules: bool,
+    pub fix: bool,
+    pub quiet: bool,
+    pub ignore_path: PathBuf,
+    pub no_ignore: bool,
+    pub ignore_pattern: Vec<String>,
+    pub max_warnings: Option<usize>,
+}
+
+impl Default for LintOptions {
+    fn default() -> Self {
+        let default_matches = ArgMatches::default();
+        Self::from(&default_matches)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AllowWarnDeny {
+    Allow,
+    // Warn,
+    Deny,
+}
+
+impl From<&'static str> for AllowWarnDeny {
+    fn from(s: &'static str) -> Self {
+        match s {
+            "allow" => Self::Allow,
+            "deny" => Self::Deny,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a> From<&'a ArgMatches> for LintOptions {
+    fn from(matches: &'a ArgMatches) -> Self {
+        let list_rules = matches.get_flag("rules");
+
+        Self {
+            paths: matches.get_many("path").map_or_else(
+                || if list_rules { vec![] } else { vec![PathBuf::from(".")] },
+                |paths| paths.into_iter().cloned().collect(),
+            ),
+            rules: Self::get_rules(matches),
+            fix: matches.get_flag("fix"),
+            quiet: matches.get_flag("quiet"),
+            ignore_path: matches
+                .get_one::<PathBuf>("ignore-path")
+                .map_or_else(|| PathBuf::from(".eslintignore"), Clone::clone),
+            no_ignore: matches.get_flag("no-ignore"),
+            ignore_pattern: matches
+                .get_many::<String>("ignore-pattern")
+                .map(|patterns| patterns.into_iter().cloned().collect())
+                .unwrap_or_default(),
+            max_warnings: matches.get_one("max-warnings").copied(),
+            list_rules,
+        }
+    }
+}
+
+impl LintOptions {
+    /// Get all rules in order, e.g.
+    /// `-A all -D no-var -D -eqeqeq` => [("allow", "all"), ("deny", "no-var"), ("deny", "eqeqeq")]
+    /// Defaults to [("deny", "correctness")];
+    fn get_rules(matches: &ArgMatches) -> Vec<(AllowWarnDeny, String)> {
+        let mut map: BTreeMap<usize, (AllowWarnDeny, String)> = BTreeMap::new();
+        for key in ["allow", "deny"] {
+            let allow_warn_deny = AllowWarnDeny::from(key);
+            if let Some(values) = matches.get_many::<String>(key) {
+                let indices = matches.indices_of(key).unwrap();
+                let zipped =
+                    values.zip(indices).map(|(value, i)| (i, (allow_warn_deny, value.clone())));
+                map.extend(zipped);
+            }
+        }
+        if map.is_empty() {
+            vec![(AllowWarnDeny::Deny, "correctness".into())]
+        } else {
+            map.into_values().collect()
+        }
+    }
+}
+
+impl RunnerOptions for LintOptions {
+    #[inline]
+    fn build_args(cmd: clap::Command) -> clap::Command {
+        lint_command(cmd)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use clap::Command;
+
+    use super::{AllowWarnDeny, LintOptions};
+    use crate::runner::RunnerOptions;
+
+    #[test]
+    fn verify_command() {
+        LintOptions::build_args(Command::new("oxc")).debug_assert();
+    }
+
+    fn get_lint_options(arg: &str) -> LintOptions {
+        let matches = LintOptions::build_args(Command::new("oxc"))
+            .try_get_matches_from(arg.split(' '))
+            .unwrap();
+        LintOptions::from(&matches)
+    }
+
+    #[test]
+    fn default() {
+        let options = get_lint_options("lint .");
+        assert_eq!(options.paths, vec![PathBuf::from(".")]);
+        assert!(!options.fix);
+        assert!(!options.quiet);
+        assert_eq!(options.ignore_path, PathBuf::from(".eslintignore"));
+        assert!(!options.no_ignore);
+        assert!(options.ignore_pattern.is_empty());
+        assert_eq!(options.max_warnings, None);
+    }
+
+    #[test]
+    fn multiple_paths() {
+        let options = get_lint_options("lint foo bar baz");
+        assert_eq!(
+            options.paths,
+            [PathBuf::from("foo"), PathBuf::from("bar"), PathBuf::from("baz")]
+        );
+    }
+
+    #[test]
+    fn rules_with_deny_and_allow() {
+        let options = get_lint_options(
+            "lint src -D suspicious --deny pedantic -A no-debugger --allow no-var",
+        );
+        assert_eq!(
+            options.rules,
+            vec![
+                (AllowWarnDeny::Deny, "suspicious".into()),
+                (AllowWarnDeny::Deny, "pedantic".into()),
+                (AllowWarnDeny::Allow, "no-debugger".into()),
+                (AllowWarnDeny::Allow, "no-var".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn quiet_true() {
+        let options = get_lint_options("lint foo.js --quiet");
+        assert!(options.quiet);
+    }
+
+    #[test]
+    fn fix_true() {
+        let options = get_lint_options("lint foo.js --fix");
+        assert!(options.fix);
+    }
+
+    #[test]
+    fn max_warnings() {
+        let options = get_lint_options("lint --max-warnings 10 foo.js");
+        assert_eq!(options.max_warnings, Some(10));
+    }
+
+    #[test]
+    fn ignore_path() {
+        let options = get_lint_options("lint --ignore-path .xxx foo.js");
+        assert_eq!(options.ignore_path, PathBuf::from(".xxx"));
+    }
+
+    #[test]
+    fn no_ignore() {
+        let options = get_lint_options("lint --no-ignore foo.js");
+        assert!(options.no_ignore);
+    }
+
+    #[test]
+    fn single_ignore_pattern() {
+        let options = get_lint_options("lint --ignore-pattern ./test foo.js");
+        assert_eq!(options.ignore_pattern, vec![String::from("./test")]);
+    }
+
+    #[test]
+    fn multiple_ignore_pattern() {
+        let options =
+            get_lint_options("lint --ignore-pattern ./test --ignore-pattern bar.js foo.js");
+        assert_eq!(options.ignore_pattern, vec![String::from("./test"), String::from("bar.js")]);
+    }
+
+    #[test]
+    fn list_rules_true() {
+        let options = get_lint_options("lint --rules");
+        assert!(options.paths.is_empty());
+        assert!(options.list_rules);
+    }
+}

--- a/crates/oxc_cli/src/main.rs
+++ b/crates/oxc_cli/src/main.rs
@@ -8,11 +8,8 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use std::env;
-
 use oxc_cli::{
-    command, CliRunResult, LintOptions, LintRunner, LintRunnerWithModuleTree, TypeCheckOptions,
-    TypeCheckRunner,
+    command, CliRunResult, LintOptions, LintRunner, Runner, TypeCheckOptions, TypeCheckRunner,
 };
 
 fn main() -> CliRunResult {
@@ -24,22 +21,13 @@ fn main() -> CliRunResult {
 
     let Some((subcommand, matches)) = matches.subcommand() else { return CliRunResult::None };
 
+    // todo: register commands in list then iterate
     match subcommand {
-        "lint" => {
+        LintRunner::NAME => {
             let options = LintOptions::from(matches);
-
-            if options.list_rules {
-                LintRunner::print_rules();
-                return CliRunResult::None;
-            }
-
-            if matches!(env::var("OXC_MODULE_TREE"), Ok(x) if x == "true" || x == "1") {
-                LintRunnerWithModuleTree::new(options).run()
-            } else {
-                LintRunner::new(options).run()
-            }
+            LintRunner::new(options).run()
         }
-        "check" => {
+        TypeCheckRunner::NAME => {
             let options = TypeCheckOptions::from(matches);
             TypeCheckRunner::new(options).run()
         }

--- a/crates/oxc_cli/src/type_check/mod.rs
+++ b/crates/oxc_cli/src/type_check/mod.rs
@@ -6,7 +6,10 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_type_synthesis::synthesize_program;
 
-use crate::CliRunResult;
+use crate::{
+    runner::{Runner, RunnerOptions},
+    CliRunResult,
+};
 
 const PRELUDE: &str = "
 type StringOrNumber = string | number;
@@ -56,32 +59,35 @@ impl<'a> From<&'a ArgMatches> for TypeCheckOptions {
         }
     }
 }
-
-pub fn type_check_command() -> Command {
-    Command::new("check")
-        .about(
-            "NOTE: Experimental / work in progress. Check source code for type errors using Ezno",
-        )
-        .arg(Arg::new("path").value_name("PATH").num_args(1).help("File to type check"))
-        .arg(
-            Arg::new("print_expression_mappings")
-                .required(false)
-                .help("Print types of expressions"),
-        )
-        .arg(Arg::new("print_called_functions").required(false).help("Print called functions"))
+impl RunnerOptions for TypeCheckOptions {
+    fn build_args(cmd: Command) -> Command {
+        cmd.arg(Arg::new("path").value_name("PATH").num_args(1).help("File to type check"))
+            .arg(
+                Arg::new("print_expression_mappings")
+                    .required(false)
+                    .help("Print types of expressions"),
+            )
+            .arg(Arg::new("print_called_functions").required(false).help("Print called functions"))
+    }
 }
 
 pub struct TypeCheckRunner {
     options: TypeCheckOptions,
 }
 
-impl TypeCheckRunner {
-    pub fn new(options: TypeCheckOptions) -> Self {
+impl Runner for TypeCheckRunner {
+    type Options = TypeCheckOptions;
+
+    const ABOUT: &'static str =
+        "NOTE: Experimental / work in progress. Check source code for type errors using Ezno";
+    const NAME: &'static str = "check";
+
+    fn new(options: TypeCheckOptions) -> Self {
         Self { options }
     }
 
     /// # Panics
-    pub fn run(&self) -> CliRunResult {
+    fn run(&self) -> CliRunResult {
         let now = std::time::Instant::now();
 
         let path = Path::new(&self.options.path);


### PR DESCRIPTION
# What
Introduces a standardized API for interacting with different parts of `oxc` within `oxc_cli` using a trait called `Runner`.

# Why
For the following reasons:
1. Prepare `oxc_cli` for new subcommand we plan on adding (e.g. `minify`)
2. Deduplicate code within `lint`
3. Prepare to expose runners as a public API, with the intention of using it to build an LSP

# How

The `check` and `lint` commands have been updated to implement `Runner`. This exposes three pieces of functionality:
1. A method for building `clap`-compatible `Commands`
2. Creating `Runner`s using their associated `RunnerOption`s
3. Executing whatever action they implement via `run()`