### PR TITLE
Adding types to the symbol table - consistent export type sample rule implemented

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1850,6 +1850,7 @@ pub struct ExportSpecifier {
     pub span: Span,
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
+    pub export_kind: ImportOrExportKind,              // `export type *`
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1850,7 +1850,7 @@ pub struct ExportSpecifier {
     pub span: Span,
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
-    pub export_kind: ImportOrExportKind,              // `export type *`
+    pub export_kind: ImportOrExportKind, // `export type *`
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -23,7 +23,7 @@ pub struct TSEnumDeclaration<'a> {
 }
 /// Enum Body
 ///
-/// A scope must be created on the enum body so this abstration exists
+/// A scope must be created on the enum body so this abstraction exists
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct TSEnumBody<'a> {

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -31,6 +31,7 @@ pub struct TSEnumBody<'a> {
     pub span: Span,
     pub members: Vec<'a, TSEnumMember<'a>>,
 }
+
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct TSEnumMember<'a> {

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -17,11 +17,20 @@ pub struct TSEnumDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub id: BindingIdentifier,
-    pub members: Vec<'a, TSEnumMember<'a>>,
+    pub body: TSEnumBody<'a>,
     /// Valid Modifiers: `const`, `export`, `declare`
     pub modifiers: Modifiers<'a>,
 }
-
+/// Enum Body
+///
+/// A scope must be created on the enum body so this abstration exists
+#[derive(Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+pub struct TSEnumBody<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub span: Span,
+    pub members: Vec<'a, TSEnumMember<'a>>,
+}
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 pub struct TSEnumMember<'a> {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1297,7 +1297,7 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSEnumDeclaration(self.alloc(TSEnumDeclaration {
             span,
             id,
-            members,
+            body: TSEnumBody { span, members },
             modifiers,
         }))
     }

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -131,6 +131,8 @@ pub enum AstKind<'a> {
 
     TSEnumDeclaration(&'a TSEnumDeclaration<'a>),
     TSEnumMember(&'a TSEnumMember<'a>),
+    TSEnumBody(&'a TSEnumBody<'a>),
+
     TSImportEqualsDeclaration(&'a TSImportEqualsDeclaration<'a>),
     TSInterfaceDeclaration(&'a TSInterfaceDeclaration<'a>),
     TSModuleDeclaration(&'a TSModuleDeclaration<'a>),
@@ -357,6 +359,8 @@ impl<'a> GetSpan for AstKind<'a> {
 
             Self::TSEnumDeclaration(x) => x.span,
             Self::TSEnumMember(x) => x.span,
+            Self::TSEnumBody(x) => x.span,
+
             Self::TSImportEqualsDeclaration(x) => x.span,
             Self::TSInterfaceDeclaration(x) => x.span,
             Self::TSModuleDeclaration(x) => x.span,

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -517,6 +517,8 @@ impl<'a> AstKind<'a> {
             Self::TSNonNullExpression(_) => "TSNonNullExpression".into(),
 
             Self::TSEnumDeclaration(decl) => format!("TSEnumDeclaration({})", &decl.id.name).into(),
+            Self::TSEnumBody(_) => "TSEnumBody".into(),
+
             Self::TSEnumMember(_) => "TSEnumMember".into(),
 
             Self::TSImportEqualsDeclaration(_) => "TSImportEqualsDeclaration".into(),

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -1232,13 +1232,20 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
+    fn visit_enum_body(&mut self, body: &'a TSEnumBody<'a>) {
+        let kind = AstKind::TSEnumBody(body);
+        self.enter_node(kind);
+        for member in &body.members {
+            self.visit_enum_member(member);
+        }
+        self.leave_node(kind);
+    }
+
     fn visit_enum(&mut self, decl: &'a TSEnumDeclaration<'a>) {
         let kind = AstKind::TSEnumDeclaration(decl);
         self.enter_node(kind);
         self.visit_binding_identifier(&decl.id);
-        for member in &decl.members {
-            self.visit_enum_member(member);
-        }
+        self.visit_enum_body(&decl.body);
         self.leave_node(kind);
     }
 

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -946,7 +946,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_enum(&mut self, decl: &'b mut TSEnumDeclaration<'a>) {
         self.visit_binding_identifier(&mut decl.id);
-        for member in decl.members.iter_mut() {
+        for member in decl.body.members.iter_mut() {
             self.visit_enum_member(member);
         }
     }

--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -1276,6 +1276,15 @@ impl<'a> AstLower<'a> {
         );
         self.hir.import_specifier(specifier.span, imported, local)
     }
+    fn lower_import_export_type_or_value(
+        &mut self,
+        import_export_kind: ast::ImportOrExportKind,
+    ) -> hir::ImportOrExportKind {
+        match import_export_kind {
+            ast::ImportOrExportKind::Value => hir::ImportOrExportKind::Value,
+            ast::ImportOrExportKind::Type => hir::ImportOrExportKind::Type,
+        }
+    }
 
     fn lower_import_default_specifier(
         &mut self,
@@ -1311,10 +1320,7 @@ impl<'a> AstLower<'a> {
             .assertions
             .as_ref()
             .map(|attributes| self.lower_vec(attributes, Self::lower_import_attribute));
-        let export_kind = match decl.export_kind {
-            ast::ImportOrExportKind::Value => hir::ImportOrExportKind::Value,
-            ast::ImportOrExportKind::Type => hir::ImportOrExportKind::Type,
-        };
+        let export_kind = self.lower_import_export_type_or_value(decl.export_kind);
         self.hir.export_all_declaration(decl.span, exported, source, assertions, export_kind)
     }
 
@@ -1362,7 +1368,8 @@ impl<'a> AstLower<'a> {
     fn lower_export_specifier(&mut self, specifier: &ast::ExportSpecifier) -> hir::ExportSpecifier {
         let local = self.lower_module_export_name(&specifier.local);
         let exported = self.lower_module_export_name(&specifier.exported);
-        self.hir.export_specifier(specifier.span, local, exported)
+        let export_kind = self.lower_import_export_type_or_value(specifier.export_kind);
+        self.hir.export_specifier(specifier.span, local, exported, export_kind)
     }
 
     fn lower_declaration(&mut self, decl: &ast::Declaration<'a>) -> Option<hir::Declaration<'a>> {

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1844,6 +1844,8 @@ pub struct ExportSpecifier {
     pub span: Span,
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
+    pub export_kind: ImportOrExportKind,              // `export type *`
+
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_hir/src/hir.rs
+++ b/crates/oxc_hir/src/hir.rs
@@ -1844,8 +1844,7 @@ pub struct ExportSpecifier {
     pub span: Span,
     pub local: ModuleExportName,
     pub exported: ModuleExportName,
-    pub export_kind: ImportOrExportKind,              // `export type *`
-
+    pub export_kind: ImportOrExportKind, // `export type *`
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_hir/src/hir_builder.rs
+++ b/crates/oxc_hir/src/hir_builder.rs
@@ -1055,8 +1055,9 @@ impl<'a> HirBuilder<'a> {
         span: Span,
         local: ModuleExportName,
         exported: ModuleExportName,
+        export_kind: ImportOrExportKind,
     ) -> ExportSpecifier {
-        ExportSpecifier { span, local, exported }
+        ExportSpecifier { span, local, exported, export_kind }
     }
 
     /* ---------- JSX ----------------- */

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -60,6 +60,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::use_isnan,
     eslint::valid_typeof,
     typescript::adjacent_overload_signatures,
+    typescript::consistent_type_exports,
     typescript::isolated_declaration,
     typescript::no_empty_interface,
     typescript::no_extra_non_null_assertion,

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
@@ -1,0 +1,110 @@
+use oxc_ast::{
+    ast::{ExportNamedDeclaration, ImportOrExportKind, ModuleDeclaration},
+    AstKind,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{AstNode, ScopeId};
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("typescript-eslint(consistent-type-export): Consistent type exports")]
+#[diagnostic(severity(error), help("Consistent type export"))]
+struct ConsistentTypeExportDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct ConsistentTypeExports;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// This rule enforces a set of restrictions on typescript files to enable "isolated declaration",
+    /// i.e., .d.ts files can be generated from a single .ts file without resolving its dependencies.
+    /// The typescript implementation is at `https://github.com/microsoft/TypeScript/pull/53463`
+    /// The thread on isolated declaration is at `https://github.com/microsoft/TypeScript/issues/47947`
+    ///
+    /// ### Why is this bad?
+    /// The restrictions allow .d.ts files to be generated based on one single .ts file, which improves the
+    /// efficiency and possible parallelism of the declaration emitting process. Furthermore, it prevents syntax
+    /// errors in one file from propagating to other dependent files.
+    ///
+    /// ### Example
+    /// ```typescript
+    /// export class Test {
+    ///   x // error under isolated declarations
+    ///   private y = 0; // no error, private field types are not serialized in declarations
+    ///   #z = 1;// no error, fields is not present in declarations
+    ///   constructor(x: number) {
+    ///     this.x = 1;
+    ///   }
+    ///   get a() { // error under isolated declarations
+    ///     return 1;
+    ///   }
+    ///   set a(value) { // error under isolated declarations
+    ///     this.x = 1;
+    ///   }
+    /// }
+    /// ```
+    ConsistentTypeExports,
+    nursery,
+);
+
+impl Rule for ConsistentTypeExports {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ModuleDeclaration(module_declaration) = node.kind() else { return };
+        //let symbol_table = ctx.semantic().symbols()
+        if let ModuleDeclaration::ExportNamedDeclaration(export_named_declaration) =
+            module_declaration
+        {
+            check_export_named_declaration(node.scope_id(), export_named_declaration, ctx);
+        }
+    }
+}
+
+fn check_export_named_declaration(
+    scope_id: ScopeId,
+    export_named_declaration: &ExportNamedDeclaration,
+    ctx: &LintContext,
+) {
+    let symbol_table = ctx.semantic().symbols();
+    let scopes = ctx.scopes();
+    for specifier in export_named_declaration.specifiers.iter() {
+        if matches!(specifier.export_kind, ImportOrExportKind::Type) {
+            continue;
+        }
+        let Some(symbol_id) = scopes.get_binding(scope_id, specifier.local.name()) else {
+            continue;
+        };
+
+        let symbol_is_type = symbol_table.get_flag(symbol_id).is_type();
+        if symbol_is_type {
+            ctx.diagnostic(ConsistentTypeExportDiagnostic(specifier.span));
+        }
+    }
+}
+
+
+
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass: Vec<(&str, Option<serde_json::Value>)> =
+        vec![
+            ("type foo = number; export {type foo}", None),
+            ("type foo = number; const foo = 3; export {foo}", None),
+
+        ];
+
+    let fail = vec![
+        ("type foo = number; export {foo}", None)
+
+        ];
+
+    Tester::new(ConsistentTypeExports::NAME, pass, fail).test();
+}

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -374,7 +374,7 @@ impl<'a> SeparatedList<'a> for ExportNamedSpecifiers<'a> {
 
         let local = p.parse_module_export_name()?;
         let exported = if p.eat(Kind::As) { p.parse_module_export_name()? } else { local.clone() };
-        let element = ExportSpecifier { span: p.end_span(specifier_span), local, exported };
+        let element = ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
         self.elements.push(element);
         Ok(())
     }

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -374,7 +374,8 @@ impl<'a> SeparatedList<'a> for ExportNamedSpecifiers<'a> {
 
         let local = p.parse_module_export_name()?;
         let exported = if p.eat(Kind::As) { p.parse_module_export_name()? } else { local.clone() };
-        let element = ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
+        let element =
+            ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
         self.elements.push(element);
         Ok(())
     }

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -251,6 +251,20 @@ impl<'a> Binder for TSEnumMember<'a> {
     }
 }
 
+impl<'a> Binder for TSModuleDeclaration<'a> {
+    fn bind(&self, builder: &mut SemanticBuilder) {
+        // At declaration time a module has no value declaration it is only when a value declaration
+        // is made inside a the scope of a module that the symbol is modified
+        let ambient = if self.modifiers.contains(ModifierKind::Declare) {SymbolFlags::Ambient} else {SymbolFlags::None};
+        builder.declare_symbol(
+            self.span,
+            self.id.name(),
+            SymbolFlags::NameSpaceModule | ambient,
+            SymbolFlags::None,
+        );
+    }
+}
+
 impl<'a> Binder for TSTypeParameter<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         builder.declare_symbol(

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -255,7 +255,11 @@ impl<'a> Binder for TSModuleDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         // At declaration time a module has no value declaration it is only when a value declaration
         // is made inside a the scope of a module that the symbol is modified
-        let ambient = if self.modifiers.contains(ModifierKind::Declare) {SymbolFlags::Ambient} else {SymbolFlags::None};
+        let ambient = if self.modifiers.contains(ModifierKind::Declare) {
+            SymbolFlags::Ambient
+        } else {
+            SymbolFlags::None
+        };
         builder.declare_symbol(
             self.span,
             self.id.name(),

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -3,7 +3,7 @@
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
 use oxc_ast::{syntax_directed_operations::BoundNames, AstKind};
-use oxc_span::{SourceType, Atom};
+use oxc_span::{Atom, SourceType};
 
 use crate::{scope::ScopeFlags, symbol::SymbolFlags, SemanticBuilder};
 
@@ -206,7 +206,6 @@ impl<'a> Binder for TSTypeAliasDeclaration<'a> {
     }
 }
 
-
 impl<'a> Binder for TSInterfaceDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         builder.declare_symbol(
@@ -220,15 +219,14 @@ impl<'a> Binder for TSInterfaceDeclaration<'a> {
 
 impl<'a> Binder for TSEnumDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
-        let is_const =  self.modifiers.contains(ModifierKind::Const);
-        let includes = if is_const {SymbolFlags::ConstEnum} else {SymbolFlags::RegularEnum};
-        let excludes = if is_const {SymbolFlags::ConstEnumExcludes} else {SymbolFlags::RegularEnumExcludes};
-        builder.declare_symbol(
-            self.id.span,
-            &self.id.name,
-            includes,
-            excludes
-        );
+        let is_const = self.modifiers.contains(ModifierKind::Const);
+        let includes = if is_const { SymbolFlags::ConstEnum } else { SymbolFlags::RegularEnum };
+        let excludes = if is_const {
+            SymbolFlags::ConstEnumExcludes
+        } else {
+            SymbolFlags::RegularEnumExcludes
+        };
+        builder.declare_symbol(self.id.span, &self.id.name, includes, excludes);
     }
 }
 
@@ -242,18 +240,16 @@ impl<'a> Binder for TSEnumMember<'a> {
             TSEnumMemberName::Identifier(id) => id.name.clone(),
             TSEnumMemberName::StringLiteral(s) => s.value.clone(),
             TSEnumMemberName::NumberLiteral(n) => Atom::new_inline(&n.value.to_string()),
-            TSEnumMemberName::ComputedPropertyName(_) =>  panic!("TODO: implement"),
+            TSEnumMemberName::ComputedPropertyName(_) => panic!("TODO: implement"),
         };
-        builder.declare_symbol(self.span, 
+        builder.declare_symbol(
+            self.span,
             &name,
-            SymbolFlags::EnumMember, 
-            SymbolFlags::EnumMemberExcludes);
+            SymbolFlags::EnumMember,
+            SymbolFlags::EnumMemberExcludes,
+        );
     }
-    
-
 }
-
-
 
 impl<'a> Binder for TSTypeParameter<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
@@ -265,4 +261,3 @@ impl<'a> Binder for TSTypeParameter<'a> {
         );
     }
 }
-

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -561,7 +561,9 @@ impl<'a> SemanticBuilder<'a> {
     fn make_all_namespaces_valuelike(&mut self) {
         for symbol_id in &self.namespace_stack {
             // Ambient modules cannot be value modules
-            if self.symbols.get_flag(*symbol_id).intersects(SymbolFlags::Ambient) {continue;}
+            if self.symbols.get_flag(*symbol_id).intersects(SymbolFlags::Ambient) {
+                continue;
+            }
             self.symbols.set_flag(*symbol_id, SymbolFlags::ValueModule);
         }
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -245,7 +245,7 @@ impl<'a> SemanticBuilder<'a> {
         excludes: SymbolFlags,
     ) -> SymbolId {
         if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
-            self.symbols.set_flag(symbol_id, includes);
+            self.symbols.union_flag(symbol_id, includes);
             return symbol_id;
         }
 
@@ -564,7 +564,7 @@ impl<'a> SemanticBuilder<'a> {
             if self.symbols.get_flag(*symbol_id).intersects(SymbolFlags::Ambient) {
                 continue;
             }
-            self.symbols.set_flag(*symbol_id, SymbolFlags::ValueModule);
+            self.symbols.union_flag(*symbol_id, SymbolFlags::ValueModule);
         }
     }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -51,6 +51,11 @@ pub struct SemanticBuilder<'a> {
     pub current_scope_id: ScopeId,
     /// Stores current `AstKind::Function` and `AstKind::ArrowExpression` during AST visit
     pub function_stack: Vec<AstNodeId>,
+    // To make a namespace/module value like
+    // we need the to know the modules we are inside
+    // and when we reach a value declaration we set it
+    // to value like
+    pub namespace_stack: Vec<SymbolId>,
 
     // builders
     pub nodes: AstNodes<'a>,
@@ -87,6 +92,7 @@ impl<'a> SemanticBuilder<'a> {
             current_symbol_flags: SymbolFlags::empty(),
             current_scope_id,
             function_stack: vec![],
+            namespace_stack: vec![],
             nodes: AstNodes::default(),
             scope,
             symbols: SymbolTable::default(),
@@ -440,23 +446,35 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::VariableDeclarator(decl) => {
                 decl.bind(self);
+                self.make_all_namespaces_valuelike();
             }
             AstKind::Function(func) => {
                 self.function_stack.push(self.current_node_id);
                 func.bind(self);
+                self.make_all_namespaces_valuelike();
             }
             AstKind::ArrowExpression(_) => {
                 self.function_stack.push(self.current_node_id);
+                self.make_all_namespaces_valuelike();
             }
             AstKind::Class(class) => {
                 self.current_node_flags |= NodeFlags::Class;
                 class.bind(self);
+                self.make_all_namespaces_valuelike();
             }
             AstKind::FormalParameters(params) => {
                 params.bind(self);
             }
             AstKind::CatchClause(clause) => {
                 clause.bind(self);
+            }
+            AstKind::TSModuleDeclaration(module_declaration) => {
+                module_declaration.bind(self);
+                let symbol_id = self
+                    .scope
+                    .get_bindings(self.current_scope_id)
+                    .get(module_declaration.id.name());
+                self.namespace_stack.push(*symbol_id.unwrap());
             }
             AstKind::TSTypeAliasDeclaration(type_alias_declaration) => {
                 type_alias_declaration.bind(self);
@@ -466,6 +484,8 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::TSEnumDeclaration(enum_declaration) => {
                 enum_declaration.bind(self);
+                // TODO: const enum?
+                self.make_all_namespaces_valuelike();
             }
             AstKind::TSEnumMember(enum_member) => {
                 enum_member.bind(self);
@@ -531,7 +551,18 @@ impl<'a> SemanticBuilder<'a> {
             AstKind::Function(_) | AstKind::ArrowExpression(_) => {
                 self.function_stack.pop();
             }
+            AstKind::TSModuleBlock(_) => {
+                self.namespace_stack.pop();
+            }
             _ => {}
+        }
+    }
+
+    fn make_all_namespaces_valuelike(&mut self) {
+        for symbol_id in &self.namespace_stack {
+            // Ambient modules cannot be value modules
+            if self.symbols.get_flag(*symbol_id).intersects(SymbolFlags::Ambient) {continue;}
+            self.symbols.set_flag(*symbol_id, SymbolFlags::ValueModule);
         }
     }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -239,6 +239,7 @@ impl<'a> SemanticBuilder<'a> {
         excludes: SymbolFlags,
     ) -> SymbolId {
         if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
+            self.symbols.set_flag(symbol_id, includes);
             return symbol_id;
         }
 
@@ -456,6 +457,21 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::CatchClause(clause) => {
                 clause.bind(self);
+            }
+            AstKind::TSTypeAliasDeclaration(type_alias_declaration) => {
+                type_alias_declaration.bind(self);
+            }
+            AstKind::TSInterfaceDeclaration(interface_declaration) => {
+                interface_declaration.bind(self);
+            }
+            AstKind::TSEnumDeclaration(enum_declaration) => {
+                enum_declaration.bind(self);
+            }
+            AstKind::TSEnumMember(enum_member) => {
+                enum_member.bind(self);
+            }
+            AstKind::TSTypeParameter(type_parameter) => {
+                type_parameter.bind(self);
             }
             AstKind::IdentifierReference(ident) => {
                 self.reference_identifier(ident);

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -131,6 +131,8 @@ impl ScopeTree {
             AstKind::ArrowExpression(_) => Some(ScopeFlags::Function | ScopeFlags::Arrow),
             AstKind::StaticBlock(_) => Some(ScopeFlags::ClassStaticBlock),
             AstKind::TSModuleBlock(_) => Some(ScopeFlags::TsModuleBlock),
+            AstKind::TSTypeParameter(_) => Some(ScopeFlags::empty()),
+            AstKind::TSEnumBody(_) => Some(ScopeFlags::empty()),
             AstKind::Class(class) if matches!(class.r#type, ClassType::ClassExpression) => {
                 // Class expression creates a temporary scope with the class name as its only variable
                 // E.g., `let c = class A { foo() { console.log(A) } }`

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -131,8 +131,6 @@ impl ScopeTree {
             AstKind::ArrowExpression(_) => Some(ScopeFlags::Function | ScopeFlags::Arrow),
             AstKind::StaticBlock(_) => Some(ScopeFlags::ClassStaticBlock),
             AstKind::TSModuleBlock(_) => Some(ScopeFlags::TsModuleBlock),
-            AstKind::TSTypeParameter(_) => Some(ScopeFlags::empty()),
-            AstKind::TSEnumBody(_) => Some(ScopeFlags::empty()),
             AstKind::Class(class) if matches!(class.r#type, ClassType::ClassExpression) => {
                 // Class expression creates a temporary scope with the class name as its only variable
                 // E.g., `let c = class A { foo() { console.log(A) } }`
@@ -143,6 +141,8 @@ impl ScopeTree {
             | AstKind::ForStatement(_)
             | AstKind::ForInStatement(_)
             | AstKind::ForOfStatement(_)
+            | AstKind::TSTypeParameter(_)
+            | AstKind::TSEnumBody(_)
             | AstKind::SwitchStatement(_) => Some(ScopeFlags::empty()),
             _ => None,
         }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -54,7 +54,7 @@ impl SymbolTable {
         self.flags[symbol_id]
     }
 
-    pub fn set_flag(&mut self, symbol_id: SymbolId, includes: SymbolFlags) {
+    pub fn union_flag(&mut self, symbol_id: SymbolId, includes: SymbolFlags) {
         self.flags[symbol_id] |= includes;
     }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -54,6 +54,10 @@ impl SymbolTable {
         self.flags[symbol_id]
     }
 
+    pub fn set_flag(&mut self, symbol_id: SymbolId, includes: SymbolFlags) {
+        self.flags[symbol_id] |= includes;
+    }
+
     pub fn get_scope_id(&self, symbol_id: SymbolId) -> ScopeId {
         self.scope_ids[symbol_id]
     }

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -12,10 +12,9 @@ pub struct Atom(CompactString);
 const BASE54_CHARS: &[u8; 64] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
 
 impl Atom {
-
     pub const fn new_inline(s: &str) -> Self {
         Self(CompactString::new_inline(s))
-    } 
+    }
 
     #[inline]
     pub fn as_str(&self) -> &str {

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -12,6 +12,11 @@ pub struct Atom(CompactString);
 const BASE54_CHARS: &[u8; 64] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789";
 
 impl Atom {
+
+    pub const fn new_inline(s: &str) -> Self {
+        Self(CompactString::new_inline(s))
+    } 
+
     #[inline]
     pub fn as_str(&self) -> &str {
         self.0.as_str()

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -36,7 +36,7 @@ bitflags! {
         const NameSpaceModule         = 1 << 16;
         const ValueModule             = 1 << 17;
         // In a dts file or there is a declare flag
-        const Ambient                 = 1 << 18; 
+        const Ambient                 = 1 << 18;
 
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -55,7 +55,7 @@ bitflags! {
         const InterfaceExcludes = Self::Type.bits() & !(Self::Interface.bits() | Self::Class.bits());
         const TypeParameterExcludes = Self::Type.bits() & !Self::TypeParameter.bits();
         const ConstEnumExcludes = (Self::Type.bits() | Self::Value.bits()) & !Self::ConstEnum.bits();
-        // TODO: include value module in regualr enum excludes
+        // TODO: include value module in regular enum excludes
         const RegularEnumExcludes = (Self::Value.bits() | Self::Type.bits()) & !(Self::RegularEnum.bits() );
         const EnumMemberExcludes = Self::EnumMember.bits();
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -9,7 +9,7 @@ define_index_type! {
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct SymbolFlags: u16 {
+    pub struct SymbolFlags: u32 {
         const None                    = 0;
         /// Variable (var) or parameter
         const FunctionScopedVariable  = 1 << 0;
@@ -33,11 +33,15 @@ bitflags! {
         const EnumMember              = 1 << 13;
         const TypeLiteral             = 1 << 14;
         const TypeParameter           = 1 << 15;
+        const NameSpaceModule         = 1 << 16;
+        const ValueModule             = 1 << 17;
+        // In a dts file or there is a declare flag
+        const Ambient                 = 1 << 18; 
 
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
 
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();
-        const Value = Self::Variable.bits() | Self::Class.bits() | Self::Enum.bits();
+        const Value = Self::Variable.bits() | Self::Class.bits() | Self::Enum.bits() | Self::ValueModule.bits();
         const Type =  Self::Class.bits() | Self::Interface.bits() | Self::Enum.bits() | Self::TypeLiteral.bits() | Self::TypeParameter.bits()  |  Self::TypeAlias.bits();
 
         /// Variables can be redeclared, but can not redeclare a block-scoped declaration with the
@@ -48,7 +52,7 @@ bitflags! {
         /// they can not merge with anything in the value space
         const BlockScopedVariableExcludes = Self::Value.bits();
 
-        const ClassExcludes = Self::Value.bits() | Self::TypeAlias.bits();
+        const ClassExcludes = (Self::Value.bits() | Self::TypeAlias.bits()) & !Self::ValueModule.bits() ;
         const ImportBindingExcludes = Self::ImportBinding.bits();
         // Type specific excludes
         const TypeAliasExcludes = Self::Type.bits();
@@ -56,7 +60,7 @@ bitflags! {
         const TypeParameterExcludes = Self::Type.bits() & !Self::TypeParameter.bits();
         const ConstEnumExcludes = (Self::Type.bits() | Self::Value.bits()) & !Self::ConstEnum.bits();
         // TODO: include value module in regular enum excludes
-        const RegularEnumExcludes = (Self::Value.bits() | Self::Type.bits()) & !(Self::RegularEnum.bits() );
+        const RegularEnumExcludes = (Self::Value.bits() | Self::Type.bits()) & !(Self::RegularEnum.bits() | Self::ValueModule.bits() );
         const EnumMemberExcludes = Self::EnumMember.bits();
 
     }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -10,7 +10,7 @@ define_index_type! {
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SymbolFlags: u16 {
-        const None                    = 0 << 0;
+        const None                    = 0;
         /// Variable (var) or parameter
         const FunctionScopedVariable  = 1 << 0;
         /// A block-scoped variable (let or const)
@@ -30,10 +30,10 @@ bitflags! {
         const Interface               = 1 << 10;
         const RegularEnum             = 1 << 11;
         const ConstEnum               = 1 << 12;
-        const EnumMember              = 1 << 13; 
-        const TypeLiteral             = 1 << 14; 
+        const EnumMember              = 1 << 13;
+        const TypeLiteral             = 1 << 14;
         const TypeParameter           = 1 << 15;
-        
+
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
 
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();
@@ -57,8 +57,8 @@ bitflags! {
         const ConstEnumExcludes = (Self::Type.bits() | Self::Value.bits()) & !Self::ConstEnum.bits();
         // TODO: include value module in regualr enum excludes
         const RegularEnumExcludes = (Self::Value.bits() | Self::Type.bits()) & !(Self::RegularEnum.bits() );
-        const EnumMemberExcludes = Self::EnumMember.bits(); 
-        
+        const EnumMemberExcludes = Self::EnumMember.bits();
+
     }
 }
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -30,14 +30,14 @@ bitflags! {
         const Interface               = 1 << 10;
         const RegularEnum             = 1 << 11;
         const ConstEnum               = 1 << 12;
-        const EnumMember              = 1 << 13; // TODO: implement
-        const TypeLiteral             = 1 << 14; // Unsure if this is needed
+        const EnumMember              = 1 << 13; 
+        const TypeLiteral             = 1 << 14; 
         const TypeParameter           = 1 << 15;
         
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
 
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();
-        const Value = Self::Variable.bits() | Self::Class.bits();
+        const Value = Self::Variable.bits() | Self::Class.bits() | Self::Enum.bits();
         const Type =  Self::Class.bits() | Self::Interface.bits() | Self::Enum.bits() | Self::TypeLiteral.bits() | Self::TypeParameter.bits()  |  Self::TypeAlias.bits();
 
         /// Variables can be redeclared, but can not redeclare a block-scoped declaration with the
@@ -48,7 +48,7 @@ bitflags! {
         /// they can not merge with anything in the value space
         const BlockScopedVariableExcludes = Self::Value.bits();
 
-        const ClassExcludes = Self::Value.bits();
+        const ClassExcludes = Self::Value.bits() | Self::TypeAlias.bits();
         const ImportBindingExcludes = Self::ImportBinding.bits();
         // Type specific excludes
         const TypeAliasExcludes = Self::Type.bits();

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -1,7 +1,7 @@
 parser_babel Summary:
 AST Parsed     : 2072/2078 (99.71%)
 Positive Passed: 2069/2078 (99.57%)
-Negative Passed: 1324/1507 (87.86%)
+Negative Passed: 1342/1507 (89.05%)
 Expect Syntax Error: "annex-b/disabled/1.1-html-comments-close/input.js"
 Expect Syntax Error: "annex-b/disabled/3.1-sloppy-labeled-functions/input.js"
 Expect Syntax Error: "annex-b/disabled/3.1-sloppy-labeled-functions-if-body/input.js"
@@ -127,24 +127,6 @@ Expect Syntax Error: "typescript/interface/invalid-modifiers-method/input.ts"
 Expect Syntax Error: "typescript/interface/invalid-modifiers-method-babel-7/input.ts"
 Expect Syntax Error: "typescript/interface/invalid-modifiers-property/input.ts"
 Expect Syntax Error: "typescript/regression/keyword-qualified-type-disallowed/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-class-enum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-class-type/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-constenum-enum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-class/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-constenum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-function/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-interface/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-let/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-type/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-enum-var/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-function-enum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-interface-enum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-let-enum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-type-class/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-type-enum/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-type-interface/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-type-type/input.ts"
-Expect Syntax Error: "typescript/scope/redeclaration-var-enum/input.ts"
 Expect Syntax Error: "typescript/static-blocks/invalid-static-block-with-accessibility-private-01/input.ts"
 Expect Syntax Error: "typescript/static-blocks/invalid-static-block-with-accessibility-protected-01/input.ts"
 Expect Syntax Error: "typescript/static-blocks/invalid-static-block-with-accessibility-public-01/input.ts"
@@ -9907,6 +9889,116 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ·       ╰── It can not be redeclared here
    ╰────
 
+  × Identifier `A` has already been declared
+   ╭─[typescript/scope/redeclaration-class-enum/input.ts:1:1]
+ 1 │ class A {}
+   ·       ┬
+   ·       ╰── `A` has already been declared here
+ 2 │ enum A {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
+   ╭─[typescript/scope/redeclaration-class-type/input.ts:1:1]
+ 1 │ class A {}
+   ·       ┬
+   ·       ╰── `A` has already been declared here
+ 2 │ type A = number;
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[typescript/scope/redeclaration-constenum-enum/input.ts:1:1]
+ 1 │ const enum X {}
+   ·            ┬
+   ·            ╰── `X` has already been declared here
+ 2 │ enum X {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-class/input.ts:1:1]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ class X {}
+   ·       ┬
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-constenum/input.ts:1:1]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ const enum X {}
+   ·            ┬
+   ·            ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-function/input.ts:1:1]
+ 1 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── `Foo` has already been declared here
+ 2 │ function Foo() {}
+   ·          ─┬─
+   ·           ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-interface/input.ts:1:1]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ interface X {}
+   ·           ┬
+   ·           ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-let/input.ts:1:1]
+ 1 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── `Foo` has already been declared here
+ 2 │ let Foo;
+   ·     ─┬─
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-type/input.ts:1:1]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ type X = number;
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[typescript/scope/redeclaration-enum-var/input.ts:1:1]
+ 1 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── `Foo` has already been declared here
+ 2 │ let Foo;
+   ·     ─┬─
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[typescript/scope/redeclaration-function-enum/input.ts:1:1]
+ 1 │ function Foo() {}
+   ·          ─┬─
+   ·           ╰── `Foo` has already been declared here
+ 2 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── It can not be redeclared here
+   ╰────
+
   × Identifier `Context` has already been declared
    ╭─[typescript/scope/redeclaration-import-type-import/input.ts:1:1]
  1 │ import type { Context } from 'react';
@@ -9915,6 +10007,76 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
  2 │ import { Context } from 'react';
    ·          ───┬───
    ·             ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[typescript/scope/redeclaration-interface-enum/input.ts:1:1]
+ 1 │ interface X {}
+   ·           ┬
+   ·           ╰── `X` has already been declared here
+ 2 │ enum X {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[typescript/scope/redeclaration-let-enum/input.ts:1:1]
+ 1 │ let Foo;
+   ·     ─┬─
+   ·      ╰── `Foo` has already been declared here
+ 2 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
+   ╭─[typescript/scope/redeclaration-type-class/input.ts:1:1]
+ 1 │ type A = number;
+   ·      ┬
+   ·      ╰── `A` has already been declared here
+ 2 │ class A {}
+   ·       ┬
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
+   ╭─[typescript/scope/redeclaration-type-enum/input.ts:1:1]
+ 1 │ type A = number;
+   ·      ┬
+   ·      ╰── `A` has already been declared here
+ 2 │ enum A {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
+   ╭─[typescript/scope/redeclaration-type-interface/input.ts:1:1]
+ 1 │ type A = number;
+   ·      ┬
+   ·      ╰── `A` has already been declared here
+ 2 │ interface A {}
+   ·           ┬
+   ·           ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
+   ╭─[typescript/scope/redeclaration-type-type/input.ts:1:1]
+ 1 │ type A = number;
+   ·      ┬
+   ·      ╰── `A` has already been declared here
+ 2 │ type A = string;
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[typescript/scope/redeclaration-var-enum/input.ts:1:1]
+ 1 │ let Foo;
+   ·     ─┬─
+   ·      ╰── `Foo` has already been declared here
+ 2 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── It can not be redeclared here
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1,7 +1,7 @@
 parser_typescript Summary:
 AST Parsed     : 5060/5063 (99.94%)
 Positive Passed: 5051/5063 (99.76%)
-Negative Passed: 992/4761 (20.84%)
+Negative Passed: 995/4761 (20.90%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
 Expect Syntax Error: "compiler/ClassDeclaration13.ts"
@@ -163,8 +163,6 @@ Expect Syntax Error: "compiler/asyncFunctionNoReturnType.ts"
 Expect Syntax Error: "compiler/asyncFunctionReturnExpressionErrorSpans.ts"
 Expect Syntax Error: "compiler/augmentedClassWithPrototypePropertyOnModule.ts"
 Expect Syntax Error: "compiler/augmentedTypesEnum3.ts"
-Expect Syntax Error: "compiler/augmentedTypesModules.ts"
-Expect Syntax Error: "compiler/augmentedTypesModules2.ts"
 Expect Syntax Error: "compiler/augmentedTypesModules3.ts"
 Expect Syntax Error: "compiler/autolift3.ts"
 Expect Syntax Error: "compiler/autolift4.ts"
@@ -528,7 +526,6 @@ Expect Syntax Error: "compiler/duplicateObjectLiteralProperty_computedName1.ts"
 Expect Syntax Error: "compiler/duplicateObjectLiteralProperty_computedName2.ts"
 Expect Syntax Error: "compiler/duplicatePropertiesInStrictMode.ts"
 Expect Syntax Error: "compiler/duplicateStringNamedProperty1.ts"
-Expect Syntax Error: "compiler/duplicateSymbolsExportMatching.ts"
 Expect Syntax Error: "compiler/duplicateTypeParameters1.ts"
 Expect Syntax Error: "compiler/duplicateTypeParameters2.ts"
 Expect Syntax Error: "compiler/duplicateTypeParameters3.ts"
@@ -4349,6 +4346,103 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  27 │ 
     ╰────
 
+  × Identifier `m1a` has already been declared
+   ╭─[compiler/augmentedTypesModules.ts:4:1]
+ 4 │ 
+ 5 │ module m1a { var y = 2; } // error
+   · ────────────┬────────────
+   ·             ╰── `m1a` has already been declared here
+ 6 │ var m1a = 1; // error
+   ·     ─┬─
+   ·      ╰── It can not be redeclared here
+ 7 │ 
+   ╰────
+
+  × Identifier `m1b` has already been declared
+    ╭─[compiler/augmentedTypesModules.ts:7:1]
+  7 │ 
+  8 │ module m1b { export var y = 2; } // error
+    · ────────────────┬───────────────
+    ·                 ╰── `m1b` has already been declared here
+  9 │ var m1b = 1; // error
+    ·     ─┬─
+    ·      ╰── It can not be redeclared here
+ 10 │ 
+    ╰────
+
+  × Identifier `m1d` has already been declared
+    ╭─[compiler/augmentedTypesModules.ts:15:1]
+ 15 │     
+ 16 │ ╭─▶ module m1d { // error
+ 17 │ │       export class I { foo() { } }
+ 18 │ ├─▶ }
+    · ╰──── `m1d` has already been declared here
+ 19 │ ╭─▶ var m1d = 1; // error
+    · │     ─┬─
+    · │      ╰── It can not be redeclared here
+ 20 │     
+    ╰────
+
+  × Identifier `m2a` has already been declared
+    ╭─[compiler/augmentedTypesModules.ts:24:1]
+ 24 │ 
+ 25 │ module m2a { var y = 2; }
+    · ────────────┬────────────
+    ·             ╰── `m2a` has already been declared here
+ 26 │ function m2a() { }; // error since the module is instantiated
+    ·          ─┬─
+    ·           ╰── It can not be redeclared here
+ 27 │ 
+    ╰────
+
+  × Identifier `m2b` has already been declared
+    ╭─[compiler/augmentedTypesModules.ts:27:1]
+ 27 │ 
+ 28 │ module m2b { export var y = 2; }
+    · ────────────────┬───────────────
+    ·                 ╰── `m2b` has already been declared here
+ 29 │ function m2b() { };  // error since the module is instantiated
+    ·          ─┬─
+    ·           ╰── It can not be redeclared here
+ 30 │ 
+    ╰────
+
+  × Identifier `m2a` has already been declared
+   ╭─[compiler/augmentedTypesModules2.ts:4:1]
+ 4 │ 
+ 5 │ module m2a { var y = 2; }
+   · ────────────┬────────────
+   ·             ╰── `m2a` has already been declared here
+ 6 │ function m2a() { }; // error since the module is instantiated
+   ·          ─┬─
+   ·           ╰── It can not be redeclared here
+ 7 │ 
+   ╰────
+
+  × Identifier `m2b` has already been declared
+    ╭─[compiler/augmentedTypesModules2.ts:7:1]
+  7 │ 
+  8 │ module m2b { export var y = 2; }
+    · ────────────────┬───────────────
+    ·                 ╰── `m2b` has already been declared here
+  9 │ function m2b() { };  // error since the module is instantiated
+    ·          ─┬─
+    ·           ╰── It can not be redeclared here
+ 10 │ 
+    ╰────
+
+  × Identifier `m2cc` has already been declared
+    ╭─[compiler/augmentedTypesModules2.ts:13:1]
+ 13 │ 
+ 14 │ module m2cc { export var y = 2; }
+    · ────────────────┬────────────────
+    ·                 ╰── `m2cc` has already been declared here
+ 15 │ function m2cc() { }; // error to have module first
+    ·          ──┬─
+    ·            ╰── It can not be redeclared here
+ 16 │ 
+    ╰────
+
   × Identifier `x4` has already been declared
     ╭─[compiler/augmentedTypesVar.ts:12:1]
  12 │ // var then class
@@ -5960,6 +6054,19 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  6 │   while (true) {
    ╰────
 
+  × Identifier `F` has already been declared
+    ╭─[compiler/duplicateSymbolsExportMatching.ts:49:1]
+ 49 │     module M {
+ 50 │ ╭─▶     module F {
+ 51 │ │           var t;
+ 52 │ ├─▶     }
+    · ╰──── `F` has already been declared here
+ 53 │ ╭─▶     export function F() { } // Only one error for duplicate identifier (don't consider visibility)
+    · │                     ┬
+    · │                     ╰── It can not be redeclared here
+ 54 │     }
+    ╰────
+
   × Empty parenthesized expression
    ╭─[compiler/emptyMemberAccess.ts:2:1]
  2 │ 
@@ -7294,6 +7401,19 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    · ──────
  2 │     .then((role: Role) =>
    ╰────
+
+  × Identifier `z` has already been declared
+    ╭─[compiler/nameCollisions.ts:9:1]
+  9 │     
+ 10 │ ╭─▶     module z {
+ 11 │ │           var t;
+ 12 │ ├─▶     }
+    · ╰──── `z` has already been declared here
+ 13 │ ╭─▶     var z; // error
+    · │         ┬
+    · │         ╰── It can not be redeclared here
+ 14 │     
+    ╰────
 
   × Identifier `C` has already been declared
     ╭─[compiler/nameCollisions.ts:32:1]

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1,7 +1,7 @@
 parser_typescript Summary:
 AST Parsed     : 5060/5063 (99.94%)
 Positive Passed: 5051/5063 (99.76%)
-Negative Passed: 984/4761 (20.67%)
+Negative Passed: 992/4761 (20.84%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
 Expect Syntax Error: "compiler/ClassDeclaration13.ts"
@@ -162,11 +162,7 @@ Expect Syntax Error: "compiler/assignmentToReferenceTypes.ts"
 Expect Syntax Error: "compiler/asyncFunctionNoReturnType.ts"
 Expect Syntax Error: "compiler/asyncFunctionReturnExpressionErrorSpans.ts"
 Expect Syntax Error: "compiler/augmentedClassWithPrototypePropertyOnModule.ts"
-Expect Syntax Error: "compiler/augmentedTypesClass2.ts"
-Expect Syntax Error: "compiler/augmentedTypesEnum.ts"
-Expect Syntax Error: "compiler/augmentedTypesEnum2.ts"
 Expect Syntax Error: "compiler/augmentedTypesEnum3.ts"
-Expect Syntax Error: "compiler/augmentedTypesInterface.ts"
 Expect Syntax Error: "compiler/augmentedTypesModules.ts"
 Expect Syntax Error: "compiler/augmentedTypesModules2.ts"
 Expect Syntax Error: "compiler/augmentedTypesModules3.ts"
@@ -565,7 +561,6 @@ Expect Syntax Error: "compiler/enumAssignmentCompat5.ts"
 Expect Syntax Error: "compiler/enumBasics1.ts"
 Expect Syntax Error: "compiler/enumBasics2.ts"
 Expect Syntax Error: "compiler/enumBasics3.ts"
-Expect Syntax Error: "compiler/enumGenericTypeClash.ts"
 Expect Syntax Error: "compiler/enumIdentifierLiterals.ts"
 Expect Syntax Error: "compiler/enumLiteralAssignableToEnumInsideUnion.ts"
 Expect Syntax Error: "compiler/enumPropertyAccess.ts"
@@ -1532,7 +1527,6 @@ Expect Syntax Error: "compiler/sourceMap-SemiColon1.ts"
 Expect Syntax Error: "compiler/sourceMap-SingleSpace1.ts"
 Expect Syntax Error: "compiler/sourceMap-StringLiteralWithNewLine.ts"
 Expect Syntax Error: "compiler/sourceMapSample.ts"
-Expect Syntax Error: "compiler/sourceMapValidationEnums.ts"
 Expect Syntax Error: "compiler/sourceMapValidationFor.ts"
 Expect Syntax Error: "compiler/specialIntersectionsInMappedTypes.ts"
 Expect Syntax Error: "compiler/specializedSignatureAsCallbackParameter1.ts"
@@ -3617,8 +3611,6 @@ Expect Syntax Error: "conformance/types/tuple/wideningTuples7.ts"
 Expect Syntax Error: "conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts"
 Expect Syntax Error: "conformance/types/typeAliases/intrinsicKeyword.ts"
 Expect Syntax Error: "conformance/types/typeAliases/intrinsicTypes.ts"
-Expect Syntax Error: "conformance/types/typeAliases/typeAliasesDoNotMerge.ts"
-Expect Syntax Error: "conformance/types/typeAliases/typeAliasesForObjectTypes.ts"
 Expect Syntax Error: "conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts"
 Expect Syntax Error: "conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts"
 Expect Syntax Error: "conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts"
@@ -4172,6 +4164,33 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  4 │ 
    ╰────
 
+  × Identifier `c4` has already been declared
+   ╭─[compiler/augmentedTypesClass.ts:5:1]
+ 5 │ //// class then enum
+ 6 │ class c4 { public foo() { } }
+   ·       ─┬
+   ·        ╰── `c4` has already been declared here
+ 7 │ enum c4 { One } // error
+   ·      ─┬
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `c33` has already been declared
+    ╭─[compiler/augmentedTypesClass2.ts:15:1]
+ 15 │ // class then enum 
+ 16 │ class c33 {
+    ·       ─┬─
+    ·        ╰── `c33` has already been declared here
+ 17 │     foo() {
+ 18 │         return 1;
+ 19 │     }
+ 20 │ }
+ 21 │ enum c33 { One };
+    ·      ─┬─
+    ·       ╰── It can not be redeclared here
+ 22 │ 
+    ╰────
+
   × Identifier `c2` has already been declared
    ╭─[compiler/augmentedTypesClass2a.ts:1:1]
  1 │ //// class then function
@@ -4207,6 +4226,79 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ·        ╰── It can not be redeclared here
    ╰────
 
+  × Identifier `e1111` has already been declared
+   ╭─[compiler/augmentedTypesEnum.ts:1:1]
+ 1 │ // enum then var
+ 2 │ enum e1111 { One } // error
+   ·      ──┬──
+   ·        ╰── `e1111` has already been declared here
+ 3 │ var e1111 = 1; // error
+   ·     ──┬──
+   ·       ╰── It can not be redeclared here
+ 4 │ 
+   ╰────
+
+  × Identifier `e2` has already been declared
+   ╭─[compiler/augmentedTypesEnum.ts:5:1]
+ 5 │ // enum then function
+ 6 │ enum e2 { One } // error
+   ·      ─┬
+   ·       ╰── `e2` has already been declared here
+ 7 │ function e2() { } // error
+   ·          ─┬
+   ·           ╰── It can not be redeclared here
+ 8 │ 
+   ╰────
+
+  × Identifier `e3` has already been declared
+    ╭─[compiler/augmentedTypesEnum.ts:8:1]
+  8 │ 
+  9 │ enum e3 { One } // error
+    ·      ─┬
+    ·       ╰── `e3` has already been declared here
+ 10 │ var e3 = () => { } // error
+    ·     ─┬
+    ·      ╰── It can not be redeclared here
+ 11 │ 
+    ╰────
+
+  × Identifier `e4` has already been declared
+    ╭─[compiler/augmentedTypesEnum.ts:12:1]
+ 12 │ // enum then class
+ 13 │ enum e4 { One } // error
+    ·      ─┬
+    ·       ╰── `e4` has already been declared here
+ 14 │ class e4 { public foo() { } } // error
+    ·       ─┬
+    ·        ╰── It can not be redeclared here
+ 15 │ 
+    ╰────
+
+  × Identifier `e1` has already been declared
+   ╭─[compiler/augmentedTypesEnum2.ts:1:1]
+ 1 │ // enum then interface
+ 2 │ enum e1 { One } // error
+   ·      ─┬
+   ·       ╰── `e1` has already been declared here
+ 3 │ 
+ 4 │ interface e1 { // error
+   ·           ─┬
+   ·            ╰── It can not be redeclared here
+ 5 │     foo(): void;
+   ╰────
+
+  × Identifier `e2` has already been declared
+    ╭─[compiler/augmentedTypesEnum2.ts:10:1]
+ 10 │ // enum then class
+ 11 │ enum e2 { One }; // error
+    ·      ─┬
+    ·       ╰── `e2` has already been declared here
+ 12 │ class e2 { // error
+    ·       ─┬
+    ·        ╰── It can not be redeclared here
+ 13 │     foo() {
+    ╰────
+
   × Identifier `y3` has already been declared
     ╭─[compiler/augmentedTypesFunction.ts:12:1]
  12 │ // function then class
@@ -4231,6 +4323,32 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  18 │ 
     ╰────
 
+  × Identifier `y4` has already been declared
+    ╭─[compiler/augmentedTypesFunction.ts:19:1]
+ 19 │ // function then enum
+ 20 │ function y4() { } // error
+    ·          ─┬
+    ·           ╰── `y4` has already been declared here
+ 21 │ enum y4 { One } // error
+    ·      ─┬
+    ·       ╰── It can not be redeclared here
+ 22 │ 
+    ╰────
+
+  × Identifier `i3` has already been declared
+    ╭─[compiler/augmentedTypesInterface.ts:22:1]
+ 22 │ // interface then enum
+ 23 │ interface i3 { // error
+    ·           ─┬
+    ·            ╰── `i3` has already been declared here
+ 24 │     foo(): void;
+ 25 │ }
+ 26 │ enum i3 { One }; // error
+    ·      ─┬
+    ·       ╰── It can not be redeclared here
+ 27 │ 
+    ╰────
+
   × Identifier `x4` has already been declared
     ╭─[compiler/augmentedTypesVar.ts:12:1]
  12 │ // var then class
@@ -4253,6 +4371,18 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ·       ─┬─
     ·        ╰── It can not be redeclared here
  18 │ 
+    ╰────
+
+  × Identifier `x5` has already been declared
+    ╭─[compiler/augmentedTypesVar.ts:19:1]
+ 19 │ // var then enum
+ 20 │ var x5 = 1;
+    ·     ─┬
+    ·      ╰── `x5` has already been declared here
+ 21 │ enum x5 { One } // error
+    ·      ─┬
+    ·       ╰── It can not be redeclared here
+ 22 │ 
     ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -5845,6 +5975,16 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ·    ─
    ╰────
   help: Try insert a semicolon here
+
+  × Identifier `X` has already been declared
+   ╭─[compiler/enumGenericTypeClash.ts:1:1]
+ 1 │ class X<A,B,C> { }
+   ·       ┬
+   ·       ╰── `X` has already been declared here
+ 2 │ enum X { MyVal }
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[compiler/enumMemberResolution.ts:4:1]
@@ -8071,6 +8211,19 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/slashBeforeVariableDeclaration1.ts:1:1]
  1 │ \ declare var v;
    · ─────────
+   ╰────
+
+  × Identifier `x` has already been declared
+   ╭─[compiler/sourceMapValidationEnums.ts:2:1]
+ 2 │ enum e {
+ 3 │     x,
+   ·     ┬
+   ·     ╰── `x` has already been declared here
+ 4 │     y,
+ 5 │     x
+   ·     ┬
+   ·     ╰── It can not be redeclared here
+ 6 │ }
    ╰────
 
   × 'with' statements are not allowed
@@ -19003,6 +19156,28 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  7 │ type object = I;
    ╰────
   help: Try insert a semicolon here
+
+  × Identifier `A` has already been declared
+   ╭─[conformance/types/typeAliases/typeAliasesDoNotMerge.ts:1:1]
+ 1 │ export type A = {}
+   ·             ┬
+   ·             ╰── `A` has already been declared here
+ 2 │ type A = {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `T2` has already been declared
+    ╭─[conformance/types/typeAliases/typeAliasesForObjectTypes.ts:9:1]
+  9 │ // An interface can have multiple merged declarations, but a type alias for an object type literal cannot.
+ 10 │ type T2 = { x: string }
+    ·      ─┬
+    ·       ╰── `T2` has already been declared here
+ 11 │ type T2 = { y: number }
+    ·      ─┬
+    ·       ╰── It can not be redeclared here
+ 12 │ 
+    ╰────
 
   × Unexpected token
     ╭─[conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts:20:1]


### PR DESCRIPTION
Fixes 11 TS conformance tests and 18 babel tests.

Adds types to the symbol table functionally conformant to TS behavior but symbol flags implemented slightly differently.

Symbol redeclaration check is also not entirely conformant but fixing this seems like a separate PR.

For testing purposes - consistent-export-type was also implemented (WIP).

Major TODOs:
* Fully implement consistent type exports - (good enough at this point imo)
* Computed property names of enums is currently unimplemented - (This seems out of scope to properly implement actually)
* Tests/Documentation - (If you want me to write tests let me know where but I think conformance tests are good for now?)

