### PR TITLE
rename get_node_by_ident to get_declaration_of_variable

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -266,7 +266,7 @@ pub fn get_name_from_property_key(key: &PropertyKey<'_>) -> Option<Atom> {
     }
 }
 
-pub fn get_node_by_ident<'a, 'b>(
+pub fn get_declaration_of_variable<'a, 'b>(
     ident: &IdentifierReference,
     ctx: &'b LintContext<'a>,
 ) -> Option<&'b AstNode<'a>> {

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -11,7 +11,7 @@ use oxc_span::Span;
 use regex::Regex;
 
 use crate::{
-    ast_util::get_node_by_ident,
+    ast_util::get_declaration_of_variable,
     context::LintContext,
     jest_ast_util::{get_node_name, is_type_of_jest_fn_call, JestFnKind, JestGeneralFnKind},
     rule::Rule,
@@ -151,7 +151,7 @@ fn check_assert_function_used<'a>(
             return has_assert_function;
         }
         Expression::Identifier(ident) => {
-            let Some(node) = get_node_by_ident(ident, ctx) else {
+            let Some(node) = get_declaration_of_variable(ident, ctx) else {
                 return false;
             };
             let AstKind::Function(function) = node.kind() else {

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::get_node_by_ident, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("typescript-eslint(no-var-requires): Require statement not part of import statement.")]
@@ -72,7 +72,7 @@ impl Rule for NoVarRequires {
 
 fn no_local_require_declaration(expr: &Expression, ctx: &LintContext) -> bool {
     let Expression::Identifier(ident) = expr else { return true };
-    get_node_by_ident(ident, ctx).is_none()
+    get_declaration_of_variable(ident, ctx).is_none()
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test() {
             const json = require('./some.json');
         "#,
         "
-            let require = () => 'foo'; 
+            let require = () => 'foo';
             {
                 let foo = require('foo');
             }


### PR DESCRIPTION
The previous function name wasn't really clear to me, I think this is better.