### PR TITLE
fix(tasks): escape more special characters

### DIFF
--- a/tasks/prettier_conformance/prettier.snap.md
+++ b/tasks/prettier_conformance/prettier.snap.md
@@ -1,10 +1,9 @@
-Compatibility: 221/561 (39.39%)
+Compatibility: 227/561 (40.46%)
 
 # Failed
 
 ### arrays
 * arrays/empty.js
-* arrays/issue-10159.js
 * arrays/numbers-in-args.js
 * arrays/numbers-negative-comment-after-minus.js
 * arrays/numbers-negative.js
@@ -45,8 +44,6 @@ Compatibility: 221/561 (39.39%)
 * assignment/chain.js
 * assignment/discussion-15196.js
 * assignment/issue-10218.js
-* assignment/issue-15534.js
-* assignment/issue-2540.js
 * assignment/issue-6922.js
 * assignment/issue-7572.js
 * assignment/lone-arg.js
@@ -311,7 +308,6 @@ Compatibility: 221/561 (39.39%)
 * method-chain/inline_merge.js
 * method-chain/issue-11298.js
 * method-chain/issue-3594.js
-* method-chain/issue-3621.js
 * method-chain/issue-4125.js
 * method-chain/logical.js
 * method-chain/multiple-members.js
@@ -395,9 +391,6 @@ Compatibility: 221/561 (39.39%)
 * quotes/objects.js
 * quotes/strings.js
 
-### regex
-* regex/test.js
-
 ### require-amd
 * require-amd/named-amd-module.js
 * require-amd/require.js
@@ -419,7 +412,6 @@ Compatibility: 221/561 (39.39%)
 ### strings
 * strings/escaped.js
 * strings/multiline-literal.js
-* strings/non-octal-eight-and-nine.js
 * strings/strings.js
 * strings/template-literals.js
 

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -280,19 +280,15 @@ impl TestRunner {
             if snapshot_line.is_empty() { String::new() } else { title_snapshot_options }
         );
 
-        let mut output = Self::prettier(path, input, prettier_options).replace('`', "\\`");
-        let mut input = input.replace('`', "\\`");
+        let need_eol_visualized = snap_content.contains("<LF>");
+        let output = Self::prettier(path, input, prettier_options);
+        let output = Self::escape_and_convert_snap_string(&output, need_eol_visualized);
+        let input = Self::escape_and_convert_snap_string(input, need_eol_visualized);
         let snapshot_options = snapshot_options
             .iter()
             .map(|(k, v)| format!("{k}: {v}"))
             .collect::<Vec<_>>()
             .join("\n");
-
-        let need_eol_visualized = snap_content.contains("<LF>");
-        if need_eol_visualized {
-            input = Self::visualize_end_of_line(&input);
-            output = Self::visualize_end_of_line(&output);
-        }
 
         let space_line = " ".repeat(prettier_options.print_width);
         let snapshot_without_output = format!(
@@ -366,6 +362,15 @@ impl TestRunner {
         }
 
         result
+    }
+
+    fn escape_and_convert_snap_string(input: &str, need_eol_visualized: bool) -> String {
+        let input = input.replace('\\', "\\\\").replace('`', "\\`").replace("${", "\\${");
+        if need_eol_visualized {
+            Self::visualize_end_of_line(&input)
+        } else {
+            input
+        }
     }
 
     fn prettier(path: &Path, source_text: &str, prettier_options: PrettierOptions) -> String {


### PR DESCRIPTION
We also need escape `$` and `\`: https://github.com/vitest-dev/vitest/blob/9527e65a382e0775f171f88be0ca37c465317e25/packages/snapshot/src/port/inlineSnapshot.ts#L78-L94