### PR TITLE
refactor(ast): fix the lifetime annotations around Vist and VisitMut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "oxc_ast",
  "oxc_formatter",
  "oxc_parser",
+ "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
 ]

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -7,8 +7,8 @@ use oxc_span::Span;
 use crate::ast::*;
 
 /// Syntax tree traversal to mutate an exclusive borrow of a syntax tree in place.
-pub trait VisitMut<'a, 'b>: Sized {
-    fn visit_program(&mut self, program: &'b mut Program<'a>) {
+pub trait VisitMut<'a>: Sized {
+    fn visit_program(&mut self, program: &mut Program<'a>) {
         for directive in program.directives.iter_mut() {
             self.visit_directive(directive);
         }
@@ -17,17 +17,17 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     /* ----------  Statement ---------- */
 
-    fn visit_statements(&mut self, stmts: &'b mut Vec<'a, Statement<'a>>) {
+    fn visit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>) {
         for stmt in stmts.iter_mut() {
             self.visit_statement(stmt);
         }
     }
 
-    fn visit_statement(&mut self, stmt: &'b mut Statement<'a>) {
+    fn visit_statement(&mut self, stmt: &mut Statement<'a>) {
         self.visit_statement_match(stmt);
     }
 
-    fn visit_statement_match(&mut self, stmt: &'b mut Statement<'a>) {
+    fn visit_statement_match(&mut self, stmt: &mut Statement<'a>) {
         match stmt {
             Statement::BlockStatement(stmt) => self.visit_block_statement(stmt),
             Statement::BreakStatement(stmt) => self.visit_break_statement(stmt),
@@ -53,36 +53,36 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_block_statement(&mut self, stmt: &'b mut BlockStatement<'a>) {
+    fn visit_block_statement(&mut self, stmt: &mut BlockStatement<'a>) {
         self.visit_statements(&mut stmt.body);
     }
 
-    fn visit_break_statement(&mut self, stmt: &'b mut BreakStatement) {
+    fn visit_break_statement(&mut self, stmt: &mut BreakStatement) {
         if let Some(break_target) = &mut stmt.label {
             self.visit_label_identifier(break_target);
         }
     }
 
-    fn visit_continue_statement(&mut self, stmt: &'b mut ContinueStatement) {
+    fn visit_continue_statement(&mut self, stmt: &mut ContinueStatement) {
         if let Some(continue_target) = &mut stmt.label {
             self.visit_label_identifier(continue_target);
         }
     }
 
-    fn visit_debugger_statement(&mut self, _stmt: &'b mut DebuggerStatement) {}
+    fn visit_debugger_statement(&mut self, _stmt: &mut DebuggerStatement) {}
 
-    fn visit_do_while_statement(&mut self, stmt: &'b mut DoWhileStatement<'a>) {
+    fn visit_do_while_statement(&mut self, stmt: &mut DoWhileStatement<'a>) {
         self.visit_statement(&mut stmt.body);
         self.visit_expression(&mut stmt.test);
     }
 
-    fn visit_empty_statement(&mut self, _stmt: &'b mut EmptyStatement) {}
+    fn visit_empty_statement(&mut self, _stmt: &mut EmptyStatement) {}
 
-    fn visit_expression_statement(&mut self, stmt: &'b mut ExpressionStatement<'a>) {
+    fn visit_expression_statement(&mut self, stmt: &mut ExpressionStatement<'a>) {
         self.visit_expression(&mut stmt.expression);
     }
 
-    fn visit_for_statement(&mut self, stmt: &'b mut ForStatement<'a>) {
+    fn visit_for_statement(&mut self, stmt: &mut ForStatement<'a>) {
         if let Some(init) = &mut stmt.init {
             self.visit_for_statement_init(init);
         }
@@ -95,7 +95,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_statement(&mut stmt.body);
     }
 
-    fn visit_for_statement_init(&mut self, init: &'b mut ForStatementInit<'a>) {
+    fn visit_for_statement_init(&mut self, init: &mut ForStatementInit<'a>) {
         match init {
             ForStatementInit::VariableDeclaration(decl) => {
                 self.visit_variable_declaration(decl);
@@ -107,19 +107,19 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_for_in_statement(&mut self, stmt: &'b mut ForInStatement<'a>) {
+    fn visit_for_in_statement(&mut self, stmt: &mut ForInStatement<'a>) {
         self.visit_for_statement_left(&mut stmt.left);
         self.visit_expression(&mut stmt.right);
         self.visit_statement(&mut stmt.body);
     }
 
-    fn visit_for_of_statement(&mut self, stmt: &'b mut ForOfStatement<'a>) {
+    fn visit_for_of_statement(&mut self, stmt: &mut ForOfStatement<'a>) {
         self.visit_for_statement_left(&mut stmt.left);
         self.visit_expression(&mut stmt.right);
         self.visit_statement(&mut stmt.body);
     }
 
-    fn visit_for_statement_left(&mut self, left: &'b mut ForStatementLeft<'a>) {
+    fn visit_for_statement_left(&mut self, left: &mut ForStatementLeft<'a>) {
         match left {
             ForStatementLeft::VariableDeclaration(decl) => {
                 self.visit_variable_declaration(decl);
@@ -131,7 +131,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_if_statement(&mut self, stmt: &'b mut IfStatement<'a>) {
+    fn visit_if_statement(&mut self, stmt: &mut IfStatement<'a>) {
         self.visit_expression(&mut stmt.test);
         self.visit_statement(&mut stmt.consequent);
         if let Some(alternate) = &mut stmt.alternate {
@@ -139,36 +139,36 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_labeled_statement(&mut self, stmt: &'b mut LabeledStatement<'a>) {
+    fn visit_labeled_statement(&mut self, stmt: &mut LabeledStatement<'a>) {
         self.visit_label_identifier(&mut stmt.label);
         self.visit_statement(&mut stmt.body);
     }
 
-    fn visit_return_statement(&mut self, stmt: &'b mut ReturnStatement<'a>) {
+    fn visit_return_statement(&mut self, stmt: &mut ReturnStatement<'a>) {
         if let Some(arg) = &mut stmt.argument {
             self.visit_expression(arg);
         }
     }
 
-    fn visit_switch_statement(&mut self, stmt: &'b mut SwitchStatement<'a>) {
+    fn visit_switch_statement(&mut self, stmt: &mut SwitchStatement<'a>) {
         self.visit_expression(&mut stmt.discriminant);
         for case in stmt.cases.iter_mut() {
             self.visit_switch_case(case);
         }
     }
 
-    fn visit_switch_case(&mut self, case: &'b mut SwitchCase<'a>) {
+    fn visit_switch_case(&mut self, case: &mut SwitchCase<'a>) {
         if let Some(expr) = &mut case.test {
             self.visit_expression(expr);
         }
         self.visit_statements(&mut case.consequent);
     }
 
-    fn visit_throw_statement(&mut self, stmt: &'b mut ThrowStatement<'a>) {
+    fn visit_throw_statement(&mut self, stmt: &mut ThrowStatement<'a>) {
         self.visit_expression(&mut stmt.argument);
     }
 
-    fn visit_try_statement(&mut self, stmt: &'b mut TryStatement<'a>) {
+    fn visit_try_statement(&mut self, stmt: &mut TryStatement<'a>) {
         self.visit_block_statement(&mut stmt.block);
         if let Some(handler) = &mut stmt.handler {
             self.visit_catch_clause(handler);
@@ -178,47 +178,47 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_catch_clause(&mut self, clause: &'b mut CatchClause<'a>) {
+    fn visit_catch_clause(&mut self, clause: &mut CatchClause<'a>) {
         if let Some(param) = &mut clause.param {
             self.visit_binding_pattern(param);
         }
         self.visit_statements(&mut clause.body.body);
     }
 
-    fn visit_finally_clause(&mut self, clause: &'b mut BlockStatement<'a>) {
+    fn visit_finally_clause(&mut self, clause: &mut BlockStatement<'a>) {
         self.visit_block_statement(clause);
     }
 
-    fn visit_while_statement(&mut self, stmt: &'b mut WhileStatement<'a>) {
+    fn visit_while_statement(&mut self, stmt: &mut WhileStatement<'a>) {
         self.visit_expression(&mut stmt.test);
         self.visit_statement(&mut stmt.body);
     }
 
-    fn visit_with_statement(&mut self, stmt: &'b mut WithStatement<'a>) {
+    fn visit_with_statement(&mut self, stmt: &mut WithStatement<'a>) {
         self.visit_expression(&mut stmt.object);
         self.visit_statement(&mut stmt.body);
     }
 
-    fn visit_directive(&mut self, directive: &'b mut Directive) {
+    fn visit_directive(&mut self, directive: &mut Directive) {
         self.visit_string_literal(&mut directive.expression);
     }
 
     /* ----------  Declaration ---------- */
 
-    fn visit_variable_declaration(&mut self, decl: &'b mut VariableDeclaration<'a>) {
+    fn visit_variable_declaration(&mut self, decl: &mut VariableDeclaration<'a>) {
         for declarator in decl.declarations.iter_mut() {
             self.visit_variable_declarator(declarator);
         }
     }
 
-    fn visit_variable_declarator(&mut self, declarator: &'b mut VariableDeclarator<'a>) {
+    fn visit_variable_declarator(&mut self, declarator: &mut VariableDeclarator<'a>) {
         self.visit_binding_pattern(&mut declarator.id);
         if let Some(init) = &mut declarator.init {
             self.visit_expression(init);
         }
     }
 
-    fn visit_using_declaration(&mut self, declaration: &'b mut UsingDeclaration<'a>) {
+    fn visit_using_declaration(&mut self, declaration: &mut UsingDeclaration<'a>) {
         for decl in declaration.declarations.iter_mut() {
             self.visit_variable_declarator(decl);
         }
@@ -226,7 +226,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     /* ----------  Function ---------- */
 
-    fn visit_function(&mut self, func: &'b mut Function<'a>) {
+    fn visit_function(&mut self, func: &mut Function<'a>) {
         if let Some(ident) = &mut func.id {
             self.visit_binding_identifier(ident);
         }
@@ -242,14 +242,14 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_function_body(&mut self, body: &'b mut FunctionBody<'a>) {
+    fn visit_function_body(&mut self, body: &mut FunctionBody<'a>) {
         for directive in body.directives.iter_mut() {
             self.visit_directive(directive);
         }
         self.visit_statements(&mut body.statements);
     }
 
-    fn visit_formal_parameters(&mut self, params: &'b mut FormalParameters<'a>) {
+    fn visit_formal_parameters(&mut self, params: &mut FormalParameters<'a>) {
         for param in params.items.iter_mut() {
             self.visit_formal_parameter(param);
         }
@@ -258,7 +258,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_formal_parameter(&mut self, param: &'b mut FormalParameter<'a>) {
+    fn visit_formal_parameter(&mut self, param: &mut FormalParameter<'a>) {
         for decorator in param.decorators.iter_mut() {
             self.visit_decorator(decorator);
         }
@@ -267,11 +267,11 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     /* ----------  Class ---------- */
 
-    fn visit_decorator(&mut self, decorator: &'b mut Decorator<'a>) {
+    fn visit_decorator(&mut self, decorator: &mut Decorator<'a>) {
         self.visit_expression(&mut decorator.expression);
     }
 
-    fn visit_class(&mut self, class: &'b mut Class<'a>) {
+    fn visit_class(&mut self, class: &mut Class<'a>) {
         for decorator in class.decorators.iter_mut() {
             self.visit_decorator(decorator);
         }
@@ -291,17 +291,17 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_class_body(&mut class.body);
     }
 
-    fn visit_class_heritage(&mut self, expr: &'b mut Expression<'a>) {
+    fn visit_class_heritage(&mut self, expr: &mut Expression<'a>) {
         self.visit_expression(expr);
     }
 
-    fn visit_class_body(&mut self, body: &'b mut ClassBody<'a>) {
+    fn visit_class_body(&mut self, body: &mut ClassBody<'a>) {
         for elem in body.body.iter_mut() {
             self.visit_class_element(elem);
         }
     }
 
-    fn visit_class_element(&mut self, elem: &'b mut ClassElement<'a>) {
+    fn visit_class_element(&mut self, elem: &mut ClassElement<'a>) {
         match elem {
             ClassElement::StaticBlock(block) => self.visit_static_block(block),
             ClassElement::MethodDefinition(def) => self.visit_method_definition(def),
@@ -317,11 +317,11 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_static_block(&mut self, block: &'b mut StaticBlock<'a>) {
+    fn visit_static_block(&mut self, block: &mut StaticBlock<'a>) {
         self.visit_statements(&mut block.body);
     }
 
-    fn visit_method_definition(&mut self, def: &'b mut MethodDefinition<'a>) {
+    fn visit_method_definition(&mut self, def: &mut MethodDefinition<'a>) {
         for decorator in def.decorators.iter_mut() {
             self.visit_decorator(decorator);
         }
@@ -329,7 +329,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_function(&mut def.value);
     }
 
-    fn visit_property_definition(&mut self, def: &'b mut PropertyDefinition<'a>) {
+    fn visit_property_definition(&mut self, def: &mut PropertyDefinition<'a>) {
         for decorator in def.decorators.iter_mut() {
             self.visit_decorator(decorator);
         }
@@ -344,11 +344,11 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     /* ----------  Expression ---------- */
 
-    fn visit_expression(&mut self, expr: &'b mut Expression<'a>) {
+    fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         self.visit_expression_match(expr);
     }
 
-    fn visit_expression_match(&mut self, expr: &'b mut Expression<'a>) {
+    fn visit_expression_match(&mut self, expr: &mut Expression<'a>) {
         match expr {
             Expression::BigintLiteral(lit) => self.visit_bigint_literal(lit),
             Expression::BooleanLiteral(lit) => self.visit_boolean_literal(lit),
@@ -402,15 +402,15 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_meta_property(&mut self, _meta: &'b mut MetaProperty) {}
+    fn visit_meta_property(&mut self, _meta: &mut MetaProperty) {}
 
-    fn visit_array_expression(&mut self, expr: &'b mut ArrayExpression<'a>) {
+    fn visit_array_expression(&mut self, expr: &mut ArrayExpression<'a>) {
         for elem in expr.elements.iter_mut() {
             self.visit_array_expression_element(elem);
         }
     }
 
-    fn visit_array_expression_element(&mut self, arg: &'b mut ArrayExpressionElement<'a>) {
+    fn visit_array_expression_element(&mut self, arg: &mut ArrayExpressionElement<'a>) {
         match arg {
             ArrayExpressionElement::SpreadElement(spread) => self.visit_spread_element(spread),
             ArrayExpressionElement::Expression(expr) => self.visit_expression_array_element(expr),
@@ -418,29 +418,29 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_argument(&mut self, arg: &'b mut Argument<'a>) {
+    fn visit_argument(&mut self, arg: &mut Argument<'a>) {
         match arg {
             Argument::SpreadElement(spread) => self.visit_spread_element(spread),
             Argument::Expression(expr) => self.visit_expression(expr),
         }
     }
 
-    fn visit_spread_element(&mut self, elem: &'b mut SpreadElement<'a>) {
+    fn visit_spread_element(&mut self, elem: &mut SpreadElement<'a>) {
         self.visit_expression(&mut elem.argument);
     }
 
-    fn visit_expression_array_element(&mut self, expr: &'b mut Expression<'a>) {
+    fn visit_expression_array_element(&mut self, expr: &mut Expression<'a>) {
         self.visit_expression(expr);
     }
 
     fn visit_elision(&mut self, _span: Span) {}
 
-    fn visit_assignment_expression(&mut self, expr: &'b mut AssignmentExpression<'a>) {
+    fn visit_assignment_expression(&mut self, expr: &mut AssignmentExpression<'a>) {
         self.visit_assignment_target(&mut expr.left);
         self.visit_expression(&mut expr.right);
     }
 
-    fn visit_arrow_expression(&mut self, expr: &'b mut ArrowExpression<'a>) {
+    fn visit_arrow_expression(&mut self, expr: &mut ArrowExpression<'a>) {
         self.visit_formal_parameters(&mut expr.params);
         self.visit_function_body(&mut expr.body);
         if let Some(parameters) = &mut expr.type_parameters {
@@ -448,16 +448,16 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_await_expression(&mut self, expr: &'b mut AwaitExpression<'a>) {
+    fn visit_await_expression(&mut self, expr: &mut AwaitExpression<'a>) {
         self.visit_expression(&mut expr.argument);
     }
 
-    fn visit_binary_expression(&mut self, expr: &'b mut BinaryExpression<'a>) {
+    fn visit_binary_expression(&mut self, expr: &mut BinaryExpression<'a>) {
         self.visit_expression(&mut expr.left);
         self.visit_expression(&mut expr.right);
     }
 
-    fn visit_call_expression(&mut self, expr: &'b mut CallExpression<'a>) {
+    fn visit_call_expression(&mut self, expr: &mut CallExpression<'a>) {
         for arg in expr.arguments.iter_mut() {
             self.visit_argument(arg);
         }
@@ -467,36 +467,36 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_chain_expression(&mut self, expr: &'b mut ChainExpression<'a>) {
+    fn visit_chain_expression(&mut self, expr: &mut ChainExpression<'a>) {
         self.visit_chain_element(&mut expr.expression);
     }
 
-    fn visit_chain_element(&mut self, elem: &'b mut ChainElement<'a>) {
+    fn visit_chain_element(&mut self, elem: &mut ChainElement<'a>) {
         match elem {
             ChainElement::CallExpression(expr) => self.visit_call_expression(expr),
             ChainElement::MemberExpression(expr) => self.visit_member_expression(expr),
         }
     }
 
-    fn visit_conditional_expression(&mut self, expr: &'b mut ConditionalExpression<'a>) {
+    fn visit_conditional_expression(&mut self, expr: &mut ConditionalExpression<'a>) {
         self.visit_expression(&mut expr.test);
         self.visit_expression(&mut expr.consequent);
         self.visit_expression(&mut expr.alternate);
     }
 
-    fn visit_import_expression(&mut self, expr: &'b mut ImportExpression<'a>) {
+    fn visit_import_expression(&mut self, expr: &mut ImportExpression<'a>) {
         self.visit_expression(&mut expr.source);
         for arg in expr.arguments.iter_mut() {
             self.visit_expression(arg);
         }
     }
 
-    fn visit_logical_expression(&mut self, expr: &'b mut LogicalExpression<'a>) {
+    fn visit_logical_expression(&mut self, expr: &mut LogicalExpression<'a>) {
         self.visit_expression(&mut expr.left);
         self.visit_expression(&mut expr.right);
     }
 
-    fn visit_member_expression(&mut self, expr: &'b mut MemberExpression<'a>) {
+    fn visit_member_expression(&mut self, expr: &mut MemberExpression<'a>) {
         match expr {
             MemberExpression::ComputedMemberExpression(expr) => {
                 self.visit_computed_member_expression(expr);
@@ -510,22 +510,22 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_computed_member_expression(&mut self, expr: &'b mut ComputedMemberExpression<'a>) {
+    fn visit_computed_member_expression(&mut self, expr: &mut ComputedMemberExpression<'a>) {
         self.visit_expression(&mut expr.object);
         self.visit_expression(&mut expr.expression);
     }
 
-    fn visit_static_member_expression(&mut self, expr: &'b mut StaticMemberExpression<'a>) {
+    fn visit_static_member_expression(&mut self, expr: &mut StaticMemberExpression<'a>) {
         self.visit_expression(&mut expr.object);
         self.visit_identifier_name(&mut expr.property);
     }
 
-    fn visit_private_field_expression(&mut self, expr: &'b mut PrivateFieldExpression<'a>) {
+    fn visit_private_field_expression(&mut self, expr: &mut PrivateFieldExpression<'a>) {
         self.visit_expression(&mut expr.object);
         self.visit_private_identifier(&mut expr.field);
     }
 
-    fn visit_new_expression(&mut self, expr: &'b mut NewExpression<'a>) {
+    fn visit_new_expression(&mut self, expr: &mut NewExpression<'a>) {
         self.visit_expression(&mut expr.callee);
         if let Some(parameters) = &mut expr.type_parameters {
             self.visit_ts_type_parameter_instantiation(parameters);
@@ -535,25 +535,25 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_object_expression(&mut self, expr: &'b mut ObjectExpression<'a>) {
+    fn visit_object_expression(&mut self, expr: &mut ObjectExpression<'a>) {
         for prop in expr.properties.iter_mut() {
             self.visit_object_property_kind(prop);
         }
     }
 
-    fn visit_object_property_kind(&mut self, prop: &'b mut ObjectPropertyKind<'a>) {
+    fn visit_object_property_kind(&mut self, prop: &mut ObjectPropertyKind<'a>) {
         match prop {
             ObjectPropertyKind::ObjectProperty(prop) => self.visit_object_property(prop),
             ObjectPropertyKind::SpreadProperty(elem) => self.visit_spread_element(elem),
         }
     }
 
-    fn visit_object_property(&mut self, prop: &'b mut ObjectProperty<'a>) {
+    fn visit_object_property(&mut self, prop: &mut ObjectProperty<'a>) {
         self.visit_property_key(&mut prop.key);
         self.visit_expression(&mut prop.value);
     }
 
-    fn visit_property_key(&mut self, key: &'b mut PropertyKey<'a>) {
+    fn visit_property_key(&mut self, key: &mut PropertyKey<'a>) {
         match key {
             PropertyKey::Identifier(ident) => self.visit_identifier_name(ident),
             PropertyKey::PrivateIdentifier(ident) => self.visit_private_identifier(ident),
@@ -561,45 +561,45 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_parenthesized_expression(&mut self, expr: &'b mut ParenthesizedExpression<'a>) {
+    fn visit_parenthesized_expression(&mut self, expr: &mut ParenthesizedExpression<'a>) {
         self.visit_expression(&mut expr.expression);
     }
 
-    fn visit_private_in_expression(&mut self, expr: &'b mut PrivateInExpression<'a>) {
+    fn visit_private_in_expression(&mut self, expr: &mut PrivateInExpression<'a>) {
         self.visit_private_identifier(&mut expr.left);
         self.visit_expression(&mut expr.right);
     }
 
-    fn visit_sequence_expression(&mut self, expr: &'b mut SequenceExpression<'a>) {
+    fn visit_sequence_expression(&mut self, expr: &mut SequenceExpression<'a>) {
         for expr in expr.expressions.iter_mut() {
             self.visit_expression(expr);
         }
     }
 
-    fn visit_tagged_template_expression(&mut self, expr: &'b mut TaggedTemplateExpression<'a>) {
+    fn visit_tagged_template_expression(&mut self, expr: &mut TaggedTemplateExpression<'a>) {
         self.visit_expression(&mut expr.tag);
         self.visit_template_literal(&mut expr.quasi);
     }
 
-    fn visit_this_expression(&mut self, _expr: &'b mut ThisExpression) {}
+    fn visit_this_expression(&mut self, _expr: &mut ThisExpression) {}
 
-    fn visit_unary_expression(&mut self, expr: &'b mut UnaryExpression<'a>) {
+    fn visit_unary_expression(&mut self, expr: &mut UnaryExpression<'a>) {
         self.visit_expression(&mut expr.argument);
     }
 
-    fn visit_update_expression(&mut self, expr: &'b mut UpdateExpression<'a>) {
+    fn visit_update_expression(&mut self, expr: &mut UpdateExpression<'a>) {
         self.visit_simple_assignment_target(&mut expr.argument);
     }
 
-    fn visit_yield_expression(&mut self, expr: &'b mut YieldExpression<'a>) {
+    fn visit_yield_expression(&mut self, expr: &mut YieldExpression<'a>) {
         if let Some(argument) = &mut expr.argument {
             self.visit_expression(argument);
         }
     }
 
-    fn visit_super(&mut self, _expr: &'b mut Super) {}
+    fn visit_super(&mut self, _expr: &mut Super) {}
 
-    fn visit_assignment_target(&mut self, target: &'b mut AssignmentTarget<'a>) {
+    fn visit_assignment_target(&mut self, target: &mut AssignmentTarget<'a>) {
         match target {
             AssignmentTarget::SimpleAssignmentTarget(target) => {
                 self.visit_simple_assignment_target(target);
@@ -610,7 +610,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_simple_assignment_target(&mut self, target: &'b mut SimpleAssignmentTarget<'a>) {
+    fn visit_simple_assignment_target(&mut self, target: &mut SimpleAssignmentTarget<'a>) {
         match target {
             SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) => {
                 self.visit_identifier_reference(ident);
@@ -633,7 +633,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_assignment_target_pattern(&mut self, pat: &'b mut AssignmentTargetPattern<'a>) {
+    fn visit_assignment_target_pattern(&mut self, pat: &mut AssignmentTargetPattern<'a>) {
         match pat {
             AssignmentTargetPattern::ArrayAssignmentTarget(target) => {
                 self.visit_array_assignment_target(target);
@@ -644,7 +644,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_array_assignment_target(&mut self, target: &'b mut ArrayAssignmentTarget<'a>) {
+    fn visit_array_assignment_target(&mut self, target: &mut ArrayAssignmentTarget<'a>) {
         for element in target.elements.iter_mut().flatten() {
             self.visit_assignment_target_maybe_default(element);
         }
@@ -655,7 +655,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_assignment_target_maybe_default(
         &mut self,
-        target: &'b mut AssignmentTargetMaybeDefault<'a>,
+        target: &mut AssignmentTargetMaybeDefault<'a>,
     ) {
         match target {
             AssignmentTargetMaybeDefault::AssignmentTarget(target) => {
@@ -669,13 +669,13 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_assignment_target_with_default(
         &mut self,
-        target: &'b mut AssignmentTargetWithDefault<'a>,
+        target: &mut AssignmentTargetWithDefault<'a>,
     ) {
         self.visit_assignment_target(&mut target.binding);
         self.visit_expression(&mut target.init);
     }
 
-    fn visit_object_assignment_target(&mut self, target: &'b mut ObjectAssignmentTarget<'a>) {
+    fn visit_object_assignment_target(&mut self, target: &mut ObjectAssignmentTarget<'a>) {
         for property in target.properties.iter_mut() {
             self.visit_assignment_target_property(property);
         }
@@ -684,7 +684,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_assignment_target_property(&mut self, property: &'b mut AssignmentTargetProperty<'a>) {
+    fn visit_assignment_target_property(&mut self, property: &mut AssignmentTargetProperty<'a>) {
         match property {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(ident) => {
                 self.visit_assignment_target_property_identifier(ident);
@@ -697,7 +697,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_assignment_target_property_identifier(
         &mut self,
-        ident: &'b mut AssignmentTargetPropertyIdentifier<'a>,
+        ident: &mut AssignmentTargetPropertyIdentifier<'a>,
     ) {
         self.visit_identifier_reference(&mut ident.binding);
         if let Some(expr) = &mut ident.init {
@@ -707,7 +707,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_assignment_target_property_property(
         &mut self,
-        property: &'b mut AssignmentTargetPropertyProperty<'a>,
+        property: &mut AssignmentTargetPropertyProperty<'a>,
     ) {
         self.visit_property_key(&mut property.name);
         self.visit_assignment_target_maybe_default(&mut property.binding);
@@ -715,23 +715,23 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     /* ----------  Expression ---------- */
 
-    fn visit_jsx_element(&mut self, elem: &'b mut JSXElement<'a>) {
+    fn visit_jsx_element(&mut self, elem: &mut JSXElement<'a>) {
         self.visit_jsx_opening_element(&mut elem.opening_element);
         for child in elem.children.iter_mut() {
             self.visit_jsx_child(child);
         }
     }
 
-    fn visit_jsx_opening_element(&mut self, elem: &'b mut JSXOpeningElement<'a>) {
+    fn visit_jsx_opening_element(&mut self, elem: &mut JSXOpeningElement<'a>) {
         self.visit_jsx_element_name(&mut elem.name);
         for attribute in elem.attributes.iter_mut() {
             self.visit_jsx_attribute_item(attribute);
         }
     }
 
-    fn visit_jsx_element_name(&mut self, __name: &'b mut JSXElementName<'a>) {}
+    fn visit_jsx_element_name(&mut self, __name: &mut JSXElementName<'a>) {}
 
-    fn visit_jsx_attribute_item(&mut self, item: &'b mut JSXAttributeItem<'a>) {
+    fn visit_jsx_attribute_item(&mut self, item: &mut JSXAttributeItem<'a>) {
         match item {
             JSXAttributeItem::Attribute(attribute) => self.visit_jsx_attribute(attribute),
             JSXAttributeItem::SpreadAttribute(attribute) => {
@@ -740,17 +740,17 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_jsx_attribute(&mut self, attribute: &'b mut JSXAttribute<'a>) {
+    fn visit_jsx_attribute(&mut self, attribute: &mut JSXAttribute<'a>) {
         if let Some(value) = &mut attribute.value {
             self.visit_jsx_attribute_value(value);
         }
     }
 
-    fn visit_jsx_spread_attribute(&mut self, attribute: &'b mut JSXSpreadAttribute<'a>) {
+    fn visit_jsx_spread_attribute(&mut self, attribute: &mut JSXSpreadAttribute<'a>) {
         self.visit_expression(&mut attribute.argument);
     }
 
-    fn visit_jsx_attribute_value(&mut self, value: &'b mut JSXAttributeValue<'a>) {
+    fn visit_jsx_attribute_value(&mut self, value: &mut JSXAttributeValue<'a>) {
         match value {
             JSXAttributeValue::ExpressionContainer(expr) => {
                 self.visit_jsx_expression_container(expr);
@@ -761,24 +761,24 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_jsx_expression_container(&mut self, expr: &'b mut JSXExpressionContainer<'a>) {
+    fn visit_jsx_expression_container(&mut self, expr: &mut JSXExpressionContainer<'a>) {
         self.visit_jsx_expression(&mut expr.expression);
     }
 
-    fn visit_jsx_expression(&mut self, expr: &'b mut JSXExpression<'a>) {
+    fn visit_jsx_expression(&mut self, expr: &mut JSXExpression<'a>) {
         match expr {
             JSXExpression::Expression(expr) => self.visit_expression(expr),
             JSXExpression::EmptyExpression(_) => {}
         }
     }
 
-    fn visit_jsx_fragment(&mut self, elem: &'b mut JSXFragment<'a>) {
+    fn visit_jsx_fragment(&mut self, elem: &mut JSXFragment<'a>) {
         for child in elem.children.iter_mut() {
             self.visit_jsx_child(child);
         }
     }
 
-    fn visit_jsx_child(&mut self, child: &'b mut JSXChild<'a>) {
+    fn visit_jsx_child(&mut self, child: &mut JSXChild<'a>) {
         match child {
             JSXChild::Element(elem) => self.visit_jsx_element(elem),
             JSXChild::Fragment(elem) => self.visit_jsx_fragment(elem),
@@ -788,13 +788,13 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_jsx_spread_child(&mut self, child: &'b mut JSXSpreadChild<'a>) {
+    fn visit_jsx_spread_child(&mut self, child: &mut JSXSpreadChild<'a>) {
         self.visit_expression(&mut child.expression);
     }
 
     /* ----------  Pattern ---------- */
 
-    fn visit_binding_pattern(&mut self, pat: &'b mut BindingPattern<'a>) {
+    fn visit_binding_pattern(&mut self, pat: &mut BindingPattern<'a>) {
         match &mut pat.kind {
             BindingPatternKind::BindingIdentifier(ident) => {
                 self.visit_binding_identifier(ident);
@@ -808,20 +808,20 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_binding_identifier(&mut self, __ident: &'b mut BindingIdentifier) {}
+    fn visit_binding_identifier(&mut self, __ident: &mut BindingIdentifier) {}
 
-    fn visit_object_pattern(&mut self, pat: &'b mut ObjectPattern<'a>) {
+    fn visit_object_pattern(&mut self, pat: &mut ObjectPattern<'a>) {
         for prop in pat.properties.iter_mut() {
             self.visit_binding_property(prop);
         }
     }
 
-    fn visit_binding_property(&mut self, prop: &'b mut BindingProperty<'a>) {
+    fn visit_binding_property(&mut self, prop: &mut BindingProperty<'a>) {
         self.visit_property_key(&mut prop.key);
         self.visit_binding_pattern(&mut prop.value);
     }
 
-    fn visit_array_pattern(&mut self, pat: &'b mut ArrayPattern<'a>) {
+    fn visit_array_pattern(&mut self, pat: &mut ArrayPattern<'a>) {
         for pat in pat.elements.iter_mut().flatten() {
             self.visit_binding_pattern(pat);
         }
@@ -830,38 +830,38 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_rest_element(&mut self, pat: &'b mut RestElement<'a>) {
+    fn visit_rest_element(&mut self, pat: &mut RestElement<'a>) {
         self.visit_binding_pattern(&mut pat.argument);
     }
 
-    fn visit_assignment_pattern(&mut self, pat: &'b mut AssignmentPattern<'a>) {
+    fn visit_assignment_pattern(&mut self, pat: &mut AssignmentPattern<'a>) {
         self.visit_binding_pattern(&mut pat.left);
         self.visit_expression(&mut pat.right);
     }
 
     /* ----------  Identifier ---------- */
 
-    fn visit_identifier_reference(&mut self, _ident: &'b mut IdentifierReference) {}
+    fn visit_identifier_reference(&mut self, _ident: &mut IdentifierReference) {}
 
-    fn visit_private_identifier(&mut self, _ident: &'b mut PrivateIdentifier) {}
+    fn visit_private_identifier(&mut self, _ident: &mut PrivateIdentifier) {}
 
-    fn visit_label_identifier(&mut self, _ident: &'b mut LabelIdentifier) {}
+    fn visit_label_identifier(&mut self, _ident: &mut LabelIdentifier) {}
 
-    fn visit_identifier_name(&mut self, _ident: &'b mut IdentifierName) {}
+    fn visit_identifier_name(&mut self, _ident: &mut IdentifierName) {}
 
     /* ----------  Literal ---------- */
 
-    fn visit_number_literal(&mut self, _lit: &'b mut NumberLiteral<'a>) {}
+    fn visit_number_literal(&mut self, _lit: &mut NumberLiteral<'a>) {}
 
-    fn visit_boolean_literal(&mut self, _lit: &'b mut BooleanLiteral) {}
+    fn visit_boolean_literal(&mut self, _lit: &mut BooleanLiteral) {}
 
-    fn visit_null_literal(&mut self, _lit: &'b mut NullLiteral) {}
+    fn visit_null_literal(&mut self, _lit: &mut NullLiteral) {}
 
-    fn visit_bigint_literal(&mut self, _lit: &'b mut BigintLiteral) {}
+    fn visit_bigint_literal(&mut self, _lit: &mut BigintLiteral) {}
 
-    fn visit_string_literal(&mut self, _lit: &'b mut StringLiteral) {}
+    fn visit_string_literal(&mut self, _lit: &mut StringLiteral) {}
 
-    fn visit_template_literal(&mut self, lit: &'b mut TemplateLiteral<'a>) {
+    fn visit_template_literal(&mut self, lit: &mut TemplateLiteral<'a>) {
         for elem in lit.quasis.iter_mut() {
             self.visit_template_element(elem);
         }
@@ -870,13 +870,13 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_reg_expr_literal(&mut self, _lit: &'b mut RegExpLiteral) {}
+    fn visit_reg_expr_literal(&mut self, _lit: &mut RegExpLiteral) {}
 
-    fn visit_template_element(&mut self, _elem: &'b mut TemplateElement) {}
+    fn visit_template_element(&mut self, _elem: &mut TemplateElement) {}
 
     /* ----------  Module ---------- */
 
-    fn visit_module_declaration(&mut self, decl: &'b mut ModuleDeclaration<'a>) {
+    fn visit_module_declaration(&mut self, decl: &mut ModuleDeclaration<'a>) {
         match decl {
             ModuleDeclaration::ImportDeclaration(decl) => {
                 self.visit_import_declaration(decl);
@@ -897,7 +897,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_import_declaration(&mut self, decl: &'b mut ImportDeclaration<'a>) {
+    fn visit_import_declaration(&mut self, decl: &mut ImportDeclaration<'a>) {
         for specifier in decl.specifiers.iter_mut() {
             self.visit_import_declaration_specifier(specifier);
         }
@@ -905,10 +905,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         // TODO: assertions
     }
 
-    fn visit_import_declaration_specifier(
-        &mut self,
-        specifier: &'b mut ImportDeclarationSpecifier,
-    ) {
+    fn visit_import_declaration_specifier(&mut self, specifier: &mut ImportDeclarationSpecifier) {
         match specifier {
             ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
                 self.visit_import_specifier(specifier);
@@ -922,22 +919,22 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_import_specifier(&mut self, specifier: &'b mut ImportSpecifier) {
+    fn visit_import_specifier(&mut self, specifier: &mut ImportSpecifier) {
         // TODO: imported
         self.visit_binding_identifier(&mut specifier.local);
     }
 
-    fn visit_import_default_specifier(&mut self, specifier: &'b mut ImportDefaultSpecifier) {
+    fn visit_import_default_specifier(&mut self, specifier: &mut ImportDefaultSpecifier) {
         self.visit_binding_identifier(&mut specifier.local);
     }
 
-    fn visit_import_name_specifier(&mut self, specifier: &'b mut ImportNamespaceSpecifier) {
+    fn visit_import_name_specifier(&mut self, specifier: &mut ImportNamespaceSpecifier) {
         self.visit_binding_identifier(&mut specifier.local);
     }
 
-    fn visit_export_all_declaration(&mut self, _decl: &'b mut ExportAllDeclaration<'a>) {}
+    fn visit_export_all_declaration(&mut self, _decl: &mut ExportAllDeclaration<'a>) {}
 
-    fn visit_export_default_declaration(&mut self, decl: &'b mut ExportDefaultDeclaration<'a>) {
+    fn visit_export_default_declaration(&mut self, decl: &mut ExportDefaultDeclaration<'a>) {
         match &mut decl.declaration {
             ExportDefaultDeclarationKind::Expression(expr) => self.visit_expression(expr),
             ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
@@ -948,26 +945,26 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_export_named_declaration(&mut self, decl: &'b mut ExportNamedDeclaration<'a>) {
+    fn visit_export_named_declaration(&mut self, decl: &mut ExportNamedDeclaration<'a>) {
         if let Some(decl) = &mut decl.declaration {
             self.visit_declaration(decl);
         }
     }
 
-    fn visit_enum_member(&mut self, member: &'b mut TSEnumMember<'a>) {
+    fn visit_enum_member(&mut self, member: &mut TSEnumMember<'a>) {
         if let Some(initializer) = &mut member.initializer {
             self.visit_expression(initializer);
         }
     }
 
-    fn visit_enum(&mut self, decl: &'b mut TSEnumDeclaration<'a>) {
+    fn visit_enum(&mut self, decl: &mut TSEnumDeclaration<'a>) {
         self.visit_binding_identifier(&mut decl.id);
         for member in decl.body.members.iter_mut() {
             self.visit_enum_member(member);
         }
     }
 
-    fn visit_declaration(&mut self, decl: &'b mut Declaration<'a>) {
+    fn visit_declaration(&mut self, decl: &mut Declaration<'a>) {
         match decl {
             Declaration::VariableDeclaration(decl) => self.visit_variable_declaration(decl),
             Declaration::FunctionDeclaration(func) => self.visit_function(func),
@@ -989,11 +986,11 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_import_equals_declaration(&mut self, decl: &'b mut TSImportEqualsDeclaration<'a>) {
+    fn visit_ts_import_equals_declaration(&mut self, decl: &mut TSImportEqualsDeclaration<'a>) {
         self.visit_binding_identifier(&mut decl.id);
     }
 
-    fn visit_ts_module_declaration(&mut self, decl: &'b mut TSModuleDeclaration<'a>) {
+    fn visit_ts_module_declaration(&mut self, decl: &mut TSModuleDeclaration<'a>) {
         match &mut decl.id {
             TSModuleDeclarationName::Identifier(ident) => self.visit_identifier_name(ident),
             TSModuleDeclarationName::StringLiteral(lit) => self.visit_string_literal(lit),
@@ -1006,11 +1003,11 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_module_block(&mut self, block: &'b mut TSModuleBlock<'a>) {
+    fn visit_ts_module_block(&mut self, block: &mut TSModuleBlock<'a>) {
         self.visit_statements(&mut block.body);
     }
 
-    fn visit_ts_type_alias_declaration(&mut self, decl: &'b mut TSTypeAliasDeclaration<'a>) {
+    fn visit_ts_type_alias_declaration(&mut self, decl: &mut TSTypeAliasDeclaration<'a>) {
         self.visit_binding_identifier(&mut decl.id);
         if let Some(parameters) = &mut decl.type_parameters {
             self.visit_ts_type_parameter_declaration(parameters);
@@ -1018,7 +1015,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_ts_type(&mut decl.type_annotation);
     }
 
-    fn visit_ts_interface_declaration(&mut self, decl: &'b mut TSInterfaceDeclaration<'a>) {
+    fn visit_ts_interface_declaration(&mut self, decl: &mut TSInterfaceDeclaration<'a>) {
         self.visit_binding_identifier(&mut decl.id);
         if let Some(parameters) = &mut decl.type_parameters {
             self.visit_ts_type_parameter_declaration(parameters);
@@ -1028,35 +1025,35 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_as_expression(&mut self, expr: &'b mut TSAsExpression<'a>) {
+    fn visit_ts_as_expression(&mut self, expr: &mut TSAsExpression<'a>) {
         self.visit_expression(&mut expr.expression);
         self.visit_ts_type(&mut expr.type_annotation);
     }
 
-    fn visit_ts_satisfies_expression(&mut self, expr: &'b mut TSSatisfiesExpression<'a>) {
+    fn visit_ts_satisfies_expression(&mut self, expr: &mut TSSatisfiesExpression<'a>) {
         self.visit_expression(&mut expr.expression);
         self.visit_ts_type(&mut expr.type_annotation);
     }
 
-    fn visit_ts_non_null_expression(&mut self, expr: &'b mut TSNonNullExpression<'a>) {
+    fn visit_ts_non_null_expression(&mut self, expr: &mut TSNonNullExpression<'a>) {
         self.visit_expression(&mut expr.expression);
     }
 
-    fn visit_ts_type_assertion(&mut self, expr: &'b mut TSTypeAssertion<'a>) {
+    fn visit_ts_type_assertion(&mut self, expr: &mut TSTypeAssertion<'a>) {
         self.visit_expression(&mut expr.expression);
         self.visit_ts_type(&mut expr.type_annotation);
     }
 
-    fn visit_ts_instantiation_expression(&mut self, expr: &'b mut TSInstantiationExpression<'a>) {
+    fn visit_ts_instantiation_expression(&mut self, expr: &mut TSInstantiationExpression<'a>) {
         self.visit_expression(&mut expr.expression);
         self.visit_ts_type_parameter_instantiation(&mut expr.type_parameters);
     }
 
-    fn visit_ts_type_annotation(&mut self, annotation: &'b mut TSTypeAnnotation<'a>) {
+    fn visit_ts_type_annotation(&mut self, annotation: &mut TSTypeAnnotation<'a>) {
         self.visit_ts_type(&mut annotation.type_annotation);
     }
 
-    fn visit_ts_type(&mut self, ty: &'b mut TSType<'a>) {
+    fn visit_ts_type(&mut self, ty: &mut TSType<'a>) {
         match ty {
             TSType::TSAnyKeyword(ty) => self.visit_ts_any_keyword(ty),
             TSType::TSNullKeyword(ty) => self.visit_ts_null_keyword(ty),
@@ -1079,34 +1076,34 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_type_literal(&mut self, ty: &'b mut TSTypeLiteral<'a>) {
+    fn visit_ts_type_literal(&mut self, ty: &mut TSTypeLiteral<'a>) {
         for signature in ty.members.iter_mut() {
             self.visit_ts_signature(signature);
         }
     }
 
-    fn visit_ts_indexed_access_type(&mut self, ty: &'b mut TSIndexedAccessType<'a>) {
+    fn visit_ts_indexed_access_type(&mut self, ty: &mut TSIndexedAccessType<'a>) {
         self.visit_ts_type(&mut ty.object_type);
         self.visit_ts_type(&mut ty.index_type);
     }
 
-    fn visit_ts_type_predicate(&mut self, ty: &'b mut TSTypePredicate<'a>) {
+    fn visit_ts_type_predicate(&mut self, ty: &mut TSTypePredicate<'a>) {
         if let Some(annotation) = &mut ty.type_annotation {
             self.visit_ts_type_annotation(annotation);
         }
     }
 
-    fn visit_ts_type_operator_type(&mut self, ty: &'b mut TSTypeOperatorType<'a>) {
+    fn visit_ts_type_operator_type(&mut self, ty: &mut TSTypeOperatorType<'a>) {
         self.visit_ts_type(&mut ty.type_annotation);
     }
 
-    fn visit_ts_tuple_type(&mut self, ty: &'b mut TSTupleType<'a>) {
+    fn visit_ts_tuple_type(&mut self, ty: &mut TSTupleType<'a>) {
         for element in ty.element_types.iter_mut() {
             self.visit_ts_tuple_element(element);
         }
     }
 
-    fn visit_ts_tuple_element(&mut self, ty: &'b mut TSTupleElement<'a>) {
+    fn visit_ts_tuple_element(&mut self, ty: &mut TSTupleElement<'a>) {
         match ty {
             TSTupleElement::TSType(ty) => self.visit_ts_type(ty),
             TSTupleElement::TSOptionalType(ty) => self.visit_ts_type(&mut ty.type_annotation),
@@ -1115,7 +1112,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         };
     }
 
-    fn visit_ts_mapped_type(&mut self, ty: &'b mut TSMappedType<'a>) {
+    fn visit_ts_mapped_type(&mut self, ty: &mut TSMappedType<'a>) {
         self.visit_ts_type_parameter(&mut ty.type_parameter);
         if let Some(name) = &mut ty.name_type {
             self.visit_ts_type(name);
@@ -1125,7 +1122,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_function_type(&mut self, ty: &'b mut TSFunctionType<'a>) {
+    fn visit_ts_function_type(&mut self, ty: &mut TSFunctionType<'a>) {
         self.visit_formal_parameters(&mut ty.params);
         if let Some(parameters) = &mut ty.type_parameters {
             self.visit_ts_type_parameter_declaration(parameters);
@@ -1133,7 +1130,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_ts_type_annotation(&mut ty.return_type);
     }
 
-    fn visit_ts_type_parameter(&mut self, ty: &'b mut TSTypeParameter<'a>) {
+    fn visit_ts_type_parameter(&mut self, ty: &mut TSTypeParameter<'a>) {
         if let Some(constraint) = &mut ty.constraint {
             self.visit_ts_type(constraint);
         }
@@ -1143,22 +1140,19 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_type_parameter_instantiation(
-        &mut self,
-        ty: &'b mut TSTypeParameterInstantiation<'a>,
-    ) {
+    fn visit_ts_type_parameter_instantiation(&mut self, ty: &mut TSTypeParameterInstantiation<'a>) {
         for ts_parameter in ty.params.iter_mut() {
             self.visit_ts_type(ts_parameter);
         }
     }
 
-    fn visit_ts_type_parameter_declaration(&mut self, ty: &'b mut TSTypeParameterDeclaration<'a>) {
+    fn visit_ts_type_parameter_declaration(&mut self, ty: &mut TSTypeParameterDeclaration<'a>) {
         for ts_parameter in ty.params.iter_mut() {
             self.visit_ts_type_parameter(ts_parameter);
         }
     }
 
-    fn visit_ts_constructor_type(&mut self, ty: &'b mut TSConstructorType<'a>) {
+    fn visit_ts_constructor_type(&mut self, ty: &mut TSConstructorType<'a>) {
         self.visit_formal_parameters(&mut ty.params);
         if let Some(parameters) = &mut ty.type_parameters {
             self.visit_ts_type_parameter_declaration(parameters);
@@ -1166,50 +1160,50 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_ts_type_annotation(&mut ty.return_type);
     }
 
-    fn visit_ts_conditional_type(&mut self, ty: &'b mut TSConditionalType<'a>) {
+    fn visit_ts_conditional_type(&mut self, ty: &mut TSConditionalType<'a>) {
         self.visit_ts_type(&mut ty.check_type);
         self.visit_ts_type(&mut ty.extends_type);
         self.visit_ts_type(&mut ty.true_type);
         self.visit_ts_type(&mut ty.false_type);
     }
 
-    fn visit_ts_array_type(&mut self, ty: &'b mut TSArrayType<'a>) {
+    fn visit_ts_array_type(&mut self, ty: &mut TSArrayType<'a>) {
         self.visit_ts_type(&mut ty.element_type);
     }
 
-    fn visit_ts_type_name(&mut self, name: &'b mut TSTypeName<'a>) {
+    fn visit_ts_type_name(&mut self, name: &mut TSTypeName<'a>) {
         match name {
             TSTypeName::IdentifierReference(ident) => self.visit_identifier_reference(ident),
             TSTypeName::QualifiedName(_) => {}
         }
     }
 
-    fn visit_ts_null_keyword(&mut self, _ty: &'b mut TSNullKeyword) {}
+    fn visit_ts_null_keyword(&mut self, _ty: &mut TSNullKeyword) {}
 
-    fn visit_ts_any_keyword(&mut self, _ty: &'b mut TSAnyKeyword) {}
+    fn visit_ts_any_keyword(&mut self, _ty: &mut TSAnyKeyword) {}
 
-    fn visit_ts_void_keyword(&mut self, _ty: &'b mut TSVoidKeyword) {}
+    fn visit_ts_void_keyword(&mut self, _ty: &mut TSVoidKeyword) {}
 
-    fn visit_ts_intersection_type(&mut self, ty: &'b mut TSIntersectionType<'a>) {
+    fn visit_ts_intersection_type(&mut self, ty: &mut TSIntersectionType<'a>) {
         for ty in ty.types.iter_mut() {
             self.visit_ts_type(ty);
         }
     }
 
-    fn visit_ts_type_reference(&mut self, ty: &'b mut TSTypeReference<'a>) {
+    fn visit_ts_type_reference(&mut self, ty: &mut TSTypeReference<'a>) {
         self.visit_ts_type_name(&mut ty.type_name);
         if let Some(parameters) = &mut ty.type_parameters {
             self.visit_ts_type_parameter_instantiation(parameters);
         }
     }
 
-    fn visit_ts_union_type(&mut self, ty: &'b mut TSUnionType<'a>) {
+    fn visit_ts_union_type(&mut self, ty: &mut TSUnionType<'a>) {
         for ty in ty.types.iter_mut() {
             self.visit_ts_type(ty);
         }
     }
 
-    fn visit_ts_literal_type(&mut self, ty: &'b mut TSLiteralType<'a>) {
+    fn visit_ts_literal_type(&mut self, ty: &mut TSLiteralType<'a>) {
         match &mut ty.literal {
             TSLiteral::BigintLiteral(lit) => self.visit_bigint_literal(lit),
             TSLiteral::BooleanLiteral(lit) => self.visit_boolean_literal(lit),
@@ -1222,7 +1216,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_signature(&mut self, signature: &'b mut TSSignature<'a>) {
+    fn visit_ts_signature(&mut self, signature: &mut TSSignature<'a>) {
         match signature {
             TSSignature::TSPropertySignature(sig) => self.visit_ts_property_signature(sig),
             TSSignature::TSCallSignatureDeclaration(sig) => {
@@ -1238,7 +1232,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_ts_construct_signature_declaration(
         &mut self,
-        signature: &'b mut TSConstructSignatureDeclaration<'a>,
+        signature: &mut TSConstructSignatureDeclaration<'a>,
     ) {
         self.visit_formal_parameters(&mut signature.params);
         if let Some(parameters) = &mut signature.type_parameters {
@@ -1249,7 +1243,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_method_signature(&mut self, signature: &'b mut TSMethodSignature<'a>) {
+    fn visit_ts_method_signature(&mut self, signature: &mut TSMethodSignature<'a>) {
         self.visit_formal_parameters(&mut signature.params);
         if let Some(parameters) = &mut signature.type_parameters {
             self.visit_ts_type_parameter_declaration(parameters);
@@ -1259,11 +1253,11 @@ pub trait VisitMut<'a, 'b>: Sized {
         }
     }
 
-    fn visit_ts_index_signature_name(&mut self, name: &'b mut TSIndexSignatureName<'a>) {
+    fn visit_ts_index_signature_name(&mut self, name: &mut TSIndexSignatureName<'a>) {
         self.visit_ts_type_annotation(&mut name.type_annotation);
     }
 
-    fn visit_ts_index_signature(&mut self, signature: &'b mut TSIndexSignature<'a>) {
+    fn visit_ts_index_signature(&mut self, signature: &mut TSIndexSignature<'a>) {
         for name in signature.parameters.iter_mut() {
             self.visit_ts_index_signature_name(name);
         }
@@ -1271,7 +1265,7 @@ pub trait VisitMut<'a, 'b>: Sized {
         self.visit_ts_type_annotation(&mut signature.type_annotation);
     }
 
-    fn visit_ts_property_signature(&mut self, signature: &'b mut TSPropertySignature<'a>) {
+    fn visit_ts_property_signature(&mut self, signature: &mut TSPropertySignature<'a>) {
         self.visit_property_key(&mut signature.key);
         if let Some(annotation) = &mut signature.type_annotation {
             self.visit_ts_type_annotation(annotation);
@@ -1280,7 +1274,7 @@ pub trait VisitMut<'a, 'b>: Sized {
 
     fn visit_ts_call_signature_declaration(
         &mut self,
-        signature: &'b mut TSCallSignatureDeclaration<'a>,
+        signature: &mut TSCallSignatureDeclaration<'a>,
     ) {
         self.visit_formal_parameters(&mut signature.params);
         if let Some(parameters) = &mut signature.type_parameters {

--- a/crates/oxc_minifier/src/compressor/prepass.rs
+++ b/crates/oxc_minifier/src/compressor/prepass.rs
@@ -12,7 +12,7 @@ impl<'a> Prepass<'a> {
         Self { ast: AstBuilder::new(allocator) }
     }
 
-    fn strip_parenthesized_expression<'b>(&self, expr: &'b mut Expression<'a>) {
+    fn strip_parenthesized_expression(&self, expr: &mut Expression<'a>) {
         if let Expression::ParenthesizedExpression(paren_expr) = expr {
             *expr = self.ast.move_expression(&mut paren_expr.expression);
             self.strip_parenthesized_expression(expr);
@@ -20,15 +20,15 @@ impl<'a> Prepass<'a> {
     }
 }
 
-impl<'a, 'b> VisitMut<'a, 'b> for Prepass<'a> {
-    fn visit_statements(&mut self, stmts: &'b mut Vec<'a, Statement<'a>>) {
+impl<'a> VisitMut<'a> for Prepass<'a> {
+    fn visit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>) {
         stmts.retain(|stmt| !matches!(stmt, Statement::EmptyStatement(_)));
         for stmt in stmts.iter_mut() {
             self.visit_statement(stmt);
         }
     }
 
-    fn visit_expression(&mut self, expr: &'b mut Expression<'a>) {
+    fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         self.strip_parenthesized_expression(expr);
         self.visit_expression_match(expr);
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -150,7 +150,7 @@ impl<'a> SemanticBuilder<'a> {
         self
     }
 
-    pub fn build(mut self, program: &'a Program<'a>) -> SemanticBuilderReturn<'a> {
+    pub fn build(mut self, program: &Program<'a>) -> SemanticBuilderReturn<'a> {
         if !self.source_type.is_typescript_definition() {
             self.visit_program(program);
 

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -20,6 +20,7 @@ oxc_ast       = { workspace = true }
 oxc_span      = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_syntax    = { workspace = true }
+oxc_semantic  = { workspace = true }
 
 [dev-dependencies]
 oxc_parser    = { workspace = true }

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -3,6 +3,7 @@ use std::{env, path::Path};
 use oxc_allocator::Allocator;
 use oxc_formatter::{Formatter, FormatterOptions};
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_transformer::{TransformOptions, TransformReactOptions, TransformTarget, Transformer};
 
@@ -28,11 +29,12 @@ fn main() {
     }
 
     let formatter_options = FormatterOptions::default();
-    let program = allocator.alloc(ret.program);
-    let printed = Formatter::new(source_text.len(), formatter_options.clone()).build(program);
+    let printed = Formatter::new(source_text.len(), formatter_options.clone()).build(&ret.program);
     println!("Original:\n");
     println!("{printed}");
 
+    let program = allocator.alloc(ret.program);
+    let _ = SemanticBuilder::new(&source_text, source_type).build(program);
     let transform_options = TransformOptions {
         target: TransformTarget::ES2015,
         react: Some(TransformReactOptions::default()),

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -84,13 +84,13 @@ impl<'a> Transformer<'a> {
         t
     }
 
-    pub fn build<'b>(mut self, program: &'b mut Program<'a>) {
+    pub fn build(mut self, program: &mut Program<'a>) {
         self.visit_program(program);
     }
 }
 
-impl<'a, 'b> VisitMut<'a, 'b> for Transformer<'a> {
-    fn visit_expression(&mut self, expr: &'b mut Expression<'a>) {
+impl<'a> VisitMut<'a> for Transformer<'a> {
+    fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         // self.typescript.as_mut().map(|t| t.transform_expression(expr));
         // self.react_jsx.as_mut().map(|t| t.transform_expression(expr));
         self.es2021_logical_assignment_operators.as_mut().map(|t| t.transform_expression(expr));
@@ -100,7 +100,7 @@ impl<'a, 'b> VisitMut<'a, 'b> for Transformer<'a> {
         self.visit_expression_match(expr);
     }
 
-    fn visit_catch_clause(&mut self, clause: &'b mut CatchClause<'a>) {
+    fn visit_catch_clause(&mut self, clause: &mut CatchClause<'a>) {
         self.es2019_optional_catch_binding.as_mut().map(|t| t.transform_catch_clause(clause));
 
         if let Some(param) = &mut clause.param {
@@ -109,7 +109,7 @@ impl<'a, 'b> VisitMut<'a, 'b> for Transformer<'a> {
         self.visit_statements(&mut clause.body.body);
     }
 
-    fn visit_object_property(&mut self, prop: &'b mut ObjectProperty<'a>) {
+    fn visit_object_property(&mut self, prop: &mut ObjectProperty<'a>) {
         self.es2015_shorthand_properties.as_mut().map(|t| t.transform_object_property(prop));
 
         self.visit_property_key(&mut prop.key);
@@ -119,7 +119,7 @@ impl<'a, 'b> VisitMut<'a, 'b> for Transformer<'a> {
         }
     }
 
-    fn visit_class_body(&mut self, class_body: &'b mut ClassBody<'a>) {
+    fn visit_class_body(&mut self, class_body: &mut ClassBody<'a>) {
         self.es2022_class_static_block.as_mut().map(|t| t.transform_class_body(class_body));
 
         class_body.body.iter_mut().for_each(|class_element| {


### PR DESCRIPTION
I don't know what I'm doing ... but with an unsafe hack:

```rust
    fn alloc<T>(&self, t: &T) -> &'a T {
        unsafe { std::mem::transmute(t) }
    }
```

I managed to remove the annoying lifetime annotation of

```rust
fn visit_program(&mut self, program: &'a Program<'a>) {
```

to 

```rust
fn visit_program(&mut self, program: &Program<'a>) {
```

(Notice `&'a` is removed from `program`)

This is needed because we wouldn't be able to run the semantic builder before the transformer or minifier, because it will error

```
error[E0502]: cannot borrow `*program` as mutable because it is also borrowed as immutable
  --> crates/oxc_minifier/src/lib.rs:48:9
   |
47 |         let semantic = SemanticBuilder::new("", program.source_type).build(program);
   |                                                                            ------- immutable borrow occurs here
48 |         Compressor::new(&allocator, self.options.compress).build(program);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
...
52 |             let mangler = ManglerBuilder.build(program);
   |                                                ------- immutable borrow later used here
```

This also removes the weird allocation before running the semantic builder.

```rust
let program = allocator.alloc(ret.program);
```