### PR TITLE
feat(query): Unify spread types, add ExpressionArrayElement, and ancestors is nullish now

### DIFF
--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -318,12 +318,11 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 resolve_info,
                 self,
             ),
-            "ArrayElementAST" | "ArrayElement" => super::edges::resolve_array_element_edge(
+            "ArrayElement" => super::edges::resolve_array_element_edge(
                 contexts,
                 edge_name.as_ref(),
                 parameters,
                 resolve_info,
-                self,
             ),
             "ArrowFunctionAST" | "ArrowFunction" => super::edges::resolve_arrow_function_edge(
                 contexts,
@@ -414,6 +413,15 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
+            "ExpressionArrayElementAST" | "ExpressionArrayElement" => {
+                super::edges::resolve_expression_array_element_edge(
+                    contexts,
+                    edge_name.as_ref(),
+                    parameters,
+                    resolve_info,
+                    self,
+                )
+            }
             "ExpressionStatementAST" | "ExpressionStatement" => {
                 super::edges::resolve_expression_statement_edge(
                     contexts,

--- a/crates/oxc_query/src/adapter.rs
+++ b/crates/oxc_query/src/adapter.rs
@@ -669,23 +669,13 @@ impl<'a, 'b: 'a> trustfall::provider::Adapter<'a> for &'a Adapter<'b> {
                 parameters,
                 resolve_info,
             ),
-            "SpreadArrayElementAST" | "SpreadArrayElement" => {
-                super::edges::resolve_spread_array_element_edge(
-                    contexts,
-                    edge_name.as_ref(),
-                    parameters,
-                    resolve_info,
-                )
-            }
-            "SpreadIntoObjectAST" | "SpreadIntoObject" => {
-                super::edges::resolve_spread_into_object_edge(
-                    contexts,
-                    edge_name.as_ref(),
-                    parameters,
-                    resolve_info,
-                    self,
-                )
-            }
+            "SpreadAST" | "Spread" => super::edges::resolve_spread_edge(
+                contexts,
+                edge_name.as_ref(),
+                parameters,
+                resolve_info,
+                self,
+            ),
             "Statement" => super::edges::resolve_statement_edge(
                 contexts,
                 edge_name.as_ref(),

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -2568,7 +2568,7 @@ mod object_literal {
     use super::{super::vertex::Vertex, get_span};
     use crate::{
         util::expr_to_maybe_const_string,
-        vertex::{ObjectEntryVertex, SpreadIntoObjectVertex},
+        vertex::{ObjectEntryVertex, SpreadVertex},
     };
 
     pub(super) fn span<'a, 'b: 'a>(
@@ -2626,9 +2626,7 @@ mod object_literal {
                     Vertex::ObjectEntry(ObjectEntryVertex { property, ast_node: None }.into())
                 }
                 oxc_ast::ast::ObjectPropertyKind::SpreadProperty(property) => {
-                    Vertex::SpreadIntoObject(
-                        SpreadIntoObjectVertex { property, ast_node: None }.into(),
-                    )
+                    Vertex::Spread(SpreadVertex { spread: property, ast_node: None }.into())
                 }
             }))
         })
@@ -3123,56 +3121,7 @@ mod specific_import {
     }
 }
 
-pub(super) fn resolve_spread_array_element_edge<'a, 'b: 'a>(
-    contexts: ContextIterator<'a, Vertex<'b>>,
-    edge_name: &str,
-    _parameters: &EdgeParameters,
-    resolve_info: &ResolveEdgeInfo,
-) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-    match edge_name {
-        "span" => spread_array_element::span(contexts, resolve_info),
-        "spread" => spread_array_element::spread(contexts, resolve_info),
-        _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'SpreadArrayElement'"
-            )
-        }
-    }
-}
-
-mod spread_array_element {
-    use trustfall::provider::{
-        resolve_neighbors_with, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
-        VertexIterator,
-    };
-
-    use super::{super::vertex::Vertex, get_span};
-
-    pub(super) fn spread<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        resolve_neighbors_with(contexts, |v| {
-            Box::new(std::iter::once(
-                (v.as_spread_array_element()
-                    .unwrap_or_else(|| {
-                        panic!("expected to have a spreadarrayelement vertex, instead have: {v:#?}")
-                    })
-                    .spread)
-                    .into(),
-            ))
-        })
-    }
-
-    pub(super) fn span<'a, 'b: 'a>(
-        contexts: ContextIterator<'a, Vertex<'b>>,
-        _resolve_info: &ResolveEdgeInfo,
-    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
-        get_span(contexts)
-    }
-}
-
-pub(super) fn resolve_spread_into_object_edge<'a, 'b: 'a>(
+pub(super) fn resolve_spread_edge<'a, 'b: 'a>(
     contexts: ContextIterator<'a, Vertex<'b>>,
     edge_name: &str,
     _parameters: &EdgeParameters,
@@ -3180,19 +3129,17 @@ pub(super) fn resolve_spread_into_object_edge<'a, 'b: 'a>(
     adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
-        "span" => resolve_spread_into_object_edge::span(contexts, resolve_info),
-        "value" => resolve_spread_into_object_edge::value(contexts, resolve_info),
+        "span" => spread::span(contexts, resolve_info),
+        "expression" => spread::expression(contexts, resolve_info),
         "ancestor" => ancestors(contexts, adapter),
         "parent" => parents(contexts, adapter),
         _ => {
-            unreachable!(
-                "attempted to resolve unexpected edge '{edge_name}' on type 'SpreadIntoObject'"
-            )
+            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Spread'")
         }
     }
 }
 
-mod resolve_spread_into_object_edge {
+mod spread {
     use trustfall::provider::{
         resolve_neighbors_with, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
         VertexIterator,
@@ -3200,17 +3147,15 @@ mod resolve_spread_into_object_edge {
 
     use super::{super::vertex::Vertex, get_span};
 
-    pub(super) fn value<'a, 'b: 'a>(
+    pub(super) fn expression<'a, 'b: 'a>(
         contexts: ContextIterator<'a, Vertex<'b>>,
         _resolve_info: &ResolveEdgeInfo,
     ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
         resolve_neighbors_with(contexts, |v| {
             let argument = &v
-                .as_spread_into_object()
-                .map_or_else(
-                    || panic!("expected to have a spreadintoobject vertex, instead have: {v:#?}"),
-                    |x| &x.property,
-                )
+                .as_spread()
+                .unwrap_or_else(|| panic!("expected to have a spread vertex, instead have: {v:#?}"))
+                .spread
                 .argument;
 
             Box::new(std::iter::once(argument.into()))

--- a/crates/oxc_query/src/edges.rs
+++ b/crates/oxc_query/src/edges.rs
@@ -26,12 +26,12 @@ pub(super) fn resolve_array_edge<'a, 'b: 'a>(
 }
 
 mod array {
+    use std::convert::Into;
+
     use trustfall::provider::{
         resolve_neighbors_with, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
         VertexIterator,
     };
-
-    use crate::vertex::{ArrayElementVertex, ElidedArrayElementVertex, SpreadArrayElementVertex};
 
     use super::super::vertex::Vertex;
 
@@ -48,29 +48,60 @@ mod array {
                     .array_expression
                     .elements
                     .iter()
-                    .map(|x| match x {
-                        oxc_ast::ast::ArrayExpressionElement::SpreadElement(spread) => {
-                            Vertex::SpreadArrayElement(
-                                SpreadArrayElementVertex {
-                                    ast_node: None,
-                                    spread: &spread.argument,
-                                }
-                                .into(),
-                            )
-                        }
-                        oxc_ast::ast::ArrayExpressionElement::Elision(span) => {
-                            Vertex::ElidedArrayElement(
-                                ElidedArrayElementVertex { ast_node: None, span: *span }.into(),
-                            )
-                        }
-                        oxc_ast::ast::ArrayExpressionElement::Expression(_) => {
-                            Vertex::ArrayElement(
-                                ArrayElementVertex { array_expression_element: x, ast_node: None }
-                                    .into(),
-                            )
-                        }
-                    }),
+                    .map(Into::into),
             )
+        })
+    }
+
+    pub(super) fn span<'a, 'b: 'a>(
+        contexts: ContextIterator<'a, Vertex<'b>>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+        super::get_span(contexts)
+    }
+}
+
+pub(super) fn resolve_expression_array_element_edge<'a, 'b: 'a>(
+    contexts: ContextIterator<'a, Vertex<'b>>,
+    edge_name: &str,
+    _parameters: &EdgeParameters,
+    resolve_info: &ResolveEdgeInfo,
+    adapter: &'a Adapter<'b>,
+) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+    match edge_name {
+        "span" => expression_array_element::span(contexts, resolve_info),
+        "expression" => expression_array_element::expression(contexts, resolve_info),
+        "ancestor" => ancestors(contexts, adapter),
+        "parent" => parents(contexts, adapter),
+        _ => {
+            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'ExpressionArrayElement'")
+        }
+    }
+}
+
+mod expression_array_element {
+    use trustfall::provider::{
+        resolve_neighbors_with, ContextIterator, ContextOutcomeIterator, ResolveEdgeInfo,
+        VertexIterator,
+    };
+
+    use super::super::vertex::Vertex;
+
+    pub(super) fn expression<'a, 'b: 'a>(
+        contexts: ContextIterator<'a, Vertex<'b>>,
+        _resolve_info: &ResolveEdgeInfo,
+    ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
+        resolve_neighbors_with(contexts, |v| {
+            Box::new(std::iter::once(
+                (v.as_expression_array_element()
+                    .unwrap_or_else(|| {
+                        panic!(
+                        "expected to have an expression_array_element vertex, instead have: {v:#?}"
+                    )
+                    })
+                    .expression)
+                    .into(),
+            ))
         })
     }
 
@@ -87,14 +118,13 @@ pub(super) fn resolve_array_element_edge<'a, 'b: 'a>(
     edge_name: &str,
     _parameters: &EdgeParameters,
     resolve_info: &ResolveEdgeInfo,
-    adapter: &'a Adapter<'b>,
 ) -> ContextOutcomeIterator<'a, Vertex<'b>, VertexIterator<'a, Vertex<'b>>> {
     match edge_name {
         "span" => array_element::span(contexts, resolve_info),
-        "ancestor" => ancestors(contexts, adapter),
-        "parent" => parents(contexts, adapter),
         _ => {
-            unreachable!("attempted to resolve unexpected edge '{edge_name}' on type 'Array'")
+            unreachable!(
+                "attempted to resolve unexpected edge '{edge_name}' on type 'ArrayElement'"
+            )
         }
     }
 }

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -340,7 +340,7 @@ type ArrayAST implements HasSpan & Expression & Array & ASTNode {
   element: [ArrayElement!]
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -378,7 +378,7 @@ type NumberLiteralAST implements HasSpan & ASTNode & Expression & NumberLiteral 
   number: Float
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -428,7 +428,7 @@ type SpreadIntoObjectAST implements ASTNode & SpreadIntoObject & ObjectProperty 
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # HasSpan
   span: Span!
@@ -448,7 +448,7 @@ type ObjectEntryAST implements ASTNode & ObjectEntry & ObjectProperty & HasSpan 
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # HasSpan
   span: Span!
@@ -480,7 +480,7 @@ type ObjectLiteralAST implements ObjectLiteral & Expression & HasSpan & ASTNode 
   strip_parens(strip_all: Boolean): Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -508,7 +508,7 @@ type ArgumentAST implements Argument & HasSpan & ASTNode {
   value: Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -539,7 +539,7 @@ type FnCallAST implements FnCall & Expression & HasSpan & ASTNode {
   strip_parens(strip_all: Boolean): Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -586,7 +586,7 @@ type ReassignmentAST implements HasSpan & ASTNode & Reassignment & Expression {
   span: Span!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 }
 
 interface Statement implements HasSpan {
@@ -608,7 +608,7 @@ type FunctionBodyAST implements HasSpan & ASTNode & FunctionBody {
   span: Span!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 }
 
 interface Function implements Expression & HasSpan {
@@ -667,7 +667,7 @@ type UnaryExpressionAST implements UnaryExpression & ASTNode & HasSpan & Express
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # Expression
   """
@@ -719,7 +719,7 @@ type LogicalExpressionAST implements LogicalExpression & ASTNode & HasSpan & Exp
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # Expression
   """
@@ -752,7 +752,7 @@ type ParameterAST implements ASTNode & HasSpan {
   span: Span!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 }
 
 interface ArrowFunction implements Function & HasSpan & Expression {
@@ -799,7 +799,7 @@ type ArrowFunctionAST implements Function & HasSpan & ArrowFunction & ASTNode & 
   span: Span!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 }
 
 """
@@ -848,7 +848,7 @@ type FnDeclarationAST implements Function & ASTNode & FnDeclaration & HasSpan & 
   parameter: [Parameter]!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   """
   Only non-null if the string can be trivially coerced to a constant string
@@ -881,7 +881,7 @@ type VarRefAST implements HasSpan & Expression & VarRef & ASTNode {
   declaration: ASTNode
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -912,7 +912,7 @@ Only includes strings declared with ' or " not `
 type StringLiteralAST implements HasSpan & Expression & ASTNode & StringLiteral {
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -937,7 +937,7 @@ interface TemplateLiteral implements HasSpan & Expression {
 type TemplateLiteralAST implements HasSpan & Expression & TemplateLiteral & ASTNode {
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -964,7 +964,7 @@ type RegExpLiteralAST implements HasSpan & Expression & RegExpLiteral & ASTNode 
   pattern: String!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -991,7 +991,7 @@ type ParenthesizedExpressionAST implements HasSpan & Expression & ASTNode & Pare
   expression: Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -1012,7 +1012,7 @@ type NameAST implements ASTNode & Name & HasSpan {
   name: String!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1047,7 +1047,7 @@ type DotPropertyAST implements DotProperty & ASTNode & HasSpan & Expression {
   accessed_property: Name!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -1083,7 +1083,7 @@ type ExpressionStatementAST implements Statement & HasSpan & ASTNode & Expressio
   expression: Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1100,7 +1100,7 @@ type WhileStatementAST implements Statement & HasSpan & ASTNode & WhileStatement
   body: Statement!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1117,7 +1117,7 @@ type DoWhileStatementAST implements Statement & HasSpan & ASTNode & DoWhileState
   body: Statement!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1136,7 +1136,7 @@ type ForStatementAST implements Statement & HasSpan & ForStatement & ASTNode {
   body: Statement!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1151,7 +1151,7 @@ type BlockStatementAST implements Statement & HasSpan & ASTNode & BlockStatement
   statement: [Statement!]
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1176,7 +1176,7 @@ type TernaryExpressionAST implements Expression & HasSpan & ASTNode & TernaryExp
   if_false: Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -1205,7 +1205,7 @@ type NewAST implements Expression & HasSpan & New & ASTNode {
   argument: [Argument!]
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -1232,7 +1232,7 @@ type ThrowAST implements Expression & HasSpan & Throw & ASTNode {
   to_throw: Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # Expression
   as_constant_string: String
   """
@@ -1257,7 +1257,7 @@ type VariableDeclarationAST implements VariableDeclaration & ASTNode & HasSpan {
   kind: String!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1266,7 +1266,7 @@ type TypeAnnotationAST implements TypeAnnotation & ASTNode & HasSpan {
   type: Type!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1278,7 +1278,7 @@ type InterfaceAST implements Interface & ASTNode & HasSpan {
   entire_span: Span!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1296,7 +1296,7 @@ type ImportAST implements Import & ASTNode & HasSpan {
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1321,7 +1321,7 @@ type JSXElementAST implements JSXElement & Expression & ASTNode & HasSpan {
   strip_parens(strip_all: Boolean): Expression!
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   # HasSpan
   span: Span!
 }
@@ -1349,7 +1349,7 @@ type ClassAST implements ASTNode & Class & HasSpan {
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # HasSpan
   span: Span!
@@ -1360,7 +1360,7 @@ type IfStatementAST implements ASTNode & HasSpan {
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # HasSpan
   span: Span!
@@ -1371,7 +1371,7 @@ type ReturnStatement implements Statement & HasSpan {
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # HasSpan
   span: Span!
@@ -1382,7 +1382,7 @@ type ReturnAST implements ASTNode & HasSpan {
 
   # ASTNode
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
 
   # HasSpan
   span: Span!
@@ -1391,7 +1391,7 @@ type ReturnAST implements ASTNode & HasSpan {
 # MAKE SURE TO KEEP ANCESTOR&CHILD IN SYNC
 interface ASTNode implements HasSpan {
   parent: ASTNode
-  ancestor: [ASTNode!]!
+  ancestor: [ASTNode!]
   span: Span!
 }
 

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -288,6 +288,18 @@ type SpreadArrayElementAST implements ArrayElement & HasSpan & SpreadArrayElemen
   span: Span!
 }
 
+interface ExpressionArrayElement implements ArrayElement & HasSpan {
+  expression: Expression!
+  # HasSpan
+  span: Span!
+}
+
+type ExpressionArrayElementAST implements ArrayElement & HasSpan & ExpressionArrayElement {
+  expression: Expression!
+  # HasSpan
+  span: Span!
+}
+
 """
 The element in this array would be elided: [,]
 The element in the middle of this array is elided: [1,,3]
@@ -307,14 +319,6 @@ type ElidedArrayElementAST implements ArrayElement & HasSpan & ElidedArrayElemen
 }
 
 interface ArrayElement implements HasSpan {
-  # HasSpan
-  span: Span!
-}
-
-type ArrayElementAST implements HasSpan & ASTNode {
-  # ASTNode
-  parent: ASTNode
-  ancestor: [ASTNode!]!
   # HasSpan
   span: Span!
 }

--- a/crates/oxc_query/src/schema.graphql
+++ b/crates/oxc_query/src/schema.graphql
@@ -276,18 +276,6 @@ type JSXText {
   span: Span!
 }
 
-interface SpreadArrayElement implements ArrayElement & HasSpan {
-  spread: Expression!
-  # HasSpan
-  span: Span!
-}
-
-type SpreadArrayElementAST implements ArrayElement & HasSpan & SpreadArrayElement {
-  spread: Expression!
-  # HasSpan
-  span: Span!
-}
-
 interface ExpressionArrayElement implements ArrayElement & HasSpan {
   expression: Expression!
   # HasSpan
@@ -416,15 +404,21 @@ interface ObjectProperty implements HasSpan {
   span: Span!
 }
 
-interface SpreadIntoObject implements ObjectProperty & HasSpan {
-  value: Expression!
+"""
+Array Spread ([...x]) or Object spread ({...y})
+"""
+interface Spread implements ObjectProperty & ArrayElement & HasSpan {
+  expression: Expression!
 
   # HasSpan
   span: Span!
 }
 
-type SpreadIntoObjectAST implements ASTNode & SpreadIntoObject & ObjectProperty & HasSpan {
-  value: Expression!
+"""
+Array Spread ([...x]) or Object spread ({...y})
+"""
+type SpreadAST implements ASTNode & Spread & ObjectProperty & ArrayElement & HasSpan {
+  expression: Expression!
 
   # ASTNode
   parent: ASTNode


### PR DESCRIPTION
```diff

- ArrayElementAST
- SpreadArrayElement
- SpreadArrayElementAST
- SpreadIntoObject
- SpreadIntoObjectAST

+ ExpressionArrayElement
+ ExpressionArrayElement implements HasSpan
+ ExpressionArrayElement implements ArrayElement
+ ExpressionArrayElement.expression

+ ExpressionArrayElementAST
+ ExpressionArrayElementAST implements ArrayElement
+ ExpressionArrayElementAST implements HasSpan
+ ExpressionArrayElementAST implements ExpressionArrayElement

+ Spread
+ Spread implements ObjectProperty
+ Spread implements ArrayElement
+ Spread implements HasSpan
+ Spread.expression

+ SpreadAST
+ SpreadAST implements ObjectProperty
+ SpreadAST implements HasSpan
+ SpreadAST implements ArrayElement
+ SpreadAST implements ASTNode
+ SpreadAST implements Spread

```