### PR TITLE
feat(tasks/prettier-conformance): parse the specs and pass the correct options to prettier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "jemallocator",
  "mimalloc",
  "oxc_allocator",
+ "oxc_ast",
  "oxc_parser",
  "oxc_prettier",
  "oxc_span",

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -19,6 +19,7 @@ oxc_parser       = { workspace = true }
 oxc_prettier     = { workspace = true }
 oxc_span         = { workspace = true }
 oxc_tasks_common = { workspace = true }
+oxc_ast          = { workspace = true }
 
 walkdir   = { workspace = true }
 pico-args = { workspace = true }

--- a/tasks/prettier_conformance/prettier.snap.md
+++ b/tasks/prettier_conformance/prettier.snap.md
@@ -1,4 +1,4 @@
-Compatibility: 4/173 (2.31%)
+Compatibility: 5/173 (2.89%)
 
 # Failed
 
@@ -157,7 +157,6 @@ Compatibility: 4/173 (2.31%)
 * test-declarations
 * throw_expressions
 * throw_statement
-* top-level-await
 * trailing-comma
 * trailing-whitespace
 * try

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -6,9 +6,15 @@ use std::{
 use walkdir::{DirEntry, WalkDir};
 
 use oxc_allocator::Allocator;
+use oxc_ast::{
+    ast::{
+        Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind, Program,
+    },
+    VisitMut,
+};
 use oxc_parser::Parser;
-use oxc_prettier::{Prettier, PrettierOptions};
-use oxc_span::SourceType;
+use oxc_prettier::{Prettier, PrettierOptions, TrailingComma};
+use oxc_span::{Atom, SourceType};
 use oxc_tasks_common::project_root;
 
 // #[test]
@@ -22,9 +28,27 @@ pub struct TestRunnerOptions {
     pub filter: Option<String>,
 }
 
+#[derive(Default)]
+pub struct SpecParser {
+    source_text: String,
+    calls: Vec<(PrettierOptions, Vec<(Atom, String)>)>,
+}
+
+impl SpecParser {
+    pub fn parse(&mut self, spec: &Path) {
+        let spec_content = fs::read_to_string(spec).unwrap_or_default();
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path(spec).unwrap_or_default();
+        let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
+        self.source_text = spec_content.clone();
+        self.visit_program(&mut ret.program);
+    }
+}
+
 /// The test runner which walks the prettier repository and searches for formatting tests.
 pub struct TestRunner {
     options: TestRunnerOptions,
+    spec: SpecParser,
 }
 
 fn root() -> PathBuf {
@@ -35,14 +59,102 @@ fn fixtures_root() -> PathBuf {
     project_root().join(root()).join("prettier/tests/format/js")
 }
 
+impl VisitMut<'_> for SpecParser {
+    fn visit_program(&mut self, program: &mut Program<'_>) {
+        self.visit_statements(&mut program.body);
+    }
+
+    fn visit_call_expression(&mut self, expr: &mut CallExpression<'_>) {
+        let Some(ident) = expr.callee.get_identifier_reference() else { return };
+        if ident.name != "run_spec" {
+            return;
+        }
+        let mut parsers = vec![];
+        let mut snapshot_options = vec![];
+        let mut options = PrettierOptions::default();
+
+        if let Some(argument) = expr.arguments.get(1) {
+            if let Argument::Expression(Expression::ArrayExpression(arr_expr)) = argument {
+                parsers = arr_expr
+                    .elements
+                    .iter()
+                    .filter_map(|el| {
+                        if let ArrayExpressionElement::Expression(Expression::StringLiteral(
+                            literal,
+                        )) = el
+                        {
+                            return Some(literal.value.to_string());
+                        }
+                        None
+                    })
+                    .collect::<Vec<String>>();
+            }
+        } else {
+            return;
+        }
+
+        if let Some(Argument::Expression(Expression::ObjectExpression(obj_expr))) =
+            expr.arguments.get(2)
+        {
+            obj_expr.properties.iter().for_each(|item| {
+                if let ObjectPropertyKind::ObjectProperty(obj_prop) = item {
+                    if let Some(name) = obj_prop.key.static_name() {
+                        match &obj_prop.value {
+                            Expression::BooleanLiteral(literal) => {
+                                if name == "semi" {
+                                    options.semi = literal.value;
+                                }
+                                snapshot_options.push((name, literal.value.to_string()));
+                            }
+                            Expression::NumberLiteral(literal) => {
+                                if name == "printWidth" {
+                                    options.print_width =
+                                        str::parse(&literal.value.to_string()).unwrap_or(80);
+                                }
+                                snapshot_options.push((name, literal.value.to_string()));
+                            }
+                            Expression::StringLiteral(literal) => {
+                                if name == "trailingComma" {
+                                    options.trailing_comma = match literal.value.as_str() {
+                                        "none" => TrailingComma::None,
+                                        "es5" => TrailingComma::ES5,
+                                        _ => TrailingComma::All,
+                                    }
+                                }
+                                snapshot_options.push((name, format!("\"{}\"", literal.value)));
+                            }
+                            _ => {}
+                        };
+                    };
+                }
+            });
+        }
+
+        snapshot_options.push((
+            "parsers".into(),
+            format!(
+                "[{}]",
+                parsers.iter().map(|p| format!("\"{p}\"")).collect::<Vec<_>>().join(", ")
+            ),
+        ));
+        if !snapshot_options.iter().any(|item| item.0 == "printWidth") {
+            snapshot_options.push(("printWidth".into(), "80".into()));
+        }
+
+        snapshot_options.sort_by(|a, b| a.0.cmp(&b.0));
+
+        self.calls.push((options, snapshot_options));
+    }
+}
+
 impl TestRunner {
     pub fn new(options: TestRunnerOptions) -> Self {
-        Self { options }
+        Self { options, spec: SpecParser::default() }
     }
 
     /// # Panics
     #[allow(clippy::cast_precision_loss)]
-    pub fn run(self) {
+    pub fn run(mut self) {
         let fixture_root = fixtures_root();
         // Read the first level of directories that contain `__snapshots__`
         let mut dirs = WalkDir::new(&fixture_root)
@@ -74,6 +186,8 @@ impl TestRunner {
                 .map(|e| e.path().to_path_buf())
                 .partition(|path| path.file_name().is_some_and(|name| name == "jsfmt.spec.js"));
 
+            self.spec.parse(&specs[0]);
+
             inputs.sort_unstable();
             if !self.test_snapshot(&specs[0], &inputs) {
                 failed.push(format!(
@@ -96,27 +210,41 @@ impl TestRunner {
         }
     }
 
-    fn test_snapshot(&self, spec: &Path, inputs: &[PathBuf]) -> bool {
-        let inputs = inputs
-            .iter()
-            .map(|path| {
-                let input = fs::read_to_string(path).unwrap();
-                self.get_single_snapshot(path, &input)
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+    fn test_snapshot(&self, spec_path: &Path, inputs: &[PathBuf]) -> bool {
+        return self.spec.calls.iter().any(|spec| {
+            let inputs = inputs
+                .iter()
+                .map(|path| {
+                    let input = fs::read_to_string(path).unwrap();
+                    self.get_single_snapshot(path, &input, spec.0, spec.1.clone())
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
 
-        let snapshot = format!("// Jest Snapshot v1, https://goo.gl/fbAQLP\n{inputs}");
+            let snapshot = format!("// Jest Snapshot v1, https://goo.gl/fbAQLP\n{inputs}\n");
 
-        let expected_file = spec.parent().unwrap().join("__snapshots__/jsfmt.spec.js.snap");
-        let expected = fs::read_to_string(expected_file).unwrap();
+            let expected_file =
+                spec_path.parent().unwrap().join("__snapshots__/jsfmt.spec.js.snap");
+            let expected = fs::read_to_string(expected_file).unwrap();
 
-        snapshot == expected
+            snapshot.contains(&expected)
+        });
     }
 
-    fn get_single_snapshot(&self, path: &Path, input: &str) -> String {
+    fn get_single_snapshot(
+        &self,
+        path: &Path,
+        input: &str,
+        prettier_options: PrettierOptions,
+        snapshot_options: Vec<(Atom, String)>,
+    ) -> String {
         let filename = path.file_name().unwrap().to_string_lossy();
         let output = Self::prettier(path, input);
+        let snapshot_options = snapshot_options
+            .iter()
+            .map(|(k, v)| format!("{k}: {v}"))
+            .collect::<Vec<_>>()
+            .join("\n");
 
         if self.options.filter.is_some() {
             println!("Input:");
@@ -125,20 +253,37 @@ impl TestRunner {
             println!("{output}");
         }
 
+        let space_line = " ".repeat(prettier_options.print_width);
+        let full_equal_sign = "=".repeat(prettier_options.print_width);
+
+        let get_text_line = |text: &'static str| {
+            let equal_half_length = (prettier_options.print_width - text.len()) / 2;
+            let sign = "=".repeat(equal_half_length);
+            let string = format!("{sign}{text}{sign}");
+
+            if (prettier_options.print_width - string.len()) == 1 {
+                format!("{string}=")
+            } else {
+                string
+            }
+        };
+
+        let options_line = get_text_line("options");
+        let input_line = get_text_line("input");
+        let output_line = get_text_line("output");
+
         format!(
             r#"
 exports[`{filename} format 1`] = `
-====================================options=====================================
-parsers: ["babel", "flow", "typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
+{options_line}
+{snapshot_options}
+{space_line}| printWidth
+{input_line}
 {input}
-=====================================output=====================================
+{output_line}
 {output}
-================================================================================
-`;
-"#
+{full_equal_sign}
+`;"#
         )
     }
 

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -239,7 +239,7 @@ impl TestRunner {
         snapshot_options: &[(Atom, String)],
     ) -> String {
         let filename = path.file_name().unwrap().to_string_lossy();
-        let output = Self::prettier(path, input);
+        let output = Self::prettier(path, input, prettier_options);
         let snapshot_options = snapshot_options
             .iter()
             .map(|(k, v)| format!("{k}: {v}"))
@@ -287,11 +287,10 @@ exports[`{filename} format 1`] = `
         )
     }
 
-    fn prettier(path: &Path, source_text: &str) -> String {
+    fn prettier(path: &Path, source_text: &str, prettier_options: PrettierOptions) -> String {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).unwrap();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
-        Prettier::new(&allocator, source_text, ret.trivias, PrettierOptions::default())
-            .build(&ret.program)
+        Prettier::new(&allocator, source_text, ret.trivias, prettier_options).build(&ret.program)
     }
 }

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -1,19 +1,16 @@
+mod spec;
+
 use std::{
     fs,
     path::{Path, PathBuf},
 };
 
+use spec::SpecParser;
 use walkdir::{DirEntry, WalkDir};
 
 use oxc_allocator::Allocator;
-use oxc_ast::{
-    ast::{
-        Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind, Program,
-    },
-    VisitMut,
-};
 use oxc_parser::Parser;
-use oxc_prettier::{Prettier, PrettierOptions, TrailingComma};
+use oxc_prettier::{Prettier, PrettierOptions};
 use oxc_span::{Atom, SourceType};
 use oxc_tasks_common::project_root;
 
@@ -28,23 +25,6 @@ pub struct TestRunnerOptions {
     pub filter: Option<String>,
 }
 
-#[derive(Default)]
-pub struct SpecParser {
-    source_text: String,
-    calls: Vec<(PrettierOptions, Vec<(Atom, String)>)>,
-}
-
-impl SpecParser {
-    pub fn parse(&mut self, spec: &Path) {
-        let spec_content = fs::read_to_string(spec).unwrap_or_default();
-        let allocator = Allocator::default();
-        let source_type = SourceType::from_path(spec).unwrap_or_default();
-        let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
-        self.source_text = spec_content.clone();
-        self.visit_program(&mut ret.program);
-    }
-}
-
 /// The test runner which walks the prettier repository and searches for formatting tests.
 pub struct TestRunner {
     options: TestRunnerOptions,
@@ -57,94 +37,6 @@ fn root() -> PathBuf {
 
 fn fixtures_root() -> PathBuf {
     project_root().join(root()).join("prettier/tests/format/js")
-}
-
-impl VisitMut<'_> for SpecParser {
-    fn visit_program(&mut self, program: &mut Program<'_>) {
-        self.visit_statements(&mut program.body);
-    }
-
-    fn visit_call_expression(&mut self, expr: &mut CallExpression<'_>) {
-        let Some(ident) = expr.callee.get_identifier_reference() else { return };
-        if ident.name != "run_spec" {
-            return;
-        }
-        let mut parsers = vec![];
-        let mut snapshot_options = vec![];
-        let mut options = PrettierOptions::default();
-
-        if let Some(argument) = expr.arguments.get(1) {
-            if let Argument::Expression(Expression::ArrayExpression(arr_expr)) = argument {
-                parsers = arr_expr
-                    .elements
-                    .iter()
-                    .filter_map(|el| {
-                        if let ArrayExpressionElement::Expression(Expression::StringLiteral(
-                            literal,
-                        )) = el
-                        {
-                            return Some(literal.value.to_string());
-                        }
-                        None
-                    })
-                    .collect::<Vec<String>>();
-            }
-        } else {
-            return;
-        }
-
-        if let Some(Argument::Expression(Expression::ObjectExpression(obj_expr))) =
-            expr.arguments.get(2)
-        {
-            obj_expr.properties.iter().for_each(|item| {
-                if let ObjectPropertyKind::ObjectProperty(obj_prop) = item {
-                    if let Some(name) = obj_prop.key.static_name() {
-                        match &obj_prop.value {
-                            Expression::BooleanLiteral(literal) => {
-                                if name == "semi" {
-                                    options.semi = literal.value;
-                                }
-                                snapshot_options.push((name, literal.value.to_string()));
-                            }
-                            Expression::NumberLiteral(literal) => {
-                                if name == "printWidth" {
-                                    options.print_width =
-                                        str::parse(&literal.value.to_string()).unwrap_or(80);
-                                }
-                                snapshot_options.push((name, literal.value.to_string()));
-                            }
-                            Expression::StringLiteral(literal) => {
-                                if name == "trailingComma" {
-                                    options.trailing_comma = match literal.value.as_str() {
-                                        "none" => TrailingComma::None,
-                                        "es5" => TrailingComma::ES5,
-                                        _ => TrailingComma::All,
-                                    }
-                                }
-                                snapshot_options.push((name, format!("\"{}\"", literal.value)));
-                            }
-                            _ => {}
-                        };
-                    };
-                }
-            });
-        }
-
-        snapshot_options.push((
-            "parsers".into(),
-            format!(
-                "[{}]",
-                parsers.iter().map(|p| format!("\"{p}\"")).collect::<Vec<_>>().join(", ")
-            ),
-        ));
-        if !snapshot_options.iter().any(|item| item.0 == "printWidth") {
-            snapshot_options.push(("printWidth".into(), "80".into()));
-        }
-
-        snapshot_options.sort_by(|a, b| a.0.cmp(&b.0));
-
-        self.calls.push((options, snapshot_options));
-    }
 }
 
 impl TestRunner {

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -216,7 +216,7 @@ impl TestRunner {
                 .iter()
                 .map(|path| {
                     let input = fs::read_to_string(path).unwrap();
-                    self.get_single_snapshot(path, &input, spec.0, spec.1.clone())
+                    self.get_single_snapshot(path, &input, spec.0, &spec.1)
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
@@ -236,7 +236,7 @@ impl TestRunner {
         path: &Path,
         input: &str,
         prettier_options: PrettierOptions,
-        snapshot_options: Vec<(Atom, String)>,
+        snapshot_options: &[(Atom, String)],
     ) -> String {
         let filename = path.file_name().unwrap().to_string_lossy();
         let output = Self::prettier(path, input);

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -1,0 +1,117 @@
+use std::{fs, path::Path};
+
+use oxc_allocator::Allocator;
+use oxc_ast::{
+    ast::{
+        Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind, Program,
+    },
+    VisitMut,
+};
+use oxc_parser::Parser;
+use oxc_prettier::{PrettierOptions, TrailingComma};
+use oxc_span::{Atom, SourceType};
+
+#[derive(Default)]
+pub struct SpecParser {
+    pub calls: Vec<(PrettierOptions, Vec<(Atom, String)>)>,
+    source_text: String,
+}
+
+impl SpecParser {
+    pub fn parse(&mut self, spec: &Path) {
+        let spec_content = fs::read_to_string(spec).unwrap_or_default();
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path(spec).unwrap_or_default();
+        let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
+        self.source_text = spec_content.clone();
+        self.visit_program(&mut ret.program);
+    }
+}
+
+impl VisitMut<'_> for SpecParser {
+    fn visit_program(&mut self, program: &mut Program<'_>) {
+        self.visit_statements(&mut program.body);
+    }
+
+    fn visit_call_expression(&mut self, expr: &mut CallExpression<'_>) {
+        let Some(ident) = expr.callee.get_identifier_reference() else { return };
+        if ident.name != "run_spec" {
+            return;
+        }
+        let mut parsers = vec![];
+        let mut snapshot_options = vec![];
+        let mut options = PrettierOptions::default();
+
+        if let Some(argument) = expr.arguments.get(1) {
+            if let Argument::Expression(Expression::ArrayExpression(arr_expr)) = argument {
+                parsers = arr_expr
+                    .elements
+                    .iter()
+                    .filter_map(|el| {
+                        if let ArrayExpressionElement::Expression(Expression::StringLiteral(
+                            literal,
+                        )) = el
+                        {
+                            return Some(literal.value.to_string());
+                        }
+                        None
+                    })
+                    .collect::<Vec<String>>();
+            }
+        } else {
+            return;
+        }
+
+        if let Some(Argument::Expression(Expression::ObjectExpression(obj_expr))) =
+            expr.arguments.get(2)
+        {
+            obj_expr.properties.iter().for_each(|item| {
+                if let ObjectPropertyKind::ObjectProperty(obj_prop) = item {
+                    if let Some(name) = obj_prop.key.static_name() {
+                        match &obj_prop.value {
+                            Expression::BooleanLiteral(literal) => {
+                                if name == "semi" {
+                                    options.semi = literal.value;
+                                }
+                                snapshot_options.push((name, literal.value.to_string()));
+                            }
+                            Expression::NumberLiteral(literal) => {
+                                if name == "printWidth" {
+                                    options.print_width =
+                                        str::parse(&literal.value.to_string()).unwrap_or(80);
+                                }
+                                snapshot_options.push((name, literal.value.to_string()));
+                            }
+                            Expression::StringLiteral(literal) => {
+                                if name == "trailingComma" {
+                                    options.trailing_comma = match literal.value.as_str() {
+                                        "none" => TrailingComma::None,
+                                        "es5" => TrailingComma::ES5,
+                                        _ => TrailingComma::All,
+                                    }
+                                }
+                                snapshot_options.push((name, format!("\"{}\"", literal.value)));
+                            }
+                            _ => {}
+                        };
+                    };
+                }
+            });
+        }
+
+        snapshot_options.push((
+            "parsers".into(),
+            format!(
+                "[{}]",
+                parsers.iter().map(|p| format!("\"{p}\"")).collect::<Vec<_>>().join(", ")
+            ),
+        ));
+        if !snapshot_options.iter().any(|item| item.0 == "printWidth") {
+            snapshot_options.push(("printWidth".into(), "80".into()));
+        }
+
+        snapshot_options.sort_by(|a, b| a.0.cmp(&b.0));
+
+        self.calls.push((options, snapshot_options));
+    }
+}


### PR DESCRIPTION
### This PR did the following things.

1. Parse specs
2. Collect `run_spec's` arguments
3. Pass the correct `PrettierOptions` to the `Prettier`
4. Printing snapshots correctly 