### PR TITLE
TSTypeName change identifer name to identifier reference

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -371,20 +371,20 @@ pub struct TSTypeReference<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 pub enum TSTypeName<'a> {
-    IdentifierName(Box<'a, IdentifierName>),
+    IdentifierReference(Box<'a, IdentifierReference>),
     QualifiedName(Box<'a, TSQualifiedName<'a>>),
 }
 
 impl<'a> TSTypeName<'a> {
-    pub fn get_first_name(name: &TSTypeName) -> IdentifierName {
+    pub fn get_first_name(name: &TSTypeName) -> IdentifierReference {
         match name {
-            TSTypeName::IdentifierName(name) => (*name).clone(),
+            TSTypeName::IdentifierReference(name) => (*name).clone(),
             TSTypeName::QualifiedName(name) => TSTypeName::get_first_name(&name.left),
         }
     }
 
     pub fn is_const(&self) -> bool {
-        if let TSTypeName::IdentifierName(ident) = self {
+        if let TSTypeName::IdentifierReference(ident) = self {
             if ident.name == "const" {
                 return true;
             }
@@ -393,7 +393,7 @@ impl<'a> TSTypeName<'a> {
     }
 
     pub fn is_identifier(&self) -> bool {
-        matches!(self, Self::IdentifierName(_))
+        matches!(self, Self::IdentifierReference(_))
     }
 
     pub fn is_qualified_name(&self) -> bool {

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1,4 +1,7 @@
+//! TypeScript Definitions
+//!
 //! [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/ast-spec)
+//! [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
 
 use oxc_allocator::{Box, Vec};
 use oxc_span::{Atom, Span};
@@ -368,6 +371,9 @@ pub struct TSTypeReference<'a> {
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
+/// TypeName:
+///     IdentifierReference
+///     NamespaceName . IdentifierReference
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 pub enum TSTypeName<'a> {

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -1510,7 +1510,7 @@ pub trait Visit<'a>: Sized {
 
     fn visit_ts_type_name(&mut self, name: &'a TSTypeName<'a>) {
         match &name {
-            TSTypeName::IdentifierName(ident) => self.visit_identifier_name(ident),
+            TSTypeName::IdentifierReference(ident) => self.visit_identifier_reference(ident),
             TSTypeName::QualifiedName(_) => {}
         }
     }

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -1164,7 +1164,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_ts_type_name(&mut self, name: &'b mut TSTypeName<'a>) {
         match name {
-            TSTypeName::IdentifierName(ident) => self.visit_identifier_name(ident),
+            TSTypeName::IdentifierReference(ident) => self.visit_identifier_reference(ident),
             TSTypeName::QualifiedName(_) => {}
         }
     }

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -67,7 +67,7 @@ impl Rule for NoMisusedNew {
                         if let Some(return_type) = &sig.return_type {
                             if let TSType::TSTypeReference(type_ref) = &return_type.type_annotation
                             {
-                                if let TSTypeName::IdentifierName(id) = &type_ref.type_name {
+                                if let TSTypeName::IdentifierReference(id) = &type_ref.type_name {
                                     if id.name == decl_name {
                                         ctx.diagnostic(NoMisusedNewInterfaceDiagnostic(Span::new(
                                             sig.span.start,
@@ -98,7 +98,7 @@ impl Rule for NoMisusedNew {
                                     if let TSType::TSTypeReference(type_ref) =
                                         &return_type.type_annotation
                                     {
-                                        if let TSTypeName::IdentifierName(current_id) =
+                                        if let TSTypeName::IdentifierReference(current_id) =
                                             &type_ref.type_name
                                         {
                                             if current_id.name == cls_name {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -87,16 +87,6 @@ impl<'a> Parser<'a> {
         Ok(IdentifierName { span, name })
     }
 
-    // syntactically types are identifier name but semantically they need reference id
-    pub(crate) fn parse_identifier_name_with_reference(&mut self) -> Result<IdentifierReference> {
-        if !self.cur_kind().is_identifier_name() {
-            return Err(self.unexpected());
-        }
-        let (span, name) = self.parse_identifier_kind(Kind::Ident);
-        let reference_id = Cell::default();
-        Ok(IdentifierReference { span, name, reference_id })
-    }
-
     /// Parse keyword kind as identifier
     pub(crate) fn parse_keyword_identifier(&mut self, kind: Kind) -> IdentifierName {
         let (span, name) = self.parse_identifier_kind(kind);

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -94,7 +94,7 @@ impl<'a> Parser<'a> {
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         let reference_id = Cell::default();
-        Ok(IdentifierReference{ span, name, reference_id })
+        Ok(IdentifierReference { span, name, reference_id })
     }
 
     /// Parse keyword kind as identifier

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -87,6 +87,16 @@ impl<'a> Parser<'a> {
         Ok(IdentifierName { span, name })
     }
 
+    // syntactically types are identifier name but semantically they need reference id
+    pub(crate) fn parse_identifier_name_with_reference(&mut self) -> Result<IdentifierReference> {
+        if !self.cur_kind().is_identifier_name() {
+            return Err(self.unexpected());
+        }
+        let (span, name) = self.parse_identifier_kind(Kind::Ident);
+        let reference_id = Cell::default();
+        Ok(IdentifierReference{ span, name, reference_id })
+    }
+
     /// Parse keyword kind as identifier
     pub(crate) fn parse_keyword_identifier(&mut self, kind: Kind) -> IdentifierName {
         let (span, name) = self.parse_identifier_kind(kind);

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -413,7 +413,7 @@ impl<'a> Parser<'a> {
                 expression,
             })
         } else {
-            TSModuleReference::TypeName(self.parse_ts_qualified_name()?)
+            TSModuleReference::TypeName(self.parse_ts_type_name()?)
         };
 
         self.asi()?;

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -485,8 +485,8 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn parse_ts_qualified_name(&mut self) -> Result<TSTypeName<'a>> {
         let span = self.start_span();
-        let identifier_name = self.parse_identifier_name()?;
-        let mut left = TSTypeName::IdentifierName(self.ast.alloc(identifier_name));
+        let identifier_name = self.parse_identifier_name_with_reference()?;
+        let mut left = TSTypeName::IdentifierReference(self.ast.alloc(identifier_name));
 
         while self.eat(Kind::Dot) {
             let right = self.parse_identifier_name()?;

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -187,6 +187,15 @@ mod tests {
             }
         }
     }
+    
+    #[test]
+    fn type_alias_gets_reference() {
+        let source = "type A = 1; type B = A";
+        let allocator = Allocator::default();
+        let source_type: SourceType = SourceType::default().with_typescript(true);
+        let semantic = get_semantic(&allocator, source, source_type);
+        assert!(semantic.symbols().references.len()==1);
+    }
 
     #[test]
     fn test_reference_resolutions_simple_read_write() {

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -187,14 +187,14 @@ mod tests {
             }
         }
     }
-    
+
     #[test]
     fn type_alias_gets_reference() {
         let source = "type A = 1; type B = A";
         let allocator = Allocator::default();
         let source_type: SourceType = SourceType::default().with_typescript(true);
         let semantic = get_semantic(&allocator, source, source_type);
-        assert!(semantic.symbols().references.len()==1);
+        assert!(semantic.symbols().references.len() == 1);
     }
 
     #[test]

--- a/crates/oxc_type_synthesis/src/interfaces.rs
+++ b/crates/oxc_type_synthesis/src/interfaces.rs
@@ -90,7 +90,7 @@ pub(crate) fn synthesize_signatures<T: ezno_checker::FSResolver>(
 												    Some(tp),
 											    ) = (&type_ref.type_name, &type_ref.type_parameters)
 											    {
-												    if let ast::TSTypeName::IdentifierName(
+												    if let ast::TSTypeName::IdentifierReference(
 													    ref parent_name,
 												    ) = qual.left
 												    {

--- a/crates/oxc_type_synthesis/src/types.rs
+++ b/crates/oxc_type_synthesis/src/types.rs
@@ -224,7 +224,7 @@ pub(crate) fn synthesize_type_annotation<T: FSResolver>(
             }
             let tn = &reference.type_name;
             match tn {
-                ast::TSTypeName::IdentifierName(name) => environment
+                ast::TSTypeName::IdentifierReference(name) => environment
                     .get_type_by_name_handle_errors(
                         &name.name,
                         oxc_span_to_source_map_span(name.span),

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -11287,8 +11287,7 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  12 │     }
     ╰────
 
-  × Invalid Character `
-`
+  × Invalid Character ``
    ╭─[conformance/classes/members/privateNames/privateNameHashCharName.ts:2:1]
  2 │ 
  3 │ #

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1,7 +1,7 @@
 parser_typescript Summary:
 AST Parsed     : 5060/5063 (99.94%)
 Positive Passed: 5051/5063 (99.76%)
-Negative Passed: 995/4761 (20.90%)
+Negative Passed: 996/4761 (20.92%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
 Expect Syntax Error: "compiler/ClassDeclaration13.ts"
@@ -3158,7 +3158,6 @@ Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parser50966
 Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parser509693.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parser509698.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parser536727.ts"
-Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parser553699.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parser618973.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts"
 Expect Syntax Error: "conformance/parser/ecmascript5/RegularExpressions/parseRegularExpressionMixedWithComments.ts"
@@ -8667,6 +8666,14 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╰────
 
   × The keyword 'public' is reserved
+   ╭─[compiler/strictModeReservedWordInClassDeclaration.ts:6:1]
+ 6 │     }
+ 7 │     public banana(x: public) { }
+   ·                      ──────
+ 8 │ }
+   ╰────
+
+  × The keyword 'public' is reserved
     ╭─[compiler/strictModeReservedWordInClassDeclaration.ts:10:1]
  10 │ class C {
  11 │     constructor(public public, let) {
@@ -11280,7 +11287,8 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  12 │     }
     ╰────
 
-  × Invalid Character ``
+  × Invalid Character `
+`
    ╭─[conformance/classes/members/privateNames/privateNameHashCharName.ts:2:1]
  2 │ 
  3 │ #
@@ -16893,6 +16901,14 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ·              ─
    ╰────
   help: Try insert a semicolon here
+
+  × The keyword 'public' is reserved
+   ╭─[conformance/parser/ecmascript5/RegressionTests/parser553699.ts:2:1]
+ 2 │   constructor() { }
+ 3 │   public banana (x: public) { }
+   ·                     ──────
+ 4 │ }
+   ╰────
 
   × Empty parenthesized expression
    ╭─[conformance/parser/ecmascript5/RegressionTests/parser566700.ts:1:1]


### PR DESCRIPTION
I can't run cargo coverage in forks? But this fixes 1 TS conformance test. I think it should also be useful for ezno or other typechecker implementations.

When initially written types were not in the symbol table. Now that types are in the symbol table it makes sense given
```ts
type A = 1
type B = A
```
that you can get to the symbol id for for A from type B = A.

Please correct me if I'm wrong about how I implemented this. I also verified that occurrence (I believe this is the correct word) behaves how I would expect.

```ts
type RecursiveType = string | {[x: string]: RecursiveType}
```
Does populate a reference.

