### PR TITLE
fix(resolver): fix cases with conflicting node_modules path

### DIFF
--- a/crates/oxc_resolver/src/tests/resolve.rs
+++ b/crates/oxc_resolver/src/tests/resolve.rs
@@ -51,8 +51,18 @@ fn resolve() {
     }
 }
 
-// #[test]
-// fn issue238_resolve() {}
+#[test]
+fn issue238_resolve() {
+    let f = super::fixture().join("issue-238");
+    let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".js".into(), ".jsx".into(), ".ts".into(), ".tsx".into()],
+        modules: vec!["src/a".into(), "src/b".into(), "src/common".into(), "node_modules".into()],
+        ..ResolveOptions::default()
+    });
+    let resolved_path =
+        resolver.resolve(f.join("src/common"), "config/myObjectFile").map(|r| r.full_path());
+    assert_eq!(resolved_path, Ok(f.join("src/common/config/myObjectFile.js")),);
+}
 
 #[test]
 fn prefer_relative() {


### PR DESCRIPTION
This will make the code slower, but we can cache the node_modules lookup in another PR.