### PR TITLE
Fix: return 0 exit code when warnings<max_warnings

### DIFF
--- a/crates/oxc_cli/src/result.rs
+++ b/crates/oxc_cli/src/result.rs
@@ -62,7 +62,7 @@ impl Termination for CliRunResult {
                     if number_of_errors == 1 { "" } else { "s" }
                 );
 
-                let exit_code = u8::from(number_of_diagnostics > 0);
+                let exit_code = u8::from(number_of_errors > 0);
                 ExitCode::from(exit_code)
             }
             Self::TypeCheckResult { duration, number_of_diagnostics } => {


### PR DESCRIPTION
`oxlint --max-warnings 99999` should exit with success status code when there are warnings but no errors found. Currently any warning or error results in an exit status of 1.