### PR TITLE
chore(linter): downgrade category of `expect-expect` and `no-alias-methods`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
     /// test('should assert something', () => {});
     /// ```
     ExpectExpect,
-    correctness
+    suspicious
 );
 
 impl Rule for ExpectExpect {

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     /// expect(a).toThrowError();
     /// ```
     NoAliasMethods,
-    correctness
+    style
 );
 
 impl Rule for NoAliasMethods {


### PR DESCRIPTION
There are too many errors(7000+) in vscode repo, so downgrade this rule.

And I think [no-alias-methods](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-alias-methods.md) is also too strict when it is placed in [style config](https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#style), so change it also.