### PR TITLE
chore(parser): add an AST `Send` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1436,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ba07320d39dfea882faa70554b4bd342a5f273ed59ba7c1c6b4c840492c954"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1742,7 @@ dependencies = [
  "bitflags 2.3.3",
  "miette",
  "num-bigint",
+ "ouroboros",
  "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -31,3 +31,4 @@ num-bigint = { workspace = true }
 oxc_ast    = { workspace = true, features = ["serde"] }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 serde_json = { workspace = true }
+ouroboros  = "0.17.2" # for `multi-thread` example

--- a/crates/oxc_parser/examples/multi-thread.rs
+++ b/crates/oxc_parser/examples/multi-thread.rs
@@ -1,0 +1,84 @@
+//! Parse files in parallel and then `Send` them to the main thread for processing.
+
+#![allow(clippy::future_not_send)] // clippy warns `Allocator` is not `Send`
+#![allow(clippy::redundant_pub_crate)] // comes from  `ouroboros`'s macro
+
+// Instruction:
+// run `cargo run -p oxc_parser --example multi-thread`
+// or `cargo watch -x "run -p oxc_parser --example multi-thread"`
+
+use std::sync::mpsc;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{sync::Arc, thread};
+
+/// Wrap the AST for unsafe `Send` and `Sync`
+struct BumpaloProgram<'a>(Program<'a>);
+
+// SAFETY: It is now our responsibility to never simultaneously mutate the AST across threads.
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl<'a> Send for BumpaloProgram<'a> {}
+unsafe impl<'a> Sync for BumpaloProgram<'a> {}
+
+/// `ouroboros` is used to "bind" the allocator and AST together to remove the lifetime.
+#[ouroboros::self_referencing]
+struct AST {
+    index: usize,
+    allocator: Allocator,
+    source_text: Arc<str>,
+    #[borrows(allocator, source_text)]
+    #[not_covariant]
+    ast: &'this BumpaloProgram<'this>,
+}
+
+/// Example output:
+/// ```
+/// sent ast(0) in ThreadId(2) at 1691652865800
+/// sent ast(1) in ThreadId(3) at 1691652865801
+/// sent ast(2) in ThreadId(4) at 1691652865801
+/// received ast(0) in ThreadId(1) at 1691652865801
+/// received ast(1) in ThreadId(1) at 1691652865801
+/// received ast(2) in ThreadId(1) at 1691652865801
+/// ```
+fn main() {
+    let (ast_tx, ast_rx) = mpsc::channel::<AST>();
+    let sources = (0..3).map(|i| Arc::from(format!("const a = {i};"))).collect::<Vec<_>>();
+
+    // Construct AST from different threads
+    for (index, source_text) in sources.iter().enumerate() {
+        let ast_tx = ast_tx.clone();
+        let source_text = Arc::clone(source_text);
+
+        _ = thread::spawn(move || {
+            let ast = ASTBuilder {
+                index,
+                allocator: Allocator::default(),
+                source_text,
+                ast_builder: |allocator, source_text| {
+                    let ret = Parser::new(allocator, source_text, SourceType::default()).parse();
+                    allocator.alloc(BumpaloProgram(ret.program))
+                },
+            }
+            .build();
+
+            ast_tx.send(ast).unwrap();
+            println!("sent ast({index}) in {:?} at {}", thread::current().id(), timestamp());
+        })
+        .join();
+    }
+
+    // Collect all ASTs on the main thread
+    for _ in 0..sources.len() {
+        let ast = ast_rx.recv().unwrap();
+        let index = ast.borrow_index();
+        println!("received ast({index}) in {:?} at {}", thread::current().id(), timestamp());
+    }
+}
+
+fn timestamp() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()
+}


### PR DESCRIPTION
relates #709

The allocator and lifetime gets in the way if we want to parse in parallel but process them in a single thread.

This example uses `ouroboros` to provide a safe API for working with this unsafe behavior.