### PR TITLE
eat(linter): implement `no-useless-backreference`

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -69,6 +69,7 @@ mod eslint {
     pub mod require_yield;
     pub mod use_isnan;
     pub mod valid_typeof;
+    pub mod no_useless_backreference;
 }
 
 mod typescript {
@@ -146,6 +147,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_unsafe_negation,
     eslint::no_unsafe_optional_chaining,
     eslint::no_unused_labels,
+    eslint::no_useless_backreference,
     eslint::no_useless_catch,
     eslint::no_useless_escape,
     eslint::require_yield,

--- a/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
@@ -1,0 +1,49 @@
+use oxc_ast::AstKind;
+
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint(no-useless-backreference): Unnecessary backreference {0:?}")]
+#[diagnostic(severity(warning))]
+struct NoUselessBackreferenceDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUselessBackreference;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Example
+    /// ```javascript
+    /// ```
+    NoUselessBackreference,
+    correctness
+);
+
+impl Rule for NoUselessBackreference {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::RegExpLiteral(reg_exp) = node.kind() else { return };
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["/^(?:(a)|(b)\\2)$/;"];
+
+    let fail = vec!["/^(?:(a)|\\1b)$/;"];
+
+    Tester::new_without_config(NoUselessBackreference::NAME, pass, fail).test_and_snapshot();
+}


### PR DESCRIPTION
close #622 

Note: current just draft PR.