### PR TITLE
fix(linter): fix covered span of eslint-disable-next-line comments

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -81,8 +81,7 @@ impl<'a, 'b> DisableDirectivesBuilder<'a, 'b> {
                     let stop = self.source_text[span.end as usize..]
                         .lines()
                         .take(if comment.is_single_line() { 1 } else { 2 })
-                        .map(|line| span.end + line.len() as u32)
-                        .sum();
+                        .fold(span.end, |acc, line| acc + line.len() as u32);
                     if text.trim().is_empty() {
                         self.add_interval(span.end, stop, DisabledRule::All);
                     } else {
@@ -280,6 +279,19 @@ fn test() {
               quotes,
               semi
             */
+            debugger;
+        ",
+        "
+            /* eslint-disable-next-line no-debugger --
+             * Here's a very long description about why this configuration is necessary
+             * along with some additional information
+            **/
+            debugger;
+            debugger;
+        ",
+        "
+            // eslint-disable-next-line no-debugger
+            debugger;
             debugger;
         ",
     ];


### PR DESCRIPTION
This PR fixes the covered span (specifically the stop position) of `eslint-disable-next-line` comments.

Note that the covered span is not very accurate in the case of multi-line comments. For example, the start and stop positions of the `eslint-disable-next-line` comment in the example below are marked in comments.

```js
            /* eslint-disable-next-line no-debugger --
             * Here's a very long description about why this configuration is necessary
             * along with some additional information
            **/
//           ^start
            debugger;
//                  ^stop
            debugger;
```

The stop position has an offset of one or two depending on the line ending (\r\n or \n). I am not sure if this would be a problem.