### PR TITLE
feat(transformer): RegexpFlags

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -1,5 +1,3 @@
 mod shorthand_properties;
-mod sticky_regex;
 
 pub use shorthand_properties::ShorthandProperties;
-pub use sticky_regex::StickyRegex;

--- a/crates/oxc_transformer/src/options.rs
+++ b/crates/oxc_transformer/src/options.rs
@@ -10,9 +10,11 @@ pub enum TransformTarget {
     ES5,
     ES2015,
     ES2016,
+    ES2018,
     ES2019,
     ES2021,
     ES2022,
+    ES2024,
     #[default]
     ESNext,
 }

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -1,0 +1,3 @@
+mod regexp_flags;
+
+pub use regexp_flags::RegexpFlags;

--- a/crates/oxc_transformer/src/regexp/regexp_flags.rs
+++ b/crates/oxc_transformer/src/regexp/regexp_flags.rs
@@ -3,23 +3,32 @@ use oxc_span::{Atom, Span};
 
 use std::rc::Rc;
 
-/// ES2015: Sticky Regex
-///
-/// References:
-/// * <https://babel.dev/docs/babel-plugin-transform-sticky-regex>
-/// * <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-sticky-regex>
-pub struct StickyRegex<'a> {
+use crate::TransformTarget;
+
+/// Regexp
+pub struct RegexpFlags<'a> {
     ast: Rc<AstBuilder<'a>>,
+    transform_flags: RegExpFlags,
 }
 
-impl<'a> StickyRegex<'a> {
-    pub fn new(ast: Rc<AstBuilder<'a>>) -> Self {
-        Self { ast }
+impl<'a> RegexpFlags<'a> {
+    pub fn new_with_transform_target(
+        ast: Rc<AstBuilder<'a>>,
+        transform_target: TransformTarget,
+    ) -> Option<Self> {
+        let transform_flags = from_transform_target(transform_target);
+
+        if transform_flags.is_empty() {
+            None
+        } else {
+            Some(Self { ast, transform_flags })
+        }
     }
 
     pub fn transform_expression<'b>(&mut self, expr: &'b mut Expression<'a>) {
         let Expression::RegExpLiteral(reg_literal) = expr else { return };
-        if !reg_literal.regex.flags.contains(RegExpFlags::Y) {
+
+        if reg_literal.regex.flags.intersection(self.transform_flags).is_empty() {
             return;
         }
 
@@ -40,4 +49,32 @@ impl<'a> StickyRegex<'a> {
 
         *expr = self.ast.new_expression(Span::default(), callee, arguments, None);
     }
+}
+
+fn from_transform_target(value: TransformTarget) -> RegExpFlags {
+    let mut flag = RegExpFlags::empty();
+
+    if value < TransformTarget::ESNext {
+        flag |= RegExpFlags::I;
+        flag |= RegExpFlags::M;
+    }
+
+    if value < TransformTarget::ES2024 {
+        flag |= RegExpFlags::V;
+    }
+
+    if value < TransformTarget::ES2022 {
+        flag |= RegExpFlags::D;
+    }
+
+    if value < TransformTarget::ES2018 {
+        flag |= RegExpFlags::S;
+    }
+
+    if value < TransformTarget::ES2015 {
+        flag |= RegExpFlags::Y;
+        flag |= RegExpFlags::U;
+    }
+
+    flag
 }

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,4 +1,10 @@
-Passed: 97/1080
+Passed: 97/1091
+
+# babel-plugin-transform-unicode-sets-regex
+* Failed: basic/basic/input.js
+* Failed: basic/string-properties/input.js
+* Failed: transform-u/basic/input.js
+* Failed: transform-u/string-properties/input.js
 
 # babel-plugin-transform-class-properties
 * Failed: assumption-constantSuper/complex-super-class/input.js
@@ -701,6 +707,11 @@ Passed: 97/1080
 * Failed: regression/gh-7388/input.js
 * Failed: regression/gh-8323/input.js
 
+# babel-plugin-transform-dotall-regex
+* Failed: dotall-regex/simple/input.js
+* Failed: dotall-regex/with-unicode-flag/input.js
+* Failed: dotall-regex/with-unicode-property-escape/input.js
+
 # babel-plugin-transform-async-to-generator
 * Failed: assumption-ignoreFunctionLength-true/basic/input.mjs
 * Failed: assumption-ignoreFunctionLength-true/export-default-function/input.mjs
@@ -763,6 +774,12 @@ Passed: 97/1080
 [All passed]
 * Passed: sticky-regex/basic/input.js
 * Passed: sticky-regex/ignore-non-sticky/input.js
+
+# babel-plugin-transform-unicode-regex
+* Failed: unicode-regex/basic/input.js
+* Failed: unicode-regex/ignore-non-unicode/input.js
+* Failed: unicode-regex/negated-set/input.js
+* Failed: unicode-regex/slash/input.js
 
 # babel-plugin-transform-typescript
 * Failed: class/abstract-class-decorated/input.ts

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -22,7 +22,7 @@ pub fn babel(options: &BabelOptions) {
 
     let cases = [
         // ES2024
-        // [Regex] "babel-plugin-transform-unicode-sets-regex",
+        "babel-plugin-transform-unicode-sets-regex",
         // ES2022
         "babel-plugin-transform-class-properties",
         "babel-plugin-transform-class-static-block",
@@ -48,7 +48,7 @@ pub fn babel(options: &BabelOptions) {
         "babel-plugin-transform-async-generator-functions",
         "babel-plugin-transform-object-rest-spread",
         // [Regex] "babel-plugin-transform-unicode-property-regex",
-        // [Regex] "babel-plugin-transform-dotall-regex",
+        "babel-plugin-transform-dotall-regex",
         // [Regex] "babel-plugin-transform-named-capturing-groups-regex",
         // ES2017
         "babel-plugin-transform-async-to-generator",
@@ -57,6 +57,7 @@ pub fn babel(options: &BabelOptions) {
         // ES2015
         "babel-plugin-transform-shorthand-properties",
         "babel-plugin-transform-sticky-regex",
+        "babel-plugin-transform-unicode-regex",
         // TypeScript
         "babel-plugin-transform-typescript",
         // React


### PR DESCRIPTION
I use a different strategy than Babel. (but same with swc)
I converted unsupported Regexp flags into `RegExp` constructors so they can be polyfilled by users.