### PR TITLE
refactor(linter): remove unused logic in `resolve_to_jest_fn`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -10,10 +10,9 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        collect_possible_jest_call_node, parse_general_jest_fn_call, JestFnKind, JestGeneralFnKind,
-        ParsedGeneralJestFnCall,
+        collect_possible_jest_call_node, parse_general_jest_fn_call_new, JestFnKind,
+        JestGeneralFnKind, ParsedGeneralJestFnCallNew, PossibleJestNode,
     },
-    AstNode,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -85,16 +84,18 @@ impl Message {
 
 impl Rule for NoDisabledTests {
     fn run_once(&self, ctx: &LintContext) {
-        for node in collect_possible_jest_call_node(ctx) {
-            run(node, ctx);
+        for possible_jest_node in &collect_possible_jest_call_node(ctx) {
+            run(possible_jest_node, ctx);
         }
     }
 }
 
-fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    let node = possible_jest_node.node;
+    let original = possible_jest_node.original;
     if let AstKind::CallExpression(call_expr) = node.kind() {
-        if let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, node, ctx) {
-            let ParsedGeneralJestFnCall { kind, members, name } = jest_fn_call;
+        if let Some(jest_fn_call) = parse_general_jest_fn_call_new(call_expr, node, original, ctx) {
+            let ParsedGeneralJestFnCallNew { kind, members, name } = jest_fn_call;
             // `test('foo')`
             let kind = match kind {
                 JestFnKind::Expect | JestFnKind::Unknown => return,

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -92,9 +92,10 @@ impl Rule for NoDisabledTests {
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
     let node = possible_jest_node.node;
-    let original = possible_jest_node.original;
     if let AstKind::CallExpression(call_expr) = node.kind() {
-        if let Some(jest_fn_call) = parse_general_jest_fn_call_new(call_expr, node, original, ctx) {
+        if let Some(jest_fn_call) =
+            parse_general_jest_fn_call_new(call_expr, possible_jest_node, ctx)
+        {
             let ParsedGeneralJestFnCallNew { kind, members, name } = jest_fn_call;
             // `test('foo')`
             let kind = match kind {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -115,6 +115,24 @@ pub fn is_type_of_jest_fn_call<'a>(
     false
 }
 
+// TODO: The new version of `is_type_of_jest_fn_call`, will rename to `is_type_of_jest_fn_call` after all replaced.
+pub fn is_type_of_jest_fn_call_new<'a>(
+    call_expr: &'a CallExpression<'a>,
+    possible_jest_node: &PossibleJestNode<'a, '_>,
+    ctx: &LintContext<'a>,
+    kinds: &[JestFnKind],
+) -> bool {
+    let jest_fn_call = parse_jest_fn_call_new(call_expr, possible_jest_node, ctx);
+    if let Some(jest_fn_call) = jest_fn_call {
+        let kind = jest_fn_call.kind();
+        if kinds.contains(&kind) {
+            return true;
+        }
+    }
+
+    false
+}
+
 pub fn parse_general_jest_fn_call<'a>(
     call_expr: &'a CallExpression<'a>,
     node: &AstNode<'a>,
@@ -131,11 +149,10 @@ pub fn parse_general_jest_fn_call<'a>(
 // TODO: The new version of `parse_general_jest_fn_call`, will rename to `parse_general_jest_fn_call` after all replaced.
 pub fn parse_general_jest_fn_call_new<'a>(
     call_expr: &'a CallExpression<'a>,
-    node: &AstNode<'a>,
-    original: Option<&'a Atom>,
+    possible_jest_node: &PossibleJestNode<'a, '_>,
     ctx: &LintContext<'a>,
 ) -> Option<ParsedGeneralJestFnCallNew<'a>> {
-    let jest_fn_call = parse_jest_fn_call_new(call_expr, node, original, ctx)?;
+    let jest_fn_call = parse_jest_fn_call_new(call_expr, possible_jest_node, ctx)?;
 
     if let ParsedJestFnCallNew::GeneralJestFnCall(jest_fn_call) = jest_fn_call {
         return Some(jest_fn_call);

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -1,10 +1,14 @@
 use std::borrow::Cow;
 
 use oxc_ast::{
-    ast::{CallExpression, Expression, ModuleDeclaration, TemplateLiteral},
+    ast::{
+        CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
+        ModuleDeclaration, TemplateLiteral,
+    },
     AstKind,
 };
 use oxc_semantic::{AstNode, ReferenceId};
+use oxc_span::Atom;
 use phf::phf_set;
 
 use crate::LintContext;
@@ -16,6 +20,12 @@ pub use crate::utils::jest::parse_jest_fn::{
     parse_jest_fn_call, ExpectError, KnownMemberExpressionParentKind,
     KnownMemberExpressionProperty, MemberExpressionElement, ParsedExpectFnCall,
     ParsedGeneralJestFnCall,
+};
+
+mod parse_jest_fn_new;
+pub use crate::utils::jest::parse_jest_fn_new::{
+    parse_jest_fn_call as parse_jest_fn_call_new,
+    ParsedGeneralJestFnCall as ParsedGeneralJestFnCallNew, ParsedJestFnCall as ParsedJestFnCallNew,
 };
 
 const JEST_METHOD_NAMES: phf::Set<&'static str> = phf_set![
@@ -118,6 +128,21 @@ pub fn parse_general_jest_fn_call<'a>(
     None
 }
 
+// TODO: The new version of `parse_general_jest_fn_call`, will rename to `parse_general_jest_fn_call` after all replaced.
+pub fn parse_general_jest_fn_call_new<'a>(
+    call_expr: &'a CallExpression<'a>,
+    node: &AstNode<'a>,
+    original: Option<&'a Atom>,
+    ctx: &LintContext<'a>,
+) -> Option<ParsedGeneralJestFnCallNew<'a>> {
+    let jest_fn_call = parse_jest_fn_call_new(call_expr, node, original, ctx)?;
+
+    if let ParsedJestFnCallNew::GeneralJestFnCall(jest_fn_call) = jest_fn_call {
+        return Some(jest_fn_call);
+    }
+    None
+}
+
 pub fn parse_expect_jest_fn_call<'a>(
     call_expr: &'a CallExpression<'a>,
     node: &AstNode<'a>,
@@ -131,9 +156,16 @@ pub fn parse_expect_jest_fn_call<'a>(
     None
 }
 
+pub struct PossibleJestNode<'a, 'b> {
+    pub node: &'b AstNode<'a>,
+    pub original: Option<&'a Atom>, // if this node is imported from 'jest/globals', this field will be Some(original_name), otherwise None
+}
+
 /// Collect all possible Jest fn Call Expression,
 /// for `expect(1).toBe(1)`, the result will be a collection of node `expect(1)` and node `expect(1).toBe(1)`.
-pub fn collect_possible_jest_call_node<'a, 'b>(ctx: &'b LintContext<'a>) -> Vec<&'b AstNode<'a>> {
+pub fn collect_possible_jest_call_node<'a, 'b>(
+    ctx: &'b LintContext<'a>,
+) -> Vec<PossibleJestNode<'a, 'b>> {
     let import_entries = &ctx.semantic().module_record().import_entries;
 
     // Whether test functions are imported from 'jest/globals'.
@@ -142,13 +174,14 @@ pub fn collect_possible_jest_call_node<'a, 'b>(ctx: &'b LintContext<'a>) -> Vec<
         .iter()
         .any(|import_entry| matches!(import_entry.module_request.name().as_str(), "@jest/globals"));
 
-    let reference_ids = if is_import_mode {
+    let reference_id_with_original_list = if is_import_mode {
         collect_ids_referenced_to_import(ctx)
     } else if JEST_METHOD_NAMES
         .iter()
         .any(|name| ctx.scopes().root_unresolved_references().contains_key(*name))
     {
-        collect_ids_referenced_to_global(ctx)
+        // set original of global test function to None
+        collect_ids_referenced_to_global(ctx).iter().map(|id| (*id, None)).collect()
     } else {
         // we are not test file, just return empty vec.
         vec![]
@@ -157,14 +190,15 @@ pub fn collect_possible_jest_call_node<'a, 'b>(ctx: &'b LintContext<'a>) -> Vec<
     // The longest length of Jest chains is 4, e.g.`expect(1).not.resolved.toBe()`.
     // We take 4 ancestors of node and collect all Call Expression.
     // The invalid Jest Call Expression will be bypassed in `parse_jest_fn_call`
-    reference_ids.iter().fold(vec![], |mut acc, id| {
-        let mut id = ctx.symbols().get_reference(*id).node_id();
+    reference_id_with_original_list.iter().fold(vec![], |mut acc, id_with_original| {
+        let (reference_id, original) = id_with_original;
+        let mut id = ctx.symbols().get_reference(*reference_id).node_id();
         for _ in 0..4 {
             let parent = ctx.nodes().parent_node(id);
             if let Some(parent) = parent {
                 let parent_kind = parent.kind();
                 if matches!(parent_kind, AstKind::CallExpression(_)) {
-                    acc.push(parent);
+                    acc.push(PossibleJestNode { node: parent, original: *original });
                     id = parent.id();
                 } else if matches!(
                     parent_kind,
@@ -183,28 +217,52 @@ pub fn collect_possible_jest_call_node<'a, 'b>(ctx: &'b LintContext<'a>) -> Vec<
     })
 }
 
-fn collect_ids_referenced_to_import(ctx: &LintContext) -> Vec<ReferenceId> {
+fn collect_ids_referenced_to_import<'a, 'b>(
+    ctx: &'b LintContext<'a>,
+) -> Vec<(ReferenceId, Option<&'a Atom>)> {
     ctx.symbols()
         .resolved_references
         .iter_enumerated()
-        .filter(|(symbol_id, _)| {
-            if ctx.symbols().get_flag(*symbol_id).is_import_binding() {
-                let id = ctx.symbols().get_declaration(*symbol_id);
+        .filter_map(|(symbol_id, reference_ids)| {
+            if ctx.symbols().get_flag(symbol_id).is_import_binding() {
+                let id = ctx.symbols().get_declaration(symbol_id);
                 let node = ctx.nodes().get_node(id);
                 let AstKind::ModuleDeclaration(module_decl) = node.kind() else {
-                    return false;
+                    return None;
                 };
                 let ModuleDeclaration::ImportDeclaration(import_decl) = module_decl else {
-                    return false;
+                    return None;
                 };
+                let name = ctx.symbols().get_name(symbol_id);
 
-                return import_decl.source.value == "@jest/globals";
+                if import_decl.source.value == "@jest/globals" {
+                    let original = find_original_name(import_decl, name);
+                    let mut ret = vec![];
+                    for reference_id in reference_ids {
+                        ret.push((*reference_id, original));
+                    }
+
+                    return Some(ret);
+                }
             }
 
-            false
+            None
         })
-        .flat_map(|(_, reference_ids)| reference_ids.clone())
-        .collect::<Vec<ReferenceId>>()
+        .flatten()
+        .collect::<Vec<(ReferenceId, Option<&'a Atom>)>>()
+}
+
+/// Find name in the Import Declaration, not use name because of lifetime not long enough.
+fn find_original_name<'a>(import_decl: &'a ImportDeclaration<'a>, name: &Atom) -> Option<&'a Atom> {
+    import_decl.specifiers.iter().flatten().find_map(|specifier| match specifier {
+        ImportDeclarationSpecifier::ImportSpecifier(import_specifier) => {
+            if import_specifier.local.name.as_str() == name.as_str() {
+                return Some(import_specifier.imported.name());
+            }
+            None
+        }
+        _ => None,
+    })
 }
 
 fn collect_ids_referenced_to_global(ctx: &LintContext) -> Vec<ReferenceId> {

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn_new.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn_new.rs
@@ -1,0 +1,559 @@
+use std::{borrow::Cow, cmp::Ordering};
+
+use oxc_ast::{
+    ast::{
+        Argument, CallExpression, Expression, IdentifierName, IdentifierReference, MemberExpression,
+    },
+    AstKind,
+};
+use oxc_semantic::AstNode;
+use oxc_span::{Atom, Span};
+
+use crate::context::LintContext;
+
+use crate::utils::jest::{is_pure_string, JestFnKind, JestGeneralFnKind};
+
+pub fn parse_jest_fn_call<'a>(
+    call_expr: &'a CallExpression<'a>,
+    node: &AstNode<'a>,
+    original: Option<&'a Atom>,
+    ctx: &LintContext<'a>,
+) -> Option<ParsedJestFnCall<'a>> {
+    let callee = &call_expr.callee;
+    // If bailed out, we're not jest function
+    let resolved = resolve_to_jest_fn(call_expr, original)?;
+
+    let params = NodeChainParams {
+        expr: callee,
+        parent: None, // TODO: not really know how to convert type of call_expr to Expression, set to `None` temporarily.
+        parent_kind: Some(KnownMemberExpressionParentKind::Call),
+        grandparent_kind: None,
+    };
+    let chain = get_node_chain(&params);
+    let all_member_expr_except_last =
+        chain.iter().rev().skip(1).all(|member| {
+            matches!(member.parent_kind, Some(KnownMemberExpressionParentKind::Member))
+        });
+
+    if let Some(last) = chain.last() {
+        // If we're an `each()`, ensure we're the outer CallExpression (i.e `.each()()`)
+        if last.is_name_equal("each")
+            && !matches!(
+                callee,
+                Expression::CallExpression(_) | Expression::TaggedTemplateExpression(_)
+            )
+        {
+            return None;
+        }
+
+        if matches!(callee, Expression::TaggedTemplateExpression(_)) && last.is_name_unequal("each")
+        {
+            return None;
+        }
+
+        let name = resolved.original.unwrap_or(resolved.local).as_str();
+        let kind = JestFnKind::from(name);
+        let mut members = Vec::new();
+        let mut iter = chain.into_iter();
+        let head = iter.next()?;
+        let rest = iter;
+
+        // every member node must have a member expression as their parent
+        // in order to be part of the call chain we're parsing
+        for member in rest {
+            members.push(member);
+        }
+
+        if matches!(kind, JestFnKind::Expect) {
+            let options = ExpectFnCallOptions { call_expr, members, name, head, node, ctx };
+            return parse_jest_expect_fn_call(options);
+        }
+
+        // Ensure that we're at the "top" of the function call chain otherwise when
+        // parsing e.g. x().y.z(), we'll incorrectly find & parse "x()" even though
+        // the full chain is not a valid jest function call chain
+        if ctx.nodes().parent_node(node.id()).is_some_and(|parent_node| {
+            matches!(parent_node.kind(), AstKind::CallExpression(_) | AstKind::MemberExpression(_))
+        }) {
+            return None;
+        }
+
+        if matches!(kind, JestFnKind::General(JestGeneralFnKind::Jest)) {
+            return parse_jest_jest_fn_call(members, name);
+        }
+
+        // Check every link in the chain except the last is a member expression
+        if !all_member_expr_except_last {
+            return None;
+        }
+
+        let mut call_chains = Vec::from([Cow::Borrowed(name)]);
+        call_chains.extend(members.iter().filter_map(KnownMemberExpressionProperty::name));
+        if !is_valid_jest_call(&call_chains) {
+            return None;
+        }
+
+        return Some(ParsedJestFnCall::GeneralJestFnCall(ParsedGeneralJestFnCall {
+            kind,
+            members,
+            name: Cow::Borrowed(name),
+        }));
+    }
+
+    None
+}
+
+fn parse_jest_expect_fn_call<'a>(
+    options: ExpectFnCallOptions<'a, '_>,
+) -> Option<ParsedJestFnCall<'a>> {
+    let ExpectFnCallOptions { call_expr, members, name, head, node, ctx } = options;
+    let (modifiers, matcher, mut expect_error) = match find_modifiers_and_matcher(&members) {
+        Ok((modifier, matcher)) => (modifier, matcher, None),
+        Err(e) => (vec![], None, Some(e)),
+    };
+
+    // if the `expect` call chain is not valid, only report on the topmost node
+    // since all members in the chain are likely to get flagged for some reason
+    if expect_error.is_some() && !is_top_most_call_expr(node, ctx) {
+        return None;
+    }
+
+    if matches!(expect_error, Some(ExpectError::MatcherNotFound)) {
+        let parent = ctx.nodes().parent_node(node.id())?;
+        if matches!(parent.kind(), AstKind::MemberExpression(_)) {
+            expect_error = Some(ExpectError::MatcherNotCalled);
+        }
+    }
+
+    return Some(ParsedJestFnCall::ExpectFnCall(ParsedExpectFnCall {
+        kind: JestFnKind::Expect,
+        head,
+        members,
+        name: Cow::Borrowed(name),
+        args: &call_expr.arguments,
+        matcher_index: matcher,
+        modifier_indices: modifiers,
+        expect_error,
+    }));
+}
+
+type ModifiersAndMatcherIndex = (Vec<usize>, Option<usize>);
+
+#[derive(PartialEq, Eq)]
+pub enum ModifierName {
+    Not,
+    Rejects,
+    Resolves,
+}
+
+impl ModifierName {
+    pub fn from(name: &str) -> Option<Self> {
+        match name {
+            "not" => Some(Self::Not),
+            "rejects" => Some(Self::Rejects),
+            "resolves" => Some(Self::Resolves),
+            _ => None,
+        }
+    }
+}
+
+fn find_modifiers_and_matcher(
+    members: &[KnownMemberExpressionProperty],
+) -> Result<ModifiersAndMatcherIndex, ExpectError> {
+    let mut modifiers: Vec<usize> = vec![];
+
+    for (index, member) in members.iter().enumerate() {
+        // check if the member is being called, which means it is the matcher
+        // (and also the end of the entire "expect" call chain)
+        if matches!(member.parent_kind, Some(KnownMemberExpressionParentKind::Member))
+            && matches!(member.grandparent_kind, Some(KnownMemberExpressionParentKind::Call))
+        {
+            let matcher = Some(index);
+            return Ok((modifiers, matcher));
+        }
+
+        // the first modifier can be any of the three modifiers
+        if modifiers.is_empty() {
+            if !member.is_name_in_modifiers(&[
+                ModifierName::Not,
+                ModifierName::Resolves,
+                ModifierName::Rejects,
+            ]) {
+                return Err(ExpectError::ModifierUnknown);
+            }
+        } else if modifiers.len() == 1 {
+            // the second modifier can only be "not"
+            if !member.is_name_in_modifiers(&[ModifierName::Not]) {
+                return Err(ExpectError::ModifierUnknown);
+            }
+            // and the first modifier has to be either "resolves" or "rejects"
+            if !members[modifiers[0]]
+                .is_name_in_modifiers(&[ModifierName::Resolves, ModifierName::Rejects])
+            {
+                return Err(ExpectError::ModifierUnknown);
+            }
+        } else {
+            return Err(ExpectError::ModifierUnknown);
+        }
+
+        modifiers.push(index);
+    }
+
+    Err(ExpectError::MatcherNotFound)
+}
+
+fn is_top_most_call_expr<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+    let mut node = node;
+
+    loop {
+        let Some(parent) = ctx.nodes().parent_node(node.id()) else { return true };
+
+        match parent.kind() {
+            AstKind::CallExpression(_) => return false,
+            AstKind::MemberExpression(_) => node = parent,
+            _ => {
+                return true;
+            }
+        }
+    }
+}
+
+fn parse_jest_jest_fn_call<'a>(
+    members: Vec<KnownMemberExpressionProperty<'a>>,
+    name: &'a str,
+) -> Option<ParsedJestFnCall<'a>> {
+    if !name.to_ascii_lowercase().eq_ignore_ascii_case("jest") {
+        return None;
+    }
+
+    return Some(ParsedJestFnCall::GeneralJestFnCall(ParsedGeneralJestFnCall {
+        kind: JestFnKind::General(JestGeneralFnKind::Jest),
+        members,
+        name: Cow::Borrowed(name),
+    }));
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ExpectError {
+    ModifierUnknown,
+    MatcherNotFound,
+    MatcherNotCalled,
+}
+
+pub struct ExpectFnCallOptions<'a, 'b> {
+    pub call_expr: &'a CallExpression<'a>,
+    pub members: Vec<KnownMemberExpressionProperty<'a>>,
+    pub name: &'a str,
+    pub head: KnownMemberExpressionProperty<'a>,
+    pub node: &'b AstNode<'a>,
+    pub ctx: &'b LintContext<'a>,
+}
+
+// If find a match in `VALID_JEST_FN_CALL_CHAINS`, return true.
+fn is_valid_jest_call(members: &[Cow<str>]) -> bool {
+    VALID_JEST_FN_CALL_CHAINS
+        .binary_search_by(|chain| {
+            chain
+                .iter()
+                .zip(members.iter())
+                .find_map(|(&chain, member)| {
+                    let ordering = chain.cmp(member.as_ref());
+                    if ordering != Ordering::Equal {
+                        return Some(ordering);
+                    }
+                    None
+                })
+                .unwrap_or(Ordering::Equal)
+        })
+        .is_ok()
+}
+
+fn resolve_to_jest_fn<'a>(
+    call_expr: &'a CallExpression<'a>,
+    original: Option<&'a Atom>,
+) -> Option<ResolvedJestFn<'a>> {
+    let ident = resolve_first_ident(&call_expr.callee)?;
+    Some(ResolvedJestFn { local: &ident.name, original })
+}
+
+fn resolve_first_ident<'a>(expr: &'a Expression) -> Option<&'a IdentifierReference> {
+    match expr {
+        Expression::Identifier(ident) => Some(ident),
+        Expression::MemberExpression(member_expr) => resolve_first_ident(member_expr.object()),
+        Expression::CallExpression(call_expr) => resolve_first_ident(&call_expr.callee),
+        Expression::TaggedTemplateExpression(tagged_expr) => resolve_first_ident(&tagged_expr.tag),
+        _ => None,
+    }
+}
+
+pub enum ParsedJestFnCall<'a> {
+    GeneralJestFnCall(ParsedGeneralJestFnCall<'a>),
+    ExpectFnCall(ParsedExpectFnCall<'a>),
+}
+
+impl<'a> ParsedJestFnCall<'a> {
+    #[allow(unused)]
+    pub fn kind(&self) -> JestFnKind {
+        match self {
+            Self::GeneralJestFnCall(call) => call.kind,
+            Self::ExpectFnCall(call) => call.kind,
+        }
+    }
+}
+
+pub struct ParsedGeneralJestFnCall<'a> {
+    pub kind: JestFnKind,
+    pub members: Vec<KnownMemberExpressionProperty<'a>>,
+    pub name: Cow<'a, str>,
+}
+
+pub struct ParsedExpectFnCall<'a> {
+    pub kind: JestFnKind,
+    pub members: Vec<KnownMemberExpressionProperty<'a>>,
+    pub name: Cow<'a, str>,
+    pub head: KnownMemberExpressionProperty<'a>,
+    pub args: &'a oxc_allocator::Vec<'a, Argument<'a>>,
+    // In `expect(1).not.resolved.toBe()`, "not", "resolved" will be modifier
+    // it save a group of modifier index from members
+    pub modifier_indices: Vec<usize>,
+    // In `expect(1).toBe(2)`, "toBe" will be matcher
+    // it save the matcher index from members
+    pub matcher_index: Option<usize>,
+    pub expect_error: Option<ExpectError>,
+}
+
+impl<'a> ParsedExpectFnCall<'a> {
+    #[allow(unused)]
+    pub fn matcher(&self) -> Option<&KnownMemberExpressionProperty<'a>> {
+        let matcher_index = self.matcher_index?;
+        self.members.get(matcher_index)
+    }
+    pub fn modifiers(&self) -> Vec<&KnownMemberExpressionProperty<'a>> {
+        self.modifier_indices.iter().filter_map(|i| self.members.get(*i)).collect::<Vec<_>>()
+    }
+}
+
+struct ResolvedJestFn<'a> {
+    pub local: &'a Atom,
+    pub original: Option<&'a Atom>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum KnownMemberExpressionParentKind {
+    Member,
+    Call,
+    TaggedTemplate,
+}
+
+pub struct KnownMemberExpressionProperty<'a> {
+    pub element: MemberExpressionElement<'a>,
+    pub parent: Option<&'a Expression<'a>>,
+    pub parent_kind: Option<KnownMemberExpressionParentKind>,
+    pub grandparent_kind: Option<KnownMemberExpressionParentKind>,
+    pub span: Span,
+}
+
+impl<'a> KnownMemberExpressionProperty<'a> {
+    pub fn name(&self) -> Option<Cow<'a, str>> {
+        match &self.element {
+            MemberExpressionElement::Expression(expr) => match expr {
+                Expression::Identifier(ident) => Some(Cow::Borrowed(ident.name.as_str())),
+                Expression::StringLiteral(string_literal) => {
+                    Some(Cow::Borrowed(string_literal.value.as_str()))
+                }
+                Expression::TemplateLiteral(template_literal) => Some(Cow::Borrowed(
+                    template_literal.quasi().expect("get string content").as_str(),
+                )),
+                _ => None,
+            },
+            MemberExpressionElement::IdentName(ident_name) => {
+                Some(Cow::Borrowed(ident_name.name.as_str()))
+            }
+        }
+    }
+    pub fn is_name_equal(&self, name: &str) -> bool {
+        self.name().map_or(false, |n| n == name)
+    }
+    pub fn is_name_unequal(&self, name: &str) -> bool {
+        !self.is_name_equal(name)
+    }
+    pub fn is_name_in_modifiers(&self, modifiers: &[ModifierName]) -> bool {
+        self.name().map_or(false, |name| {
+            if let Some(modifier_name) = ModifierName::from(name.as_ref()) {
+                return modifiers.contains(&modifier_name);
+            }
+            false
+        })
+    }
+}
+
+pub enum MemberExpressionElement<'a> {
+    Expression(&'a Expression<'a>),
+    IdentName(&'a IdentifierName),
+}
+
+impl<'a> MemberExpressionElement<'a> {
+    pub fn from_member_expr(
+        member_expr: &'a MemberExpression<'a>,
+    ) -> Option<(Span, MemberExpressionElement<'a>)> {
+        let (span, _) = member_expr.static_property_info()?;
+        match member_expr {
+            MemberExpression::ComputedMemberExpression(expr) => {
+                Some((span, Self::Expression(&expr.expression)))
+            }
+            MemberExpression::StaticMemberExpression(expr) => {
+                Some((span, Self::IdentName(&expr.property)))
+            }
+            // Jest fn chains don't have private fields, just ignore it.
+            MemberExpression::PrivateFieldExpression(_) => None,
+        }
+    }
+    #[allow(unused)]
+    pub fn is_string_literal(&self) -> bool {
+        matches!(
+            self,
+            Self::Expression(Expression::StringLiteral(_) | Expression::TemplateLiteral(_))
+        )
+    }
+}
+
+struct NodeChainParams<'a> {
+    expr: &'a Expression<'a>,
+    parent: Option<&'a Expression<'a>>,
+    parent_kind: Option<KnownMemberExpressionParentKind>,
+    grandparent_kind: Option<KnownMemberExpressionParentKind>,
+}
+
+/// Port from [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest/blob/a058f22f94774eeea7980ea2d1f24c6808bf3e2c/src/rules/utils/parseJestFnCall.ts#L36-L51)
+fn get_node_chain<'a>(params: &NodeChainParams<'a>) -> Vec<KnownMemberExpressionProperty<'a>> {
+    let mut chain = Vec::new();
+    let NodeChainParams { expr, parent, parent_kind, grandparent_kind } = params;
+
+    match expr {
+        Expression::MemberExpression(member_expr) => {
+            let params = NodeChainParams {
+                expr: member_expr.object(),
+                parent: Some(expr),
+                parent_kind: Some(KnownMemberExpressionParentKind::Member),
+                grandparent_kind: *parent_kind,
+            };
+
+            chain.extend(get_node_chain(&params));
+            if let Some((span, element)) = MemberExpressionElement::from_member_expr(member_expr) {
+                chain.push(KnownMemberExpressionProperty {
+                    element,
+                    parent: Some(expr),
+                    parent_kind: Some(KnownMemberExpressionParentKind::Member),
+                    grandparent_kind: *parent_kind,
+                    span,
+                });
+            }
+        }
+        Expression::Identifier(ident) => {
+            chain.push(KnownMemberExpressionProperty {
+                element: MemberExpressionElement::Expression(expr),
+                parent: *parent,
+                parent_kind: *parent_kind,
+                grandparent_kind: *grandparent_kind,
+                span: ident.span,
+            });
+        }
+        Expression::CallExpression(call_expr) => {
+            let params = NodeChainParams {
+                expr: &call_expr.callee,
+                parent: Some(expr),
+                parent_kind: Some(KnownMemberExpressionParentKind::Call),
+                grandparent_kind: *parent_kind,
+            };
+            let sub_chain = get_node_chain(&params);
+            chain.extend(sub_chain);
+        }
+        Expression::TaggedTemplateExpression(tagged_expr) => {
+            let params = NodeChainParams {
+                expr: &tagged_expr.tag,
+                parent: Some(expr),
+                parent_kind: Some(KnownMemberExpressionParentKind::TaggedTemplate),
+                grandparent_kind: *parent_kind,
+            };
+
+            let sub_chain = get_node_chain(&params);
+            chain.extend(sub_chain);
+        }
+        Expression::StringLiteral(string_literal) => {
+            chain.push(KnownMemberExpressionProperty {
+                element: MemberExpressionElement::Expression(expr),
+                parent: *parent,
+                parent_kind: *parent_kind,
+                grandparent_kind: *grandparent_kind,
+                span: string_literal.span,
+            });
+        }
+        Expression::TemplateLiteral(template_literal) if is_pure_string(template_literal) => {
+            chain.push(KnownMemberExpressionProperty {
+                element: MemberExpressionElement::Expression(expr),
+                parent: *parent,
+                parent_kind: *parent_kind,
+                grandparent_kind: *grandparent_kind,
+                span: template_literal.span,
+            });
+        }
+        _ => {}
+    };
+
+    chain
+}
+
+// sorted list for binary search.
+const VALID_JEST_FN_CALL_CHAINS: [[&str; 4]; 51] = [
+    ["afterAll", "", "", ""],
+    ["afterEach", "", "", ""],
+    ["beforeAll", "", "", ""],
+    ["beforeEach", "", "", ""],
+    ["describe", "", "", ""],
+    ["describe", "each", "", ""],
+    ["describe", "only", "", ""],
+    ["describe", "only", "each", ""],
+    ["describe", "skip", "", ""],
+    ["describe", "skip", "each", ""],
+    ["fdescribe", "", "", ""],
+    ["fdescribe", "each", "", ""],
+    ["fit", "", "", ""],
+    ["fit", "each", "", ""],
+    ["fit", "failing", "", ""],
+    ["it", "", "", ""],
+    ["it", "concurrent", "", ""],
+    ["it", "concurrent", "each", ""],
+    ["it", "concurrent", "only", "each"],
+    ["it", "concurrent", "skip", "each"],
+    ["it", "each", "", ""],
+    ["it", "failing", "", ""],
+    ["it", "only", "", ""],
+    ["it", "only", "each", ""],
+    ["it", "only", "failing", ""],
+    ["it", "skip", "", ""],
+    ["it", "skip", "each", ""],
+    ["it", "skip", "failing", ""],
+    ["it", "todo", "", ""],
+    ["test", "", "", ""],
+    ["test", "concurrent", "", ""],
+    ["test", "concurrent", "each", ""],
+    ["test", "concurrent", "only", "each"],
+    ["test", "concurrent", "skip", "each"],
+    ["test", "each", "", ""],
+    ["test", "failing", "", ""],
+    ["test", "only", "", ""],
+    ["test", "only", "each", ""],
+    ["test", "only", "failing", ""],
+    ["test", "skip", "", ""],
+    ["test", "skip", "each", ""],
+    ["test", "skip", "failing", ""],
+    ["test", "todo", "", ""],
+    ["xdescribe", "", "", ""],
+    ["xdescribe", "each", "", ""],
+    ["xit", "", "", ""],
+    ["xit", "each", "", ""],
+    ["xit", "failing", "", ""],
+    ["xtest", "", "", ""],
+    ["xtest", "each", "", ""],
+    ["xtest", "failing", "", ""],
+];

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn_new.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn_new.rs
@@ -11,14 +11,15 @@ use oxc_span::{Atom, Span};
 
 use crate::context::LintContext;
 
-use crate::utils::jest::{is_pure_string, JestFnKind, JestGeneralFnKind};
+use crate::utils::jest::{is_pure_string, JestFnKind, JestGeneralFnKind, PossibleJestNode};
 
 pub fn parse_jest_fn_call<'a>(
     call_expr: &'a CallExpression<'a>,
-    node: &AstNode<'a>,
-    original: Option<&'a Atom>,
+    possible_jest_node: &PossibleJestNode<'a, '_>,
     ctx: &LintContext<'a>,
 ) -> Option<ParsedJestFnCall<'a>> {
+    let original = possible_jest_node.original;
+    let node = possible_jest_node.node;
     let callee = &call_expr.callee;
     // If bailed out, we're not jest function
     let resolved = resolve_to_jest_fn(call_expr, original)?;


### PR DESCRIPTION
I copied parse_jest_fn.rs file to parse_jest_fn_new.rs, the new file only changed `resolve_to_jest_fn` now. The new version of `parse_jest_fn_call` doesn't need to get the original of node, and I changed its parameters. I tried to add it to the old file, but it will influence other files, so I created a new file for it. I will delete the old file after all rules migrated. 