### PR TITLE
fix(linter) Report error instead of panicing if the file fails to open

### DIFF
--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -25,3 +25,8 @@ use thiserror::Error;
 #[error("File is too long to fit on the screen")]
 #[diagnostic(help("{0:?} seems like a minified file"))]
 pub struct MinifiedFileError(pub PathBuf);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Failed to open file")]
+#[diagnostic(help("Failed to open file {0:?} with error \"{1}\""))]
+pub struct FailedToOpenFileError(pub PathBuf, pub std::io::Error);


### PR DESCRIPTION
closes #1093


e.g.

```
RUST_BACKTRACE=full cargo run  --bin=oxc_cli lint -D=suspicious -D=style -D=restriction -D=pedantic -D=nursery -D=correctness -A=no-useless-escape ./tasks/coverage/typescript/tests/cases/compiler/corrupted.ts
```

Results in:
```

  × Failed to open file
  help: Failed to open file "./tasks/coverage/typescript/tests/cases/compiler/corrupted.ts" with error "stream did not contain valid UTF-8"

Finished in 10ms on 1 file with 126 rules using 12 threads.
Found 0 warnings and 1 error.
```