### PR TITLE
feat(minifier): drop console statements and exprs

### DIFF
--- a/crates/oxc_minifier/src/compressor/util.rs
+++ b/crates/oxc_minifier/src/compressor/util.rs
@@ -1,0 +1,10 @@
+use oxc_hir::hir::Expression;
+
+pub(super) fn is_console(expr: &Expression<'_>) -> bool {
+    // let Statement::ExpressionStatement(expr) = stmt else { return false };
+    let Expression::CallExpression(call_expr) = &expr else { return false };
+    let Expression::MemberExpression(member_expr) = &call_expr.callee else { return false };
+    let obj = member_expr.object();
+    let Some(ident) = obj.get_identifier_reference() else { return false };
+    ident.name == "console"
+}

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -11,8 +11,15 @@ use oxc_minifier::{CompressOptions, Minifier, MinifierOptions, PrinterOptions};
 use oxc_span::SourceType;
 
 pub(crate) fn test(source_text: &str, expected: &str) {
-    let source_type = SourceType::default();
+    // let source_type = SourceType::default();
     let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
+    test_with_options(source_text, expected, options);
+    // let minified = Minifier::new(source_text, source_type, options).build();
+    // assert_eq!(expected, minified, "for source {source_text}");
+}
+
+pub(crate) fn test_with_options(source_text: &str, expected: &str, options: MinifierOptions) {
+    let source_type = SourceType::default();
     let minified = Minifier::new(source_text, source_type, options).build();
     assert_eq!(expected, minified, "for source {source_text}");
 }

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -11,11 +11,8 @@ use oxc_minifier::{CompressOptions, Minifier, MinifierOptions, PrinterOptions};
 use oxc_span::SourceType;
 
 pub(crate) fn test(source_text: &str, expected: &str) {
-    // let source_type = SourceType::default();
     let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
     test_with_options(source_text, expected, options);
-    // let minified = Minifier::new(source_text, source_type, options).build();
-    // assert_eq!(expected, minified, "for source {source_text}");
 }
 
 pub(crate) fn test_with_options(source_text: &str, expected: &str, options: MinifierOptions) {

--- a/crates/oxc_minifier/tests/oxc/code_removal.rs
+++ b/crates/oxc_minifier/tests/oxc/code_removal.rs
@@ -1,4 +1,4 @@
-use crate::test;
+use crate::{test, test_with_options, CompressOptions, MinifierOptions};
 
 #[test]
 fn undefined_assignment() {
@@ -16,4 +16,20 @@ fn undefined_return() {
     test("function f(){return void 0;}", "function f(){return}");
     test("function f(){return void foo();}", "function f(){return void foo()}");
     test("function f(){if(a()){return undefined;}}", "function f(){if(a())return}");
+}
+
+#[test]
+fn console_removal() {
+    let options = MinifierOptions {
+        mangle: false,
+        compress: CompressOptions { drop_console: true, ..CompressOptions::default() },
+        ..MinifierOptions::default()
+    };
+    test_with_options("console.log('hi')", "", options);
+    test_with_options("let x = console.error('oops')", "let x", options);
+    test_with_options(
+        "function f() { return console.warn('problem') }",
+        "function f(){return}",
+        options,
+    );
 }

--- a/crates/oxc_minifier/tests/oxc/code_removal.rs
+++ b/crates/oxc_minifier/tests/oxc/code_removal.rs
@@ -32,4 +32,9 @@ fn console_removal() {
         "function f(){return}",
         options,
     );
+
+    // console isn't removed when drop_console is `false`. This is also the
+    // default value.
+    let options = MinifierOptions { mangle: false, ..MinifierOptions::default() };
+    test_with_options("console.log('hi')", "console.log('hi')", options);
 }


### PR DESCRIPTION
> Deprecates #527

Adds support for `drop_console`, which removes console statements and compresses console expressions.