### PR TITLE
feat(rulegen): escape from `“` to `\”`

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -58,11 +58,17 @@ impl<'a> TestCase<'a> {
         self.code
             .as_ref()
             .map(|code| {
-                let code = if code.contains('\n') {
+                let mut code = if code.contains('\n') {
                     code.replace('\n', "\n\t\t\t").replace('\\', "\\\\").replace('\"', "\\\"")
                 } else {
                     code.to_string()
                 };
+
+                if code.contains('"') {
+                    // handle " to \" and then \\" to \"
+                    code = code.replace('"', "\\\"").replace("\\\\\"", "\\\"");
+                }
+
                 let config = self.config.as_ref().map_or_else(
                     || "None".to_string(),
                     |config| format!("Some(serde_json::json!({config}))"),


### PR DESCRIPTION
If the code contains `"` we should replace it `\"`.

<img width="722" alt="image" src="https://github.com/web-infra-dev/oxc/assets/29533304/2e97611b-54f0-4c9e-b528-e695e6e181d9">
