### PR TITLE
chore: switch to `tikv-jemallocator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,26 +843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.3+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,7 +1248,6 @@ name = "oxc_benchmark"
 version = "0.0.0"
 dependencies = [
  "criterion",
- "jemallocator",
  "mimalloc",
  "oxc_allocator",
  "oxc_minifier",
@@ -1277,6 +1256,7 @@ dependencies = [
  "oxc_span",
  "oxc_tasks_common",
  "pico-args",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1288,7 +1268,6 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "ignore",
- "jemallocator",
  "miette",
  "mimalloc",
  "oxc_allocator",
@@ -1301,6 +1280,7 @@ dependencies = [
  "oxc_type_synthesis",
  "rayon",
  "rustc-hash",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1422,7 +1402,6 @@ name = "oxc_minifier"
 version = "0.0.7"
 dependencies = [
  "bitflags 2.3.3",
- "jemallocator",
  "mimalloc",
  "num-bigint",
  "num-traits",
@@ -1436,6 +1415,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "pico-args",
+ "tikv-jemallocator",
  "walkdir",
 ]
 
@@ -1491,13 +1471,13 @@ dependencies = [
  "criterion",
  "dashmap",
  "dunce",
- "jemallocator",
  "mimalloc",
  "nodejs-resolver",
  "rustc-hash",
  "serde",
  "serde_json",
  "static_assertions",
+ "tikv-jemallocator",
  "vfs",
 ]
 
@@ -2279,6 +2259,26 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ glob              = { version = "0.3.1" }
 ignore            = { version = "0.4.20" }
 indextree         = { version = "4.6.0" }
 itertools         = { version = "0.10.5" }
-jemallocator      = { version = "0.5.0" }
 lazy_static       = { version = "1.4.0" }
 miette            = { version = "5.10.0" }
 mimalloc          = { version = "0.1.37" }
@@ -70,6 +69,7 @@ serde             = { version = "1.0.173" }
 serde_json        = { version = "1.0.103" }
 syn               = { version = "1.0.109" }
 thiserror         = { version = "1.0.43" }
+tikv-jemallocator = { version = "0.5.0" }
 tokio             = { version = "1" }
 unicode-id-start  = { version = "1.1.0" }
 ureq              = { version = "2.7.1", default-features = false, features = ["tls"] }

--- a/crates/oxc_cli/Cargo.toml
+++ b/crates/oxc_cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "oxlint"
 path = "src/lint/main.rs"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }

--- a/crates/oxc_cli/src/lint/main.rs
+++ b/crates/oxc_cli/src/lint/main.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]

--- a/crates/oxc_cli/src/main.rs
+++ b/crates/oxc_cli/src/main.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -29,7 +29,7 @@ walkdir   = { workspace = true }
 pico-args = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -6,7 +6,7 @@ use pico_args::Arguments;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]

--- a/crates/oxc_resolver/Cargo.toml
+++ b/crates/oxc_resolver/Cargo.toml
@@ -24,7 +24,7 @@ vfs               = "0.9.0"              # for testing with in memory file syste
 nodejs-resolver   = "0.0.88"             # for benchmark
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 mimalloc = { workspace = true }

--- a/crates/oxc_resolver/benches/resolver.rs
+++ b/crates/oxc_resolver/benches/resolver.rs
@@ -10,7 +10,7 @@
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }

--- a/tasks/benchmark/src/main.rs
+++ b/tasks/benchmark/src/main.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]


### PR DESCRIPTION
We are currently using [jemallocator](https://github.com/gnzlbg/jemallocator). We should switch to [tikv-jemallocator](https://github.com/tikv/jemallocator).

See [This PR](https://github.com/rust-lang/rust/pull/83152) for context.

TL;DR: 
> [tikv-jemallocator](https://crates.io/crates/tikv-jemallocator) is a fork of the jemallocator crate. As of December 2021, tikv-jemallocator uses a jemalloc version that is newer and has [better performance](https://github.com/rust-lang/rust/pull/83152) than the jemalloc version used by jemallocator.

from [this site](https://nnethercote.github.io/perf-book/heap-allocations.html#using-an-alternative-allocator).