### PR TITLE
fix(website): convert utf8 <> utf16 span for correct unicode hover display

### DIFF
--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -75,6 +75,7 @@ const setStringToStorage = (whatToSet, value) => {
 
 class Playground {
   oxc;
+  sourceTextUtf8 // source text in Uint8Array, for converting from utf8 to utf16 span
 
   runOptions;
   parserOptions;
@@ -119,6 +120,7 @@ class Playground {
     const sourceText = text;
     this.urlParams.updateCode(sourceText);
     this.oxc.sourceText = sourceText;
+    this.sourceTextUtf8 = new TextEncoder().encode(sourceText);
     this.updateView();
   }
 
@@ -639,11 +641,15 @@ query {
       }
     }
     // if we didn't find a start or an end, return early
-    if (start === undefined || end === undefined) return;
+    if (start == undefined || end == undefined) return;
+
+    // convert utf8 to utf16 span so they show correctly in the editor
+    start = new TextDecoder().decode(this.sourceTextUtf8.slice(0, start)).length;
+    end = new TextDecoder().decode(this.sourceTextUtf8.slice(0, end)).length;
 
     this.highlightEditorRange(
       this.editor,
-      EditorSelection.range(Number(start), Number(end))
+      EditorSelection.range(start, end)
     );
   }
 }


### PR DESCRIPTION
closes #426
closes #749

This fixes the unicode 16 issue but I'm not sure if this is the correct solution.