### PR TITLE
refactor(parser) Updated comments mentioning the ecma specification section 12.x

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -14,9 +14,9 @@ pub enum Kind {
     MultiLineComment,
     // 12.5 Hashbang Comments
     HashbangComment,
-    // 12.6 identifier
+    // 12.7.1 identifier
     Ident,
-    // 12.6.2 keyword
+    // 12.7.2 keyword
     Await,
     Break,
     Case,
@@ -102,7 +102,7 @@ pub enum Kind {
     Public,
     Static,
     Yield,
-    // 12.7 punctuators
+    // 12.8 punctuators
     Amp, // &
     Amp2,
     Amp2Eq,
@@ -161,12 +161,12 @@ pub enum Kind {
     Tilde,
     // arrow function
     Arrow,
-    // 12.8.1 Null Literals
+    // 12.9.1 Null Literals
     Null,
-    // 12.8.2 Boolean Literals
+    // 12.9.2 Boolean Literals
     True,
     False,
-    // 12.8.3 Numeric Literals
+    // 12.9.3 Numeric Literals
     Decimal,
     Float,
     Binary,
@@ -176,12 +176,12 @@ pub enum Kind {
     PositiveExponential,
     // for `1e-10`
     NegativeExponential,
-    // 12.8.4 String Literals
+    // 12.9.4 String Literals
     /// String Type
     Str,
-    // 12.8.5 Regular Expression Literals
+    // 12.9.5 Regular Expression Literals
     RegExp,
-    // 12.8.6 Template Literal
+    // 12.9.6 Template Literal
     NoSubstitutionTemplate,
     TemplateHead,
     TemplateMiddle,

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -417,7 +417,7 @@ impl<'a> Lexer<'a> {
         Kind::HashbangComment
     }
 
-    /// Section 12.6.1 Identifier Names
+    /// Section 12.7.1 Identifier Names
     fn identifier_tail(&mut self, mut builder: AutoCow<'a>) -> (bool, &'a str) {
         // ident tail
         while let Some(c) = self.peek() {
@@ -450,7 +450,7 @@ impl<'a> Lexer<'a> {
         self.identifier_name(builder)
     }
 
-    /// Section 12.7 Punctuators
+    /// Section 12.8 Punctuators
     fn read_dot(&mut self, builder: &mut AutoCow<'a>) -> Kind {
         if self.peek() == Some('.') && self.peek2() == Some('.') {
             self.current.chars.next();
@@ -553,7 +553,7 @@ impl<'a> Lexer<'a> {
         Kind::PrivateIdentifier
     }
 
-    /// 12.8.3 Numeric Literals with `0` prefix
+    /// 12.9.3 Numeric Literals with `0` prefix
     fn read_zero(&mut self, builder: &mut AutoCow<'a>) -> Kind {
         match self.peek() {
             Some('b' | 'B') => self.read_non_decimal(Kind::Binary, builder),
@@ -770,7 +770,7 @@ impl<'a> Lexer<'a> {
         Kind::Undetermined
     }
 
-    /// 12.8.4 String Literals
+    /// 12.9.4 String Literals
     fn read_string_literal(&mut self, delimiter: char) -> Kind {
         let mut builder = AutoCow::new(self);
         loop {
@@ -804,7 +804,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// 12.8.5 Regular Expression Literals
+    /// 12.9.5 Regular Expression Literals
     fn read_regex(&mut self) -> Kind {
         let start = self.current.token.start + 1; // +1 to exclude `/`
         let mut in_escape = false;
@@ -1238,7 +1238,7 @@ impl<'a> Lexer<'a> {
                 }
                 // 0 [lookahead ∉ DecimalDigit]
                 '0' if !self.peek().is_some_and(|c| c.is_ascii_digit()) => text.push('\0'),
-                // Section 12.8.4 String Literals
+                // Section 12.9.4 String Literals
                 // LegacyOctalEscapeSequence
                 // NonOctalDecimalEscapeSequence
                 a @ '0'..='7' if !in_template => {

--- a/crates/oxc_syntax/src/identifier.rs
+++ b/crates/oxc_syntax/src/identifier.rs
@@ -90,7 +90,7 @@ pub fn is_identifier_start_ascii(c: char) -> bool {
     ASCII_START.0[c as usize]
 }
 
-/// Section 12.6 Detect `IdentifierStartChar`
+/// Section 12.7 Detect `IdentifierStartChar`
 #[inline]
 pub fn is_identifier_start_all(c: char) -> bool {
     if c.is_ascii() {
@@ -99,7 +99,7 @@ pub fn is_identifier_start_all(c: char) -> bool {
     is_id_start_unicode(c)
 }
 
-/// Section 12.6 Detect `IdentifierPartChar`
+/// Section 12.7 Detect `IdentifierPartChar`
 /// NOTE 2: The nonterminal `IdentifierPart` derives _ via `UnicodeIDContinue`.
 #[inline]
 pub fn is_identifier_part(c: char) -> bool {


### PR DESCRIPTION
The ECMA specification seems to added the "Tokens" section to the specification as 12.6. This pushed all the other sections down, resulting in e.g. former 12.6 now being 12.7. Comments in the parser mention this part of the specification. All the mentions of section 12.6+ therefor are outdated now. This pull request tries to fix that by updating all the comments.