### PR TITLE
fix(ast_lower): remove wrong usage of `SymbolFlags::Function`

### DIFF
--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -1438,7 +1438,6 @@ impl<'a> AstLower<'a> {
         } else {
             (SymbolFlags::empty(), SymbolFlags::empty())
         };
-        let includes = includes | SymbolFlags::Function;
         let id =
             func.id.as_ref().map(|ident| self.lower_binding_identifier(ident, includes, excludes));
         self.enter_function_scope();


### PR DESCRIPTION
closes #678

SymbolFlags::Function means something else (the whole function declaration stored as a anonymous symbol) in TypeScript