### PR TITLE
chore(coverage): remove regex-v-flag feature from parser tests

### DIFF
--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -1,35 +1,7 @@
 parser_test262 Summary:
-AST Parsed     : 44219/44219 (100.00%)
-Positive Passed: 44219/44219 (100.00%)
-Negative Passed: 3919/3947 (99.29%)
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-01.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-02.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-03.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-04.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-05.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-06.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-07.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-08.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-09.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-10.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-11.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-12.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-13.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-14.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-15.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-16.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-17.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-18.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-19.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-20.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-21.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-22.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-23.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-24.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-25.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-26.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-27.js"
-Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-from-u-to-v-28.js"
+AST Parsed     : 44161/44161 (100.00%)
+Positive Passed: 44161/44161 (100.00%)
+Negative Passed: 3918/3918 (100.00%)
   × '0'-prefixed octal literals and octal escape sequences are deprecated
     ╭─[annexB/language/expressions/template-literal/legacy-octal-escape-sequence-strict.js:17:1]
  17 │ 
@@ -81,13 +53,6 @@ Expect Syntax Error: "built-ins/RegExp/prototype/unicodeSets/breaking-change-fro
  14 │ for (var {a} = 0 in {});
     ·      ───────────
  15 │ 
-    ╰────
-
-  × The 'u' and 'v' regular expression flags cannot be enabled at the same time
-    ╭─[built-ins/RegExp/prototype/unicodeSets/uv-flags.js:16:1]
- 16 │ 
- 17 │ /./uv;
-    · ─────
     ╰────
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/src/test262.rs
+++ b/tasks/coverage/src/test262.rs
@@ -156,6 +156,8 @@ impl Case for Test262Case {
 
     fn skip_test_case(&self) -> bool {
         [
+            // Regex parser is required. See https://github.com/web-infra-dev/oxc/issues/385#issuecomment-1755566240
+            "regexp-v-flag",
             "regexp-unicode-property-escapes",
             // Stage 3 `https://github.com/tc39/proposal-json-modules`
             "json-modules",


### PR DESCRIPTION
A regex parser is required to implement this.

Relates #385