### PR TITLE
fix(parser,semantic): make semantic own `Trivias`

### DIFF
--- a/crates/oxc_cli/src/lint/isolated_handler.rs
+++ b/crates/oxc_cli/src/lint/isolated_handler.rs
@@ -167,7 +167,7 @@ impl IsolatedLintHandler {
 
         let program = allocator.alloc(ret.program);
         let semantic_ret = SemanticBuilder::new(&source_text, source_type)
-            .with_trivias(&ret.trivias)
+            .with_trivias(ret.trivias)
             .with_check_syntax_error(true)
             .with_module_record_builder(true)
             .build(program);

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -33,7 +33,7 @@ fn main() {
 
     let program = allocator.alloc(ret.program);
     let semantic_ret =
-        SemanticBuilder::new(&source_text, source_type).with_trivias(&ret.trivias).build(program);
+        SemanticBuilder::new(&source_text, source_type).with_trivias(ret.trivias).build(program);
 
     let mut errors: Vec<oxc_diagnostics::Error> = vec![];
 

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -135,7 +135,7 @@ impl Tester {
         assert!(ret.errors.is_empty(), "{:?}", &ret.errors);
         let program = allocator.alloc(ret.program);
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(&ret.trivias)
+            .with_trivias(ret.trivias)
             .with_module_record_builder(true)
             .build(program);
         assert!(semantic_ret.errors.is_empty(), "{:?}", &semantic_ret.errors);

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use oxc_ast::Trivias;
 use oxc_span::Span;
 
@@ -9,8 +7,8 @@ pub struct TriviaBuilder {
 }
 
 impl TriviaBuilder {
-    pub fn build(self) -> Rc<Trivias> {
-        Rc::new(self.trivias)
+    pub fn build(self) -> Trivias {
+        self.trivias
     }
 
     pub fn add_single_line_comment(&mut self, start: u32, end: u32) {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -73,8 +73,6 @@ mod ts;
 mod diagnostics;
 mod lexer;
 
-use std::rc::Rc;
-
 use context::{Context, StatementContext};
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::Program, AstBuilder, Trivias};
@@ -94,7 +92,7 @@ use crate::{
 pub struct ParserReturn<'a> {
     pub program: Program<'a>,
     pub errors: Vec<Error>,
-    pub trivias: Rc<Trivias>,
+    pub trivias: Trivias,
     pub panicked: bool,
 }
 

--- a/crates/oxc_query/examples/simple.rs
+++ b/crates/oxc_query/examples/simple.rs
@@ -22,7 +22,7 @@ fn main() {
 
     let program = allocator.alloc(ret.program);
     let semantic_ret =
-        SemanticBuilder::new(&source_text, source_type).with_trivias(&ret.trivias).build(program);
+        SemanticBuilder::new(&source_text, source_type).with_trivias(ret.trivias).build(program);
 
     let adapter = Adapter::new(Rc::new(semantic_ret.semantic), vec![Some("index".to_string())]);
 

--- a/crates/oxc_query/src/tests.rs
+++ b/crates/oxc_query/src/tests.rs
@@ -17,7 +17,7 @@ fn run_query<T: for<'de> serde::Deserialize<'de> + std::cmp::Ord>(
     let ret = Parser::new(&allocator, code, source_type).parse();
     let program = allocator.alloc(ret.program);
     let semantic_ret =
-        SemanticBuilder::new(code, source_type).with_trivias(&ret.trivias).build(program);
+        SemanticBuilder::new(code, source_type).with_trivias(ret.trivias).build(program);
 
     let adapter = Adapter {
         path_components: vec![Some("index".to_string())],
@@ -199,7 +199,7 @@ fn test_invariants() {
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = allocator.alloc(ret.program);
     let semantic_ret =
-        SemanticBuilder::new(source_text, source_type).with_trivias(&ret.trivias).build(program);
+        SemanticBuilder::new(source_text, source_type).with_trivias(ret.trivias).build(program);
 
     let adapter = Adapter { path_components: vec![], semantic: Rc::new(semantic_ret.semantic) };
     check_adapter_invariants(schema(), &adapter);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -106,9 +106,10 @@ impl<'a> SemanticBuilder<'a> {
     }
 
     #[must_use]
-    pub fn with_trivias(mut self, trivias: &Rc<Trivias>) -> Self {
-        self.trivias = Rc::clone(trivias);
-        self.jsdoc = JSDocBuilder::new(self.source_text, trivias);
+    pub fn with_trivias(mut self, trivias: Trivias) -> Self {
+        let trivias = Rc::new(trivias);
+        self.trivias = Rc::clone(&trivias);
+        self.jsdoc = JSDocBuilder::new(self.source_text, &trivias);
         self
     }
 

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -83,7 +83,7 @@ mod test {
         let ret = Parser::new(allocator, source_text, source_type).parse();
         let program = allocator.alloc(ret.program);
         let semantic = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(&ret.trivias)
+            .with_trivias(ret.trivias)
             .build(program)
             .semantic;
         let jsdoc = semantic.jsdoc();

--- a/crates/oxc_semantic/src/module_record/mod.rs
+++ b/crates/oxc_semantic/src/module_record/mod.rs
@@ -18,7 +18,7 @@ mod module_record_tests {
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let program = allocator.alloc(ret.program);
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(&ret.trivias)
+            .with_trivias(ret.trivias)
             .with_module_record_builder(true)
             .build(program);
         semantic_ret.semantic.module_record

--- a/crates/oxc_semantic/tests/util/mod.rs
+++ b/crates/oxc_semantic/tests/util/mod.rs
@@ -85,7 +85,7 @@ impl SemanticTester {
         let program = self.allocator.alloc(parse.program);
         let semantic_ret = SemanticBuilder::new(self.source_text, self.source_type)
             .with_check_syntax_error(true)
-            .with_trivias(&parse.trivias)
+            .with_trivias(parse.trivias)
             .with_module_record_builder(self.use_module_record_builder)
             .build(program);
 

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -173,15 +173,13 @@ impl Oxc {
 
         if run_options.syntax() && !run_options.lint() {
             let semantic_ret = SemanticBuilder::new(source_text, source_type)
-                .with_trivias(&ret.trivias)
+                .with_trivias(ret.trivias)
                 .with_check_syntax_error(true)
                 .build(program);
             self.save_diagnostics(semantic_ret.errors);
-        }
-
-        if run_options.lint() {
+        } else if run_options.lint() {
             let semantic_ret = SemanticBuilder::new(source_text, source_type)
-                .with_trivias(&ret.trivias)
+                .with_trivias(ret.trivias)
                 .with_check_syntax_error(true)
                 .build(program);
             self.save_diagnostics(semantic_ret.errors);

--- a/editor/vscode/server/src/linter.rs
+++ b/editor/vscode/server/src/linter.rs
@@ -238,7 +238,7 @@ impl IsolatedLintHandler {
 
         let program = allocator.alloc(ret.program);
         let semantic_ret = SemanticBuilder::new(&source_text, source_type)
-            .with_trivias(&ret.trivias)
+            .with_trivias(ret.trivias)
             .with_check_syntax_error(true)
             .build(program);
 

--- a/tasks/coverage/src/suite.rs
+++ b/tasks/coverage/src/suite.rs
@@ -281,7 +281,7 @@ pub trait Case: Sized + Sync + Send + UnwindSafe {
 
         let program = allocator.alloc(parser_ret.program);
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(&parser_ret.trivias)
+            .with_trivias(parser_ret.trivias)
             .with_module_record_builder(true)
             .with_check_syntax_error(true)
             .build(program);


### PR DESCRIPTION
closes #708

Making the parser return Rc<Trivias> is not a good API, and ideally `Semantic` should just own `Trivias` so it can process or mutate it.