### PR TITLE
fix(semantic): symbol of identifier of top level function declaration should be in the root scope

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -253,7 +253,7 @@ impl<'a> SemanticBuilder<'a> {
 
         let includes = includes | self.current_symbol_flags;
         let symbol_id =
-            self.symbols.create_symbol(span, name.clone(), includes, self.current_scope_id);
+            self.symbols.create_symbol(span, name.clone(), includes, scope_id);
         self.symbols.add_declaration(self.current_node_id);
         self.scope.add_binding(scope_id, name.clone(), symbol_id);
         symbol_id

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -252,8 +252,7 @@ impl<'a> SemanticBuilder<'a> {
         }
 
         let includes = includes | self.current_symbol_flags;
-        let symbol_id =
-            self.symbols.create_symbol(span, name.clone(), includes, scope_id);
+        let symbol_id = self.symbols.create_symbol(span, name.clone(), includes, scope_id);
         self.symbols.add_declaration(self.current_node_id);
         self.scope.add_binding(scope_id, name.clone(), symbol_id);
         symbol_id

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -177,7 +177,9 @@ mod tests {
 
         let top_level_a = semantic
             .scopes()
-            .iter_bindings().find(|(_scope_id, _symbol_id, name)| name == &Atom::from("Fn")).unwrap();
+            .iter_bindings()
+            .find(|(_scope_id, _symbol_id, name)| name == &Atom::from("Fn"))
+            .unwrap();
         assert_eq!(semantic.symbols.get_scope_id(top_level_a.1), top_level_a.0);
     }
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -170,6 +170,18 @@ mod tests {
     }
 
     #[test]
+    fn test_top_level_symbols() {
+        let source = "function Fn() {}";
+        let allocator = Allocator::default();
+        let semantic = get_semantic(&allocator, source, SourceType::default());
+
+        let top_level_a = semantic
+            .scopes()
+            .iter_bindings().find(|(_scope_id, _symbol_id, name)| name == &Atom::from("Fn")).unwrap();
+        assert_eq!(semantic.symbols.get_scope_id(top_level_a.1), top_level_a.0);
+    }
+
+    #[test]
     fn test_is_global() {
         let source = "
             var a = 0;


### PR DESCRIPTION
Just happen to found this, not sure why.