### PR TITLE
perf(resolver): improve cache hit for package.json

### DIFF
--- a/crates/oxc_resolver/tests/description_file.rs
+++ b/crates/oxc_resolver/tests/description_file.rs
@@ -1,4 +1,5 @@
-//! FYI webpack does not have any tests for description files
+//! `enhanced_resolve` does not have any tests for description files,
+//! this is added for completeness.
 
 use std::env;
 
@@ -8,12 +9,14 @@ use oxc_resolver::{Resolution, ResolveError, ResolveOptions, Resolver};
 fn no_description_file() {
     let f = env::current_dir().unwrap().join("tests/enhanced_resolve");
 
+    // has description file
     let resolver = Resolver::default();
     assert_eq!(
         resolver.resolve(&f, ".").map(Resolution::into_path_buf),
         Ok(f.join("lib/index.js"))
     );
 
+    // without description file
     let resolver =
         Resolver::new(ResolveOptions { description_files: vec![], ..ResolveOptions::default() });
     assert_eq!(resolver.resolve(&f, "."), Err(ResolveError::NotFound(f.into_boxed_path())));


### PR DESCRIPTION
Previously all ancestor paths are checked existence of package.json, they are now cached by linking parent directories.

oxc_resolver is now faster than nodejs_resolver because nodejs_resolver reads all parent directories and try to read their package.json, but oxc_resolver only lazily read then when required.

oxc_resolver is performing less file reads and hashes.