### PR TITLE
feat(linter) Parse eslint configuration

### DIFF
--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -123,6 +123,12 @@ pub struct LintOptions {
     #[bpaf(external)]
     pub codeowner_options: CodeownerOptions,
 
+    /// ESLint configuration file (experimental)
+    ///
+    /// * only `.json` extension is supported
+    #[bpaf(long("config"), short('c'), argument("PATH"))]
+    pub config: Option<PathBuf>,
+
     /// Single file, single path or list of paths
     #[bpaf(positional("PATH"), many)]
     pub paths: Vec<PathBuf>,

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -27,6 +27,6 @@ use thiserror::Error;
 pub struct MinifiedFileError(pub PathBuf);
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Failed to open file")]
+#[error("Failed to open file {0:?} with error \"{1}\"")]
 #[diagnostic(help("Failed to open file {0:?} with error \"{1}\""))]
 pub struct FailedToOpenFileError(pub PathBuf, pub std::io::Error);

--- a/crates/oxc_linter/src/config/errors.rs
+++ b/crates/oxc_linter/src/config/errors.rs
@@ -1,0 +1,41 @@
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+    Report,
+};
+use std::path::PathBuf;
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Failed to parse config {0:?} with error {1:?}")]
+#[diagnostic()]
+pub struct FailedToParseConfigJsonError(pub PathBuf, pub String);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Failed to parse eslint config")]
+#[diagnostic()]
+pub struct FailedToParseConfigError(#[related] pub Vec<Report>);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Failed to parse config at {0:?} with error {1:?}")]
+#[diagnostic()]
+pub struct FailedToParseConfigPropertyError(pub &'static str, pub &'static str);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Failed to rule value {0:?} with error {1:?}")]
+#[diagnostic()]
+pub struct FailedToParseRuleValueError(pub String, pub &'static str);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(r#"Failed to parse rule severity, expected one of "allow", "off", "deny", "error" or "warn", but got {0:?}"#)]
+#[diagnostic()]
+pub struct FailedToParseAllowWarnDenyFromStringError(pub String);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(r#"Failed to parse rule severity, expected one of `0`, `1` or `2`, but got {0:?}"#)]
+#[diagnostic()]
+pub struct FailedToParseAllowWarnDenyFromNumberError(pub String);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(r#"Failed to parse rule severity, expected a string or a number, but got {0:?}"#)]
+#[diagnostic()]
+pub struct FailedToParseAllowWarnDenyFromJsonValueError(pub String);

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -1,0 +1,200 @@
+use std::path::PathBuf;
+
+pub mod errors;
+use oxc_diagnostics::{Error, FailedToOpenFileError, Report};
+use phf::{phf_map, Map};
+use serde_json::Value;
+
+use crate::{
+    rules::{RuleEnum, RULES},
+    AllowWarnDeny,
+};
+
+use self::errors::{
+    FailedToParseConfigError, FailedToParseConfigJsonError, FailedToParseConfigPropertyError,
+    FailedToParseRuleValueError,
+};
+
+pub struct ESLintConfig {
+    rules: std::vec::Vec<RuleEnum>,
+}
+
+impl ESLintConfig {
+    pub fn new(path: &PathBuf) -> Result<Self, Report> {
+        let file = match std::fs::read_to_string(path) {
+            Ok(file) => file,
+            Err(e) => {
+                return Err(FailedToParseConfigError(vec![Error::new(FailedToOpenFileError(
+                    path.clone(),
+                    e,
+                ))])
+                .into());
+            }
+        };
+
+        let file = match serde_json::from_str::<serde_json::Value>(&file) {
+            Ok(file) => file,
+            Err(e) => {
+                return Err(FailedToParseConfigError(vec![Error::new(
+                    FailedToParseConfigJsonError(path.clone(), e.to_string()),
+                )])
+                .into());
+            }
+        };
+
+        let extends_hm = match parse_extends(&file) {
+            Ok(Some(extends_hm)) => {
+                extends_hm.into_iter().collect::<std::collections::HashSet<_>>()
+            }
+            Ok(None) => std::collections::HashSet::new(),
+            Err(e) => {
+                return Err(FailedToParseConfigError(vec![Error::new(
+                    FailedToParseConfigJsonError(path.clone(), e.to_string()),
+                )])
+                .into());
+            }
+        };
+        let roles_hm = match parse_rules(&file) {
+            Ok(roles_hm) => roles_hm
+                .into_iter()
+                .map(|(plugin_name, rule_name, allow_warn_deny, config)| {
+                    ((plugin_name, rule_name), (allow_warn_deny, config))
+                })
+                .collect::<std::collections::HashMap<_, _>>(),
+            Err(e) => {
+                return Err(e);
+            }
+        };
+
+        // `extends` provides the defaults
+        // `rules` provides the overrides
+        let rules = RULES.clone().into_iter().filter_map(|rule| {
+            // Check if the extends set is empty or contains the plugin name
+            let in_extends = extends_hm.contains(rule.plugin_name());
+
+            // Check if there's a custom rule that explicitly handles this rule
+            let (is_explicitly_handled, policy, config) =
+                if let Some((policy, config)) = roles_hm.get(&(rule.plugin_name(), rule.name())) {
+                    // Return true for handling, and also whether it's enabled or not
+                    (true, *policy, config)
+                } else {
+                    // Not explicitly handled
+                    (false, AllowWarnDeny::Allow, &None)
+                };
+
+            // The rule is included if it's in the extends set and not explicitly disabled,
+            // or if it's explicitly enabled
+            if (in_extends && !is_explicitly_handled) || policy.is_enabled() {
+                Some(rule.read_json(config.cloned()))
+            } else {
+                None
+            }
+        });
+
+        Ok(Self { rules: rules.collect::<Vec<_>>() })
+    }
+
+    pub fn into_rules(mut self) -> Vec<RuleEnum> {
+        self.rules.sort_unstable_by_key(RuleEnum::name);
+        self.rules
+    }
+}
+
+fn parse_extends(root_json: &Value) -> Result<Option<Vec<&'static str>>, Report> {
+    let Some(extends) = root_json.get("extends") else {
+        return Ok(None);
+    };
+
+    let extends_obj = match extends {
+        Value::Array(v) => v,
+        _ => {
+            return Err(FailedToParseConfigPropertyError("extends", "Expected an array.").into());
+        }
+    };
+
+    let extends_rule_groups = extends_obj
+        .iter()
+        .filter_map(|v| {
+            let v = match v {
+                Value::String(s) => s,
+                _ => return None,
+            };
+
+            if let Some(m) = EXTENDS_MAP.get(v.as_str()) {
+                return Some(*m);
+            }
+
+            None
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Some(extends_rule_groups))
+}
+
+#[allow(clippy::type_complexity)]
+fn parse_rules(
+    root_json: &Value,
+) -> Result<Vec<(&str, &str, AllowWarnDeny, Option<&Value>)>, Error> {
+    let Value::Object(rules_object) = root_json else { return Ok(vec![]) };
+
+    let Some(Value::Object(rules_object)) = rules_object.get("rules") else { return Ok(vec![]) };
+
+    rules_object
+        .iter()
+        .map(|(key, value)| {
+            let (plugin_name, name) = parse_rule_name(key);
+
+            let (rule_severity, rule_config) = resolve_rule_value(value)?;
+
+            Ok((plugin_name, name, rule_severity, rule_config))
+        })
+        .collect::<Result<Vec<_>, Error>>()
+}
+
+pub const EXTENDS_MAP: Map<&'static str, &'static str> = phf_map! {
+    "eslint:recommended" => "eslint",
+    "plugin:react/recommended" => "react",
+    "plugin:@typescript-eslint/recommended" => "typescript",
+    "plugin:react-hooks/recommended" => "react",
+    "plugin:unicorn/recommended" => "unicorn",
+    "plugin:jest/recommended" => "jest",
+};
+
+fn parse_rule_name(name: &str) -> (&str, &str) {
+    if let Some((category, name)) = name.split_once('/') {
+        let category = category.trim_start_matches('@');
+
+        // if it matches typescript-eslint, map it to typescript
+        let category = match category {
+            "typescript-eslint" => "typescript",
+            _ => category,
+        };
+
+        (category, name)
+    } else {
+        ("eslint", name)
+    }
+}
+
+/// Resolves the level of a rule and its config
+///
+/// Two cases here
+/// ```json
+/// {
+///     "rule": "off",
+///     "rule": ["off", "config"],
+/// }
+/// ```
+fn resolve_rule_value(value: &serde_json::Value) -> Result<(AllowWarnDeny, Option<&Value>), Error> {
+    if let Some(v) = value.as_str() {
+        return Ok((AllowWarnDeny::try_from(v)?, None));
+    }
+
+    if let Some(v) = value.as_array() {
+        if let Some(v_idx_0) = v.get(0) {
+            return Ok((AllowWarnDeny::try_from(v_idx_0)?, v.get(1)));
+        }
+    }
+
+    Err(FailedToParseRuleValueError(value.to_string(), "Invalid rule value").into())
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,10 +1,11 @@
-#![deny(clippy::print_stdout)]
+#![warn(clippy::print_stdout)]
 #![allow(clippy::self_named_module_files)] // for rules.rs
 
 #[cfg(test)]
 mod tester;
 
 mod ast_util;
+mod config;
 mod context;
 mod disable_directives;
 mod fixer;
@@ -18,6 +19,7 @@ mod utils;
 
 use std::{self, fs, io::Write, rc::Rc, time::Duration};
 
+use oxc_diagnostics::Report;
 pub(crate) use oxc_semantic::AstNode;
 use rustc_hash::FxHashMap;
 
@@ -53,9 +55,12 @@ impl Linter {
         Self { rules, options: LintOptions::default() }
     }
 
-    pub fn from_options(options: LintOptions) -> Self {
-        let rules = options.derive_rules();
-        Self { rules, options }
+    /// # Errors
+    ///
+    /// Returns `Err` if there are any errors parsing the configuration file.
+    pub fn from_options(options: LintOptions) -> Result<Self, Report> {
+        let rules = options.derive_rules()?;
+        Ok(Self { rules, options })
     }
 
     #[must_use]

--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -17,7 +17,7 @@ use oxc_resolver::{ResolveOptions, Resolver};
 use oxc_semantic::{ModuleRecord, SemanticBuilder};
 use oxc_span::{SourceType, VALID_EXTENSIONS};
 
-use crate::{Fixer, LintContext, LintOptions, Linter, Message};
+use crate::{Fixer, LintContext, Linter, Message};
 
 #[derive(Clone)]
 pub struct LintService {
@@ -25,8 +25,7 @@ pub struct LintService {
 }
 
 impl LintService {
-    pub fn new(cwd: Box<Path>, paths: &[Box<Path>], options: LintOptions) -> Self {
-        let linter = Linter::from_options(options);
+    pub fn new(cwd: Box<Path>, paths: &[Box<Path>], linter: Linter) -> Self {
         let runtime = Arc::new(Runtime::new(cwd, paths, linter));
         Self { runtime }
     }

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -155,7 +155,7 @@ impl Tester {
             .with_import_plugin(self.import_plugin)
             .with_jest_plugin(self.jest_plugin)
             .with_jsx_a11y_plugin(self.jsx_a11y_plugin);
-        let linter = Linter::from_options(options).with_rules(vec![rule]);
+        let linter = Linter::from_options(options).unwrap().with_rules(vec![rule]);
         let path_to_lint = if self.import_plugin {
             self.current_working_directory.join(&self.rule_path)
         } else {

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -35,7 +35,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     .with_filter(vec![(AllowWarnDeny::Deny, "all".into())])
                     .with_jest_plugin(true)
                     .with_jsx_a11y_plugin(true);
-                let linter = Linter::from_options(lint_options);
+                let linter = Linter::from_options(lint_options).unwrap();
                 let semantic = Rc::new(semantic_ret.semantic);
                 b.iter(|| {
                     linter.run(LintContext::new(PathBuf::from("").into_boxed_path(), &semantic))


### PR DESCRIPTION
**DRAFT**

Adds support for parsing `eslint` configuration files.

Example: 
```sh
cargo run --bin=oxc_cli lint --config-path ./.eslintrc.json .
```

This isn't a full implementation of how eslint parses configs but should be fine for now:

Currently supported `extends`:
 - `eslint:recommended` -> `eslint`
 - `plugin:react/recommended` -> `react`
 - `plugin:@typescript-eslint/recommended` -> `typescript`
 - `plugin:react-hooks/recommended` -> `react`
 - `plugin:unicorn/recommended` -> `unicorn`
 - `plugin:jest/recommended` -> `jest`

These defaults can _all_ be overridden by configuring the rule in the `rules` section of the estlint config:

e.g.
```json
{
    "extends": [
        "eslint:recommended"
    ],
    "rules": {
        "eqeqeq": "off"
    },
}
```

This would enable of of the rules within the `eslint` group. But would not enable `eqeqeq` as it is explicitly disabled

Note, we do not currently support the following:
 - supplying a `filter` and `config-path`
 - supplying a `plugin` and `config-path`

---

Edit:

- [x] @Boshen Test this manually
