### PR TITLE
fix typo (turing -> tuning)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Build the extension and run it inside vscode:
 5. open a `.js` / `.ts` file, add `debugger;` and save
 6. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`
 
-# Performance Turing
+# Performance Tuning
 
 ## Mac Xcode Instruments
 


### PR DESCRIPTION
I'm not sure if it was intentional, but something that seemed to be "Tuning" was written as "Turing", so I've corrected it. 
If it's unnecessary, please close it 🙏🏻 