### PR TITLE
fix(linter) Fix panic when linting declaration files

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -151,7 +151,9 @@ impl<'a> SemanticBuilder<'a> {
     }
 
     pub fn build(mut self, program: &Program<'a>) -> SemanticBuilderReturn<'a> {
-        if !self.source_type.is_typescript_definition() {
+        if self.source_type.is_typescript_definition() {
+            self.scope.add_scope(None, ScopeFlags::Top);
+        } else {
             self.visit_program(program);
 
             // Checking syntax error on module record requires scope information from the previous AST pass


### PR DESCRIPTION
When linting declaration files, it panics here 

https://github.com/web-infra-dev/oxc/blob/6628fc8d9c541f09574adbd6a544c76f07eb04a7/crates/oxc_linter/src/rules/eslint/no_global_assign.rs#L57

with this error:
```
index out of bounds: the len is 0 but the index is 0
```

Because it expects the array to have the root scope id inside (non zero len)

https://github.com/web-infra-dev/oxc/blob/0fcad275151073a6832f9dfd944e4f1d61e7f4de/crates/oxc_semantic/src/scope.rs#L52-L54
