### PR TITLE
fix(prettier): incorrect dot operator in MetaProperty

### DIFF
--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -1117,7 +1117,7 @@ impl<'a> Format<'a> for NewExpression<'a> {
 
 impl<'a> Format<'a> for MetaProperty {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
-        array![p, format!(p, self.meta), ss!(","), format!(p, self.property)]
+        array![p, format!(p, self.meta), ss!("."), format!(p, self.property)]
     }
 }
 

--- a/tasks/prettier_conformance/prettier.snap.md
+++ b/tasks/prettier_conformance/prettier.snap.md
@@ -1,4 +1,4 @@
-Compatibility: 13/173 (7.51%)
+Compatibility: 14/173 (8.09%)
 
 # Failed
 
@@ -81,7 +81,6 @@ Compatibility: 13/173 (7.51%)
 * import-assertions/bracket-spacing
 * import-attributes
 * import-attributes/bracket-spacing
-* import-meta
 * import-reflection
 * in
 * label


### PR DESCRIPTION
fix(prettier): incorrect dot operator in MetaProperty

test: update snap