### PR TITLE
fix(linter): fix handling of repeated eslint-disable comments

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -71,7 +71,9 @@ impl<'a, 'b> DisableDirectivesBuilder<'a, 'b> {
             if let Some(text) = text.strip_prefix("eslint-disable") {
                 // `eslint-disable`
                 if text.trim().is_empty() {
-                    self.disable_all_start = Some(span.end);
+                    if self.disable_all_start.is_none() {
+                        self.disable_all_start = Some(span.end);
+                    }
                     continue;
                 }
 
@@ -116,7 +118,7 @@ impl<'a, 'b> DisableDirectivesBuilder<'a, 'b> {
 
                 // `eslint-disable rule-name1, rule-name2`
                 Self::get_rule_names(text, |rule_name| {
-                    self.disable_start_map.insert(rule_name, span.end);
+                    self.disable_start_map.entry(rule_name).or_insert(span.end);
                 });
 
                 continue;
@@ -235,6 +237,20 @@ fn test() {
               quotes,
               semi
             */
+            debugger;
+        ",
+        // To disable all rules twice:
+        "
+        /* eslint-disable */
+            debugger;
+        /* eslint-disable */
+            debugger;
+        ",
+        // To disable a rule twice:
+        "
+        /* eslint-disable no-debugger */
+            debugger;
+        /* eslint-disable no-debugger */
             debugger;
         ",
         // Comment descriptions


### PR DESCRIPTION
This PR fixes how the linter handles repeated `eslint-disable` comments. As shown by examples below, in ESLint, repeated `eslint-disable` comments are allowed and all errors below the first `eslint-disable` comment are ignored.

The first new test case in ESLint Playground: https://eslint.org/play/#eyJ0ZXh0IjoiICAgICAgICAvKiBlc2xpbnQtZGlzYWJsZSAqL1xuICAgICAgICAgICAgZGVidWdnZXI7XG4gICAgICAgIC8qIGVzbGludC1kaXNhYmxlICovXG4gICAgICAgICAgICBkZWJ1Z2dlcjsiLCJvcHRpb25zIjp7ImVudiI6e30sInJ1bGVzIjp7Im5vLWRlYnVnZ2VyIjpbImVycm9yIl19LCJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e30sImVjbWFWZXJzaW9uIjoibGF0ZXN0Iiwic291cmNlVHlwZSI6Im1vZHVsZSJ9fX0=

The second new test case in ESLint Playground:
https://eslint.org/play/#eyJ0ZXh0IjoiICAgICAgICAvKiBlc2xpbnQtZGlzYWJsZSBuby1kZWJ1Z2dlciAqL1xuICAgICAgICAgICAgZGVidWdnZXI7XG4gICAgICAgIC8qIGVzbGludC1kaXNhYmxlIG5vLWRlYnVnZ2VyICovXG4gICAgICAgICAgICBkZWJ1Z2dlcjsiLCJvcHRpb25zIjp7ImVudiI6e30sInJ1bGVzIjp7Im5vLWRlYnVnZ2VyIjpbImVycm9yIl19LCJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e30sImVjbWFWZXJzaW9uIjoibGF0ZXN0Iiwic291cmNlVHlwZSI6Im1vZHVsZSJ9fX0=