### PR TITLE
Fix oxlint --quiet suppressing errors

### DIFF
--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -110,7 +110,7 @@ impl DiagnosticService {
                     }
                     // The --quiet flag follows ESLint's --quiet behavior as documented here: https://eslint.org/docs/latest/use/command-line-interface#--quiet
                     // Note that it does not disable ALL diagnostics, only Warning diagnostics
-                    if self.quiet {
+                    else if self.quiet {
                         continue;
                     }
 


### PR DESCRIPTION
As explained by the comment in source, --quiet should only suppress warning output.

Please double-check that I haven't done something totally wrong here, I don't know Rust.