### PR TITLE
fix(linter/jsx_key): ignore ObjectProterty nodes

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -110,7 +110,9 @@ fn is_in_array_or_iter<'a, 'b>(
 
                 return None;
             }
-            AstKind::JSXElement(_) | AstKind::JSXOpeningElement(_) => return None,
+            AstKind::JSXElement(_) | AstKind::JSXOpeningElement(_) | AstKind::ObjectProperty(_) => {
+                return None
+            }
             _ => {}
         }
         node = parent;
@@ -332,6 +334,23 @@ fn test() {
               enableSorting: true,
               enableHiding: false,
             }]
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const router = createBrowserRouter([
+              {
+                path: "/",
+                element: <Root />,
+                children: [
+                  {
+                    path: "team",
+                    element: <Team />,
+                  },
+                ],
+              },
+            ]);
         "#,
             None,
         ),


### PR DESCRIPTION
Elements inside ﻿`ObjectProperty` should be ignored in this case.

Reproducible link https://web-infra-dev.github.io/oxc/playground/?code=3YCAAIBkgICAgICAgICxG0qZRraXT4%2BHfMNjiJBtGiljae%2FxPDG%2BJO0RwxenJsd5%2BlR3yNLJ5vlfyo6dyWxkTY9Mm3O0cA9BM891YAt9c0xItb72Q7pTMe3YerC2J%2FisL1OUPS%2FtM4wqycc0tXOSR6ljCgWmr5gaAISHdIxbyoQxaSumV472wrVF2NwbxJnOjXh3fgSlgA%3D%3D