### PR TITLE
feat(linter): eslint-plugin-jsx-a11y img-redundant-alt (correctness)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -10,6 +10,7 @@ extend-exclude = [
   "tasks/prettier_conformance/prettier",
   "crates/oxc_parser/src/lexer/mod.rs",
   "crates/oxc_linter/fixtures",
+  "crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs",
   "crates/oxc_syntax/src/xml_entities.rs",
   "**/*.snap",
   "pnpm-lock.yaml",

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -213,6 +213,7 @@ mod jsx_a11y {
     pub mod anchor_is_valid;
     pub mod heading_has_content;
     pub mod html_has_lang;
+    pub mod img_redundant_alt;
 }
 
 oxc_macros::declare_all_lint_rules! {
@@ -400,5 +401,6 @@ oxc_macros::declare_all_lint_rules! {
     jsx_a11y::anchor_has_content,
     jsx_a11y::anchor_is_valid,
     jsx_a11y::html_has_lang,
-    jsx_a11y::heading_has_content
+    jsx_a11y::heading_has_content,
+    jsx_a11y::img_redundant_alt
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -139,7 +139,7 @@ impl Rule for ImgRedundantAlt {
                     }
                 }
                 Expression::TemplateLiteral(lit) => {
-                    for quasi in lit.quasis.iter() {
+                    for quasi in &lit.quasis {
                         let alt_text = quasi.value.raw.as_str();
 
                         if is_redundant_alt_text(alt_text, &self.redundant_words) {
@@ -147,13 +147,9 @@ impl Rule for ImgRedundantAlt {
                         }
                     }
                 }
-                _ => {
-                    return;
-                }
+                _ => {}
             },
-            _ => {
-                return;
-            }
+            _ => {}
         };
     }
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -18,8 +18,8 @@ use crate::utils::{get_prop_value, has_jsx_prop_lowercase, is_hidden_from_screen
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.")]
-#[diagnostic(severity(warning), help("Provide no redundant alt text for image."))]
+#[error("eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.")]
+#[diagnostic(severity(warning), help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop."))]
 struct ImgRedundantAltDiagnostic(#[label] pub Span);
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -1,0 +1,245 @@
+use regex::Regex;
+
+use oxc_ast::{
+    ast::{Expression, JSXAttributeValue, JSXElementName, JSXExpression, JSXExpressionContainer},
+    AstKind,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::utils::{get_prop_value, has_jsx_prop_lowercase, is_hidden_from_screen_reader};
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.")]
+#[diagnostic(severity(warning), help("Provide no redundant alt text for image."))]
+struct ImgRedundantAltDiagnostic(#[label] pub Span);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce img alt attribute does not contain the word image, picture, or photo. Screenreaders already announce img elements as an image.
+    /// There is no need to use words such as image, photo, and/or picture.
+    ///
+    /// ### Why is this necessary?
+    ///
+    /// Alternative text is a critical component of accessibility for screen
+    /// reader users, enabling them to understand the content and function
+    /// of an element.
+    ///
+    /// ### What it checks
+    ///
+    /// This rule checks for alternative text on the following elements:
+    /// `<img>` and the components which you define in options.components with the exception of components which is hidden from screen reader.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// // Bad
+    /// <img src="foo" alt="Photo of foo being weird." />
+    /// <img src="bar" alt="Image of me at a bar!" />
+    /// <img src="baz" alt="Picture of baz fixing a bug." />
+    ///
+    /// // Good
+    /// <img src="foo" alt="Foo eating a sandwich." />
+    /// <img src="bar" aria-hidden alt="Picture of me taking a photo of an image" /> // Will pass because it is hidden.
+    /// <img src="baz" alt={`Baz taking a ${photo}`} /> // This is valid since photo is a variable name.
+    /// ```
+    ImgRedundantAlt,
+    correctness
+);
+
+#[derive(Debug, Clone)]
+pub struct ImgRedundantAlt {
+    types_to_validate: Vec<String>,
+    redundant_words: Vec<String>,
+}
+
+impl std::default::Default for ImgRedundantAlt {
+    fn default() -> Self {
+        Self {
+            types_to_validate: COMPONENTS_FIXED_TO_VALIDATE
+                .iter()
+                .map(|&s| s.to_string())
+                .collect(),
+            redundant_words: REDUNDANT_WORDS.iter().map(|&s| s.to_string()).collect(),
+        }
+    }
+}
+
+const COMPONENTS_FIXED_TO_VALIDATE: [&str; 1] = ["img"];
+const REDUNDANT_WORDS: [&str; 3] = ["image", "photo", "picture"];
+
+impl Rule for ImgRedundantAlt {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let mut img_redundant_alt = Self::default();
+        if let Some(config) = value.get(0) {
+            if let Some(components) = config.get("components").and_then(|v| v.as_array()) {
+                img_redundant_alt
+                    .types_to_validate
+                    .extend(components.iter().filter_map(|v| v.as_str().map(ToString::to_string)));
+            }
+
+            if let Some(words) = config.get("words").and_then(|v| v.as_array()) {
+                img_redundant_alt
+                    .redundant_words
+                    .extend(words.iter().filter_map(|v| v.as_str().map(ToString::to_string)));
+            }
+        }
+
+        img_redundant_alt
+    }
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else { return };
+        let JSXElementName::Identifier(iden) = &jsx_el.name else { return };
+        let name = iden.name.as_str();
+
+        if !self.types_to_validate.iter().any(|comp| comp == name) {
+            return;
+        }
+
+        if is_hidden_from_screen_reader(jsx_el) {
+            return;
+        }
+
+        let alt_prop = match has_jsx_prop_lowercase(jsx_el, "alt") {
+            Some(v) => v,
+            None => {
+                return;
+            }
+        };
+
+        let alt_attribute = match get_prop_value(alt_prop) {
+            Some(v) => v,
+            None => {
+                return;
+            }
+        };
+
+        match alt_attribute {
+            JSXAttributeValue::StringLiteral(lit) => {
+                let alt_text = lit.value.as_str();
+
+                if is_redundant_alt_text(alt_text, &self.redundant_words) {
+                    ctx.diagnostic(ImgRedundantAltDiagnostic(jsx_el.span));
+                }
+            }
+            JSXAttributeValue::ExpressionContainer(JSXExpressionContainer {
+                expression: JSXExpression::Expression(expression),
+                ..
+            }) => match expression {
+                Expression::StringLiteral(lit) => {
+                    let alt_text = lit.value.as_str();
+
+                    if is_redundant_alt_text(alt_text, &self.redundant_words) {
+                        ctx.diagnostic(ImgRedundantAltDiagnostic(jsx_el.span));
+                    }
+                }
+                Expression::TemplateLiteral(lit) => {
+                    for quasi in lit.quasis.iter() {
+                        let alt_text = quasi.value.raw.as_str();
+
+                        if is_redundant_alt_text(alt_text, &self.redundant_words) {
+                            ctx.diagnostic(ImgRedundantAltDiagnostic(jsx_el.span));
+                        }
+                    }
+                }
+                _ => {
+                    return;
+                }
+            },
+            _ => {
+                return;
+            }
+        };
+    }
+}
+
+fn is_redundant_alt_text(alt_text: &str, redundant_words: &[String]) -> bool {
+    let regexp = Regex::new(&format!(r"(?i)\b({})\b", redundant_words.join("|"),)).unwrap();
+
+    regexp.is_match(alt_text)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    fn array() -> serde_json::Value {
+        serde_json::json!([{
+            "components": ["Image"],
+            "words": ["Word1", "Word2"]
+        }])
+    }
+
+    let pass = vec![
+        (r"<img alt='foo' />;", None),
+        (r"<img alt='picture of me taking a photo of an image' aria-hidden />", None),
+        (r"<img aria-hidden alt='photo of image' />", None),
+        (r"<img ALt='foo' />;", None),
+        (r"<img {...this.props} alt='foo' />", None),
+        (r"<img {...this.props} alt={'foo'} />", None),
+        (r"<img {...this.props} alt={alt} />", None),
+        (r"<a />", None),
+        (r"<img />", None),
+        (r"<IMG />", None),
+        (r"<img alt={undefined} />", None),
+        (r"<img alt={`this should pass for ${now}`} />", None),
+        (r"<img alt={`this should pass for ${photo}`} />", None),
+        (r"<img alt={`this should pass for ${image}`} />", None),
+        (r"<img alt={`this should pass for ${picture}`} />", None),
+        (r"<img alt={`${photo}`} />", None),
+        (r"<img alt={`${image}`} />", None),
+        (r"<img alt={`${picture}`} />", None),
+        (r"<img alt={'undefined'} />", None),
+        (r"<img alt={() => {}} />", None),
+        (r"<img alt={function(e){}} />", None),
+        (r"<img aria-hidden={false} alt='Doing cool things.' />", None),
+        (r"<UX.Layout>test</UX.Layout>", None),
+        (r"<img alt />", None),
+        (r"<img alt={imageAlt} />", None),
+        (r"<img alt={imageAlt.name} />", None),
+        (r"<img alt={imageAlt?.name} />", None),
+        (r"<img alt='Doing cool things' aria-hidden={foo?.bar}/>", None),
+        (r"<img alt='Photography' />;", None),
+        (r"<img alt='ImageMagick' />;", None),
+        (r"<Image alt='Photo of a friend' />", None),
+        // TODO we need components_settings to test this
+        // (r"<Image alt='Foo' />", settings: Some(components_settings))
+    ];
+
+    let fail = vec![
+        (r"<img alt='Photo of friend.' />;", None),
+        (r"<img alt='Picture of friend.' />;", None),
+        (r"<img alt='Image of friend.' />;", None),
+        (r"<img alt='PhOtO of friend.' />;", None),
+        (r"<img alt={'photo'} />;", None),
+        (r"<img alt='piCTUre of friend.' />;", None),
+        (r"<img alt='imAGE of friend.' />;", None),
+        (r"<img alt='photo of cool person' aria-hidden={false} />", None),
+        (r"<img alt='picture of cool person' aria-hidden={false} />", None),
+        (r"<img alt='image of cool person' aria-hidden={false} />", None),
+        (r"<img alt='photo' {...this.props} />", None),
+        (r"<img alt='image' {...this.props} />", None),
+        (r"<img alt='picture' {...this.props} />", None),
+        (r"<img alt={`picture doing ${things}`} {...this.props} />", None),
+        (r"<img alt={`photo doing ${things}`} {...this.props} />", None),
+        (r"<img alt={`image doing ${things}`} {...this.props} />", None),
+        (r"<img alt={`picture doing ${picture}`} {...this.props} />", None),
+        (r"<img alt={`photo doing ${photo}`} {...this.props} />", None),
+        (r"<img alt={`image doing ${image}`} {...this.props} />", None),
+        // TODO we need components_settings to test this
+        // (r"<Image alt='Photo of a friend' />", Some(components_settings),
+
+        // TESTS FOR ARRAY OPTION TESTS
+        (r"<img alt='Word1' />;", Some(array())),
+        (r"<img alt='Word2' />;", Some(array())),
+        (r"<Image alt='Word1' />;", Some(array())),
+        (r"<Image alt='Word2' />;", Some(array())),
+    ];
+
+    Tester::new(ImgRedundantAlt::NAME, pass, fail).with_jsx_a11y_plugin(true).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/img_redundant_alt.snap
+++ b/crates/oxc_linter/src/snapshots/img_redundant_alt.snap
@@ -6,7 +6,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Photo of friend.' />;
-   · ──────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -14,7 +14,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Picture of friend.' />;
-   · ────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -22,7 +22,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Image of friend.' />;
-   · ──────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -30,7 +30,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='PhOtO of friend.' />;
-   · ──────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -38,7 +38,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={'photo'} />;
-   · ─────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -46,7 +46,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='piCTUre of friend.' />;
-   · ────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -54,7 +54,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='imAGE of friend.' />;
-   · ──────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -62,7 +62,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='photo of cool person' aria-hidden={false} />
-   · ──────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -70,7 +70,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='picture of cool person' aria-hidden={false} />
-   · ────────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -78,7 +78,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='image of cool person' aria-hidden={false} />
-   · ──────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -86,7 +86,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='photo' {...this.props} />
-   · ───────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -94,7 +94,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='image' {...this.props} />
-   · ───────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -102,7 +102,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='picture' {...this.props} />
-   · ─────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -110,7 +110,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`picture doing ${things}`} {...this.props} />
-   · ───────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -118,7 +118,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`photo doing ${things}`} {...this.props} />
-   · ─────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -126,7 +126,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`image doing ${things}`} {...this.props} />
-   · ─────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -134,7 +134,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`picture doing ${picture}`} {...this.props} />
-   · ────────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -142,7 +142,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`photo doing ${photo}`} {...this.props} />
-   · ────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -150,7 +150,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`image doing ${image}`} {...this.props} />
-   · ────────────────────────────────────────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -158,7 +158,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Word1' />;
-   · ───────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -166,7 +166,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Word2' />;
-   · ───────────────────
+   ·      ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -174,7 +174,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <Image alt='Word1' />;
-   · ─────────────────────
+   ·        ───
    ╰────
   help: Provide no redundant alt text for image.
 
@@ -182,7 +182,7 @@ expression: img_redundant_alt
   │ specified custom words) in the alt prop.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <Image alt='Word2' />;
-   · ─────────────────────
+   ·        ───
    ╰────
   help: Provide no redundant alt text for image.
 

--- a/crates/oxc_linter/src/snapshots/img_redundant_alt.snap
+++ b/crates/oxc_linter/src/snapshots/img_redundant_alt.snap
@@ -2,188 +2,188 @@
 source: crates/oxc_linter/src/tester.rs
 expression: img_redundant_alt
 ---
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Photo of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Picture of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Image of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='PhOtO of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={'photo'} />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='piCTUre of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='imAGE of friend.' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='photo of cool person' aria-hidden={false} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='picture of cool person' aria-hidden={false} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='image of cool person' aria-hidden={false} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='photo' {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='image' {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='picture' {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`picture doing ${things}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`photo doing ${things}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`image doing ${things}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`picture doing ${picture}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`photo doing ${photo}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt={`image doing ${image}`} {...this.props} />
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Word1' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <img alt='Word2' />;
    ·      ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <Image alt='Word1' />;
    ·        ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
-  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
-  │ specified custom words) in the alt prop.
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.
    ╭─[img_redundant_alt.tsx:1:1]
  1 │ <Image alt='Word2' />;
    ·        ───
    ╰────
-  help: Provide no redundant alt text for image.
+  help: Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom
+        words) in the alt prop.
 
 

--- a/crates/oxc_linter/src/snapshots/img_redundant_alt.snap
+++ b/crates/oxc_linter/src/snapshots/img_redundant_alt.snap
@@ -1,0 +1,189 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: img_redundant_alt
+---
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='Photo of friend.' />;
+   · ──────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='Picture of friend.' />;
+   · ────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='Image of friend.' />;
+   · ──────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='PhOtO of friend.' />;
+   · ──────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={'photo'} />;
+   · ─────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='piCTUre of friend.' />;
+   · ────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='imAGE of friend.' />;
+   · ──────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='photo of cool person' aria-hidden={false} />
+   · ──────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='picture of cool person' aria-hidden={false} />
+   · ────────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='image of cool person' aria-hidden={false} />
+   · ──────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='photo' {...this.props} />
+   · ───────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='image' {...this.props} />
+   · ───────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='picture' {...this.props} />
+   · ─────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={`picture doing ${things}`} {...this.props} />
+   · ───────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={`photo doing ${things}`} {...this.props} />
+   · ─────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={`image doing ${things}`} {...this.props} />
+   · ─────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={`picture doing ${picture}`} {...this.props} />
+   · ────────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={`photo doing ${photo}`} {...this.props} />
+   · ────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt={`image doing ${image}`} {...this.props} />
+   · ────────────────────────────────────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='Word1' />;
+   · ───────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <img alt='Word2' />;
+   · ───────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <Image alt='Word1' />;
+   · ─────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+  ⚠ eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any
+  │ specified custom words) in the alt prop.
+   ╭─[img_redundant_alt.tsx:1:1]
+ 1 │ <Image alt='Word2' />;
+   · ─────────────────────
+   ╰────
+  help: Provide no redundant alt text for image.
+
+


### PR DESCRIPTION
Hi team 👋 I really love this project, so I tried to contribute this to help even a little

## Summary

partof: #1141

I re-implemented img-redundant-alt rule for jsx_a11y in Rust same as the original JS one, and moved also the test related to the rule to here.

originals:
- doc: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md 
- code: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/img-redundant-alt.js
- test: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__tests__/src/rules/img-redundant-alt-test.js 