### PR TITLE
feat(transformer): drop `this` parameter from typescript functions

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -144,4 +144,14 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
             self.visit_class_element(class_element);
         });
     }
+
+    fn visit_formal_parameters(&mut self, params: &mut FormalParameters<'a>) {
+        self.typescript.as_mut().map(|t| t.transform_formal_parameters(params));
+        for param in params.items.iter_mut() {
+            self.visit_formal_parameter(param);
+        }
+        if let Some(rest) = &mut params.rest {
+            self.visit_rest_element(rest);
+        }
+    }
 }

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -1,3 +1,4 @@
+use oxc_ast::ast::*;
 use oxc_ast::AstBuilder;
 
 use std::rc::Rc;
@@ -14,5 +15,12 @@ pub struct TypeScript<'a> {
 impl<'a> TypeScript<'a> {
     pub fn new(_ast: Rc<AstBuilder<'a>>) -> Self {
         Self { _ast }
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn transform_formal_parameters(&self, params: &mut FormalParameters<'a>) {
+        if params.items.get(0).is_some_and(|param| matches!(&param.pattern.kind, BindingPatternKind::BindingIdentifier(ident) if ident.name =="this")) {
+            params.items.remove(0);
+        }
     }
 }

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,4 +1,4 @@
-Passed: 160/1087
+Passed: 162/1087
 
 # All Passed:
 * babel-plugin-transform-numeric-separator
@@ -714,7 +714,7 @@ Passed: 160/1087
 * unicode-regex/negated-set/input.js
 * unicode-regex/slash/input.js
 
-# babel-plugin-transform-typescript (71/181)
+# babel-plugin-transform-typescript (73/181)
 * class/abstract-class-decorated/input.ts
 * class/abstract-class-decorated-method/input.ts
 * class/abstract-class-decorated-parameter/input.ts
@@ -749,7 +749,6 @@ Passed: 160/1087
 * enum/string-value-template/input.ts
 * enum/string-values-computed/input.ts
 * enum/ts5.0-const-foldable/input.ts
-* exports/declare-shadowed/input.ts
 * exports/declared-types/input.ts
 * exports/export-const-enums/input.ts
 * exports/export-type/input.ts
@@ -763,7 +762,6 @@ Passed: 160/1087
 * exports/type-only-export-specifier-2/input.ts
 * exports/type-only-export-specifier-3/input.ts
 * function/overloads-exports/input.mjs
-* function/this-parameter/input.ts
 * imports/elide-injected/input.ts
 * imports/elide-preact/input.ts
 * imports/elide-react/input.ts


### PR DESCRIPTION
Found another swc bug:

https://play.swc.rs/?version=1.3.94-nightly-20231016.1&code=H4sIAAAAAAAAA0vOzysuUShWsFWo5lIAguLUEoVcjZKMzGIrhepaHYWyxJzSVEMQWxOqAgSSgbryc1L1cvLTNSAqNMFytVy11gDKEf2ZUgAAAA%3D%3D&config=H4sIAAAAAAAAA1VPSQ7DIAy88wrkcw9tpV76hz4CUSciYhN2pKIofw%2BkkDY3exbPeBFSwkQannIpY1miSoTp2AtC2bP6FAQ4RySdTGS4dJapUoOyhDu0fhlglUbk6kK6X2%2BP5gAbAmF3NMwZb4b8n6mDiwmJzsIqVX60eE4ULRVceM872X6pfWuDcs0FPxH8lD3xuA6GXt3OaUaxbkujvRocAQAA

```javascript
const s = {
    set m(this: {}, value1: {}) {
        console.log(value1)
    }
};
```

gets transformed to

```javascript
const s = {
    set m (_this){
        console.log(value1);
    }
};
```