### PR TITLE
feat(query): add many types to oxc_query

### DIFF
--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -96,6 +96,11 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 property_name.as_ref(),
                 resolve_info,
             ),
+            "DotPropertyAST" | "DotProperty" => super::properties::resolve_dot_property_property(
+                contexts,
+                property_name.as_ref(),
+                resolve_info,
+            ),
             "Expression" => super::properties::resolve_expression_property(
                 contexts,
                 property_name.as_ref(),
@@ -243,6 +248,13 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 edge_name.as_ref(),
                 parameters,
                 resolve_info,
+            ),
+            "DotPropertyAST" | "DotProperty" => super::edges::resolve_dot_property_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
+                self,
             ),
             "DefaultImport" => super::edges::resolve_default_import_edge(
                 contexts,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -269,6 +269,13 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
+            "IfStatementAST" => super::edges::resolve_if_statement_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
+                self,
+            ),
             "Import" | "ImportAST" => super::edges::resolve_import_edge(
                 contexts,
                 edge_name.as_ref(),

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -385,6 +385,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 edge_name.as_ref(),
                 parameters,
                 resolve_info,
+                self,
             ),
             "ObjectLiteral" | "ObjectLiteralAST" => super::edges::resolve_object_literal_edge(
                 contexts,
@@ -392,6 +393,12 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
                 self,
+            ),
+            "ObjectProperty" => super::edges::resolve_object_property_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
             ),
             "PathPart" => super::edges::resolve_path_part_edge(
                 contexts,
@@ -425,6 +432,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                     edge_name.as_ref(),
                     parameters,
                     resolve_info,
+                    self,
                 )
             }
             "TypeAnnotation" | "TypeAnnotationAST" => super::edges::resolve_type_annotation_edge(

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -368,7 +368,7 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 resolve_info,
                 self,
             ),
-            "ObjectEntry" => super::edges::resolve_object_entry_edge(
+            "ObjectEntryAST" | "ObjectEntry" => super::edges::resolve_object_entry_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,
@@ -407,12 +407,14 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "SpreadIntoObject" => super::edges::resolve_spread_into_object_edge(
-                contexts,
-                edge_name.as_ref(),
-                parameters,
-                resolve_info,
-            ),
+            "SpreadIntoObjectAST" | "SpreadIntoObject" => {
+                super::edges::resolve_spread_into_object_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                )
+            }
             "TypeAnnotation" | "TypeAnnotationAST" => super::edges::resolve_type_annotation_edge(
                 contexts,
                 edge_name.as_ref(),

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -143,6 +143,11 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 property_name.as_ref(),
                 resolve_info,
             ),
+            "NameAST" | "Name" => super::properties::resolve_name_property(
+                contexts,
+                property_name.as_ref(),
+                resolve_info,
+            ),
             "NumberLiteralAST" | "NumberLiteral" => {
                 super::properties::resolve_number_literal_property(
                     contexts,
@@ -341,6 +346,13 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 edge_name.as_ref(),
                 parameters,
                 resolve_info,
+            ),
+            "NameAST" | "Name" => super::edges::resolve_name_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
+                self,
             ),
             "NumberLiteralAST" | "NumberLiteral" => super::edges::resolve_number_literal_edge(
                 contexts,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -349,6 +349,12 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 resolve_info,
                 self,
             ),
+            "ObjectEntry" => super::edges::resolve_object_entry_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
+            ),
             "ObjectLiteral" | "ObjectLiteralAST" => super::edges::resolve_object_literal_edge(
                 contexts,
                 edge_name.as_ref(),
@@ -377,6 +383,12 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 resolve_info,
             ),
             "SpecificImport" => super::edges::resolve_specific_import_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
+            ),
+            "SpreadIntoObject" => super::edges::resolve_spread_into_object_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -1375,7 +1375,7 @@ pub(super) fn resolve_number_literal_edge<'a, 'b: 'a>(
         "parent" => parents(contexts, adapter),
         _ => {
             unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'MemberExtend'"
+                "attempted to resolve unexpected edge '{edge_name}' on type 'NumberLiteral'"
             )
         }
     }

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -1277,6 +1277,38 @@ mod member_extend {
     }
 }
 
+pub(super) fn resolve_name_edge<'a, 'b: 'a>(
+    contexts: ContextIterator<'a, Vertex<'b>>,
+    edge_name: &str,
+    _parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
+) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+    match edge_name {
+        "span" => name::span(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
+        _ => {
+            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Name'")
+        }
+    }
+}
+
+mod name {
+    use trustfall::provider::{
+        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
+    };
+
+    use super::{super::vertex::Vertex, get_span};
+
+    pub(super) fn span<'a, 'b: 'a>(
+        contexts: ContextIterator<'a, Vertex<'b>>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+        get_span(contexts)
+    }
+}
+
 pub(super) fn resolve_number_literal_edge<'a, 'b: 'a>(
     contexts: ContextIterator<'a, Vertex<'b>>,
     edge_name: &str,

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -1478,15 +1478,16 @@ pub(super) fn resolve_object_entry_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "span" => object_entry::span(contexts, resolve_info),
         "key" => object_entry::key(contexts, resolve_info),
         "value" => object_entry::value(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
         _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'MemberExtend'"
-            )
+            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'ObjectEntry'")
         }
     }
 }
@@ -1653,6 +1654,35 @@ mod object_literal {
                 }
             }))
         })
+    }
+}
+
+pub(super) fn resolve_object_property_edge<'a, 'b: 'a>(
+    contexts: ContextIterator<'a, Vertex<'b>>,
+    edge_name: &str,
+    _parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+    match edge_name {
+        "span" => object_property::span(contexts, resolve_info),
+        _ => {
+            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Name'")
+        }
+    }
+}
+
+mod object_property {
+    use trustfall::provider::{
+        ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo, VertexIterator,
+    };
+
+    use super::{super::vertex::Vertex, get_span};
+
+    pub(super) fn span<'a, 'b: 'a>(
+        contexts: ContextIterator<'a, Vertex<'b>>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+        get_span(contexts)
     }
 }
 
@@ -1854,10 +1884,13 @@ pub(super) fn resolve_spread_into_object_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "span" => resolve_spread_into_object_edge::span(contexts, resolve_info),
         "value" => resolve_spread_into_object_edge::value(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
         _ => {
             unreachable!(
                 "attempted to resolve unexpected edge '{edge_name}' on type 'SpreadIntoObject'"

--- a/crates/oxc_query/src/properties.rs
+++ b/crates/oxc_query/src/properties.rs
@@ -430,7 +430,7 @@ pub(super) fn resolve_number_literal_property<'a, 'b: 'a>(
         }),
         _ => {
             unreachable!(
-                "attempted to read unexpected property '{property_name}' on type 'MemberExtend'"
+                "attempted to read unexpected property '{property_name}' on type 'NumberLiteral'"
             )
         }
     }

--- a/crates/oxc_query/src/properties.rs
+++ b/crates/oxc_query/src/properties.rs
@@ -196,6 +196,23 @@ pub(super) fn resolve_default_import_property<'a, 'b: 'a>(
     }
 }
 
+pub(super) fn resolve_dot_property_property<'a, 'b: 'a>(
+    contexts: ContextIterator<'a, Vertex<'b>>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'b>, FieldValue> {
+    match property_name {
+        "as_constant_string" => resolve_property_with(contexts, |v| {
+            v.as_constant_string().map_or(FieldValue::Null, Into::into)
+        }),
+        _ => {
+            unreachable!(
+                "attempted to read unexpected property '{property_name}' on type 'DotProperty'"
+            )
+        }
+    }
+}
+
 pub(super) fn resolve_expression_property<'a, 'b: 'a>(
     contexts: ContextIterator<'a, Vertex<'b>>,
     property_name: &str,

--- a/crates/oxc_query/src/properties.rs
+++ b/crates/oxc_query/src/properties.rs
@@ -384,6 +384,26 @@ pub(super) fn resolve_member_extend_property<'a, 'b: 'a>(
     }
 }
 
+pub(super) fn resolve_name_property<'a, 'b: 'a>(
+    contexts: ContextIterator<'a, Vertex<'b>>,
+    property_name: &str,
+    _resolve_info: &ResolveInfo,
+) -> ContextOutcomeIterator<'a, Vertex<'b>, FieldValue> {
+    match property_name {
+        "name" => resolve_property_with(contexts, |v| {
+            v.as_name()
+                .unwrap_or_else(|| panic!("expected to have a name vertex, instead have: {v:#?}"))
+                .name
+                .name
+                .to_string()
+                .into()
+        }),
+        _ => {
+            unreachable!("attempted to read unexpected property '{property_name}' on type 'Name'")
+        }
+    }
+}
+
 pub(super) fn resolve_number_literal_property<'a, 'b: 'a>(
     contexts: ContextIterator<'a, Vertex<'b>>,
     property_name: &str,

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -501,6 +501,17 @@ type ClassAST implements ASTNode & Class & HasSpan {
   span: Span!
 }
 
+type IfStatementAST implements ASTNode & HasSpan {
+  condition: Expression!
+
+  # ASTNode
+  parent: ASTNode
+  ancestor: [ASTNode!]!
+
+  # HasSpan
+  span: Span!
+}
+
 type ReturnStatementAST implements ASTNode & HasSpan {
   expression: Expression
 

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -326,8 +326,29 @@ interface JSXElement implements Expression & HasSpan {
   span: Span!
 }
 
+interface ObjectProperty implements HasSpan {
+  # HasSpan
+  span: Span!
+}
+
+type SpreadIntoObject implements ObjectProperty & HasSpan {
+  spread: Expression!
+
+  # HasSpan
+  span: Span!
+}
+
+type ObjectEntry implements ObjectProperty & HasSpan {
+  key: Expression!
+  value: Expression!
+
+  # HasSpan
+  span: Span!
+}
+
 interface ObjectLiteral implements Expression & HasSpan {
   value(key: String!): [Expression!]!
+  entry: [ObjectEntry!]!
 
   # Expression
   as_constant_string: String
@@ -337,6 +358,7 @@ interface ObjectLiteral implements Expression & HasSpan {
 
 type ObjectLiteralAST implements ObjectLiteral & Expression & HasSpan & ASTNode {
   value(key: String!): [Expression!]!
+  entry: [ObjectEntry!]!
 
   # Expression
   as_constant_string: String

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -369,6 +369,21 @@ type ObjectLiteralAST implements ObjectLiteral & Expression & HasSpan & ASTNode 
   span: Span!
 }
 
+interface Name implements HasSpan {
+  name: String!
+  # HasSpan
+  span: Span!
+}
+
+type NameAST implements ASTNode & Name & HasSpan {
+  name: String!
+  # ASTNode
+  parent: ASTNode
+  ancestor: [ASTNode!]!
+  # HasSpan
+  span: Span!
+}
+
 interface Expression implements HasSpan {
   """
   Only non-null if the string can be trivially coerced to a constant string

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -347,7 +347,7 @@ type ObjectEntry implements ObjectProperty & HasSpan {
 }
 
 interface ObjectLiteral implements Expression & HasSpan {
-  value(key: String!): [Expression!]!
+  value(key: String!): Expression
   entry: [ObjectEntry!]!
 
   # Expression
@@ -357,7 +357,7 @@ interface ObjectLiteral implements Expression & HasSpan {
 }
 
 type ObjectLiteralAST implements ObjectLiteral & Expression & HasSpan & ASTNode {
-  value(key: String!): [Expression!]!
+  value(key: String!): Expression
   entry: [ObjectEntry!]!
 
   # Expression

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -407,6 +407,39 @@ type NameAST implements ASTNode & Name & HasSpan {
   span: Span!
 }
 
+interface DotProperty implements HasSpan & Expression {
+  """
+  In "data.user.name", this would be "data.user"
+  """
+  called_on: Expression!
+  """
+  In "data.user.name", this would be "name"
+  """
+  accessed_property: Name!
+  # Expression
+  as_constant_string: String
+  # HasSpan
+  span: Span!
+}
+
+type DotPropertyAST implements DotProperty & ASTNode & HasSpan & Expression {
+  """
+  In "data.user.name", this would be "data.user"
+  """
+  called_on: Expression!
+  """
+  In "data.user.name", this would be "name"
+  """
+  accessed_property: Name!
+  # ASTNode
+  parent: ASTNode
+  ancestor: [ASTNode!]!
+  # Expression
+  as_constant_string: String
+  # HasSpan
+  span: Span!
+}
+
 interface Expression implements HasSpan {
   """
   Only non-null if the string can be trivially coerced to a constant string

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -331,14 +331,25 @@ interface ObjectProperty implements HasSpan {
   span: Span!
 }
 
-type SpreadIntoObject implements ObjectProperty & HasSpan {
-  spread: Expression!
+interface SpreadIntoObject implements ObjectProperty & HasSpan {
+  value: Expression!
 
   # HasSpan
   span: Span!
 }
 
-type ObjectEntry implements ObjectProperty & HasSpan {
+type SpreadIntoObjectAST implements ASTNode & SpreadIntoObject & ObjectProperty & HasSpan {
+  value: Expression!
+
+  # ASTNode
+  parent: ASTNode
+  ancestor: [ASTNode!]!
+
+  # HasSpan
+  span: Span!
+}
+
+interface ObjectEntry implements ObjectProperty & HasSpan {
   key: Expression!
   value: Expression!
 
@@ -346,9 +357,21 @@ type ObjectEntry implements ObjectProperty & HasSpan {
   span: Span!
 }
 
+type ObjectEntryAST implements ASTNode & ObjectEntry & ObjectProperty & HasSpan {
+  key: Expression!
+  value: Expression!
+
+  # ASTNode
+  parent: ASTNode
+  ancestor: [ASTNode!]!
+
+  # HasSpan
+  span: Span!
+}
+
 interface ObjectLiteral implements Expression & HasSpan {
   value(key: String!): Expression
-  entry: [ObjectEntry!]!
+  entry: [ObjectProperty!]!
 
   # Expression
   as_constant_string: String
@@ -358,7 +381,7 @@ interface ObjectLiteral implements Expression & HasSpan {
 
 type ObjectLiteralAST implements ObjectLiteral & Expression & HasSpan & ASTNode {
   value(key: String!): Expression
-  entry: [ObjectEntry!]!
+  entry: [ObjectProperty!]!
 
   # Expression
   as_constant_string: String

--- a/crates/oxc_query/src/vertex.rs
+++ b/crates/oxc_query/src/vertex.rs
@@ -7,8 +7,8 @@ use oxc_ast::{
         ImportDefaultSpecifier, ImportSpecifier, JSXAttribute, JSXElement, JSXExpressionContainer,
         JSXFragment, JSXOpeningElement, JSXSpreadAttribute, JSXSpreadChild, JSXText,
         MemberExpression, MethodDefinition, ModuleDeclaration, NumberLiteral, ObjectExpression,
-        PropertyDefinition, ReturnStatement, TSInterfaceDeclaration, TSType, TSTypeAnnotation,
-        VariableDeclarator,
+        ObjectPropertyKind, PropertyDefinition, ReturnStatement, TSInterfaceDeclaration, TSType,
+        TSTypeAnnotation, VariableDeclarator,
     },
     AstKind,
 };
@@ -52,6 +52,8 @@ pub enum Vertex<'a> {
     Url(Rc<Url>),
     VariableDeclaration(Rc<VariableDeclarationVertex<'a>>),
     ReturnStatementAST(Rc<ReturnStatementVertex<'a>>),
+    SpreadIntoObject(&'a ObjectPropertyKind<'a>),
+    ObjectEntry(&'a ObjectPropertyKind<'a>),
 }
 
 impl<'a> Vertex<'a> {
@@ -79,6 +81,8 @@ impl<'a> Vertex<'a> {
             Self::JSXSpreadChild(data) => data.span,
             Self::JSXText(data) => data.span,
             Self::ObjectLiteral(data) => data.object_expression.span,
+            Self::SpreadIntoObject(data) => data.span(),
+            Self::ObjectEntry(data) => data.span(),
             Self::SpecificImport(data) => data.span,
             Self::TypeAnnotation(data) => data.type_annotation.span,
             Self::Type(data) => data.span(),
@@ -126,6 +130,8 @@ impl<'a> Vertex<'a> {
             | Vertex::SpecificImport(_)
             | Vertex::Span(_)
             | Vertex::SearchParameter(_)
+            | Vertex::SpreadIntoObject(_)
+            | Vertex::ObjectEntry(_)
             | Vertex::ClassProperty(_) => None,
         }
     }
@@ -182,6 +188,8 @@ impl Typename for Vertex<'_> {
             Vertex::Url(_) => "URL",
             Vertex::VariableDeclaration(vd) => vd.typename(),
             Vertex::ReturnStatementAST(_) => "ReturnStatementAST",
+            Vertex::SpreadIntoObject(_) => "SpreadIntoObject",
+            Vertex::ObjectEntry(_) => "ObjectEntry",
         }
     }
 }


### PR DESCRIPTION
Adds `Name(AST)?`, `IfStatementAST`, `SpreadIntoObject(AST)?`, `ObjectEntry(AST)?`, `DotProperty(AST)?` types

Fixes `ObjectLiteral`'s value field's output type

Added `entry` field to `ObjectLiteral(AST)?`