### PR TITLE
fix(website): incorrect import

### DIFF
--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -20,7 +20,7 @@ import { autocompletion } from "@codemirror/autocomplete";
 import { indentWithTab, deleteLine } from "@codemirror/commands";
 import throttle from "lodash.throttle";
 import { buildSchema } from "graphql";
-import { LZMA } from 'lzma/src/lzma_worker-min.js';
+import { LZMA } from 'lzma/src/lzma_worker.js';
 
 import initWasm, {
   Oxc,


### PR DESCRIPTION
This was a fun one. 1) It worked fine in dev but failed in release and 2) the fix is importing the original file instead of a minified one. I love JS.
Fixes #699, this time hopefully for good