### PR TITLE
feat(codegen): initialize the codegen crate and struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_codegen"
+version = "0.2.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+]
+
+[[package]]
 name = "oxc_coverage"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ oxc_resolver       = { path = "crates/oxc_resolver" }
 oxc_query          = { path = "crates/oxc_query" }
 oxc_linter_plugin  = { path = "crates/oxc_linter_plugin" }
 oxc_transformer    = { path = "crates/oxc_transformer" }
+oxc_codegen        = { path = "crates/oxc_codegen" }
 
 oxc_tasks_common = { path = "tasks/common" }
 oxc_vscode       = { path = "editor/vscode/server" }

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name                   = "oxc_codegen"
+version                = "0.2.0"
+publish                = false
+authors.workspace      = true
+description.workspace  = true
+edition.workspace      = true
+homepage.workspace     = true
+keywords.workspace     = true
+license.workspace      = true
+repository.workspace   = true
+rust-version.workspace = true
+categories.workspace   = true
+
+[lib]
+doctest = false
+
+[dependencies]
+oxc_ast       = { workspace = true }
+oxc_span      = { workspace = true }
+oxc_allocator = { workspace = true }
+
+[dev-dependencies]
+oxc_parser    = { workspace = true }

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -1,0 +1,36 @@
+use std::{env, path::Path};
+
+use oxc_allocator::Allocator;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+// Instruction:
+// 1. create a `test.js`
+// 2. run `cargo run -p oxc_codegen --example codegen` or `just example codegen`
+
+fn main() {
+    let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
+    let path = Path::new(&name);
+    let source_text = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("{name} not found"));
+    let source_type = SourceType::from_path(path).unwrap();
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, &source_text, source_type).parse();
+
+    if !ret.errors.is_empty() {
+        for error in ret.errors {
+            let error = error.with_source_code(source_text.clone());
+            println!("{error:?}");
+        }
+        return;
+    }
+
+    let codegen_options = CodegenOptions;
+    let minified = Codegen::<true>::new(source_text.len(), codegen_options).build(&ret.program);
+    println!("Minified:");
+    println!("{minified}");
+
+    let printed = Codegen::<false>::new(source_text.len(), codegen_options).build(&ret.program);
+    println!("Printed:");
+    println!("{printed}");
+}

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -1,0 +1,37 @@
+//! Oxc Codegen
+//!
+//! Supports
+//!
+//! * whitespace removal
+//! * sourcemaps
+
+#[allow(clippy::wildcard_imports)]
+use oxc_ast::ast::*;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CodegenOptions;
+
+pub struct Codegen<const MINIFY: bool> {
+    #[allow(unused)]
+    options: CodegenOptions,
+
+    /// Output Code
+    code: Vec<u8>,
+}
+
+impl<const MINIFY: bool> Codegen<MINIFY> {
+    pub fn new(source_len: usize, options: CodegenOptions) -> Self {
+        // Initialize the output code buffer to reduce memory reallocation.
+        // Minification will reduce by at least half of the original size.
+        let capacity = if MINIFY { source_len / 2 } else { source_len };
+        Self { options, code: Vec::with_capacity(capacity) }
+    }
+
+    pub fn build(self, _program: &Program<'_>) -> String {
+        self.into_code()
+    }
+
+    fn into_code(self) -> String {
+        unsafe { String::from_utf8_unchecked(self.code) }
+    }
+}


### PR DESCRIPTION
HOLY SHIT I HAVE TRANSCENDED I am using const generics (I don't know what I am doing).
The codegen supports two modes:

* A normal code printer with spaces, newlines and indentations.
* A minifying printer without most of the whitespaces.

```rust
pub struct Codegen<const MINIFY: bool>;
```

When MINIFY = false, we will get a very performant compiled Rust code because all logic about minification will be stripped away.

When MINIFY = true, this codegen turns into a minifying printer, where it stops printing whitespaces.

Code bloat and compilation speed should be minimal because everything is trivial, no complicated stuff.

relates to #981