### PR TITLE
feat(linter): eslint-plugin-react/no-find-dom-node

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -131,6 +131,7 @@ mod react {
     pub mod jsx_no_useless_fragment;
     pub mod no_children_prop;
     pub mod no_dangerously_set_inner_html;
+    pub mod no_find_dom_node;
 }
 
 mod unicorn {
@@ -260,6 +261,7 @@ oxc_macros::declare_all_lint_rules! {
     react::jsx_no_useless_fragment,
     react::no_children_prop,
     react::no_dangerously_set_inner_html,
+    react::no_find_dom_node,
     import::named,
     import::no_cycle,
     import::no_self_import,

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -1,0 +1,158 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode")]
+#[diagnostic(severity(warning))]
+struct NoFindDomNodeDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoFindDomNode;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// This rule disallows the use of `findDOMNode`.
+    ///
+    /// ### Why is this bad?
+    /// Facebook will eventually deprecate `findDOMNode` as it blocks certain improvements in React in the future.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// class MyComponent extends Component {
+    ///   componentDidMount() {
+    ///     findDOMNode(this).scrollIntoView();
+    ///   }
+    ///   render() {
+    ///     return <div />;
+    ///   }
+    ///  }
+    /// ```
+    NoFindDomNode,
+    correctness
+);
+
+impl Rule for NoFindDomNode {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else { return };
+        if call_expr.callee.get_identifier_reference().is_some_and(|x| x.name == "findDOMNode") {
+            ctx.diagnostic(NoFindDomNodeDiagnostic(call_expr.span));
+            return;
+        }
+
+        let Some(member) = call_expr.callee.get_member_expr() else { return };
+        let Some(prop_name) = member.static_property_name() else { return };
+        if prop_name == "findDOMNode" {
+            ctx.diagnostic(NoFindDomNodeDiagnostic(call_expr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var Hello = function() {};", None),
+        (
+            r#"
+            var Hello = createReactClass({
+              render: function() {
+                return <div>Hello</div>;
+              }
+            });              
+            "#,
+            None,
+        ),
+        (
+            r#"
+            var Hello = createReactClass({
+              componentDidMount: function() {
+                someNonMemberFunction(arg);
+                this.someFunc = React.findDOMNode;
+              },
+              render: function() {
+                return <div>Hello</div>;
+              }
+            });
+            "#,
+            None,
+        ),
+        (
+            r#"
+            var Hello = createReactClass({
+              componentDidMount: function() {
+                React.someFunc(this);
+              },
+              render: function() {
+                return <div>Hello</div>;
+              }
+            });
+            "#,
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            r#"
+            var Hello = createReactClass({
+              componentDidMount: function() {
+                React.findDOMNode(this).scrollIntoView();
+              },
+              render: function() {
+                return <div>Hello</div>;
+              }
+            });
+            "#,
+            None,
+        ),
+        (
+            r#"
+            var Hello = createReactClass({
+              componentDidMount: function() {
+                ReactDOM.findDOMNode(this).scrollIntoView();
+              },
+              render: function() {
+                return <div>Hello</div>;
+              }
+            });
+            "#,
+            None,
+        ),
+        (
+            r#"
+            class Hello extends Component {
+              componentDidMount() {
+                findDOMNode(this).scrollIntoView();
+              }
+              render() {
+                return <div>Hello</div>;
+              }
+            }
+            "#,
+            None,
+        ),
+        (
+            r#"
+            class Hello extends Component {
+              componentDidMount() {
+                this.node = findDOMNode(this);
+              }
+              render() {
+                return <div>Hello</div>;
+              }
+            }            
+            "#,
+            None,
+        ),
+    ];
+
+    Tester::new(NoFindDomNode::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -47,8 +47,8 @@ impl Rule for NoFindDomNode {
         if let Some(ident) = call_expr.callee.get_identifier_reference() {
             if ident.name == "findDOMNode" {
                 ctx.diagnostic(NoFindDomNodeDiagnostic(ident.span));
-                return;
             }
+            return;
         }
 
         let Some(member_expr) = call_expr.callee.get_member_expr() else { return };
@@ -59,9 +59,7 @@ impl Rule for NoFindDomNode {
         {
             return;
         }
-        let Some((span, "findDOMNode")) = member_expr.static_property_info() else {
-            return;
-        };
+        let Some((span, "findDOMNode")) = member_expr.static_property_info() else { return };
         ctx.diagnostic(NoFindDomNodeDiagnostic(span));
     }
 }

--- a/crates/oxc_linter/src/snapshots/no_find_dom_node.snap
+++ b/crates/oxc_linter/src/snapshots/no_find_dom_node.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 105
+expression: no_find_dom_node
+---
+  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+   ╭─[no_find_dom_node.tsx:3:1]
+ 3 │               componentDidMount: function() {
+ 4 │                 React.findDOMNode(this).scrollIntoView();
+   ·                 ───────────────────────
+ 5 │               },
+   ╰────
+
+  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+   ╭─[no_find_dom_node.tsx:3:1]
+ 3 │               componentDidMount: function() {
+ 4 │                 ReactDOM.findDOMNode(this).scrollIntoView();
+   ·                 ──────────────────────────
+ 5 │               },
+   ╰────
+
+  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+   ╭─[no_find_dom_node.tsx:3:1]
+ 3 │               componentDidMount() {
+ 4 │                 findDOMNode(this).scrollIntoView();
+   ·                 ─────────────────
+ 5 │               }
+   ╰────
+
+  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+   ╭─[no_find_dom_node.tsx:3:1]
+ 3 │               componentDidMount() {
+ 4 │                 this.node = findDOMNode(this);
+   ·                             ─────────────────
+ 5 │               }
+   ╰────
+
+

--- a/crates/oxc_linter/src/snapshots/no_find_dom_node.snap
+++ b/crates/oxc_linter/src/snapshots/no_find_dom_node.snap
@@ -3,36 +3,49 @@ source: crates/oxc_linter/src/tester.rs
 assertion_line: 105
 expression: no_find_dom_node
 ---
-  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+  ⚠ eslint-plugin-react(no-find-dom-node): Unexpected call to `findDOMNode`.
    ╭─[no_find_dom_node.tsx:3:1]
  3 │               componentDidMount: function() {
  4 │                 React.findDOMNode(this).scrollIntoView();
-   ·                 ───────────────────────
+   ·                       ───────────
  5 │               },
    ╰────
+  help: Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.
 
-  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+  ⚠ eslint-plugin-react(no-find-dom-node): Unexpected call to `findDOMNode`.
    ╭─[no_find_dom_node.tsx:3:1]
  3 │               componentDidMount: function() {
  4 │                 ReactDOM.findDOMNode(this).scrollIntoView();
-   ·                 ──────────────────────────
+   ·                          ───────────
  5 │               },
    ╰────
+  help: Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.
 
-  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+  ⚠ eslint-plugin-react(no-find-dom-node): Unexpected call to `findDOMNode`.
+   ╭─[no_find_dom_node.tsx:3:1]
+ 3 │               componentDidMount: function() {
+ 4 │                 ReactDom.findDOMNode(this).scrollIntoView();
+   ·                          ───────────
+ 5 │               },
+   ╰────
+  help: Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.
+
+  ⚠ eslint-plugin-react(no-find-dom-node): Unexpected call to `findDOMNode`.
    ╭─[no_find_dom_node.tsx:3:1]
  3 │               componentDidMount() {
  4 │                 findDOMNode(this).scrollIntoView();
-   ·                 ─────────────────
+   ·                 ───────────
  5 │               }
    ╰────
+  help: Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.
 
-  ⚠ Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode
+  ⚠ eslint-plugin-react(no-find-dom-node): Unexpected call to `findDOMNode`.
    ╭─[no_find_dom_node.tsx:3:1]
  3 │               componentDidMount() {
  4 │                 this.node = findDOMNode(this);
-   ·                             ─────────────────
+   ·                             ───────────
  5 │               }
    ╰────
+  help: Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.
 
 


### PR DESCRIPTION
This PR implements the [eslint-plugin-react/no-find-dom-node](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md) rule for oxlint.