### PR TITLE
feat(cli): add support for `TIMING` env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,7 @@ criterion         = { version = "0.5.1", default-features = false }
 crossbeam-channel = { version = "0.5.8" }
 dashmap           = { version = "5.5.0" }
 flate2            = { version = "1.0.26" }
-glob              = { version = "0.3.1" }
 ignore            = { version = "0.4.20" }
-indextree         = { version = "4.6.0" }
 itertools         = { version = "0.11.0" }
 jemallocator      = { version = "0.5.0" }
 lazy_static       = { version = "1.4.0" }

--- a/crates/oxc_cli/src/lint/command.rs
+++ b/crates/oxc_cli/src/lint/command.rs
@@ -4,7 +4,10 @@ pub(super) fn lint_command(command: Command) -> Command {
     command
             .arg_required_else_help(true)
             .after_help(
-                "To allow or deny a rule, multiple -A <NAME> or -D <NAME>.
+                "# Rule Selection
+
+To allow or deny a rule, multiple -A <NAME> or -D <NAME>.
+
 For example: -D correctness -A no-debugger.
 
 The categories are:
@@ -12,7 +15,14 @@ The categories are:
   * nursery     - new lints that are still under development
   * all         - all the categories listed above
 
-The default category is -D correctness.")
+The default category is -D correctness.
+
+# Profile Rule Performance
+
+Setting the TIMING environment variable will display the execution time of each rule.
+
+TIMING=1 \"the lint command\"
+")
             .arg(
                 Arg::new("path")
                     .value_name("PATH")

--- a/crates/oxc_cli/src/lint/options.rs
+++ b/crates/oxc_cli/src/lint/options.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, env, path::PathBuf};
 
 use clap::ArgMatches;
 
@@ -22,6 +22,7 @@ pub struct LintOptions {
     pub no_ignore: bool,
     pub ignore_pattern: Vec<String>,
     pub max_warnings: Option<usize>,
+    pub print_execution_times: bool,
 }
 
 impl Default for LintOptions {
@@ -70,6 +71,7 @@ impl<'a> From<&'a ArgMatches> for LintOptions {
                 .unwrap_or_default(),
             max_warnings: matches.get_one("max-warnings").copied(),
             list_rules,
+            print_execution_times: matches!(env::var("TIMING"), Ok(x) if x == "true" || x == "1"),
         }
     }
 }

--- a/crates/oxc_linter/src/rule_timer.rs
+++ b/crates/oxc_linter/src/rule_timer.rs
@@ -1,0 +1,27 @@
+use std::{
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
+    time::Duration,
+};
+
+#[derive(Debug)]
+pub struct RuleTimer {
+    pub secs: AtomicU64,
+    pub nanos: AtomicU32,
+}
+
+impl RuleTimer {
+    pub const fn new() -> Self {
+        Self { secs: AtomicU64::new(0), nanos: AtomicU32::new(0) }
+    }
+
+    pub fn update(&mut self, duration: &Duration) {
+        self.secs.fetch_add(duration.as_secs(), Ordering::SeqCst);
+        self.nanos.fetch_add(duration.subsec_nanos(), Ordering::SeqCst);
+    }
+
+    pub fn duration(&self) -> Duration {
+        let secs = self.secs.load(Ordering::SeqCst);
+        let nanos = self.nanos.load(Ordering::SeqCst);
+        Duration::new(secs, nanos)
+    }
+}

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -180,7 +180,7 @@ pub fn get_array_method_name<'a>(
 
             AstKind::CallExpression(call) => {
                 let AstKind::Argument(current_node_arg) = current_node.kind() else {
-                  return None;
+                    return None;
                 };
 
                 let callee = call.callee.get_inner_expression();
@@ -205,7 +205,9 @@ pub fn get_array_method_name<'a>(
                 }
 
                 // "methods",
-                let Some(method) = callee.static_property_name() else { return None; };
+                let Some(method) = callee.static_property_name() else {
+                    return None;
+                };
                 if let Some(&array_method) = TARGET_METHODS.get_key(method) {
                     // Check that current node is parent's first argument
                     if call.arguments.len() == 1 && is_nth_argument(call, current_node_arg, 0) {

--- a/crates/oxc_macros/src/declare_all_lint_rules/mod.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules/mod.rs
@@ -2,7 +2,7 @@ mod trie;
 
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{
     parse::{Parse, ParseStream},
     Result,
@@ -40,7 +40,7 @@ impl Parse for AllLintRulesMeta {
     }
 }
 
-#[allow(clippy::cognitive_complexity)]
+#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
 pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let AllLintRulesMeta { rules } = metadata;
     // all the top-level module trees
@@ -63,12 +63,17 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
             .collect::<Vec<_>>()
             .join("/")
     });
+    let rule_timer = rules
+        .iter()
+        .map(|node| format_ident!("RuleTimer{}", node.name.to_string().to_case(Case::Pascal)))
+        .collect::<Vec<_>>();
 
     quote! {
         #(#mod_stmts)*
         #(#use_stmts)*
 
-        use crate::{context::LintContext, rule::{Rule, RuleCategory}, rule::RuleMeta, AstNode};
+        use std::time::{Instant, Duration};
+        use crate::{context::LintContext, rule::{Rule, RuleCategory, RuleMeta}, rule_timer:: RuleTimer, AstNode};
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
@@ -110,16 +115,36 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+            pub fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>, print_execution_times: bool) {
+                let start = print_execution_times.then(|| Instant::now());
                 match self {
-                    #(Self::#struct_names(rule) => rule.run(node, ctx)),*
+                    #(Self::#struct_names(rule) => {
+                        let diagnostics = rule.run(node, ctx);
+                        if let Some(start) = start {
+                            unsafe { #rule_timer.update(&start.elapsed()) };
+                        }
+                        diagnostics
+                    }),*
                 }
             }
 
-            pub fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContext<'a>) {
-              match self {
-                #(Self::#struct_names(rule) => rule.run_on_symbol(symbol_id, ctx)),*
-              }
+            pub fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContext<'a>, print_execution_times: bool) {
+                let start = print_execution_times.then(|| Instant::now());
+                match self {
+                    #(Self::#struct_names(rule) => {
+                        let diagnostics = rule.run_on_symbol(symbol_id, ctx);
+                        if let Some(start) = start {
+                            unsafe { #rule_timer.update(&start.elapsed()) };
+                        }
+                        diagnostics
+                    }),*
+                }
+            }
+
+            pub fn execute_time(&self) -> Duration {
+                match self {
+                    #(Self::#struct_names(_) => unsafe { #rule_timer.duration() }),*
+                }
             }
         }
 
@@ -148,6 +173,8 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 Some(self.cmp(&other))
             }
         }
+
+        #(pub static mut #rule_timer : RuleTimer = RuleTimer::new());*;
 
         lazy_static::lazy_static! {
             pub static ref RULES: Vec<RuleEnum> = vec![


### PR DESCRIPTION
Implements support for the `TIMING` environment variable in the linter/CLI. Setting `TIMING=1` or `TIMING=true` before running the linter (via CLI) will record the time each rule takes as a whole across all files and print the result in a table after linting is complete.