### PR TITLE
feat(query): impl ASTNode for VariableDeclarationAST

### DIFF
--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -2066,7 +2066,7 @@ pub(super) fn resolve_variable_declaration_edge<'a, 'b: 'a>(
     resolve_info: &ResolveEdgeInfo,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
-        "entire_span" => variable_declaration::entire_span(contexts, resolve_info),
+        "span" => variable_declaration::span(contexts, resolve_info),
         "left" => variable_declaration::left(contexts, resolve_info),
         _ => {
             unreachable!(
@@ -2084,7 +2084,7 @@ mod variable_declaration {
 
     use super::super::vertex::Vertex;
 
-    pub(super) fn entire_span<'a, 'b: 'a>(
+    pub(super) fn span<'a, 'b: 'a>(
         contexts: ContextIterator<'a, Vertex<'b>>,
         _resolve_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
@@ -2127,7 +2127,7 @@ pub(super) fn resolve_variable_declaration_ast_edge<'a, 'b: 'a>(
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "ancestor" => variable_declaration_ast::ancestor(contexts, resolve_info, adapter),
-        "entire_span" => variable_declaration_ast::entire_span(contexts, resolve_info),
+        "span" => variable_declaration_ast::span(contexts, resolve_info),
         "left" => variable_declaration_ast::left(contexts, resolve_info),
         "parent" => variable_declaration_ast::parent(contexts, resolve_info, adapter),
         _ => {
@@ -2154,11 +2154,11 @@ mod variable_declaration_ast {
         super::ancestors(contexts, adapter)
     }
 
-    pub(super) fn entire_span<'a, 'b: 'a>(
+    pub(super) fn span<'a, 'b: 'a>(
         contexts: ContextIterator<'a, Vertex<'b>>,
         resolve_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::variable_declaration::entire_span(contexts, resolve_info)
+        super::variable_declaration::span(contexts, resolve_info)
     }
 
     pub(super) fn left<'a, 'b: 'a>(

--- a/crates/oxc_query/src/lib.rs
+++ b/crates/oxc_query/src/lib.rs
@@ -145,7 +145,7 @@ query {
                 span_asmt_type_start: 6,
                 span_asmt_type_end: 11,
                 span_start: 6,
-                span_end: 15
+                span_end: 15,
                 __typename: "VariableDeclarationAST".to_owned()
             }],
             results

--- a/crates/oxc_query/src/lib.rs
+++ b/crates/oxc_query/src/lib.rs
@@ -101,8 +101,8 @@ query {
             assignment_to_variable_name: String,
             span_asmt_type_start: u64,
             span_asmt_type_end: u64,
-            entire_span_start: u64,
-            entire_span_end: u64,
+            span_start: u64,
+            span_end: u64,
         }
 
         let mut results: Vec<Output> = execute_query(
@@ -120,7 +120,7 @@ query {
                 }
             }
 
-            entire_span_: entire_span {
+            span_: span {
                 start @output
                 end @output
             }
@@ -141,8 +141,8 @@ query {
                 assignment_to_variable_name: "apple".to_owned(),
                 span_asmt_type_start: 6,
                 span_asmt_type_end: 11,
-                entire_span_start: 6,
-                entire_span_end: 15
+                span_start: 6,
+                span_end: 15
             }],
             results
         );

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -117,9 +117,10 @@ A single VariableDeclarator. (const/let/var)!
 If you have multiple variables assigned at once with commas,
 this will fire once per assignment.
 """
-interface VariableDeclaration {
+interface VariableDeclaration implements HasSpan {
   left: AssignmentType!
-  entire_span: Span!
+  # HasSpan
+  span: Span!
 }
 
 type SearchParameter {
@@ -323,13 +324,13 @@ A single VariableDeclarator. (const/let/var)!
 If you have multiple variables assigned at once with commas,
 this will fire once per assignment.
 """
-type VariableDeclarationAST implements VariableDeclaration {
+type VariableDeclarationAST implements VariableDeclaration & ASTNode & HasSpan {
   left: AssignmentType!
   # ASTNode
   parent: ASTNode
   ancestor: [ASTNode!]!
   # HasSpan
-  entire_span: Span!
+  span: Span!
 }
 
 type TypeAnnotationAST implements TypeAnnotation & ASTNode & HasSpan {


### PR DESCRIPTION
also changes from using entire_span to just span so we don't have to have two properties point at the same span