### PR TITLE
chore(linter/no_unescaped_entities): demote to pedantic

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     /// <div> {'>'} </div>
     /// ```
     NoUnescapedEntities,
-    correctness
+    pedantic
 );
 
 impl Rule for NoUnescapedEntities {


### PR DESCRIPTION
The code is not wrong