### PR TITLE
refactor: avoid unstable let_chains

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -112,6 +112,13 @@ impl<'a> Expression<'a> {
         matches!(self, Self::StringLiteral(_) | Self::TemplateLiteral(_))
     }
 
+    pub fn is_specific_string_literal(&self, string: &str) -> bool {
+        match self {
+            Self::StringLiteral(s) => s.value == string,
+            _ => false,
+        }
+    }
+
     /// Determines whether the given expr is a `null` literal
     pub fn is_null(&self) -> bool {
         matches!(self, Expression::NullLiteral(_))
@@ -129,13 +136,12 @@ impl<'a> Expression<'a> {
 
     /// Determines whether the given expr is a `void 0`
     pub fn is_void_0(&self) -> bool {
-        if let Self::UnaryExpression(expr) = self
-            && expr.operator == UnaryOperator::Void
-            && let Self::NumberLiteral(lit) = &expr.argument
-            && lit.value == 0.0 {
-            return true
+        match self {
+            Self::UnaryExpression(expr) if expr.operator == UnaryOperator::Void => {
+                matches!(&expr.argument, Self::NumberLiteral(lit) if lit.value == 0.0)
+            }
+            _ => false,
         }
-        false
     }
 
     /// Determines whether the given expr is a `0`
@@ -193,6 +199,10 @@ impl<'a> Expression<'a> {
             Expression::TSTypeAssertion(expr) => expr.expression.get_inner_expression(),
             _ => self,
         }
+    }
+
+    pub fn is_identifier_reference(&self) -> bool {
+        matches!(self, Expression::Identifier(_))
     }
 
     pub fn get_identifier_reference(&self) -> Option<&IdentifierReference> {
@@ -355,8 +365,19 @@ impl<'a> PropertyKey<'a> {
         }
     }
 
+    pub fn is_specific_static_name(&self, name: &str) -> bool {
+        self.static_name().is_some_and(|n| n == name)
+    }
+
     pub fn is_private_identifier(&self) -> bool {
         matches!(self, Self::PrivateIdentifier(_))
+    }
+
+    pub fn is_specific_id(&self, name: &str) -> bool {
+        match self {
+            PropertyKey::Identifier(ident) => ident.name == name,
+            _ => false,
+        }
     }
 }
 
@@ -568,13 +589,12 @@ impl<'a> CallExpression<'a> {
     }
 
     pub fn common_js_require(&self) -> Option<&StringLiteral> {
-        if let Expression::Identifier(ident) = &self.callee
-            && ident.name =="require"
-            && self.arguments.len() == 1
-            && let Argument::Expression(Expression::StringLiteral(str_literal)) = &self.arguments[0] {
-            Some(str_literal)
-        } else {
-            None
+        if !(self.callee.is_specific_id("require") && self.arguments.len() == 1) {
+            return None;
+        }
+        match &self.arguments[0] {
+            Argument::Expression(Expression::StringLiteral(str_literal)) => Some(str_literal),
+            _ => None,
         }
     }
 }

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -223,6 +223,13 @@ impl<'a> AstKind<'a> {
     pub fn is_jsx(self) -> bool {
         matches!(self, Self::JSXElement(_) | Self::JSXOpeningElement(_) | Self::JSXElementName(_))
     }
+
+    pub fn is_specific_id_reference(&self, name: &str) -> bool {
+        match self {
+            Self::IdentifierReference(ident) => ident.name == name,
+            _ => false,
+        }
+    }
 }
 
 impl<'a> GetSpan for AstKind<'a> {

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -7,8 +7,6 @@
 //! ## Cargo Features
 //! * `"serde"` enables support for serde serialization
 
-#![feature(let_chains)]
-
 #[cfg(feature = "serde")]
 mod serialize;
 

--- a/crates/oxc_formatter/src/gen.rs
+++ b/crates/oxc_formatter/src/gen.rs
@@ -72,8 +72,7 @@ impl<'a> Gen for ExpressionStatement<'a> {
     fn gen(&self, p: &mut Formatter) {
         p.print_indent();
         self.expression.gen(p);
-        if let Expression::Identifier(ident) = &self.expression
-        && ident.name == "let" {
+        if self.expression.is_specific_id("let") {
             p.print_semicolon();
         } else {
             p.print_semicolon_after_statement();

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -1,8 +1,6 @@
 //! AST Formatter with whitespace minification
 //! code adapted from [esbuild](https://github.com/evanw/esbuild/blob/main/internal/js_formatter/js_formatter.go)
 
-#![feature(let_chains)]
-
 mod gen;
 
 #[allow(clippy::wildcard_imports)]

--- a/crates/oxc_hir/src/hir_util.rs
+++ b/crates/oxc_hir/src/hir_util.rs
@@ -410,11 +410,12 @@ pub fn get_boolean_value(expr: &Expression) -> Option<bool> {
         Expression::StringLiteral(string_literal) => Some(!string_literal.value.is_empty()),
         Expression::TemplateLiteral(template_literal) => {
             // only for ``
-            if let Some(quasi) = template_literal.quasis.get(0) && quasi.tail {
-                Some(quasi.value.cooked.as_ref().map_or(false, |cooked| !cooked.is_empty()))
-            } else {
-                None
-            }
+            template_literal
+                .quasis
+                .get(0)
+                .filter(|quasi| quasi.tail)
+                .and_then(|quasi| quasi.value.cooked.as_ref())
+                .map(|cooked| !cooked.is_empty())
         }
         Expression::Identifier(ident) => {
             if expr.is_undefined() || ident.name == "NaN" {
@@ -502,11 +503,12 @@ fn get_string_value<'a>(expr: &'a Expression) -> Option<Cow<'a, str>> {
         Expression::TemplateLiteral(template_literal) => {
             // TODO: I don't know how to iterate children of TemplateLiteral in order,so only checkout string like `hi`.
             // Closure-compiler do more: [case TEMPLATELIT](https://github.com/google/closure-compiler/blob/e13f5cd0a5d3d35f2db1e6c03fdf67ef02946009/src/com/google/javascript/jscomp/NodeUtil.java#L241-L256).
-            if let Some(quasi) = template_literal.quasis.get(0) && quasi.tail {
-                quasi.value.cooked.as_ref().map(|cooked| Cow::Borrowed(cooked.as_str()))
-            } else {
-                None
-            }
+            template_literal
+                .quasis
+                .get(0)
+                .filter(|quasi| quasi.tail)
+                .and_then(|quasi| quasi.value.cooked.as_ref())
+                .map(|cooked| Cow::Borrowed(cooked.as_str()))
         }
         Expression::Identifier(ident) => {
             let name = ident.name.as_str();

--- a/crates/oxc_hir/src/lib.rs
+++ b/crates/oxc_hir/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(let_chains)]
-
 #[cfg(feature = "serde")]
 mod serialize;
 

--- a/crates/oxc_linter/src/jest_ast_util.rs
+++ b/crates/oxc_linter/src/jest_ast_util.rs
@@ -74,12 +74,23 @@ pub fn parse_jest_fn_call<'a>(
         let is_valid_jest_call = if members.is_empty() {
             VALID_JEST_FN_CALL_CHAINS.iter().any(|chain| chain[0] == name)
         } else if members.len() == 1 {
-            VALID_JEST_FN_CALL_CHAINS_2.iter().any(|chain| chain[0] == name && chain[1] == members[0])
+            VALID_JEST_FN_CALL_CHAINS_2
+                .iter()
+                .any(|chain| chain[0] == name && chain[1] == members[0])
         } else if members.len() == 2 {
-            VALID_JEST_FN_CALL_CHAINS_3.iter().any(|chain| chain[0] == name && chain[1] == members[0] && chain[2] == members[1])
+            VALID_JEST_FN_CALL_CHAINS_3
+                .iter()
+                .any(|chain| chain[0] == name && chain[1] == members[0] && chain[2] == members[1])
         } else if members.len() == 3 {
-            VALID_JEST_FN_CALL_CHAINS_4.iter().any(|chain| chain[0] == name && chain[1] == members[0] && chain[2] == members[1] && chain[3] == members[2])
-        } else { false };
+            VALID_JEST_FN_CALL_CHAINS_4.iter().any(|chain| {
+                chain[0] == name
+                    && chain[1] == members[0]
+                    && chain[2] == members[1]
+                    && chain[3] == members[2]
+            })
+        } else {
+            false
+        };
 
         if !is_valid_jest_call {
             return None;

--- a/crates/oxc_linter/src/jest_ast_util.rs
+++ b/crates/oxc_linter/src/jest_ast_util.rs
@@ -43,10 +43,13 @@ pub fn parse_jest_fn_call<'a>(
     let resolved = resolve_to_jest_fn(call_expr, ctx)?;
 
     let chain = get_node_chain(callee);
-    if let Some(first) = chain.first() && let Some(last) = chain.last() {
+    if let (Some(first), Some(last)) = (chain.first(), chain.last()) {
         // if we're an `each()`, ensure we're the outer CallExpression (i.e `.each()()`)
         if last == "each"
-            && !matches!( callee, Expression::CallExpression(_) | Expression::TaggedTemplateExpression(_))
+            && !matches!(
+                callee,
+                Expression::CallExpression(_) | Expression::TaggedTemplateExpression(_)
+            )
         {
             return None;
         }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::self_named_module_files)] // for rules.rs
-#![feature(let_chains)]
 
 #[cfg(test)]
 mod tester;

--- a/crates/oxc_linter/src/rules/deepscan/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/deepscan/bad_array_method_on_arguments.rs
@@ -48,51 +48,51 @@ declare_oxc_lint!(
 
 impl Rule for BadArrayMethodOnArguments {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::IdentifierReference(reference) = node.kind()
-            && reference.name == "arguments"
-            && let Some(parent_node_id) = ctx.nodes().parent_id(node.id())
-            && let AstKind::MemberExpression(member_expr) = ctx.nodes().kind(parent_node_id)
-            && let Some(parent_node_id) = ctx.nodes().parent_id(parent_node_id)
-            && let AstKind::CallExpression(_) = ctx.nodes().kind(parent_node_id)
-        {
-            match member_expr {
-                MemberExpression::StaticMemberExpression(expr) => {
-                    if ARRAY_METHODS.binary_search(&expr.property.name.as_str()).is_ok() {
-                        ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
+        if !node.kind().is_specific_id_reference("arguments") {
+            return;
+        }
+        let Some(parent_node_id) = ctx.nodes().parent_id(node.id()) else { return };
+        let AstKind::MemberExpression(member_expr) = ctx.nodes().kind(parent_node_id) else { return };
+        let Some(parent_node_id) = ctx.nodes().parent_id(parent_node_id) else { return };
+        let AstKind::CallExpression(_) = ctx.nodes().kind(parent_node_id) else { return };
+        match member_expr {
+            MemberExpression::StaticMemberExpression(expr) => {
+                if ARRAY_METHODS.binary_search(&expr.property.name.as_str()).is_ok() {
+                    ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
                             expr.property.name.clone(),
                             expr.span,
-                        ));
-                    }
+                    ));
                 }
-                MemberExpression::ComputedMemberExpression(expr) => {
-                    match &expr.expression {
-                        Expression::StringLiteral(name) => {
-                            if ARRAY_METHODS.binary_search(&name.value.as_str()).is_ok() {
-                                ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
+            }
+            MemberExpression::ComputedMemberExpression(expr) => {
+                match &expr.expression {
+                    Expression::StringLiteral(name) => {
+                        if ARRAY_METHODS.binary_search(&name.value.as_str()).is_ok() {
+                            ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
                                     name.value.clone(),
                                     expr.span,
-                                ));
-                            }
+                            ));
                         }
-                        Expression::TemplateLiteral(template) => {
-                            // only check template string like "arguments[`METHOD_NAME`]" for Deepscan compatible
-                            if template.expressions.is_empty()
-                                && template.quasis.len() == 1
-                                && let Some(template_element) = template.quasis.get(0)
-                                && let Some(name) = template_element.value.cooked.as_deref()
-                                && ARRAY_METHODS.binary_search(&name).is_ok()
-                            {
-                                ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
+                    }
+                    Expression::TemplateLiteral(template) => {
+                        // only check template string like "arguments[`METHOD_NAME`]" for Deepscan compatible
+                        if template.expressions.is_empty()
+                            && template.quasis.len() == 1 {
+                                if let Some(name) = template.quasis.get(0).and_then(|template_element| template_element.value.cooked.as_deref()) {
+                                if ARRAY_METHODS.binary_search(&name).is_ok()
+                        {
+                            ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
                                     Atom::from(name),
                                     expr.span,
-                                ));
-                            }
+                            ));
                         }
-                        _ => {}
+                                }
+                            }
                     }
+                    _ => {}
                 }
-                MemberExpression::PrivateFieldExpression(_) => {}
             }
+            MemberExpression::PrivateFieldExpression(_) => {}
         }
     }
 }

--- a/crates/oxc_linter/src/rules/deepscan/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/deepscan/bad_bitwise_operator.rs
@@ -106,21 +106,13 @@ fn is_mistype_short_circuit(node: &AstNode) -> bool {
 }
 
 fn is_mistype_option_fallback(node: &AstNode) -> bool {
-    match node.kind() {
-        AstKind::BinaryExpression(binary_expr) => {
-            if binary_expr.operator != BinaryOperator::BitwiseOR {
-                return false;
-            }
-
-            if let Expression::Identifier(_) = &binary_expr.left
-            && !is_numeric_expr(&binary_expr.right, true) {
-                return true
-            }
-
-            false
+    let AstKind::BinaryExpression(binary_expr) = node.kind() else { return false; };
+    if binary_expr.operator == BinaryOperator::BitwiseOR {
+        if let Expression::Identifier(_) = &binary_expr.left {
+            return !is_numeric_expr(&binary_expr.right, true);
         }
-        _ => false,
     }
+    false
 }
 
 fn is_numeric_expr(expr: &Expression, is_outer_most: bool) -> bool {

--- a/crates/oxc_linter/src/rules/deepscan/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/deepscan/bad_comparison_sequence.rs
@@ -45,10 +45,8 @@ declare_oxc_lint!(
 
 impl Rule for BadComparisonSequence {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::BinaryExpression(expr) = node.kind()
-            && is_bad_comparison(expr)
-            && has_no_bad_comparison_in_parents(node, ctx)
-        {
+        let AstKind::BinaryExpression(expr) = node.kind() else { return };
+        if is_bad_comparison(expr) && has_no_bad_comparison_in_parents(node, ctx) {
             ctx.diagnostic(BadComparisonSequenceDiagnostic(expr.span));
         }
     }
@@ -70,7 +68,7 @@ fn has_no_bad_comparison_in_parents<'a, 'b>(
             return true;
         }
 
-        if let AstKind::BinaryExpression(expr) = kind && is_bad_comparison(expr) {
+        if matches!(kind, AstKind::BinaryExpression(expr) if is_bad_comparison(expr)) {
             return false;
         }
     }
@@ -79,15 +77,13 @@ fn has_no_bad_comparison_in_parents<'a, 'b>(
 
 fn is_bad_comparison(expr: &BinaryExpression) -> bool {
     if expr.operator.is_equality()
-        && let Expression::BinaryExpression(left_expr) = &expr.left
-        && left_expr.operator.is_equality()
+        && matches!(&expr.left, Expression::BinaryExpression(left_expr) if left_expr.operator.is_equality())
     {
         return true
     }
 
     if expr.operator.is_compare()
-        && let Expression::BinaryExpression(left_expr) = &expr.left
-        && left_expr.operator.is_compare()
+        && matches!(&expr.left, Expression::BinaryExpression(left_expr) if left_expr.operator.is_compare())
     {
         return true
     }

--- a/crates/oxc_linter/src/rules/deepscan/bad_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/deepscan/bad_remove_event_listener.rs
@@ -37,14 +37,13 @@ declare_oxc_lint!(
 
 impl Rule for BadRemoveEventListener {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::CallExpression(call_expr) = node.kind()
-            && let Some(member) = call_expr.callee.get_member_expr()
-            && let Some(name) = member.static_property_name()
-            && name == "removeEventListener"
-            && let Some(Argument::Expression(expr)) = call_expr.arguments.get(1)
-            && expr.is_function() {
+        let AstKind::CallExpression(call_expr) = node.kind() else { return };
+        let Some(member) = call_expr.callee.get_member_expr() else { return };
+        if member.static_property_name() == Some("removeEventListener")
+            && matches!(call_expr.arguments.get(1), Some(Argument::Expression(expr)) if expr.is_function())
+        {
             ctx.diagnostic(BadRemoveEventListenerDiagnostic(call_expr.span));
-        };
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/deepscan/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/deepscan/missing_throw.rs
@@ -36,11 +36,12 @@ declare_oxc_lint!(
 
 impl Rule for MissingThrow {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::NewExpression(new_expr) = node.kind()
-            && new_expr.callee.is_specific_id("Error")
-            && Self::has_missing_throw(node, ctx) {
+        let AstKind::NewExpression(new_expr) = node.kind() else { return };
+        if new_expr.callee.is_specific_id("Error")
+            && Self::has_missing_throw(node, ctx)
+        {
             ctx.diagnostic(MissingThrowDiagnostic(new_expr.span));
-        };
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/deepscan/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/deepscan/uninvoked_array_callback.rs
@@ -44,33 +44,33 @@ declare_oxc_lint!(
 
 impl Rule for UninvokedArrayCallback {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let new_expr = if let AstKind::NewExpression(new_expr) = node.kind()
-            && new_expr.callee.is_specific_id("Array")
-            && new_expr.arguments.len() == 1
-            && let Some(Argument::Expression(arg_expr)) = new_expr.arguments.iter().next()
-            && matches!(arg_expr, Expression::NumberLiteral(_))
-            { new_expr } else { return };
+        let AstKind::NewExpression(new_expr) = node.kind() else { return };
+        if !new_expr.callee.is_specific_id("Array") { return }
+        if new_expr.arguments.len() != 1 { return }
+        if !matches!(new_expr.arguments.get(0), Some(Argument::Expression(Expression::NumberLiteral(_)))) {
+            return;
+        }
 
         let Some(member_expr_node) = ctx.nodes().parent_node(node.id()) else { return };
 
         let AstKind::MemberExpression(member_expr) = member_expr_node.kind() else {
-            return
+            return;
         };
 
-        if let Some(AstKind::CallExpression(call_expr)) = ctx.nodes().parent_kind(member_expr_node.id())
-            && let Some(argument) = call_expr.arguments.iter().next()
-            && let Argument::Expression(arg_expr) = argument
-            && arg_expr.is_function() {
-            let property_span = match member_expr {
-                MemberExpression::ComputedMemberExpression(expr) => expr.expression.span(),
-                MemberExpression::StaticMemberExpression(expr) => expr.property.span,
-                MemberExpression::PrivateFieldExpression(expr) => expr.field.span,
-            };
-            ctx.diagnostic(UninvokedArrayCallbackDiagnostic(
+        let Some(AstKind::CallExpression(call_expr)) = ctx.nodes().parent_kind(member_expr_node.id()) else { return };
+        if !matches!(call_expr.arguments.get(0), Some(Argument::Expression(arg_expr)) if arg_expr.is_function()) {
+            return;
+        }
+
+        let property_span = match member_expr {
+            MemberExpression::ComputedMemberExpression(expr) => expr.expression.span(),
+            MemberExpression::StaticMemberExpression(expr) => expr.property.span,
+            MemberExpression::PrivateFieldExpression(expr) => expr.field.span,
+        };
+        ctx.diagnostic(UninvokedArrayCallbackDiagnostic(
                 property_span,
                 new_expr.span,
-            ));
-        }
+        ));
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
@@ -140,7 +140,7 @@ pub fn check_statement(statement: &Statement) -> StatementReturnStatus {
         Statement::WhileStatement(stmt) => {
             let test = &stmt.test;
             let inner_return = check_statement(&stmt.body);
-            if let Some(val) = test.get_boolean_value() && val {
+            if test.get_boolean_value() == Some(true) {
                 inner_return
             } else {
                 inner_return.join(StatementReturnStatus::NotReturn)

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -47,11 +47,9 @@ declare_oxc_lint!(
 
 impl Rule for ConstructorSuper {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let (ctor, class) = if let AstKind::MethodDefinition(def) = node.kind()
-            && def.kind == MethodDefinitionKind::Constructor
-            && def.value.body.is_some()
-            && let Some(AstKind::Class(class)) = ctx.nodes().parent_kind(node.id()) {
-            (def, class) } else { return };
+        let AstKind::MethodDefinition(ctor) = node.kind() else { return };
+        if ctor.kind != MethodDefinitionKind::Constructor || ctor.value.body.is_none() { return }
+        let Some(AstKind::Class(class)) = ctx.nodes().parent_kind(node.id()) else { return };
 
         // In cases where there's no super-class, calling 'super()' inside the constructor
         // is handled by the parser.

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::Expression, AstKind};
+use oxc_ast::AstKind;
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
@@ -53,8 +53,7 @@ impl Rule for NoArrayConstructor {
             _ => return,
         };
 
-        if let Expression::Identifier(ident) = callee
-            && ident.name == "Array"
+        if callee.is_specific_id("Array")
             && arguments.len() != 1
             && type_parameters.is_none()
             && !optional

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -51,22 +51,19 @@ declare_oxc_lint!(
 
 impl Rule for NoAsyncPromiseExecutor {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::NewExpression(new_expression) = node.kind() {
-            if let Expression::Identifier(ident) = &new_expression.callee && ident.name == "Promise" {
-                if let Some(Argument::Expression(expression)) = new_expression.arguments.first() {
-                    let mut span = match expression.get_inner_expression() {
-                        Expression::ArrowExpression(arrow) if arrow.r#async => arrow.span,
-                        Expression::FunctionExpression(func) if func.r#async => func.span,
+        let AstKind::NewExpression(new_expression) = node.kind() else { return };
+        if !new_expression.callee.is_specific_id("Promise") { return }
+        let Some(Argument::Expression(expression)) = new_expression.arguments.first() else { return };
+        let mut span = match expression.get_inner_expression() {
+            Expression::ArrowExpression(arrow) if arrow.r#async => arrow.span,
+            Expression::FunctionExpression(func) if func.r#async => func.span,
 
-                        _ => return,
-                    };
+            _ => return,
+        };
 
-                    span.end = span.start + 5;
+        span.end = span.start + 5;
 
-                    ctx.diagnostic(NoAsyncPromiseExecutorDiagnostic(span));
-                }
-            }
-        }
+        ctx.diagnostic(NoAsyncPromiseExecutorDiagnostic(span));
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -51,17 +51,11 @@ declare_oxc_lint!(
 
 impl Rule for NoCaller {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::MemberExpression(member_expr) = node.kind() else {return};
-        if let MemberExpression::StaticMemberExpression(expr) = member_expr
-        && let Some(reference) = expr.object.get_identifier_reference()
-         {
-            if reference.name != "arguments" {
-                return;
-            }
-
-            if expr.property.name == "callee" || expr.property.name == "caller" {
-                ctx.diagnostic(NoCallerDiagnostic(expr.property.span));
-            }
+        let AstKind::MemberExpression(MemberExpression::StaticMemberExpression(expr)) = node.kind() else { return };
+        if expr.object.is_specific_id("arguments")
+            && (expr.property.name == "callee" || expr.property.name == "caller")
+        {
+            ctx.diagnostic(NoCallerDiagnostic(expr.property.span));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -69,8 +69,10 @@ impl Rule for NoCondAssign {
                 ctx.diagnostic(NoCondAssignDiagnostic(stmt.test.span()));
             }
             AstKind::ForStatement(stmt) => {
-                if let Some(expr) = &stmt.test && self.is_assignment_expression(expr) {
-                    ctx.diagnostic(NoCondAssignDiagnostic(expr.span()));
+                if let Some(expr) = &stmt.test {
+                    if self.is_assignment_expression(expr) {
+                        ctx.diagnostic(NoCondAssignDiagnostic(expr.span()));
+                    }
                 }
             }
             AstKind::ConditionalExpression(expr) if self.is_assignment_expression(expr.test.get_inner_expression()) => {

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -137,17 +137,16 @@ impl Rule for NoControlRegex {
 }
 
 fn extract_flags<'a>(args: &'a oxc_allocator::Vec<'a, Argument<'a>>) -> Option<RegExpFlags> {
-    if args.len() > 1 &&
-    let Argument::Expression(Expression::StringLiteral(flag_arg)) = &args[1] {
-        let mut flags = RegExpFlags::empty();
-        for ch in flag_arg.value.chars() {
-            let flag = RegExpFlags::try_from(ch).ok()?;
-            flags |= flag;
-        }
-        Some(flags)
-    } else {
-        None
+    if args.len() <= 1 { return None; }
+    let Argument::Expression(Expression::StringLiteral(flag_arg)) = &args[1] else {
+        return None;
+    };
+    let mut flags = RegExpFlags::empty();
+    for ch in flag_arg.value.chars() {
+        let flag = RegExpFlags::try_from(ch).ok()?;
+        flags |= flag;
     }
+    Some(flags)
 }
 
 struct RegexPatternData<'a> {
@@ -187,20 +186,22 @@ fn regex_pattern<'a>(node: &AstNode<'a>) -> Option<RegexPatternData<'a>> {
         // new RegExp()
         AstKind::NewExpression(expr) => {
             // constructor is RegExp,
-            if let Expression::Identifier(ident) = &expr.callee &&
-            ident.name == "RegExp" &&
+            if expr.callee.is_specific_id("RegExp")
             // which is provided at least 1 parameter,
-            expr.arguments.len() > 0 &&
-            // where the first one is a string literal
-            // note: improvements required for strings used via identifier
-            // references
-            let Argument::Expression(Expression::StringLiteral(pattern)) = &expr.arguments[0]
+                && expr.arguments.len() > 0
             {
-                // get pattern from arguments. Missing or non-string arguments
-                // will be runtime errors, but are not covered by this rule.
-                // Note that we're intentionally reporting the entire "new
-                // RegExp("pat") expression, not just "pat".
-                Some(RegexPatternData { pattern: &pattern.value, flags: extract_flags(&expr.arguments), span: kind.span() })
+                // where the first one is a string literal
+                // note: improvements required for strings used via identifier
+                // references
+                if let Argument::Expression(Expression::StringLiteral(pattern)) = &expr.arguments[0] {
+                    // get pattern from arguments. Missing or non-string arguments
+                    // will be runtime errors, but are not covered by this rule.
+                    // Note that we're intentionally reporting the entire "new
+                    // RegExp("pat") expression, not just "pat".
+                    Some(RegexPatternData { pattern: &pattern.value, flags: extract_flags(&expr.arguments), span: kind.span() })
+                } else {
+                    None
+                }
             } else {
                 None
             }
@@ -209,20 +210,22 @@ fn regex_pattern<'a>(node: &AstNode<'a>) -> Option<RegexPatternData<'a>> {
         // RegExp()
         AstKind::CallExpression(expr) => {
             // constructor is RegExp,
-            if let Expression::Identifier(ident) = &expr.callee &&
-            ident.name == "RegExp" &&
-            // which is provided at least 1 parameter,
-            expr.arguments.len() > 0 &&
-            // where the first one is a string literal
-            // note: improvements required for strings used via identifier
-            // references
-            let Argument::Expression(Expression::StringLiteral(pattern)) = &expr.arguments[0]
+            if expr.callee.is_specific_id("RegExp")
+                // which is provided at least 1 parameter,
+                && expr.arguments.len() > 0
             {
-                // get pattern from arguments. Missing or non-string arguments
-                // will be runtime errors, but are not covered by this rule.
-                // Note that we're intentionally reporting the entire "new
-                // RegExp("pat") expression, not just "pat".
-                Some(RegexPatternData { pattern: &pattern.value, flags: extract_flags(&expr.arguments), span: kind.span() })
+                // where the first one is a string literal
+                // note: improvements required for strings used via identifier
+                // references
+                if let Argument::Expression(Expression::StringLiteral(pattern)) = &expr.arguments[0] {
+                    // get pattern from arguments. Missing or non-string arguments
+                    // will be runtime errors, but are not covered by this rule.
+                    // Note that we're intentionally reporting the entire "new
+                    // RegExp("pat") expression, not just "pat".
+                    Some(RegexPatternData { pattern: &pattern.value, flags: extract_flags(&expr.arguments), span: kind.span() })
+                } else {
+                    None
+                }
             } else {
                 None
             }

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::Expression, AstKind};
+use oxc_ast::AstKind;
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
@@ -37,9 +37,10 @@ declare_oxc_lint!(
 
 impl Rule for NoDeleteVar {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::UnaryExpression(expr) = node.kind()
-            && expr.operator == UnaryOperator::Delete
-            && matches!(expr.argument, Expression::Identifier(_)) {
+        let AstKind::UnaryExpression(expr) = node.kind() else { return };
+        if expr.operator == UnaryOperator::Delete
+            && expr.argument.is_identifier_reference()
+        {
             ctx.diagnostic(NoDeleteVarDiagnostic(expr.span));
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -45,12 +45,13 @@ impl Rule for NoDupeKeys {
         if let AstKind::ObjectExpression(obj_expr) = node.kind() {
             let mut map = FxHashMap::default();
             for prop in &obj_expr.properties {
-                if let ObjectPropertyKind::ObjectProperty(prop) = prop
-                    && let Some(key_name) = prop.key.static_name().as_ref() {
-                    let hash = calculate_hash(key_name);
-                    if let Some((prev_kind, prev_span)) = map.insert(hash, (prop.kind, prop.key.span())) {
-                        if prev_kind == PropertyKind::Init || prop.kind == PropertyKind::Init || prev_kind == prop.kind {
-                            ctx.diagnostic(NoDupeKeysDiagnostic(prev_span, prop.key.span()));
+                if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                    if let Some(key_name) = prop.key.static_name().as_ref() {
+                        let hash = calculate_hash(key_name);
+                        if let Some((prev_kind, prev_span)) = map.insert(hash, (prop.kind, prop.key.span())) {
+                            if prev_kind == PropertyKind::Init || prop.kind == PropertyKind::Init || prev_kind == prop.kind {
+                                ctx.diagnostic(NoDupeKeysDiagnostic(prev_span, prop.key.span()));
+                            }
                         }
                     }
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -75,8 +75,10 @@ impl Rule for NoInnerDeclarations {
         if let Some(parent_node) = parent {
             let parent_kind = parent_node.kind();
             if let AstKind::FunctionBody(_) = parent_kind {
-                if let Some(grandparent) = ctx.nodes().parent_node(parent_node.id()) && grandparent.kind().is_function_like() {
-                    return
+                if let Some(grandparent) = ctx.nodes().parent_node(parent_node.id()) {
+                    if grandparent.kind().is_function_like() {
+                        return
+                    }
                 }
             }
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_symbol.rs
@@ -41,11 +41,9 @@ declare_oxc_lint!(
 
 impl Rule for NoNewSymbol {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::NewExpression(expr) = node.kind()
-            && let Expression::Identifier(ident) = &expr.callee
-            && ident.name == "Symbol"
-            && ctx.semantic().is_reference_to_global_variable(ident)
-        {
+        let AstKind::NewExpression(expr) = node.kind() else { return };
+        let Expression::Identifier(ident) = &expr.callee else { return };
+        if ident.name == "Symbol" && ctx.semantic().is_reference_to_global_variable(ident) {
             let start = expr.span.start;
             let end = start + 3;
             ctx.diagnostic(NoNewSymbolDiagnostic(Span::new(start, end)));

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -51,10 +51,10 @@ const DISALLOWED_PROPS: &[&str; 3] = &["hasOwnProperty", "isPrototypeOf", "prope
 
 impl Rule for NoPrototypeBuiltins {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::CallExpression(expr) = node.kind()
-        && let Some(member_expr) = expr.callee.get_member_expr()
-        && let Some(prop_name) = member_expr.static_property_name()
-        && DISALLOWED_PROPS.contains(&prop_name){
+        let AstKind::CallExpression(expr) = node.kind() else { return };
+        let Some(member_expr) = expr.callee.get_member_expr() else { return };
+        let Some(prop_name) = member_expr.static_property_name() else { return };
+        if DISALLOWED_PROPS.contains(&prop_name) {
             ctx.diagnostic(NoPrototypeBuiltinsDiagnostic(
                     prop_name.to_string(),
                     member_expr.span(),

--- a/crates/oxc_linter/src/rules/eslint/no_return_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_await.rs
@@ -74,9 +74,10 @@ fn is_in_tail_call_position<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
                 }
             },
             AstKind::SequenceExpression(seq_expr) => {
-                if let Some(seq_expr_last) = seq_expr.expressions.last() 
-                    && seq_expr_last.span() == node.kind().span(){
+                if let Some(seq_expr_last) = seq_expr.expressions.last() {
+                    if seq_expr_last.span() == node.kind().span() {
                         return is_in_tail_call_position(parent, ctx);
+                    }
                 }
             },
             // `return (await b())`
@@ -94,9 +95,10 @@ fn is_in_tail_call_position<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
             },
             // last statement in `func_body`
             AstKind::FunctionBody(func_body) => {
-                if let Some(func_body_stat_last) = func_body.statements.last()
-                    && func_body_stat_last.span() == node.kind().span() {
-                    return is_in_tail_call_position(parent, ctx);
+                if let Some(func_body_stat_last) = func_body.statements.last() {
+                    if func_body_stat_last.span() == node.kind().span() {
+                        return is_in_tail_call_position(parent, ctx);
+                    }
                 }
             },
             _ => {

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -41,11 +41,12 @@ declare_oxc_lint!(
 
 impl Rule for NoSetterReturn {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::ReturnStatement(stmt) = node.kind()
-            && stmt.argument.is_some()
-            && ctx.scopes().get_flags(node.scope_id()).is_set_accessor() {
+        let AstKind::ReturnStatement(stmt) = node.kind() else { return };
+        if stmt.argument.is_some()
+            && ctx.scopes().get_flags(node.scope_id()).is_set_accessor()
+        {
             ctx.diagnostic(NoSetterReturnDiagnostic(stmt.span));
-        };
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -82,9 +82,10 @@ impl Rule for NoUnsafeFinally {
 
             let parent_kind = ctx.nodes().parent_kind(node_id);
 
-            if let Some(AstKind::LabeledStatement(labeled_stmt)) = parent_kind
-                && label_name == Some(&labeled_stmt.label.name) {
-                label_inside = true;
+            if let Some(AstKind::LabeledStatement(labeled_stmt)) = parent_kind {
+                if label_name == Some(&labeled_stmt.label.name) {
+                    label_inside = true;
+                }
             }
 
             if let Some(AstKind::FinallyClause(_)) = parent_kind {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -50,17 +50,17 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessCatch {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::TryStatement(try_stmt) = node.kind()
-          && let Some(catch_clause) = &try_stmt.handler
-          && let Some(BindingPatternKind::BindingIdentifier(binding_ident)) = catch_clause.param.as_ref().map(|pattern| &pattern.kind)
-          && let Some(Statement::ThrowStatement(throw_stmt)) = catch_clause.body.body.first()
-          && let Expression::Identifier(throw_ident) = &throw_stmt.argument
-          && binding_ident.name == throw_ident.name {
-              if try_stmt.finalizer.is_some() {
-                  ctx.diagnostic(NoUselessCatchFinalizerDiagnostic(catch_clause.span));
-              } else {
-                  ctx.diagnostic(NoUselessCatchDiagnostic(try_stmt.span));
-              }
+        let AstKind::TryStatement(try_stmt) = node.kind() else { return };
+        let Some(catch_clause) = &try_stmt.handler else { return };
+        let Some(BindingPatternKind::BindingIdentifier(binding_ident)) = catch_clause.param.as_ref().map(|pattern| &pattern.kind) else { return };
+        let Some(Statement::ThrowStatement(throw_stmt)) = catch_clause.body.body.first() else { return };
+        let Expression::Identifier(throw_ident) = &throw_stmt.argument else { return };
+        if binding_ident.name == throw_ident.name {
+            if try_stmt.finalizer.is_some() {
+                ctx.diagnostic(NoUselessCatchFinalizerDiagnostic(catch_clause.span));
+            } else {
+                ctx.diagnostic(NoUselessCatchDiagnostic(try_stmt.span));
+            }
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -89,8 +89,10 @@ impl Rule for UseIsnan {
                 }
             }
             AstKind::SwitchCase(case) if self.enforce_for_switch_case => {
-                if let Some(test) = &case.test && is_nan_identifier(test) {
-                    ctx.diagnostic(UseIsnanDiagnostic::CaseNaN(test.span()));
+                if let Some(test) = &case.test {
+                    if is_nan_identifier(test) {
+                        ctx.diagnostic(UseIsnanDiagnostic::CaseNaN(test.span()));
+                    }
                 }
             }
             AstKind::SwitchStatement(switch) if self.enforce_for_switch_case => {
@@ -100,9 +102,14 @@ impl Rule for UseIsnan {
             }
             AstKind::CallExpression(call) if self.enforce_for_index_of => {
               // Match target array prototype methods whose only argument is NaN
-              if let Some(method) = is_target_callee(&call.callee)
-                && call.arguments.len() == 1 && let Some(Argument::Expression(expr)) = &call.arguments.first() && is_nan_identifier(expr) {
-                  ctx.diagnostic(UseIsnanDiagnostic::IndexOfNaN(method, expr.span()));
+              if let Some(method) = is_target_callee(&call.callee) {
+                  if call.arguments.len() == 1 {
+                      if let Some(Argument::Expression(expr)) = &call.arguments.first() {
+                          if is_nan_identifier(expr) {
+                              ctx.diagnostic(UseIsnanDiagnostic::IndexOfNaN(method, expr.span()));
+                          }
+                      }
+                  }
               }
             }
             _ => (),

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -77,31 +77,35 @@ impl Rule for ValidTypeof {
             return;
         }
 
-        if let Expression::TemplateLiteral(template) = sibling && template.expressions.is_empty() {
-                if let Some(value) = template.quasi() && !VALID_TYPES.contains(value.as_str()) {
+        if let Expression::TemplateLiteral(template) = sibling {
+            if template.expressions.is_empty() {
+                if template.quasi().is_some_and(|value| !VALID_TYPES.contains(value.as_str())) {
                     ctx.diagnostic(ValidTypeofDiagnostic::InvalidValue(None, sibling.span()));
                 }
                 return;
             }
+        }
 
-        if let Expression::Identifier(ident) = sibling
-            && ident.name == "undefined"
-            && ctx.semantic().is_reference_to_global_variable(ident) {
-            ctx.diagnostic_with_fix(
-                if self.require_string_literals {
-                    ValidTypeofDiagnostic::NotString(
-                        Some("Use `\"undefined\"` instead of `undefined`."),
-                        sibling.span(),
-                    )
-                } else {
-                    ValidTypeofDiagnostic::InvalidValue(
-                        Some("Use `\"undefined\"` instead of `undefined`."),
-                        sibling.span(),
-                    )
-                },
-                || Fix::new("\"undefined\"", sibling.span()),
-            );
-            return;
+        if let Expression::Identifier(ident) = sibling {
+            if ident.name == "undefined"
+                && ctx.semantic().is_reference_to_global_variable(ident)
+            {
+                ctx.diagnostic_with_fix(
+                    if self.require_string_literals {
+                        ValidTypeofDiagnostic::NotString(
+                            Some("Use `\"undefined\"` instead of `undefined`."),
+                            sibling.span(),
+                        )
+                    } else {
+                        ValidTypeofDiagnostic::InvalidValue(
+                            Some("Use `\"undefined\"` instead of `undefined`."),
+                            sibling.span(),
+                        )
+                    },
+                    || Fix::new("\"undefined\"", sibling.span()),
+                );
+                return;
+            }
         }
 
         if self.require_string_literals

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -114,11 +114,12 @@ impl Rule for NoDisabledTests {
                     };
                     ctx.diagnostic(NoDisabledTestsDiagnostic(error, help, call_expr.span));
                 }
-            } else if let Expression::Identifier(ident) = &call_expr.callee 
-                && ident.name.as_str() == "pending" && ctx.semantic().is_reference_to_global_variable(ident) {
-                // `describe('foo', function () { pending() })` 
-                let (error, help) = Message::Pending.details();
-                ctx.diagnostic(NoDisabledTestsDiagnostic(error, help, call_expr.span));
+            } else if let Expression::Identifier(ident) = &call_expr.callee  {
+                if ident.name.as_str() == "pending" && ctx.semantic().is_reference_to_global_variable(ident) {
+                    // `describe('foo', function () { pending() })` 
+                    let (error, help) = Message::Pending.details();
+                    ctx.diagnostic(NoDisabledTestsDiagnostic(error, help, call_expr.span));
+                }
             } 
         }
     }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -60,8 +60,12 @@ impl Rule for NoNonNullAssertedOptionalChain {
                 Expression::CallExpression(call) => {
                     if call.optional && !is_parent_member_or_call(node, ctx) {
                         Some(call.callee.span())
-                    } else if let Expression::MemberExpression(member) = &call.callee && member.optional() && !is_parent_member_or_call(node, ctx) {
-                        Some(member.object().span())
+                    } else if let Expression::MemberExpression(member) = &call.callee {
+                        if member.optional() && !is_parent_member_or_call(node, ctx) {
+                            Some(member.object().span())
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -87,11 +87,9 @@ impl Rule for NoThisAlias {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(decl) => {
-                if decl.init.is_none() {
-                    return;
-                }
+                let Some(init) = &decl.init else { return };
 
-                if let Some(init) = &decl.init && !rhs_is_this_reference(init) {
+                if !rhs_is_this_reference(init) {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -41,7 +41,8 @@ impl Rule for NoVarRequires {
         if !ctx.source_type().is_typescript() {
             return;
         }
-        if let AstKind::CallExpression(expr) = node.kind() && expr.is_require_call() {
+        let AstKind::CallExpression(expr) = node.kind() else { return };
+        if expr.is_require_call() {
             if ctx.scopes().get_bindings(node.scope_id()).contains_key("require") {
                 return;
             }

--- a/crates/oxc_minifier/src/compressor/fold.rs
+++ b/crates/oxc_minifier/src/compressor/fold.rs
@@ -747,12 +747,8 @@ impl<'a> Compressor<'a> {
             let bits = NumberLiteral::ecmascript_to_int32(left_val);
 
             let result_val: f64 = match op {
-                BinaryOperator::ShiftLeft => {
-                    f64::from(bits << right_val_int)
-                }
-                BinaryOperator::ShiftRight => {
-                    f64::from(bits >> right_val_int)
-                }
+                BinaryOperator::ShiftLeft => f64::from(bits << right_val_int),
+                BinaryOperator::ShiftRight => f64::from(bits >> right_val_int),
                 BinaryOperator::ShiftRightZeroFill => {
                     // JavaScript always treats the result of >>> as unsigned.
                     // We must force Rust to do the same here.
@@ -760,17 +756,13 @@ impl<'a> Compressor<'a> {
                     let res = bits as u32 >> right_val_int as u32;
                     f64::from(res)
                 }
-                _ => unreachable!("Unknown binary operator {:?}", op)
+                _ => unreachable!("Unknown binary operator {:?}", op),
             };
 
             let value_raw = self.hir.new_str(result_val.to_string().as_str());
 
-            let number_literal = self.hir.number_literal(
-                span,
-                result_val,
-                value_raw,
-                NumberBase::Decimal,
-            );
+            let number_literal =
+                self.hir.number_literal(span, result_val, value_raw, NumberBase::Decimal);
 
             return Some(self.hir.literal_number_expression(number_literal));
         }

--- a/crates/oxc_minifier/src/printer/gen.rs
+++ b/crates/oxc_minifier/src/printer/gen.rs
@@ -108,8 +108,7 @@ impl<'a> Gen for ExpressionStatement<'a> {
     fn gen(&self, p: &mut Printer, ctx: Context) {
         p.start_of_stmt = p.code_len();
         self.expression.gen_expr(p, Precedence::lowest(), Context::default());
-        if let Expression::Identifier(ident) = &self.expression
-        && ident.name == "let" {
+        if self.expression.is_specific_id("let") {
             p.print_semicolon();
         } else {
             p.print_semicolon_after_statement();
@@ -509,12 +508,12 @@ impl<'a> Gen for FunctionBody<'a> {
         for directive in &self.directives {
             directive.gen(p, ctx);
         }
-        p.needs_semicolon = if let Some(Statement::ExpressionStatement(expr_stmt)) = self.statements.get(0)
-            && matches!(expr_stmt.expression, Expression::StringLiteral(_)) {
-                true
-            } else {
-                false
-            };
+        p.needs_semicolon = match self.statements.get(0) {
+            Some(Statement::ExpressionStatement(expr_stmt)) => {
+                matches!(expr_stmt.expression, Expression::StringLiteral(_))
+            }
+            _ => false,
+        };
         for stmt in &self.statements {
             p.print_semicolon_if_needed();
             stmt.gen(p, ctx);
@@ -764,12 +763,13 @@ impl<'a> GenExpr for Expression<'a> {
 
 impl Gen for IdentifierReference {
     fn gen(&self, p: &mut Printer, ctx: Context) {
-        if let Some(mangler) = &p.mangler
-            && let Some(name) = mangler.get_reference_name(self.reference_id.clone().into_inner()) {
-            p.print_str(name.clone().as_bytes());
-        } else {
-            p.print_str(self.name.as_bytes());
+        if let Some(mangler) = &p.mangler {
+            if let Some(name) = mangler.get_reference_name(self.reference_id.clone().into_inner()) {
+                p.print_str(name.clone().as_bytes());
+                return;
+            }
         }
+        p.print_str(self.name.as_bytes());
     }
 }
 

--- a/crates/oxc_minifier/src/printer/mod.rs
+++ b/crates/oxc_minifier/src/printer/mod.rs
@@ -156,12 +156,10 @@ impl Printer {
     }
 
     fn print_space_before_identifier(&mut self) {
-        let ch = self.peek_nth(0);
-
-        if let Some(ch) = ch && (
-            is_identifier_part(ch)
-            || self.prev_reg_exp_end == self.code.len()
-         ) {
+        if self
+            .peek_nth(0)
+            .is_some_and(|ch| is_identifier_part(ch) || self.prev_reg_exp_end == self.code.len())
+        {
             self.print(b' ');
         }
     }

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 #![allow(clippy::too_many_lines)]
 
 mod closure;

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -57,7 +57,8 @@ impl<'a> Binder for VariableDeclarator<'a> {
 
 impl<'a> Binder for Class<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
-        if let Some(ident) = &self.id && !self.modifiers.contains(ModifierKind::Declare) {
+        let Some(ident) = &self.id else { return };
+        if !self.modifiers.contains(ModifierKind::Declare) {
             builder.declare_symbol(
                 ident.span,
                 &ident.name,

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -130,9 +130,10 @@ fn check_module_record(ctx: &SemanticBuilder<'_>) {
 
     // `export default x;`
     // `export { y as default };`
-    if let Some(span) = module_record.exported_bindings.get("default")
-        && let Some(default_span) = &module_record.export_default {
-            ctx.error(DuplicateExport("default".into(), *default_span, *span));
+    if let (Some(span), Some(default_span)) =
+        (module_record.exported_bindings.get("default"), &module_record.export_default)
+    {
+        ctx.error(DuplicateExport("default".into(), *default_span, *span));
     }
 }
 
@@ -314,11 +315,8 @@ fn check_private_identifier<'a>(
             // ClassElement::MethodDefinition(def) => &def.key,
             // _ => return false,
             // };
-            if let Some(key) = def.property_key()
-                && let PropertyKey::PrivateIdentifier(prop_ident) = key {
-                return prop_ident.name == ident.name;
-            }
-            false
+            matches!(def.property_key(), Some(PropertyKey::PrivateIdentifier(prop_ident))
+                if prop_ident.name == ident.name)
         })
     });
 
@@ -660,8 +658,11 @@ fn check_break_statement<'a>(stmt: &BreakStatement, node: &AstNode<'a>, ctx: &Se
                 );
             }
             AstKind::LabeledStatement(labeled_statement) => {
-                if let Some(label) = &stmt.label
-                    && label.name == labeled_statement.label.name {
+                if stmt
+                    .label
+                    .as_ref()
+                    .is_some_and(|label| label.name == labeled_statement.label.name)
+                {
                     break;
                 }
             }
@@ -714,27 +715,27 @@ fn check_continue_statement<'a>(
                     |label| ctx.error(InvalidLabelJumpTarget(label.span)),
                 );
             }
-            AstKind::LabeledStatement(labeled_statement) => {
-                if let Some(label) = &stmt.label
-                    && label.name == labeled_statement.label.name {
+            AstKind::LabeledStatement(labeled_statement) => match &stmt.label {
+                Some(label) if label.name == labeled_statement.label.name => {
                     if matches!(
                         labeled_statement.body,
                         Statement::LabeledStatement(_)
-                        | Statement::DoWhileStatement(_)
-                        | Statement::WhileStatement(_)
-                        | Statement::ForStatement(_)
-                        | Statement::ForInStatement(_)
-                        | Statement::ForOfStatement(_)
+                            | Statement::DoWhileStatement(_)
+                            | Statement::WhileStatement(_)
+                            | Statement::ForStatement(_)
+                            | Statement::ForInStatement(_)
+                            | Statement::ForOfStatement(_)
                     ) {
                         break;
                     }
                     return ctx.error(InvalidLabelNonIteration(
-                            "continue",
-                            labeled_statement.label.span,
-                            label.span,
+                        "continue",
+                        labeled_statement.label.span,
+                        label.span,
                     ));
                 }
-            }
+                _ => {}
+            },
             kind if kind.is_iteration_statement() && stmt.label.is_none() => break,
             _ => {}
         }
@@ -900,11 +901,14 @@ fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
             }
             AstKind::ObjectProperty(prop) => {
                 if prop.value.is_function() {
-                    if let Some(super_call_span) = super_call_span
-                    && super_call_span.start > prop.key.span().end {
-                        return ctx.error(UnexpectedSuperCall(super_call_span));
+                    match super_call_span {
+                        Some(super_call_span) if super_call_span.start > prop.key.span().end => {
+                            return ctx.error(UnexpectedSuperCall(super_call_span));
+                        }
+                        _ => {
+                            break;
+                        }
                     }
-                    break;
                 }
             }
             // ClassStaticBlockBody : ClassStaticBlockStatementList
@@ -954,9 +958,10 @@ fn check_formal_parameters<'a>(
     _node: &AstNode<'a>,
     ctx: &SemanticBuilder<'a>,
 ) {
-    if let Some(rest) = &params.rest
-    && let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
-        ctx.error(ARestParameterCannotHaveAnInitializer(pat.span));
+    if let Some(rest) = &params.rest {
+        if let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
+            ctx.error(ARestParameterCannotHaveAnInitializer(pat.span));
+        }
     }
 
     if params.is_empty() {
@@ -977,9 +982,10 @@ fn check_formal_parameters<'a>(
 fn check_array_pattern(pattern: &ArrayPattern, ctx: &SemanticBuilder<'_>) {
     // function foo([...x = []]) { }
     //                    ^^^^ A rest element cannot have an initializer
-    if let Some(rest) = &pattern.rest
-    && let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
-        ctx.error(ARestParameterCannotHaveAnInitializer(pat.span));
+    if let Some(rest) = &pattern.rest {
+        if let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
+            ctx.error(ARestParameterCannotHaveAnInitializer(pat.span));
+        }
     }
 }
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(let_chains)]
-
 mod binder;
 mod builder;
 mod checker;

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -76,6 +76,10 @@ impl<'a> AstNode<'a> {
         // All parts of a ClassDeclaration or a ClassExpression are strict mode code.
         flags.is_strict_mode() || self.flags.has_class()
     }
+
+    pub fn is_specific_id_reference(&self, name: &str) -> bool {
+        self.kind().is_specific_id_reference(name)
+    }
 }
 
 /// Untyped AST nodes flattened into an vec

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(let_chains)]
-
 mod babel;
 mod formatter;
 mod minifier;


### PR DESCRIPTION
The let_chains Rust feature is unstable, preventing Oxc from using a stable Rust compiler. Refactor the code to avoid let_chains.

#626