### PR TITLE
feat(rulegen): Add jsx-a11y rulegen

### DIFF
--- a/justfile
+++ b/justfile
@@ -84,6 +84,9 @@ new-unicorn-rule name:
 new-react-rule name:
   cargo run -p rulegen {{name}} react
 
+new-jsx-a11y-rule name:
+  cargo run -p rulegen {{name}} jsx-a11y
+
 # Sync all submodules with their own remote repos (this is for Boshen updating the submodules)
 sync:
   git submodule update --init --remote

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -8,10 +8,10 @@ use convert_case::{Case, Casing};
 use oxc_allocator::Allocator;
 use oxc_ast::{
     ast::{
-        Argument, ArrayExpression, ArrayExpressionElement, CallExpression, Expression,
-        ExpressionStatement, MemberExpression, ObjectExpression, ObjectProperty,
-        ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
-        TaggedTemplateExpression, TemplateLiteral,
+        Argument, ArrayExpressionElement, CallExpression, Expression, ExpressionStatement,
+        MemberExpression, ObjectExpression, ObjectProperty, ObjectPropertyKind, Program,
+        PropertyKey, Statement, StaticMemberExpression, StringLiteral, TaggedTemplateExpression,
+        TemplateLiteral,
     },
     Visit,
 };
@@ -38,6 +38,9 @@ const UNICORN_TEST_PATH: &str =
 const REACT_TEST_PATH: &str =
     "https://raw.githubusercontent.com/jsx-eslint/eslint-plugin-react/master/tests/lib/rules";
 
+const JSX_A11Y_TEST_PATH: &str =
+    "https://raw.githubusercontent.com/jsx-eslint/eslint-plugin-jsx-a11y/main/__tests__/src/rules";
+
 struct TestCase<'a> {
     source_text: String,
     code: Option<String>,
@@ -45,13 +48,10 @@ struct TestCase<'a> {
 }
 
 impl<'a> TestCase<'a> {
-    fn new(source_text: &str, arg: &'a ArrayExpressionElement<'a>) -> Option<Self> {
+    fn new(source_text: &str, arg: &'a Expression<'a>) -> Self {
         let mut test_case = Self { source_text: source_text.to_string(), code: None, config: None };
-        if let ArrayExpressionElement::Expression(expr) = arg {
-            test_case.visit_expression(expr);
-            return Some(test_case);
-        }
-        None
+        test_case.visit_expression(arg);
+        test_case
     }
 
     fn code(&self, need_config: bool) -> String {
@@ -68,9 +68,9 @@ impl<'a> TestCase<'a> {
                     |config| format!("Some(serde_json::json!({config}))"),
                 );
                 if need_config {
-                    format!("(\"{code}\", {config})")
+                    format!("(r#\"{code}\"#, {config})")
                 } else {
-                    format!("\"{code}\"")
+                    format!("r#\"{code}\"#")
                 }
             })
             .unwrap_or_default()
@@ -237,8 +237,8 @@ impl Context {
 
 struct State<'a> {
     source_text: &'a str,
-    valid_tests: Vec<&'a ArrayExpression<'a>>,
-    invalid_tests: Vec<&'a ArrayExpression<'a>>,
+    valid_tests: Vec<&'a Expression<'a>>,
+    invalid_tests: Vec<&'a Expression<'a>>,
 }
 
 impl<'a> State<'a> {
@@ -247,18 +247,13 @@ impl<'a> State<'a> {
     }
 
     fn pass_cases(&self) -> Vec<TestCase> {
-        self.valid_tests
-            .iter()
-            .flat_map(|array_expr| (&array_expr.elements).into_iter())
-            .filter_map(|arg| TestCase::new(self.source_text, arg))
-            .collect::<Vec<_>>()
+        self.valid_tests.iter().map(|arg| TestCase::new(self.source_text, arg)).collect::<Vec<_>>()
     }
 
     fn fail_cases(&self) -> Vec<TestCase> {
         self.invalid_tests
             .iter()
-            .flat_map(|array_expr| (&array_expr.elements).into_iter())
-            .filter_map(|arg| TestCase::new(self.source_text, arg))
+            .map(|arg| TestCase::new(self.source_text, arg))
             .collect::<Vec<_>>()
     }
 }
@@ -302,23 +297,58 @@ impl<'a> Visit<'a> for State<'a> {
         match ident.name.as_str() {
             "valid" => {
                 if let Expression::ArrayExpression(array_expr) = &prop.value {
-                    self.valid_tests.push(self.alloc(array_expr));
+                    let array_expr = self.alloc(array_expr);
+                    for arg in &array_expr.elements {
+                        if let ArrayExpressionElement::Expression(expr) = arg {
+                            self.valid_tests.push(expr);
+                        }
+                    }
                 }
 
-                // for eslint-plugin-react
+                // for eslint-plugin-jsx-a11y
+                if let Some(args) = find_parser_arguments(&prop.value).map(|args| self.alloc(args))
+                {
+                    for arg in args {
+                        if let Argument::Expression(expr) = arg {
+                            self.valid_tests.push(expr);
+                        }
+                    }
+                }
+
                 if let Expression::CallExpression(call_expr) = &prop.value {
                     if let Expression::MemberExpression(_) = &call_expr.callee {
+                        // for eslint-plugin-react
                         if let Some(Argument::Expression(Expression::ArrayExpression(array_expr))) =
                             call_expr.arguments.first()
                         {
-                            self.valid_tests.push(self.alloc(array_expr));
+                            let array_expr = self.alloc(array_expr);
+                            for arg in &array_expr.elements {
+                                if let ArrayExpressionElement::Expression(expr) = arg {
+                                    self.valid_tests.push(expr);
+                                }
+                            }
                         }
                     }
                 }
             }
             "invalid" => {
                 if let Expression::ArrayExpression(array_expr) = &prop.value {
-                    self.invalid_tests.push(self.alloc(array_expr));
+                    let array_expr = self.alloc(array_expr);
+                    for arg in &array_expr.elements {
+                        if let ArrayExpressionElement::Expression(expr) = arg {
+                            self.invalid_tests.push(expr);
+                        }
+                    }
+                }
+
+                // for eslint-plugin-jsx-a11y
+                if let Some(args) = find_parser_arguments(&prop.value).map(|args| self.alloc(args))
+                {
+                    for arg in args {
+                        if let Argument::Expression(expr) = arg {
+                            self.invalid_tests.push(expr);
+                        }
+                    }
                 }
 
                 // for eslint-plugin-react
@@ -327,13 +357,46 @@ impl<'a> Visit<'a> for State<'a> {
                         if let Some(Argument::Expression(Expression::ArrayExpression(array_expr))) =
                             call_expr.arguments.first()
                         {
-                            self.invalid_tests.push(self.alloc(array_expr));
+                            let array_expr = self.alloc(array_expr);
+                            for arg in &array_expr.elements {
+                                if let ArrayExpressionElement::Expression(expr) = arg {
+                                    self.invalid_tests.push(expr);
+                                }
+                            }
                         }
                     }
                 }
             }
             _ => {}
         }
+    }
+}
+
+fn find_parser_arguments<'a, 'b>(
+    expr: &'b Expression<'a>,
+) -> Option<&'b oxc_allocator::Vec<'a, Argument<'a>>> {
+    let Expression::CallExpression(call_expr) = expr else { return None };
+    let Expression::MemberExpression(member_expr) = &call_expr.callee else {
+        return None;
+    };
+    let MemberExpression::StaticMemberExpression(StaticMemberExpression {
+        object, property, ..
+    }) = &member_expr.0
+    else {
+        return None;
+    };
+    match (object, call_expr.arguments.first()) {
+        (Expression::Identifier(iden), Some(Argument::Expression(arg)))
+            if iden.name == "parsers" && property.name == "all" =>
+        {
+            if let Expression::CallExpression(call_expr) = arg {
+                if let Expression::MemberExpression(_) = &call_expr.callee {
+                    return Some(&call_expr.arguments);
+                }
+            }
+            None
+        }
+        _ => find_parser_arguments(object),
     }
 }
 
@@ -344,6 +407,7 @@ pub enum RuleKind {
     Typescript,
     Unicorn,
     React,
+    JSXA11y,
 }
 
 impl RuleKind {
@@ -353,6 +417,7 @@ impl RuleKind {
             "typescript" => Self::Typescript,
             "unicorn" => Self::Unicorn,
             "react" => Self::React,
+            "jsx-a11y" => Self::JSXA11y,
             _ => Self::ESLint,
         }
     }
@@ -366,6 +431,7 @@ impl Display for RuleKind {
             Self::Jest => write!(f, "eslint-plugin-jest"),
             Self::Unicorn => write!(f, "eslint-plugin-unicorn"),
             Self::React => write!(f, "eslint-plugin-react"),
+            Self::JSXA11y => write!(f, "eslint-plugin-jsx-a11y"),
         }
     }
 }
@@ -385,6 +451,7 @@ fn main() {
         RuleKind::Typescript => format!("{TYPESCRIPT_ESLINT_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::Unicorn => format!("{UNICORN_TEST_PATH}/{kebab_rule_name}.mjs"),
         RuleKind::React => format!("{REACT_TEST_PATH}/{kebab_rule_name}.js"),
+        RuleKind::JSXA11y => format!("{JSX_A11Y_TEST_PATH}/{kebab_rule_name}-test.js"),
     };
 
     println!("Reading test file from {rule_test_path}");

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -35,6 +35,7 @@ impl<'a> Template<'a> {
             RuleKind::Typescript => Path::new("crates/oxc_linter/src/rules/typescript"),
             RuleKind::Unicorn => Path::new("crates/oxc_linter/src/rules/unicorn"),
             RuleKind::React => Path::new("crates/oxc_linter/src/rules/react"),
+            RuleKind::JSXA11y => Path::new("crates/oxc_linter/src/rules/jsx_a11y"),
         };
 
         let out_path = path.join(format!("{}.rs", self.context.snake_rule_name));


### PR DESCRIPTION
Adds the `just new-jsx-a11y-rule` for bootstrapping `eslint-plugin-jsx-a11y` linting rules.

One tricky thing about the tests in that repo is that the aren't provided as array expressions
(e.g., `[case0, case1, case2, ...]`) but rather separate arguments to `[].concat()`
(e.g., `[].concat(case0, case1, case2, ...)`). There is probably a more elegant way to match
these expressions, but this is what I came up with.

The other thing I introduced in this PR is prefer Rust's raw strings (`r#`) when generating the
test cases. Sometimes running `just new-*` spit out unescaped back quotes, which caused issues.
