### PR TITLE
feat(linter): add a `run_once` callback

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -94,6 +94,12 @@ impl Linter {
     pub fn run<'a>(&self, ctx: LintContext<'a>) -> Vec<Message<'a>> {
         let semantic = Rc::clone(ctx.semantic());
         let mut ctx = ctx.with_fix(self.fix);
+
+        for rule in &self.rules {
+            ctx.with_rule_name(rule.name());
+            rule.run_once(&ctx, self.print_execution_times);
+        }
+
         for node in semantic.nodes().iter() {
             for rule in &self.rules {
                 ctx.with_rule_name(rule.name());

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -10,9 +10,14 @@ pub trait Rule: Sized + Default + fmt::Debug {
         Self::default()
     }
 
+    /// Visit each AST Node
+    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
+
+    /// Visit each symbol
     fn run_on_symbol(&self, _symbol_id: SymbolId, _ctx: &LintContext<'_>) {}
 
-    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
+    /// Run only once. Useful for inspecting scopes and trivias etc.
+    fn run_once(&self, _ctx: &LintContext) {}
 }
 
 pub trait RuleMeta {
@@ -30,7 +35,7 @@ pub trait RuleMeta {
 pub enum RuleCategory {
     /// Code that is outright wrong or useless
     Correctness,
-    ///
+    /// Code that is most likely wrong or useless
     Suspicious,
     /// Pedantic
     Pedantic,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{Atom, Span};
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, fixer::Fix, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-unused-labels): Disallow unused labels")]
@@ -41,18 +41,16 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnusedLabels {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if matches!(node.kind(), AstKind::Program(_)) {
-            for id in ctx.semantic().unused_labels() {
-                let node = ctx.semantic().nodes().get_node(*id);
-                if let AstKind::LabeledStatement(stmt) = node.kind() {
-                    // TODO: Ignore fix where comments exist between label and statement
-                    // e.g. A: /* Comment */ function foo(){}
-                    ctx.diagnostic_with_fix(
-                        NoUnusedLabelsDiagnostic(stmt.label.name.clone(), stmt.label.span),
-                        || Fix::delete(stmt.label.span),
-                    );
-                }
+    fn run_once(&self, ctx: &LintContext) {
+        for id in ctx.semantic().unused_labels() {
+            let node = ctx.semantic().nodes().get_node(*id);
+            if let AstKind::LabeledStatement(stmt) = node.kind() {
+                // TODO: Ignore fix where comments exist between label and statement
+                // e.g. A: /* Comment */ function foo(){}
+                ctx.diagnostic_with_fix(
+                    NoUnusedLabelsDiagnostic(stmt.label.name.clone(), stmt.label.span),
+                    || Fix::delete(stmt.label.span),
+                );
             }
         }
     }

--- a/crates/oxc_macros/src/declare_all_lint_rules/mod.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules/mod.rs
@@ -141,6 +141,19 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
+            pub fn run_once<'a>(&self, ctx: &LintContext<'a>, print_execution_times: bool) {
+                let start = print_execution_times.then(|| Instant::now());
+                match self {
+                    #(Self::#struct_names(rule) => {
+                        let diagnostics = rule.run_once(ctx);
+                        if let Some(start) = start {
+                            unsafe { #rule_timer.update(&start.elapsed()) };
+                        }
+                        diagnostics
+                    }),*
+                }
+            }
+
             pub fn execute_time(&self) -> Duration {
                 match self {
                     #(Self::#struct_names(_) => unsafe { #rule_timer.duration() }),*


### PR DESCRIPTION
For situations where you want to inspect the scopes and trivias.