### PR TITLE
feat(semantic): add `node_id` to `Reference`

### DIFF
--- a/crates/oxc_ast_lower/src/lib.rs
+++ b/crates/oxc_ast_lower/src/lib.rs
@@ -50,7 +50,8 @@ impl<'a> AstLower<'a> {
         name: &Atom,
         reference_flag: ReferenceFlag,
     ) -> ReferenceId {
-        let reference = Reference::new(span, name.clone(), reference_flag);
+        let reference =
+            Reference::new(span, name.clone(), self.semantic.current_node_id, reference_flag);
         self.semantic.declare_reference(reference)
     }
 

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -90,7 +90,12 @@ impl<'a> Visit<'a> for ManglerBuilder<'a> {
     }
 
     fn visit_identifier_reference(&mut self, ident: &'a IdentifierReference) {
-        let reference = Reference::new(ident.span, ident.name.clone(), ReferenceFlag::read());
+        let reference = Reference::new(
+            ident.span,
+            ident.name.clone(),
+            self.semantic.current_node_id,
+            ReferenceFlag::read(),
+        );
         let reference_id = self.semantic.declare_reference(reference);
         ident.reference_id.replace(reference_id);
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -571,7 +571,7 @@ impl<'a> SemanticBuilder<'a> {
 
     fn reference_identifier(&mut self, ident: &IdentifierReference) {
         let flag = self.resolve_reference_usages();
-        let reference = Reference::new(ident.span, ident.name.clone(), flag);
+        let reference = Reference::new(ident.span, ident.name.clone(), self.current_node_id, flag);
         self.declare_reference(reference);
     }
 
@@ -655,8 +655,12 @@ impl<'a> SemanticBuilder<'a> {
                 JSXElementName::MemberExpression(expr) => Some(expr.get_object_identifier()),
                 _ => None,
             } {
-                let reference =
-                    Reference::new(ident.span, ident.name.clone(), ReferenceFlag::read());
+                let reference = Reference::new(
+                    ident.span,
+                    ident.name.clone(),
+                    self.current_node_id,
+                    ReferenceFlag::read(),
+                );
                 self.declare_reference(reference);
             }
         }

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 use oxc_index::define_index_type;
 use oxc_span::{Atom, Span};
 
-use crate::symbol::SymbolId;
+use crate::{symbol::SymbolId, AstNodeId};
 
 define_index_type! {
     pub struct ReferenceId = u32;
@@ -13,6 +13,7 @@ pub struct Reference {
     span: Span,
     /// The name of the identifier that was referred to
     name: Atom,
+    node_id: AstNodeId,
     symbol_id: Option<SymbolId>,
     /// Describes how this referenced is used by other AST nodes. References can
     /// be reads, writes, or both.
@@ -20,8 +21,8 @@ pub struct Reference {
 }
 
 impl Reference {
-    pub fn new(span: Span, name: Atom, flag: ReferenceFlag) -> Self {
-        Self { span, name, symbol_id: None, flag }
+    pub fn new(span: Span, name: Atom, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
+        Self { span, name, node_id, symbol_id: None, flag }
     }
 
     pub fn span(&self) -> Span {
@@ -30,6 +31,10 @@ impl Reference {
 
     pub fn name(&self) -> &Atom {
         &self.name
+    }
+
+    pub fn node_id(&self) -> AstNodeId {
+        self.node_id
     }
 
     pub fn symbol_id(&self) -> Option<SymbolId> {


### PR DESCRIPTION
Closes #685 

Intend to use this in the following ways in #672.
```rs
let node = ctx.nodes().get_node(reference.node_id());
if !self.type_of && has_typeof_operator(node, ctx) {
    return;
}
```