### PR TITLE
Add base to AST BigintLiteral

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -8,7 +8,7 @@ use std::{
 use bitflags::bitflags;
 use num_bigint::BigInt;
 use oxc_span::{Atom, Span};
-use oxc_syntax::NumberBase;
+use oxc_syntax::{BigintBase, NumberBase};
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
@@ -111,6 +111,8 @@ pub struct BigintLiteral {
     pub span: Span,
     #[cfg_attr(feature = "serde", serde(serialize_with = "crate::serialize::serialize_bigint"))]
     pub value: BigInt,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub base: BigintBase,
 }
 
 #[derive(Debug, Clone, Hash)]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -14,7 +14,7 @@ use oxc_syntax::{
     operator::{
         AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
     },
-    NumberBase,
+    BigintBase, NumberBase,
 };
 
 #[allow(clippy::wildcard_imports)]
@@ -126,8 +126,8 @@ impl<'a> AstBuilder<'a> {
         BooleanLiteral { span, value }
     }
 
-    pub fn bigint_literal(&self, span: Span, value: BigInt) -> BigintLiteral {
-        BigintLiteral { span, value }
+    pub fn bigint_literal(&self, span: Span, value: BigInt, base: BigintBase) -> BigintLiteral {
+        BigintLiteral { span, value, base }
     }
 
     pub fn template_literal(

--- a/crates/oxc_minifier/src/compressor/fold.rs
+++ b/crates/oxc_minifier/src/compressor/fold.rs
@@ -678,7 +678,8 @@ impl<'a> Compressor<'a> {
                         use std::ops::Neg;
 
                         let value = big_int_literal.value.clone().neg();
-                        let literal = self.ast.bigint_literal(unary_expr.span, value);
+                        let literal =
+                            self.ast.bigint_literal(unary_expr.span, value, big_int_literal.base);
                         return Some(self.ast.literal_bigint_expression(literal));
                     }
                     Expression::Identifier(ident) => {
@@ -706,7 +707,8 @@ impl<'a> Compressor<'a> {
                     }
                     Expression::BigintLiteral(big_int_literal) => {
                         let value = big_int_literal.value.clone().not();
-                        let leteral = self.ast.bigint_literal(unary_expr.span, value);
+                        let leteral =
+                            self.ast.bigint_literal(unary_expr.span, value, big_int_literal.base);
                         return Some(self.ast.literal_bigint_expression(leteral));
                     }
                     Expression::Identifier(ident) => {

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -26,3 +26,17 @@ impl NumberBase {
         matches!(self, Self::Float | Self::Decimal)
     }
 }
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum BigintBase {
+    Decimal,
+    Binary,
+    Octal,
+    Hex,
+}
+
+impl BigintBase {
+    pub fn is_base_10(&self) -> bool {
+        self == &Self::Decimal
+    }
+}


### PR DESCRIPTION
Add `base` to `BigintLiteral`, similar to `NumberLiteral`.

[I mentioned this in discord](https://discord.com/channels/1079625926024900739/1080712072012238858/1174998610082017330), we'll need the base to implement lint rules like [unicorn's `numeric-separators-style`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/numeric-separators-style.md).

I'm not sure where or if I should add test coverage for this, I did manually test this by running the playground and checking the IR with the following code:

```js
10n;

0b10n;
0x10n;
0o10n;

0B10n;
0X10n;
0O10n;
```

Notice in after we have the expected `base`:

| before | after |
| --- | --- |
| ![Screenshot 2023-11-18 at 18 32 56](https://github.com/oxc-project/oxc/assets/841763/91cd3498-f888-456f-9723-7b7bac2251aa) | ![Screenshot 2023-11-18 at 18 33 23](https://github.com/oxc-project/oxc/assets/841763/3676afcf-7fec-42cb-94e7-ac5bf6db3a95) |
