### PR TITLE
feat(linter): add eslint-plugin-jest/no_alias_method rule

### DIFF
--- a/crates/oxc_linter/src/jest_ast_util.rs
+++ b/crates/oxc_linter/src/jest_ast_util.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, cmp::Ordering};
 
 use oxc_ast::{
     ast::{
-        CallExpression, Expression, IdentifierName, IdentifierReference,
+        Argument, CallExpression, Expression, IdentifierName, IdentifierReference,
         ImportDeclarationSpecifier, MemberExpression, ModuleDeclaration, TemplateLiteral,
     },
     AstKind,
@@ -42,6 +42,19 @@ pub fn parse_general_jest_fn_call<'a>(
     None
 }
 
+pub fn parse_expect_jest_fn_call<'a>(
+    call_expr: &'a CallExpression<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<ParsedExpectFnCall<'a>> {
+    let jest_fn_call = parse_jest_fn_call(call_expr, node, ctx)?;
+
+    if let ParsedJestFnCall::ExpectFnCall(jest_fn_call) = jest_fn_call {
+        return Some(jest_fn_call);
+    }
+    None
+}
+
 pub fn parse_jest_fn_call<'a>(
     call_expr: &'a CallExpression<'a>,
     node: &AstNode<'a>,
@@ -55,16 +68,12 @@ pub fn parse_jest_fn_call<'a>(
     // only the top level Call expression callee's parent is None, it's not necessary to set it to None, but
     // I didn't know how to pass Expression to it.
     let chain = get_node_chain(callee, None);
+
     let all_member_expr_except_last = chain
         .iter()
         .rev()
         .skip(1)
         .all(|member| matches!(member.parent, Some(Expression::MemberExpression(_))));
-
-    // Check every link in the chain except the last is a member expression
-    if !all_member_expr_except_last {
-        return None;
-    }
 
     // Ensure that we're at the "top" of the function call chain otherwise when
     // parsing e.g. x().y.z(), we'll incorrectly find & parse "x()" even though
@@ -103,6 +112,15 @@ pub fn parse_jest_fn_call<'a>(
             members.push(member);
         }
 
+        if matches!(kind, JestFnKind::Expect) {
+            return parse_jest_expect_fn_call(call_expr, members, name);
+        }
+
+        // Check every link in the chain except the last is a member expression
+        if !all_member_expr_except_last {
+            return None;
+        }
+
         let mut call_chains = Vec::from([Cow::Borrowed(name)]);
         call_chains.extend(members.iter().filter_map(KnownMemberExpressionProperty::name));
         if !is_valid_jest_call(&call_chains) {
@@ -117,6 +135,100 @@ pub fn parse_jest_fn_call<'a>(
     }
 
     None
+}
+
+fn parse_jest_expect_fn_call<'a>(
+    call_expr: &'a CallExpression<'a>,
+    members: Vec<KnownMemberExpressionProperty<'a>>,
+    name: &'a str,
+) -> Option<ParsedJestFnCall<'a>> {
+    // check if the `member` is being called, which means it is the matcher
+    let has_matcher = match &call_expr.callee {
+        Expression::MemberExpression(member_expr) => member_expr.static_property_name().is_some(),
+        _ => false,
+    };
+
+    let Some((modifiers, matcher)) = find_modifiers_and_matcher(&members, has_matcher) else {
+        return None;
+    };
+
+    return Some(ParsedJestFnCall::ExpectFnCall(ParsedExpectFnCall {
+        kind: JestFnKind::Expect,
+        members,
+        name: Cow::Borrowed(name),
+        args: &call_expr.arguments,
+        matcher_index: matcher,
+        modifier_indices: modifiers,
+    }));
+}
+
+fn find_modifiers_and_matcher(
+    members: &[KnownMemberExpressionProperty],
+    has_matcher: bool,
+) -> Option<(Vec<usize>, Option<usize>)> {
+    let mut matcher = None;
+    let mut modifiers: Vec<usize> = vec![];
+
+    // matcher is the end of the entire "expect" call chain
+    if has_matcher {
+        matcher = Some(members.len() - 1);
+    }
+
+    for (index, member) in members.iter().enumerate() {
+        // the last member is the matcher, so we can stop here
+        if index == members.len() - 1 {
+            break;
+        }
+
+        // the first modifier can be any of the three modifiers
+        if modifiers.is_empty() {
+            if !member.is_name_in_modifiers(&[
+                ModifierName::Not,
+                ModifierName::Resolves,
+                ModifierName::Rejects,
+            ]) {
+                return None;
+            }
+        } else if modifiers.len() == 1 {
+            // the second modifier can only be "not"
+            if !member.is_name_in_modifiers(&[ModifierName::Not]) {
+                return None;
+            }
+            // and the first modifier has to be either "resolves" or "rejects"
+            if !members[modifiers[0]]
+                .is_name_in_modifiers(&[ModifierName::Resolves, ModifierName::Rejects])
+            {
+                return None;
+            }
+        } else {
+            // the third modifier can only be "resolves" or "rejects"
+            if !member.is_name_in_modifiers(&[ModifierName::Resolves, ModifierName::Rejects]) {
+                return None;
+            }
+        }
+
+        modifiers.push(index);
+    }
+
+    Some((modifiers, matcher))
+}
+
+#[derive(PartialEq, Eq)]
+pub enum ModifierName {
+    Not,
+    Rejects,
+    Resolves,
+}
+
+impl ModifierName {
+    pub fn from(name: &str) -> Option<Self> {
+        match name {
+            "not" => Some(Self::Not),
+            "rejects" => Some(Self::Rejects),
+            "resolves" => Some(Self::Resolves),
+            _ => None,
+        }
+    }
 }
 
 // If find a match in `VALID_JEST_FN_CALL_CHAINS`, return true.
@@ -260,10 +372,22 @@ pub struct ParsedGeneralJestFnCall<'a> {
 pub struct ParsedExpectFnCall<'a> {
     pub kind: JestFnKind,
     pub members: Vec<KnownMemberExpressionProperty<'a>>,
-    pub raw: Cow<'a, str>,
     pub name: Cow<'a, str>,
-    // pub args: Vec<&'a Expression<'a>>
-    // TODO: add `modifiers`, `matcher` for this struct.
+    pub args: &'a oxc_allocator::Vec<'a, Argument<'a>>,
+    // In `expect(1).not.resolved.toBe()`, "not", "resolved" will be modifier
+    // it save a group of modifier index from members
+    #[allow(unused)]
+    modifier_indices: Vec<usize>,
+    // In `expect(1).toBe(2)`, "toBe" will be matcher
+    // it save the matcher index from members
+    matcher_index: Option<usize>,
+}
+
+impl<'a> ParsedExpectFnCall<'a> {
+    pub fn matcher(&self) -> Option<&KnownMemberExpressionProperty<'a>> {
+        let matcher_index = self.matcher_index?;
+        self.members.get(matcher_index)
+    }
 }
 
 struct ResolvedJestFn<'a> {
@@ -308,6 +432,14 @@ impl<'a> KnownMemberExpressionProperty<'a> {
     pub fn is_name_unequal(&self, name: &str) -> bool {
         !self.is_name_equal(name)
     }
+    pub fn is_name_in_modifiers(&self, modifiers: &[ModifierName]) -> bool {
+        self.name().map_or(false, |name| {
+            if let Some(modifier_name) = ModifierName::from(name.as_ref()) {
+                return modifiers.contains(&modifier_name);
+            }
+            false
+        })
+    }
 }
 
 pub enum MemberExpressionElement<'a> {
@@ -330,6 +462,12 @@ impl<'a> MemberExpressionElement<'a> {
             // Jest fn chains don't have private fields, just ignore it.
             MemberExpression::PrivateFieldExpression(_) => None,
         }
+    }
+    pub fn is_string_literal(&self) -> bool {
+        matches!(
+            self,
+            Self::Expression(Expression::StringLiteral(_) | Expression::TemplateLiteral(_))
+        )
     }
 }
 

--- a/crates/oxc_linter/src/jest_ast_util.rs
+++ b/crates/oxc_linter/src/jest_ast_util.rs
@@ -68,7 +68,6 @@ pub fn parse_jest_fn_call<'a>(
     // only the top level Call expression callee's parent is None, it's not necessary to set it to None, but
     // I didn't know how to pass Expression to it.
     let chain = get_node_chain(callee, None);
-
     let all_member_expr_except_last = chain
         .iter()
         .rev()

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -93,6 +93,7 @@ mod typescript {
 
 mod jest {
     pub mod expect_expect;
+    pub mod no_alias_methods;
     pub mod no_commented_out_tests;
     pub mod no_disabled_tests;
     pub mod no_focused_tests;
@@ -188,5 +189,6 @@ oxc_macros::declare_all_lint_rules! {
     jest::valid_describe_callback,
     jest::no_commented_out_tests,
     jest::expect_expect,
+    jest::no_alias_methods,
     unicorn::no_instanceof_array,
 }

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("eslint(jest/no-alias-methods): Unexpected alias {0:?}()")]
+#[error("eslint(jest/no-alias-methods): Unexpected alias {0:?}")]
 #[diagnostic(severity(warning), help("Replace {0:?} with its canonical name of {1:?}"))]
 struct NoAliasMethodsDiagnostic(pub &'static str, pub &'static str, #[label] pub Span);
 

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -1,0 +1,175 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext, fixer::Fix, jest_ast_util::parse_expect_jest_fn_call, rule::Rule, AstNode,
+};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint(jest/no-alias-methods): Unexpected alias {0:?}()")]
+#[diagnostic(severity(warning), help("Replace {0:?} with its canonical name of {1:?}"))]
+struct NoAliasMethodsDiagnostic(pub &'static str, pub &'static str, #[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoAliasMethods;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule ensures that only the canonical name as used in the Jest documentation is used in the code.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// These aliases are going to be removed in the next major version of Jest - see [jestjs/jest#13164](https://github.com/jestjs/jest/issues/13164) for more.
+    /// This rule will makes it easier to search for all occurrences of the method within code, and it ensures consistency among the method names used.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// expect(a).toBeCalled();
+    /// expect(a).toBeCalledTimes();
+    /// expect(a).toBeCalledWith();
+    /// expect(a).lastCalledWith();
+    /// expect(a).nthCalledWith();
+    /// expect(a).toReturn();
+    /// expect(a).toReturnTimes();
+    /// expect(a).toReturnWith();
+    /// expect(a).lastReturnedWith();
+    /// expect(a).nthReturnedWith();
+    /// expect(a).toThrowError();
+    /// ```
+    NoAliasMethods,
+    correctness
+);
+
+impl Rule for NoAliasMethods {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::CallExpression(call_expr) = node.kind() {
+            if let Some(jest_fn_call) = parse_expect_jest_fn_call(call_expr, node, ctx) {
+                let parsed_expect_call = jest_fn_call;
+                let Some(matcher) = parsed_expect_call.matcher() else {
+                    return;
+                };
+                let Some(alias) = matcher.name() else {
+                    return;
+                };
+
+                if let Some(method_name) = BadAliasMethodName::from_str(alias.as_ref()) {
+                    let (name, canonical_name) = method_name.name_with_canonical();
+
+                    let Span { mut start, mut end } = matcher.span;
+                    // expect(a).not['toThrowError']()
+                    // matcher is the node of `toThrowError`, we only what to replace the content in the quotes.
+                    if matcher.element.is_string_literal() {
+                        start += 1;
+                        end -= 1;
+                    }
+
+                    ctx.diagnostic_with_fix(
+                        NoAliasMethodsDiagnostic(name, canonical_name, matcher.span),
+                        || Fix::new(canonical_name, Span { start, end }),
+                    );
+                }
+            }
+        }
+    }
+}
+
+enum BadAliasMethodName {
+    ToBeCalled,
+    ToBeCalledTimes,
+    ToBeCalledWith,
+    LastCalledWith,
+    NthCalledWith,
+    ToReturn,
+    ToReturnTimes,
+    ToReturnWith,
+    LastReturnedWith,
+    NthReturnedWith,
+    ToThrowError,
+}
+
+impl BadAliasMethodName {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "toBeCalled" => Some(Self::ToBeCalled),
+            "toBeCalledTimes" => Some(Self::ToBeCalledTimes),
+            "toBeCalledWith" => Some(Self::ToBeCalledWith),
+            "lastCalledWith" => Some(Self::LastCalledWith),
+            "nthCalledWith" => Some(Self::NthCalledWith),
+            "toReturn" => Some(Self::ToReturn),
+            "toReturnTimes" => Some(Self::ToReturnTimes),
+            "toReturnWith" => Some(Self::ToReturnWith),
+            "lastReturnedWith" => Some(Self::LastReturnedWith),
+            "nthReturnedWith" => Some(Self::NthReturnedWith),
+            "toThrowError" => Some(Self::ToThrowError),
+            _ => None,
+        }
+    }
+    fn name_with_canonical(&self) -> (&'static str, &'static str) {
+        match self {
+            Self::ToBeCalled => ("toBeCalled", "toHaveBeenCalled"),
+            Self::ToBeCalledTimes => ("toBeCalledTimes", "toHaveBeenCalledTimes"),
+            Self::ToBeCalledWith => ("toBeCalledWith", "toHaveBeenCalledWith"),
+            Self::LastCalledWith => ("lastCalledWith", "toHaveBeenLastCalledWith"),
+            Self::NthCalledWith => ("nthCalledWith", "toHaveBeenNthCalledWith"),
+            Self::ToReturn => ("toReturn", "toHaveReturned"),
+            Self::ToReturnTimes => ("toReturnTimes", "toHaveReturnedTimes"),
+            Self::ToReturnWith => ("toReturnWith", "toHaveReturnedWith"),
+            Self::LastReturnedWith => ("lastReturnedWith", "toHaveLastReturnedWith"),
+            Self::NthReturnedWith => ("nthReturnedWith", "toHaveNthReturnedWith"),
+            Self::ToThrowError => ("toThrowError", "toThrow"),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("expect(a).toHaveBeenCalled()", None),
+        ("expect(a).toHaveBeenCalledTimes()", None),
+        ("expect(a).toHaveBeenCalledWith()", None),
+        ("expect(a).toHaveBeenLastCalledWith()", None),
+        ("expect(a).toHaveBeenNthCalledWith()", None),
+        ("expect(a).toHaveReturned()", None),
+        ("expect(a).toHaveReturnedTimes()", None),
+        ("expect(a).toHaveReturnedWith()", None),
+        ("expect(a).toHaveLastReturnedWith()", None),
+        ("expect(a).toHaveNthReturnedWith()", None),
+        ("expect(a).toThrow()", None),
+        ("expect(a).rejects;", None),
+        ("expect(a);", None),
+    ];
+
+    let fail = vec![
+        ("expect(a).toBeCalled()", None),
+        ("expect(a).toBeCalledTimes()", None),
+        ("expect(a).toBeCalledWith()", None),
+        ("expect(a).lastCalledWith()", None),
+        ("expect(a).nthCalledWith()", None),
+        ("expect(a).toReturn()", None),
+        ("expect(a).toReturnTimes()", None),
+        ("expect(a).toReturnWith()", None),
+        ("expect(a).lastReturnedWith()", None),
+        ("expect(a).nthReturnedWith()", None),
+        ("expect(a).toThrowError()", None),
+        ("expect(a).resolves.toThrowError()", None),
+        ("expect(a).rejects.toThrowError()", None),
+        ("expect(a).not.toThrowError()", None),
+        ("expect(a).not['toThrowError']()", None),
+    ];
+
+    let fix = vec![
+        ("expect(a).toBeCalled()", "expect(a).toHaveBeenCalled()", None),
+        ("expect(a).not['toThrowError']()", "expect(a).not['toThrow']()", None),
+        ("expect(a).not[`toThrowError`]()", "expect(a).not[`toThrow`]()", None),
+    ];
+
+    Tester::new(NoAliasMethods::NAME, pass, fail).expect_fix(fix).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/no_alias_methods.snap
+++ b/crates/oxc_linter/src/snapshots/no_alias_methods.snap
@@ -2,105 +2,105 @@
 source: crates/oxc_linter/src/tester.rs
 expression: no_alias_methods
 ---
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalled"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalled"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toBeCalled()
    ·           ──────────
    ╰────
   help: Replace "toBeCalled" with its canonical name of "toHaveBeenCalled"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalledTimes"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalledTimes"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toBeCalledTimes()
    ·           ───────────────
    ╰────
   help: Replace "toBeCalledTimes" with its canonical name of "toHaveBeenCalledTimes"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalledWith"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalledWith"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toBeCalledWith()
    ·           ──────────────
    ╰────
   help: Replace "toBeCalledWith" with its canonical name of "toHaveBeenCalledWith"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "lastCalledWith"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "lastCalledWith"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).lastCalledWith()
    ·           ──────────────
    ╰────
   help: Replace "lastCalledWith" with its canonical name of "toHaveBeenLastCalledWith"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "nthCalledWith"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "nthCalledWith"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).nthCalledWith()
    ·           ─────────────
    ╰────
   help: Replace "nthCalledWith" with its canonical name of "toHaveBeenNthCalledWith"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturn"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturn"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toReturn()
    ·           ────────
    ╰────
   help: Replace "toReturn" with its canonical name of "toHaveReturned"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturnTimes"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturnTimes"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toReturnTimes()
    ·           ─────────────
    ╰────
   help: Replace "toReturnTimes" with its canonical name of "toHaveReturnedTimes"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturnWith"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturnWith"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toReturnWith()
    ·           ────────────
    ╰────
   help: Replace "toReturnWith" with its canonical name of "toHaveReturnedWith"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "lastReturnedWith"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "lastReturnedWith"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).lastReturnedWith()
    ·           ────────────────
    ╰────
   help: Replace "lastReturnedWith" with its canonical name of "toHaveLastReturnedWith"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "nthReturnedWith"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "nthReturnedWith"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).nthReturnedWith()
    ·           ───────────────
    ╰────
   help: Replace "nthReturnedWith" with its canonical name of "toHaveNthReturnedWith"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).toThrowError()
    ·           ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).resolves.toThrowError()
    ·                    ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).rejects.toThrowError()
    ·                   ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).not.toThrowError()
    ·               ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:1]
  1 │ expect(a).not['toThrowError']()
    ·               ──────────────

--- a/crates/oxc_linter/src/snapshots/no_alias_methods.snap
+++ b/crates/oxc_linter/src/snapshots/no_alias_methods.snap
@@ -1,0 +1,110 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_alias_methods
+---
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalled"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toBeCalled()
+   ·           ──────────
+   ╰────
+  help: Replace "toBeCalled" with its canonical name of "toHaveBeenCalled"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalledTimes"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toBeCalledTimes()
+   ·           ───────────────
+   ╰────
+  help: Replace "toBeCalledTimes" with its canonical name of "toHaveBeenCalledTimes"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toBeCalledWith"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toBeCalledWith()
+   ·           ──────────────
+   ╰────
+  help: Replace "toBeCalledWith" with its canonical name of "toHaveBeenCalledWith"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "lastCalledWith"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).lastCalledWith()
+   ·           ──────────────
+   ╰────
+  help: Replace "lastCalledWith" with its canonical name of "toHaveBeenLastCalledWith"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "nthCalledWith"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).nthCalledWith()
+   ·           ─────────────
+   ╰────
+  help: Replace "nthCalledWith" with its canonical name of "toHaveBeenNthCalledWith"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturn"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toReturn()
+   ·           ────────
+   ╰────
+  help: Replace "toReturn" with its canonical name of "toHaveReturned"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturnTimes"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toReturnTimes()
+   ·           ─────────────
+   ╰────
+  help: Replace "toReturnTimes" with its canonical name of "toHaveReturnedTimes"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toReturnWith"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toReturnWith()
+   ·           ────────────
+   ╰────
+  help: Replace "toReturnWith" with its canonical name of "toHaveReturnedWith"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "lastReturnedWith"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).lastReturnedWith()
+   ·           ────────────────
+   ╰────
+  help: Replace "lastReturnedWith" with its canonical name of "toHaveLastReturnedWith"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "nthReturnedWith"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).nthReturnedWith()
+   ·           ───────────────
+   ╰────
+  help: Replace "nthReturnedWith" with its canonical name of "toHaveNthReturnedWith"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).toThrowError()
+   ·           ────────────
+   ╰────
+  help: Replace "toThrowError" with its canonical name of "toThrow"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).resolves.toThrowError()
+   ·                    ────────────
+   ╰────
+  help: Replace "toThrowError" with its canonical name of "toThrow"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).rejects.toThrowError()
+   ·                   ────────────
+   ╰────
+  help: Replace "toThrowError" with its canonical name of "toThrow"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).not.toThrowError()
+   ·               ────────────
+   ╰────
+  help: Replace "toThrowError" with its canonical name of "toThrow"
+
+  ⚠ eslint(jest/no-alias-methods): Unexpected alias "toThrowError"()
+   ╭─[no_alias_methods.tsx:1:1]
+ 1 │ expect(a).not['toThrowError']()
+   ·               ──────────────
+   ╰────
+  help: Replace "toThrowError" with its canonical name of "toThrow"
+
+


### PR DESCRIPTION
port [no_alias_method](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-alias-methods.md)