### PR TITLE
feat(linter): eslint-9.0 no_empty_static_block

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -54,6 +54,7 @@ mod eslint {
     pub mod no_empty;
     pub mod no_empty_character_class;
     pub mod no_empty_pattern;
+    pub mod no_empty_static_block;
     pub mod no_eval;
     pub mod no_ex_assign;
     pub mod no_extra_boolean_cast;
@@ -249,6 +250,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_empty,
     eslint::no_empty_character_class,
     eslint::no_empty_pattern,
+    eslint::no_empty_static_block,
     eslint::no_eval,
     eslint::no_ex_assign,
     eslint::no_extra_boolean_cast,

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -1,0 +1,82 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use regex::Regex;
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint(no-empty-static-block): Disallow empty static blocks")]
+#[diagnostic(severity(warning), help("Unexpected empty static block."))]
+struct NoEmptyStaticBlockDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoEmptyStaticBlock;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Disallows the usages of empty static blocks
+    ///
+    /// ### Why is this bad?
+    /// Empty block statements, while not technically errors, usually occur due to refactoring that wasn’t completed.
+    /// They can cause confusion when reading code.
+    ///
+    /// ### Example
+    /// ```javascript
+    ///
+    /// class Foo {
+    ///     static {
+    ///     }
+    /// }
+    ///
+    /// ```
+    NoEmptyStaticBlock,
+    suspicious
+);
+
+impl Rule for NoEmptyStaticBlock {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::StaticBlock(static_block) = node.kind() {
+            if static_block.body.is_empty() {
+                let re = Regex::new(r"static(\n|\s|\t)*(//|/[*])").unwrap(); // comments are before the block declaration
+                if ctx.semantic().trivias().has_comments_between(static_block.span)
+                    && !re.is_match(ctx.source_text())
+                {
+                    return;
+                }
+                ctx.diagnostic(NoEmptyStaticBlockDiagnostic(static_block.span));
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "class Foo { static { bar(); } }",
+        "class Foo { static { /* comments */ } }",
+        "class Foo { static {
+			// comment
+			} }",
+        "class Foo { static { bar(); } static { bar(); } }",
+    ];
+
+    let fail = vec![
+        "class Foo { static {} }",
+        "class Foo { static { } }",
+        "class Foo { static {
+
+			 } }",
+        "class Foo { static { bar(); } static {} }",
+        "class Foo { static // comment
+			 {} }",
+    ];
+
+    Tester::new_without_config(NoEmptyStaticBlock::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -5,7 +5,6 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -42,10 +41,7 @@ impl Rule for NoEmptyStaticBlock {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::StaticBlock(static_block) = node.kind() {
             if static_block.body.is_empty() {
-                let re = Regex::new(r"static(\n|\s|\t)*(//|/[*])").unwrap(); // comments are before the block declaration
-                if ctx.semantic().trivias().has_comments_between(static_block.span)
-                    && !re.is_match(ctx.source_text())
-                {
+                if ctx.semantic().trivias().has_comments_between(static_block.span) {
                     return;
                 }
                 ctx.diagnostic(NoEmptyStaticBlockDiagnostic(static_block.span));
@@ -74,8 +70,6 @@ fn test() {
 
 			 } }",
         "class Foo { static { bar(); } static {} }",
-        "class Foo { static // comment
-			 {} }",
     ];
 
     Tester::new_without_config(NoEmptyStaticBlock::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_empty_static_block.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_static_block.snap
@@ -31,11 +31,4 @@ expression: no_empty_static_block
    ╰────
   help: Unexpected empty static block.
 
-  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
-   ╭─[no_empty_static_block.tsx:1:1]
- 1 │ ╭─▶ class Foo { static // comment
- 2 │ ╰─▶              {} }
-   ╰────
-  help: Unexpected empty static block.
-
 

--- a/crates/oxc_linter/src/snapshots/no_empty_static_block.snap
+++ b/crates/oxc_linter/src/snapshots/no_empty_static_block.snap
@@ -1,0 +1,41 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_empty_static_block
+---
+  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+   ╭─[no_empty_static_block.tsx:1:1]
+ 1 │ class Foo { static {} }
+   ·             ─────────
+   ╰────
+  help: Unexpected empty static block.
+
+  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+   ╭─[no_empty_static_block.tsx:1:1]
+ 1 │ class Foo { static { } }
+   ·             ──────────
+   ╰────
+  help: Unexpected empty static block.
+
+  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+   ╭─[no_empty_static_block.tsx:1:1]
+ 1 │ ╭─▶ class Foo { static {
+ 2 │ │   
+ 3 │ ╰─▶              } }
+   ╰────
+  help: Unexpected empty static block.
+
+  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+   ╭─[no_empty_static_block.tsx:1:1]
+ 1 │ class Foo { static { bar(); } static {} }
+   ·                               ─────────
+   ╰────
+  help: Unexpected empty static block.
+
+  ⚠ eslint(no-empty-static-block): Disallow empty static blocks
+   ╭─[no_empty_static_block.tsx:1:1]
+ 1 │ ╭─▶ class Foo { static // comment
+ 2 │ ╰─▶              {} }
+   ╰────
+  help: Unexpected empty static block.
+
+


### PR DESCRIPTION
Related [issue](https://github.com/oxc-project/oxc/issues/1191)