### PR TITLE
fix(linter/no_empty_file): point to start of file instead of the entire file

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -49,7 +49,7 @@ impl Rule for NoEmptyFile {
             return;
         }
 
-        ctx.diagnostic(NoEmptyFileDiagnostic(program.span));
+        ctx.diagnostic(NoEmptyFileDiagnostic(Span::new(0, 0)));
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/no_empty_file.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_file.snap
@@ -10,141 +10,142 @@ expression: no_empty_file
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │  
-   · ─
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │     
-   · ────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ 
-   · ─
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  0 │ 
-   · ─
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ 
-   · ─
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
- 1 │ ╭─▶ 
- 2 │ │   
- 3 │ ╰─▶         
+ 1 │ 
+   · ▲
+ 2 │ 
+ 3 │         
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ // comment
-   · ──────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ /* comment */
-   · ─────────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ #!/usr/bin/env node
-   · ───────────────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ 'use asm';
-   · ──────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ 'use strict';
-   · ─────────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ "use strict"
-   · ────────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ ""
-   · ──
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ ;
-   · ─
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ ;;
-   · ──
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ {}
-   · ──
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ {;;}
-   · ────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ {{}}
-   · ────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ "";
-   · ───
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 
   ⚠ eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ╭─[no_empty_file.tsx:1:1]
  1 │ "use strict";
-   · ─────────────
+   · ▲
    ╰────
   help: Delete this file or add some code to it.
 


### PR DESCRIPTION
Since it may contain lots of comments, which gives us a screenful of comments