### PR TITLE
refactor: remove unstable feature const_trait_impl & const_slice_index & slice_group_by

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ name = "oxc_minifier"
 version = "0.0.7"
 dependencies = [
  "bitflags 2.3.3",
+ "itertools 0.11.0",
  "jemallocator",
  "mimalloc",
  "num-bigint",

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::self_named_module_files)] // for rules.rs
-#![feature(let_chains, const_trait_impl, const_slice_index)]
+#![feature(let_chains)]
 
 #[cfg(test)]
 mod tester;

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -23,6 +23,7 @@ oxc_index     = { workspace = true }
 bitflags      = { workspace = true }
 num-bigint    = { workspace = true }
 num-traits    = { workspace = true }
+itertools.workspace = true
 
 [dev-dependencies]
 walkdir   = { workspace = true }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -1,7 +1,6 @@
 //! ECMAScript Minifier
 
 #![feature(let_chains)]
-#![feature(slice_group_by)]
 
 mod compressor;
 mod mangler;

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -6,6 +6,8 @@ use oxc_semantic::{Reference, ReferenceFlag, ReferenceId, SemanticBuilder, Symbo
 use oxc_span::{Atom, SourceType};
 use oxc_syntax::{scope::ScopeFlags, symbol::SymbolFlags};
 
+use itertools::Itertools;
+
 type Slot = usize;
 
 pub struct Mangler {
@@ -184,10 +186,11 @@ impl<'a> ManglerBuilder<'a> {
 
         let mut freq_iter = frequencies.iter();
         // 2. "N number of vars are going to be assigned names of the same length"
-        for slice_of_same_len_strings in names.group_by_mut(|a, b| a.len() == b.len()) {
+        for (_, slice_of_same_len_strings_group) in &names.into_iter().group_by(|a| a.len()) {
             // 1. "The most frequent vars get the shorter names"
             // (freq_iter is sorted by frequency from highest to lowest,
             //  so taking means take the N most frequent symbols remaining)
+            let slice_of_same_len_strings = slice_of_same_len_strings_group.collect_vec();
             let mut symbols_renamed_in_this_batch =
                 freq_iter.by_ref().take(slice_of_same_len_strings.len()).collect::<Vec<_>>();
 

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 #[allow(clippy::wildcard_imports)]
 use oxc_hir::hir::*;
 use oxc_hir::Visit;
@@ -5,8 +6,6 @@ use oxc_index::{index_vec, IndexVec};
 use oxc_semantic::{Reference, ReferenceFlag, ReferenceId, SemanticBuilder, SymbolId, SymbolTable};
 use oxc_span::{Atom, SourceType};
 use oxc_syntax::{scope::ScopeFlags, symbol::SymbolFlags};
-
-use itertools::Itertools;
 
 type Slot = usize;
 


### PR DESCRIPTION
for #626

1. Removed `const_trait_impl` & `const_slice_index`.
2. Removed `slice_group_by`.

