### PR TITLE
feat(ast/semantic): parse jsdoc on `PropertyDefinition`

### DIFF
--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -183,7 +183,7 @@ impl<'a> AstKind<'a> {
         || matches!(self, Self::Class(class) if class.is_declaration())
         || matches!(self, Self::ModuleDeclaration(_) | Self::TSEnumDeclaration(_) | Self::TSModuleDeclaration(_)
             | Self::VariableDeclaration(_) | Self::TSInterfaceDeclaration(_)
-            | Self::TSTypeAliasDeclaration(_) | Self::TSImportEqualsDeclaration(_)
+            | Self::TSTypeAliasDeclaration(_) | Self::TSImportEqualsDeclaration(_) | Self::PropertyDefinition(_)
         )
     }
 


### PR DESCRIPTION
This should be enough to handle jsdoc comments on class properties/fields.

See #1506