### PR TITLE
tweak the build instructions for vsxi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,11 +71,12 @@ Make sure the rule is registered in `crates/oxc_linter/src/rules.rs`.
 Build the extension and run it inside vscode:
 
 1. `pnpm install`
-2. `pnpm run package`
-3. open vscode and run the command palette "Extensions: Install from VSIX..."
-4. find the `oxc-vscode-x.x.x.vsix` file from `./editor/vscode` directory
-5. open a `.js` / `.ts` file, add `debugger;` and save
-6. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`
+2. `pnpm run build`
+3. `pnpm run package`
+4. open vscode and run the command palette "Extensions: Install from VSIX..."
+5. find the `oxc-vscode-x.x.x.vsix` file from `./editor/vscode` directory
+6. open a `.js` / `.ts` file, add `debugger;` and save
+7. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`
 
 # Performance Turing
 


### PR DESCRIPTION
When building the vsix file, it was necessary to execute the build command before the package command.

As a result, the documentation has been updated!