### PR TITLE
refactor(benchmark): remove global allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeec2fbed4969dc38b5ca201115dd5c2614b8ef78e0a7221dd5f0977fb1552b"
+checksum = "9b3238416c10f19985b52a937c5b3efc3ed7efe8f7ae263d2aab29a09bca9f57"
 dependencies = [
  "colored",
  "libc",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b13f0a08d40ce7c95bdf288f725b975e62fcadfa8ba152340943bab6de43af7"
+checksum = "fecc18f65b942d2b033545bb3bd8430a23eecbbe53fad3b1342fb0e5514bca7b"
 dependencies = [
  "codspeed",
  "colored",
@@ -440,8 +440,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -1511,8 +1509,6 @@ version = "0.0.0"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
- "jemallocator",
- "mimalloc",
  "oxc_allocator",
  "oxc_linter",
  "oxc_minifier",
@@ -2073,34 +2069,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "plotters"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ tracing-subscriber        = { version = "0.3" }
 trustfall                 = { version = "0.6.1" }
 insta                     = { version = "1.31.0", features = ["glob"] }
 insta-cmd                 = { version = "0.3.0" }
-codspeed-criterion-compat = { version = "2.1.0" }
+codspeed-criterion-compat = { version = "2.2.0", default-features = false }
 
 [profile.release.package.oxc_wasm]
 opt-level = 'z'

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -46,11 +46,5 @@ rayon                     = { workspace = true }
 criterion                 = { workspace = true }
 codspeed-criterion-compat = { workspace = true, optional = true }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { workspace = true }
-
 [features]
 codspeed = ["codspeed-criterion-compat"]

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use std::rc::Rc;
 
 use oxc_allocator::Allocator;

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use oxc_minifier::{Minifier, MinifierOptions};
 use oxc_span::SourceType;

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use oxc_parser::Parser;

--- a/tasks/benchmark/benches/resolver.rs
+++ b/tasks/benchmark/benches/resolver.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use std::path::PathBuf;
 
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use oxc_parser::Parser;


### PR DESCRIPTION
given we are benchmarking relative value with cpu instructions, the global allocators should be irrelevant for measurement.

This should reduce compilation time a bit.