### PR TITLE
feat(cli): add `--deny-warnings` flag

### DIFF
--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -235,6 +235,10 @@ pub struct WarningOptions {
     #[bpaf(switch, hide_usage)]
     pub quiet: bool,
 
+    /// Ensure warnings produce a non-zero exit code
+    #[bpaf(switch, hide_usage)]
+    pub deny_warnings: bool,
+
     /// Specify a warning threshold,
     /// which can be used to force exit with an error status if there are too many warning-level rule violations in your project
     #[bpaf(argument("INT"), hide_usage)]

--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -72,7 +72,6 @@ impl Runner for LintRunner {
 
         let diagnostic_service = DiagnosticService::default()
             .with_quiet(warning_options.quiet)
-            .with_deny_warnings(warning_options.deny_warnings)
             .with_max_warnings(warning_options.max_warnings);
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
@@ -94,7 +93,7 @@ impl Runner for LintRunner {
             number_of_warnings: diagnostic_service.warnings_count(),
             number_of_errors: diagnostic_service.errors_count(),
             max_warnings_exceeded: diagnostic_service.max_warnings_exceeded(),
-            violated_deny_warnings: diagnostic_service.violated_deny_warnings(),
+            deny_warnings: warning_options.deny_warnings,
         })
     }
 }

--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -72,6 +72,7 @@ impl Runner for LintRunner {
 
         let diagnostic_service = DiagnosticService::default()
             .with_quiet(warning_options.quiet)
+            .with_deny_warnings(warning_options.deny_warnings)
             .with_max_warnings(warning_options.max_warnings);
 
         // Spawn linting in another thread so diagnostics can be printed immediately from diagnostic_service.run.
@@ -93,6 +94,7 @@ impl Runner for LintRunner {
             number_of_warnings: diagnostic_service.warnings_count(),
             number_of_errors: diagnostic_service.errors_count(),
             max_warnings_exceeded: diagnostic_service.max_warnings_exceeded(),
+            violated_deny_warnings: diagnostic_service.violated_deny_warnings(),
         })
     }
 }

--- a/crates/oxc_cli/src/result.rs
+++ b/crates/oxc_cli/src/result.rs
@@ -22,6 +22,7 @@ pub struct LintResult {
     pub number_of_warnings: usize,
     pub number_of_errors: usize,
     pub max_warnings_exceeded: bool,
+    pub violated_deny_warnings: bool,
 }
 
 #[derive(Debug)]
@@ -49,6 +50,7 @@ impl Termination for CliRunResult {
                 number_of_warnings,
                 number_of_errors,
                 max_warnings_exceeded,
+                violated_deny_warnings,
             }) => {
                 let threads = rayon::current_num_threads();
                 let number_of_diagnostics = number_of_warnings + number_of_errors;
@@ -74,7 +76,7 @@ impl Termination for CliRunResult {
                     if number_of_errors == 1 { "" } else { "s" }
                 );
 
-                let exit_code = u8::from(number_of_errors > 0);
+                let exit_code = u8::from(violated_deny_warnings || number_of_errors > 0);
                 ExitCode::from(exit_code)
             }
             Self::FormatResult(FormatResult { duration, number_of_files }) => {

--- a/crates/oxc_cli/src/result.rs
+++ b/crates/oxc_cli/src/result.rs
@@ -22,7 +22,7 @@ pub struct LintResult {
     pub number_of_warnings: usize,
     pub number_of_errors: usize,
     pub max_warnings_exceeded: bool,
-    pub violated_deny_warnings: bool,
+    pub deny_warnings: bool,
 }
 
 #[derive(Debug)]
@@ -50,7 +50,7 @@ impl Termination for CliRunResult {
                 number_of_warnings,
                 number_of_errors,
                 max_warnings_exceeded,
-                violated_deny_warnings,
+                deny_warnings,
             }) => {
                 let threads = rayon::current_num_threads();
                 let number_of_diagnostics = number_of_warnings + number_of_errors;
@@ -76,7 +76,8 @@ impl Termination for CliRunResult {
                     if number_of_errors == 1 { "" } else { "s" }
                 );
 
-                let exit_code = u8::from(violated_deny_warnings || number_of_errors > 0);
+                let exit_code =
+                    u8::from((number_of_warnings > 0 && deny_warnings) || number_of_errors > 0);
                 ExitCode::from(exit_code)
             }
             Self::FormatResult(FormatResult { duration, number_of_files }) => {

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -16,9 +16,6 @@ pub struct DiagnosticService {
     /// Disable reporting on warnings, only errors are reported
     quiet: bool,
 
-    /// Report warnings as errors
-    deny_warnings: bool,
-
     /// Specify a warning threshold,
     /// which can be used to force exit with an error status if there are too many warning-level rule violations in your project
     max_warnings: Option<usize>,
@@ -38,7 +35,6 @@ impl Default for DiagnosticService {
         let (sender, receiver) = mpsc::channel();
         Self {
             quiet: false,
-            deny_warnings: false,
             max_warnings: None,
             warnings_count: Cell::new(0),
             errors_count: Cell::new(0),
@@ -52,12 +48,6 @@ impl DiagnosticService {
     #[must_use]
     pub fn with_quiet(mut self, yes: bool) -> Self {
         self.quiet = yes;
-        self
-    }
-
-    #[must_use]
-    pub fn with_deny_warnings(mut self, yes: bool) -> Self {
-        self.deny_warnings = yes;
         self
     }
 
@@ -81,10 +71,6 @@ impl DiagnosticService {
 
     pub fn max_warnings_exceeded(&self) -> bool {
         self.max_warnings.map_or(false, |max_warnings| self.warnings_count.get() > max_warnings)
-    }
-
-    pub fn violated_deny_warnings(&self) -> bool {
-        self.deny_warnings && self.warnings_count.get() > 0
     }
 
     pub fn wrap_diagnostics(


### PR DESCRIPTION
See #1403

Terminates linting with an exit code of 1 if the `--deny-warnings` flag is provided _and_ there is 1 or more warnings produced from the linting.