### PR TITLE
feat(linter): enable module record builder

### DIFF
--- a/crates/oxc_cli/src/lint/isolated_handler.rs
+++ b/crates/oxc_cli/src/lint/isolated_handler.rs
@@ -169,6 +169,7 @@ impl IsolatedLintHandler {
         let semantic_ret = SemanticBuilder::new(&source_text, source_type)
             .with_trivias(&ret.trivias)
             .with_check_syntax_error(true)
+            .with_module_record_builder(true)
             .build(program);
 
         if !semantic_ret.errors.is_empty() {

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -136,6 +136,7 @@ impl Tester {
         let program = allocator.alloc(ret.program);
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
             .with_trivias(&ret.trivias)
+            .with_module_record_builder(true)
             .build(program);
         assert!(semantic_ret.errors.is_empty(), "{:?}", &semantic_ret.errors);
         let rule = RULES

--- a/tasks/benchmark/src/main.rs
+++ b/tasks/benchmark/src/main.rs
@@ -112,7 +112,9 @@ fn bench_semantic(criterion: &mut Criterion, files: &[&TestFile]) {
                 let ret = Parser::new(&allocator, source_text, SourceType::default()).parse();
                 let program = allocator.alloc(ret.program);
                 b.iter_with_large_drop(|| {
-                    SemanticBuilder::new(source_text, source_type).build(program)
+                    SemanticBuilder::new(source_text, source_type)
+                        .with_module_record_builder(true)
+                        .build(program)
                 });
             },
         );


### PR DESCRIPTION
Experiment to see what effects turning on module record builder has on semantic analysis runtime.