### PR TITLE
chore(query): condense XAST and X resolvers into one

### DIFF
--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -355,13 +355,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "TypeAnnotation" => super::edges::resolve_type_annotation_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
-            "TypeAnnotationAST" => super::edges::resolve_type_annotation_ast_edge(
+            "TypeAnnotation" | "TypeAnnotationAST" => super::edges::resolve_type_annotation_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -274,13 +274,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "JSXElement" => super::edges::resolve_jsxelement_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
-            "JSXElementAST" => super::edges::resolve_jsxelement_ast_edge(
+            "JSXElement" | "JSXElementAST" => super::edges::resolve_jsxelement_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -255,13 +255,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 resolve_info,
                 self,
             ),
-            "Interface" => super::edges::resolve_interface_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
-            "InterfaceAST" => super::edges::resolve_interface_ast_edge(
+            "Interface" | "InterfaceAST" => super::edges::resolve_interface_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -374,19 +374,15 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "VariableDeclaration" => super::edges::resolve_variable_declaration_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
-            "VariableDeclarationAST" => super::edges::resolve_variable_declaration_ast_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-                self,
-            ),
+            "VariableDeclaration" | "VariableDeclarationAST" => {
+                super::edges::resolve_variable_declaration_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                    self,
+                )
+            }
             _ => {
                 unreachable!(
                     "attempted to resolve edge '{edge_name}' on unexpected type: {type_name}"

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -204,13 +204,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "Class" => super::edges::resolve_class_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
-            "ClassAST" => super::edges::resolve_class_ast_edge(
+            "Class" | "ClassAST" => super::edges::resolve_class_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -248,13 +248,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "Import" => super::edges::resolve_import_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
-            "ImportAST" => super::edges::resolve_import_ast_edge(
+            "Import" | "ImportAST" => super::edges::resolve_import_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -1673,10 +1673,13 @@ pub(super) fn resolve_variable_declaration_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "span" => variable_declaration::span(contexts, resolve_info),
         "left" => variable_declaration::left(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!(
                 "attempted to resolve unexpected edge '{edge_name}' on type 'VariableDeclaration'"
@@ -1724,64 +1727,5 @@ mod variable_declaration {
                     .kind,
             )));
         })
-    }
-}
-
-pub(super) fn resolve_variable_declaration_ast_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "ancestor" => variable_declaration_ast::ancestor(contexts, resolve_info, adapter),
-        "span" => variable_declaration_ast::span(contexts, resolve_info),
-        "left" => variable_declaration_ast::left(contexts, resolve_info),
-        "parent" => variable_declaration_ast::parent(contexts, resolve_info, adapter),
-        _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'VariableDeclarationAST'"
-            )
-        }
-    }
-}
-
-mod variable_declaration_ast {
-    use trustfall::provider::{
-        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
-    };
-
-    use super::super::vertex::Vertex;
-    use crate::Adapter;
-
-    pub(super) fn ancestor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::ancestors(contexts, adapter)
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::variable_declaration::span(contexts, resolve_info)
-    }
-
-    pub(super) fn left<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::variable_declaration::left(contexts, resolve_info)
-    }
-
-    pub(super) fn parent<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::parents(contexts, adapter)
     }
 }

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -133,6 +133,7 @@ pub(super) fn resolve_class_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "constructor" => class::constructor(contexts, resolve_info),
@@ -142,6 +143,9 @@ pub(super) fn resolve_class_edge<'a, 'b: 'a>(
         "name_span" => class::name_span(contexts, resolve_info),
         "property" => class::property(contexts, resolve_info),
         "setter" => class::setter(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "span" => get_span(contexts),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Class'")
         }
@@ -293,111 +297,6 @@ mod class {
         _resolve_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
         class_fn_edge_implem!(contexts, Set)
-    }
-}
-
-pub(super) fn resolve_class_ast_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "ancestor" => class_ast::ancestor(contexts, resolve_info, adapter),
-        "constructor" => class_ast::constructor(contexts, resolve_info),
-        "entire_class_span" => class_ast::entire_class_span(contexts, resolve_info),
-        "getter" => class_ast::getter(contexts, resolve_info),
-        "method" => class_ast::method(contexts, resolve_info),
-        "name_span" => class_ast::name_span(contexts, resolve_info),
-        "parent" => class_ast::parent(contexts, resolve_info, adapter),
-        "property" => class_ast::property(contexts, resolve_info),
-        "setter" => class_ast::setter(contexts, resolve_info),
-        "span" => class_ast::span(contexts, resolve_info),
-        _ => {
-            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'ClassAST'")
-        }
-    }
-}
-
-mod class_ast {
-    use trustfall::provider::{
-        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
-    };
-
-    use super::super::vertex::Vertex;
-    use crate::Adapter;
-
-    pub(super) fn ancestor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::ancestors(contexts, adapter)
-    }
-
-    pub(super) fn constructor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::constructor(contexts, resolve_info)
-    }
-
-    pub(super) fn entire_class_span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::entire_class_span(contexts, resolve_info)
-    }
-
-    pub(super) fn getter<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::getter(contexts, resolve_info)
-    }
-
-    pub(super) fn method<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::method(contexts, resolve_info)
-    }
-
-    pub(super) fn name_span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::name_span(contexts, resolve_info)
-    }
-
-    pub(super) fn parent<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::parents(contexts, adapter)
-    }
-
-    pub(super) fn property<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::property(contexts, resolve_info)
-    }
-
-    pub(super) fn setter<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::class::setter(contexts, resolve_info)
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::get_span(contexts)
     }
 }
 

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -597,11 +597,15 @@ pub(super) fn resolve_import_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "default_import" => import::default_import(contexts, resolve_info),
         "entire_span" => import::entire_span(contexts, resolve_info),
         "specific_import" => import::specific_import(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "span" => get_span(contexts),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Import'")
         }
@@ -683,79 +687,6 @@ mod import {
                     }),
             )
         })
-    }
-}
-
-pub(super) fn resolve_import_ast_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "ancestor" => import_ast::ancestor(contexts, resolve_info, adapter),
-        "default_import" => import_ast::default_import(contexts, resolve_info),
-        "entire_span" => import_ast::entire_span(contexts, resolve_info),
-        "parent" => import_ast::parent(contexts, resolve_info, adapter),
-        "span" => import_ast::span(contexts, resolve_info),
-        "specific_import" => import_ast::specific_import(contexts, resolve_info),
-        _ => {
-            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'ImportAST'")
-        }
-    }
-}
-
-mod import_ast {
-    use trustfall::provider::{
-        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
-    };
-
-    use super::super::vertex::Vertex;
-    use crate::Adapter;
-
-    pub(super) fn ancestor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::ancestors(contexts, adapter)
-    }
-
-    pub(super) fn default_import<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::import::default_import(contexts, resolve_info)
-    }
-
-    pub(super) fn entire_span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::import::entire_span(contexts, resolve_info)
-    }
-
-    pub(super) fn parent<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::parents(contexts, adapter)
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::get_span(contexts)
-    }
-
-    pub(super) fn specific_import<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::import::specific_import(contexts, resolve_info)
     }
 }
 

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -695,11 +695,15 @@ pub(super) fn resolve_interface_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "entire_span" => interface::entire_span(contexts, resolve_info),
         "extend" => interface::extend(contexts, resolve_info),
         "name_span" => interface::name_span(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "span" => get_span(contexts),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Interface'")
         }
@@ -769,81 +773,6 @@ mod interface {
                     .span,
             )))
         })
-    }
-}
-
-pub(super) fn resolve_interface_ast_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "ancestor" => interface_ast::ancestor(contexts, resolve_info, adapter),
-        "entire_span" => interface_ast::entire_span(contexts, resolve_info),
-        "extend" => interface_ast::extend(contexts, resolve_info),
-        "name_span" => interface_ast::name_span(contexts, resolve_info),
-        "parent" => interface_ast::parent(contexts, resolve_info, adapter),
-        "span" => interface_ast::span(contexts, resolve_info),
-        _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'InterfaceAST'"
-            )
-        }
-    }
-}
-
-mod interface_ast {
-    use trustfall::provider::{
-        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
-    };
-
-    use super::super::vertex::Vertex;
-    use crate::Adapter;
-
-    pub(super) fn ancestor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::ancestors(contexts, adapter)
-    }
-
-    pub(super) fn entire_span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::interface::entire_span(contexts, resolve_info)
-    }
-
-    pub(super) fn extend<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::interface::extend(contexts, resolve_info)
-    }
-
-    pub(super) fn name_span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::interface::name_span(contexts, resolve_info)
-    }
-
-    pub(super) fn parent<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::parents(contexts, adapter)
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::get_span(contexts)
     }
 }
 

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -1542,10 +1542,13 @@ pub(super) fn resolve_type_annotation_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "span" => type_annotation::span(contexts, resolve_info),
         "type" => type_annotation::type_(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!(
                 "attempted to resolve unexpected edge '{edge_name}' on type 'TypeAnnotation'"
@@ -1583,65 +1586,6 @@ mod type_annotation {
                     .type_annotation,
             )))
         })
-    }
-}
-
-pub(super) fn resolve_type_annotation_ast_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "ancestor" => type_annotation_ast::ancestor(contexts, resolve_info, adapter),
-        "parent" => type_annotation_ast::parent(contexts, resolve_info, adapter),
-        "span" => type_annotation_ast::span(contexts, resolve_info),
-        "type" => type_annotation_ast::type_(contexts, resolve_info),
-        _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'TypeAnnotationAST'"
-            )
-        }
-    }
-}
-
-mod type_annotation_ast {
-    use trustfall::provider::{
-        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
-    };
-
-    use super::super::vertex::Vertex;
-    use crate::Adapter;
-
-    pub(super) fn ancestor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::ancestors(contexts, adapter)
-    }
-
-    pub(super) fn parent<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::parents(contexts, adapter)
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::get_span(contexts)
-    }
-
-    pub(super) fn type_<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::type_annotation::type_(contexts, resolve_info)
     }
 }
 

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -883,6 +883,7 @@ pub(super) fn resolve_jsxelement_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "child_element" => jsxelement::child_element(contexts, resolve_info),
@@ -894,6 +895,8 @@ pub(super) fn resolve_jsxelement_edge<'a, 'b: 'a>(
         "child_text" => jsxelement::child_text(contexts, resolve_info),
         "opening_element" => jsxelement::opening_element(contexts, resolve_info),
         "span" => jsxelement::span(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'JSXElement'")
         }
@@ -1002,107 +1005,6 @@ mod jsxelement {
         _resolve_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
         get_span(contexts)
-    }
-}
-
-pub(super) fn resolve_jsxelement_ast_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "ancestor" => jsxelement_ast::ancestor(contexts, resolve_info, adapter),
-        "child_element" => jsxelement_ast::child_element(contexts, resolve_info),
-        "child_expression_container" => {
-            jsxelement_ast::child_expression_container(contexts, resolve_info)
-        }
-        "child_fragment" => jsxelement_ast::child_fragment(contexts, resolve_info),
-        "child_spread" => jsxelement_ast::child_spread(contexts, resolve_info),
-        "child_text" => jsxelement_ast::child_text(contexts, resolve_info),
-        "opening_element" => jsxelement_ast::opening_element(contexts, resolve_info),
-        "parent" => jsxelement_ast::parent(contexts, resolve_info, adapter),
-        "span" => jsxelement_ast::span(contexts, resolve_info),
-        _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'JSXElementAST'"
-            )
-        }
-    }
-}
-
-mod jsxelement_ast {
-    use trustfall::provider::{
-        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
-    };
-
-    use super::super::vertex::Vertex;
-    use crate::Adapter;
-
-    pub(super) fn ancestor<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::ancestors(contexts, adapter)
-    }
-
-    pub(super) fn child_element<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::jsxelement::child_element(contexts, resolve_info)
-    }
-
-    pub(super) fn child_expression_container<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::jsxelement::child_expression_container(contexts, resolve_info)
-    }
-
-    pub(super) fn child_fragment<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::jsxelement::child_fragment(contexts, resolve_info)
-    }
-
-    pub(super) fn child_spread<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::jsxelement::child_spread(contexts, resolve_info)
-    }
-
-    pub(super) fn child_text<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::jsxelement::child_text(contexts, resolve_info)
-    }
-
-    pub(super) fn opening_element<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::jsxelement::opening_element(contexts, resolve_info)
-    }
-
-    pub(super) fn parent<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-        adapter: &'a Adapter<'b>,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::parents(contexts, adapter)
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        super::get_span(contexts)
     }
 }
 


### PR DESCRIPTION
No need to needlessly duplicate code.

**Future work:**

1. remove any breakout function that calls getspan...
2. maybe: make every type that can implement span (why don't we already)