### PR TITLE
fix(linter): noTemplateLiterals configuration in no_string_refs rule not working

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_string_refs.snap
+++ b/crates/oxc_linter/src/snapshots/no_string_refs.snap
@@ -56,6 +56,15 @@ expression: no_string_refs
    ╰────
   help: Using this.xxx instead of this.refs.xxx
 
+  ⚠ eslint-plugin-react(no-string-refs): Using string literals in ref attributes is deprecated.
+   ╭─[no_string_refs.tsx:6:1]
+ 6 │                 render: function() {
+ 7 │                   return <div ref={`hello`}>Hello {this.props.name}</div>;
+   ·                               ─────────────
+ 8 │                 }
+   ╰────
+  help: Using reference callback instead
+
   ⚠ eslint-plugin-react(no-string-refs): Using this.refs is deprecated.
    ╭─[no_string_refs.tsx:3:1]
  3 │                 componentDidMount: function() {
@@ -65,22 +74,58 @@ expression: no_string_refs
    ╰────
   help: Using this.xxx instead of this.refs.xxx
 
+  ⚠ eslint-plugin-react(no-string-refs): Using string literals in ref attributes is deprecated.
+   ╭─[no_string_refs.tsx:6:1]
+ 6 │                 render: function() {
+ 7 │                   return <div ref={`hello${index}`}>Hello {this.props.name}</div>;
+   ·                               ─────────────────────
+ 8 │                 }
+   ╰────
+  help: Using reference callback instead
+
+  ⚠ eslint-plugin-react(no-string-refs): Using string literals in ref attributes is deprecated.
+   ╭─[no_string_refs.tsx:3:1]
+ 3 │                 render: function() {
+ 4 │                   return <div ref={`hello${index}`}>Hello {this.props.name}</div>;
+   ·                               ─────────────────────
+ 5 │                 }
+   ╰────
+  help: Using reference callback instead
+
   ⚠ eslint-plugin-react(no-string-refs): Using this.refs is deprecated.
    ╭─[no_string_refs.tsx:3:1]
- 3 │                       componentDidMount() {
+ 3 │                 componentDidMount() {
  4 │                   var component = this.refs.hello;
    ·                                   ─────────
- 5 │                       }
+ 5 │                 }
    ╰────
   help: Using this.xxx instead of this.refs.xxx
 
   ⚠ eslint-plugin-react(no-string-refs): Using this.refs is deprecated.
    ╭─[no_string_refs.tsx:3:1]
- 3 │                       componentDidMount() {
+ 3 │                 componentDidMount() {
  4 │                   var component = this.refs.hello;
    ·                                   ─────────
- 5 │                       }
+ 5 │                 }
    ╰────
   help: Using this.xxx instead of this.refs.xxx
+
+  ⚠ eslint-plugin-react(no-string-refs): Using this.refs is deprecated.
+   ╭─[no_string_refs.tsx:3:1]
+ 3 │                 componentDidMount() {
+ 4 │                   var component = this.refs.hello;
+   ·                                   ─────────
+ 5 │                 }
+   ╰────
+  help: Using this.xxx instead of this.refs.xxx
+
+  ⚠ eslint-plugin-react(no-string-refs): Using string literals in ref attributes is deprecated.
+   ╭─[no_string_refs.tsx:6:1]
+ 6 │                 render() {
+ 7 │                   return <div ref={`hello${index}`}>Hello {this.props.name}</div>;
+   ·                               ─────────────────────
+ 8 │                 }
+   ╰────
+  help: Using reference callback instead
 
 


### PR DESCRIPTION
I didn't notice that the `noTemplateLiterals` configuration didn't work due to the lack of test cases