### PR TITLE
perf(resolver): shrink the size of CacheValue from 152 to 72 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "sharded-slab",
  "static_assertions",
  "vfs",
 ]

--- a/crates/oxc_resolver/Cargo.toml
+++ b/crates/oxc_resolver/Cargo.toml
@@ -17,6 +17,7 @@ serde_json    = { workspace = true }
 rustc-hash    = { workspace = true }
 dunce         = "1.0.4"
 identity-hash = "0.1.0"
+sharded-slab  = "0.1.4"
 
 [dev-dependencies]
 static_assertions = { workspace = true }

--- a/crates/oxc_resolver/src/lib.rs
+++ b/crates/oxc_resolver/src/lib.rs
@@ -214,7 +214,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     }
 
     fn load_symlink(&self, cache_value: &CacheValue) -> Option<PathBuf> {
-        if self.options.symlinks { cache_value.symlink(&self.cache.fs) } else { None }
+        if self.options.symlinks { cache_value.symlink(&self.cache) } else { None }
     }
 
     fn load_index(&self, cache_value: &CacheValue) -> ResolveState {
@@ -237,7 +237,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     }
 
     fn load_alias_or_file(&self, cache_value: &CacheValue) -> ResolveState {
-        if let Some(package_json) = cache_value.find_package_json(&self.cache.fs)? {
+        if let Some(package_json) = cache_value.find_package_json(&self.cache)? {
             let path = cache_value.path();
             if let Some(path) = self.load_browser_field(path, None, &package_json)? {
                 return Ok(Some(path));
@@ -255,7 +255,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
         // 1. If X/package.json is a file,
         if !self.options.description_files.is_empty() {
             // a. Parse X/package.json, and look for "main" field.
-            if let Some(package_json) = cache_value.package_json(&self.cache.fs).transpose()? {
+            if let Some(package_json) = cache_value.package_json(&self.cache).transpose()? {
                 // b. If "main" is a falsy value, GOTO 2.
                 if let Some(main_field) = &package_json.main {
                     // c. let M = X + (json main field)
@@ -334,7 +334,7 @@ impl<Fs: FileSystem> ResolverGeneric<Fs> {
     ///
     /// * Parent of package.json is None
     fn load_package_self(&self, cache_value: &CacheValue, request: &str) -> ResolveState {
-        if let Some(package_json) = cache_value.find_package_json(&self.cache.fs)? {
+        if let Some(package_json) = cache_value.find_package_json(&self.cache)? {
             if let Some(path) =
                 self.load_browser_field(cache_value.path(), Some(request), &package_json)?
             {


### PR DESCRIPTION
This should reduce the total memory consumption, given most path do not have a package_json nor symlinks.