### PR TITLE
chore(linter): uncomment test case for `no-func-assign` rule

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -73,8 +73,7 @@ fn test() {
         ("({x: foo = 0} = bar); function foo() { };", None),
         ("function foo() { [foo] = bar; }", None),
         ("(function() { ({x: foo = 0} = bar); function foo() { }; })();", None),
-        // TODO
-        // ("var a = function foo() { foo = 123; };", None),
+        ("var a = function foo() { foo = 123; };", None),
     ];
 
     Tester::new(NoFuncAssign::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_func_assign.snap
+++ b/crates/oxc_linter/src/snapshots/no_func_assign.snap
@@ -51,4 +51,11 @@ expression: no_func_assign
    ·                     ╰── foo is re-assigned here
    ╰────
 
+  ⚠ eslint(no-func-assign): 'foo' is a function.
+   ╭─[no_func_assign.tsx:1:1]
+ 1 │ var a = function foo() { foo = 123; };
+   ·                          ─┬─
+   ·                           ╰── foo is re-assigned here
+   ╰────
+
 


### PR DESCRIPTION
Seems to be handled correctly now?