### PR TITLE
fix(playground): compatible with older encoded codes

### DIFF
--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -412,7 +412,8 @@ class Playground {
       this.parserOptions,
       this.linterOptions,
       this.formatterOptions,
-      this.minifierOptions,
+      // TODO: minifierOptions is not used temporarily, see: #917
+      // this.minifierOptions,
       this.typeCheckOptions
     );
     const elapsed = new Date() - start;
@@ -673,9 +674,20 @@ class URLParams {
 
   constructor() {
     this.params = new URLSearchParams(window.location.search);
-    this.code = this.params.has("code")
-      ? this.decodeCode(this.params.get("code"))
-      : getStringFromStorage(STORAGE_KEY_CODE);
+    this.code = this.tryReadCode(this.params);
+  }
+
+  tryReadCode(params) {
+    try {
+      if (params.has("code")) {
+        return this.decodeCode(params.get("code"));
+      }
+      return getStringFromStorage(STORAGE_KEY_CODE);
+    } catch(e) {
+      console.error(e);
+      return ''
+    }
+
   }
 
   updateCode = throttle(


### PR DESCRIPTION
The playground crashed when I visited some old links in my browser history:

https://web-infra-dev.github.io/oxc/playground/?code=ZQB4AHAAZQBjAHQAKAAxACkALgB0AG8AQgBlACgAMgApAA%3D%3D

<img width="1512" alt="image" src="https://github.com/web-infra-dev/oxc/assets/33973865/55eb63d9-2df9-431a-8eae-7e1b7817fef6">


Maybe newcomers feel confused about this(e.g. missing a part of character)