### PR TITLE
fix(playground): Enable linting on first load

### DIFF
--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -102,6 +102,7 @@ class Playground {
     this.urlParams = new URLParams();
     this.viewerIsEditableConf = new Compartment();
     this.queryResultViewerIsEditableConf = new Compartment();
+    this.linterConf = new Compartment();
     this.editor = this.initEditor();
     this.viewer = this.initViewer();
     this.queryResultsViewer = this.initQueryResultsViewer();
@@ -122,7 +123,11 @@ class Playground {
     this.runOptions.lint = true;
 
     this.runOxc(this.editor.state.doc.toString());
-    this.updateDiagnostics();
+    this.editor.dispatch({ effects: this.linterConf.reconfigure(this.linter()) });
+  }
+
+  linter() {
+    return linter(() => this.updateDiagnostics(), { delay: 0 })
   }
 
   runOxc(text) {
@@ -157,12 +162,7 @@ class Playground {
         lintGutter(),
         stateListener,
         autocompletion(),
-        linter(
-          () => {
-            return this.updateDiagnostics();
-          },
-          { delay: 0 }
-        ),
+        this.linterConf.of(this.linter()),
       ],
       doc: this.urlParams.code || placeholderText,
     });


### PR DESCRIPTION
Fixes #1095

Currently, we initialize Codemirror and update diagnostics (which default to empty as `oxc` is not initialized yet), and then we initialize `oxc`, but we only re-update diagnostics on first user interaction, causing diagnostics to remain empty until then. This fix schedules a linter pass immediately after `oxc` is initialized.

