### PR TITLE
perf(cli): force `terminal_links` to reduce sys calls

### DIFF
--- a/crates/oxc_cli/src/main.rs
+++ b/crates/oxc_cli/src/main.rs
@@ -11,6 +11,17 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use oxc_cli::{CliCommand, CliRunResult, LintRunner, Runner, TypeCheckRunner};
 
 fn main() -> CliRunResult {
+    miette::set_hook(Box::new(|_| {
+        Box::new(
+            miette::MietteHandlerOpts::new()
+                // Force the value to disable auto detection, which is an
+                // expensive syscall when called repeatedly
+                .terminal_links(true)
+                .build(),
+        )
+    }))
+    .unwrap();
+
     let options = oxc_cli::cli_command().fallback_to_usage().run();
     options.handle_threads();
     match options {


### PR DESCRIPTION
terminal_links has auto detection on by default,
it will get repeatedly called from parser rewind
with a `is_atty` system call.

closes #906