### PR TITLE
chore(benchmark): reopen jest and jsx-a11y for benchmark

### DIFF
--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -31,8 +31,10 @@ fn bench_linter(criterion: &mut Criterion) {
                     .with_trivias(ret.trivias)
                     .build_module_record(PathBuf::new(), program)
                     .build(program);
-                let lint_options =
-                    LintOptions::default().with_filter(vec![(AllowWarnDeny::Deny, "all".into())]);
+                let lint_options = LintOptions::default()
+                    .with_filter(vec![(AllowWarnDeny::Deny, "all".into())])
+                    .with_jest_plugin(true)
+                    .with_jsx_a11y_plugin(true);
                 let linter = Linter::from_options(lint_options);
                 let semantic = Rc::new(semantic_ret.semantic);
                 b.iter(|| {


### PR DESCRIPTION
I think treating JSX-a11y and jest rules as an extends rules will be more clearness, they should also be influenced by `filter`. Reopen it to observe the performance too.

```
oxlint --jest-plugin -D correctness .
```
