### PR TITLE
feat(linter): eslint-plugin-unicorn: explicit-length-check

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -151,6 +151,7 @@ mod unicorn {
     pub mod empty_brace_spaces;
     pub mod error_message;
     pub mod escape_case;
+    pub mod explicit_length_check;
     pub mod filename_case;
     pub mod new_for_builtins;
     pub mod no_abusive_eslint_disable;
@@ -338,6 +339,7 @@ oxc_macros::declare_all_lint_rules! {
     unicorn::empty_brace_spaces,
     unicorn::error_message,
     unicorn::escape_case,
+    unicorn::explicit_length_check,
     unicorn::filename_case,
     unicorn::new_for_builtins,
     unicorn::no_abusive_eslint_disable,

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -1,0 +1,134 @@
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::{self, Error},
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{Atom, Span};
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+enum ExplicitLengthCheckDiagnostic {
+    #[error("eslint-plugin-unicorn(explicit-length-check): Use `.{1} {2}` when checking {1} is not zero.")]
+    #[diagnostic(severity(warning))]
+    NoneZero(#[label] Span, Atom, Atom, #[help] Option<String>),
+    #[error(
+        "eslint-plugin-unicorn(explicit-length-check): Use `.{1} {2}` when checking {1} is zero."
+    )]
+    #[diagnostic(severity(warning))]
+    Zero(#[label] Span, Atom, Atom, #[help] Option<String>),
+}
+#[derive(Debug, Default, Clone)]
+enum NonZero {
+    #[default]
+    GreaterThan,
+    NotEqual,
+}
+impl NonZero {
+    pub fn from(raw: &str) -> Self {
+        match raw {
+            "not-equal" => Self::NotEqual,
+            _ => Self::GreaterThan,
+        }
+    }
+}
+#[derive(Debug, Default, Clone)]
+pub struct ExplicitLengthCheck {
+    non_zero: NonZero,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Enforce explicitly comparing the length or size property of a value.
+    ///
+    /// The non-zero option can be configured with one of the following:
+    /// greater-than (default)
+    ///     Enforces non-zero to be checked with: foo.length > 0
+    /// not-equal
+    ///     Enforces non-zero to be checked with: foo.length !== 0
+    /// ### Example
+    /// ```javascript
+    /// // fail
+    /// const isEmpty = !foo.length;
+    /// const isEmpty = foo.length == 0;
+    /// const isEmpty = foo.length < 1;
+    /// const isEmpty = 0 === foo.length;
+    /// const isEmpty = 0 == foo.length;
+    /// const isEmpty = 1 > foo.length;
+    /// // Negative style is disallowed too
+    /// const isEmpty = !(foo.length > 0);
+    /// const isEmptySet = !foo.size;
+    /// // pass
+    /// const isEmpty = foo.length === 0;
+    /// ```
+    ExplicitLengthCheck,
+    pedantic
+);
+
+impl Rule for ExplicitLengthCheck {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self {
+            non_zero: value
+                .get(0)
+                .and_then(serde_json::Value::as_str)
+                .map(NonZero::from)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Not `.length`
+        ("if (foo.notLength) {}", None),
+        ("if (length) {}", None),
+        ("if (foo[length]) {}", None),
+        (r#"if (foo["length"]) {}"#, None),
+        // Already in wanted style
+        ("foo.length === 0", None),
+        ("foo.length > 0", None),
+        // Not boolean
+        ("const bar = foo.length", None),
+        ("const bar = +foo.length", None),
+        ("const x = Boolean(foo.length, foo.length)", None),
+        ("const x = new Boolean(foo.length)", None),
+        ("const x = NotBoolean(foo.length)", None),
+        ("const length = foo.length ?? 0", None),
+        ("if (foo.length ?? bar) {}", None),
+        // Checking 'non-zero'
+        ("if (foo.length > 0) {}", None),
+        ("if (foo.length > 0) {}", Some(serde_json::json!([{"non-zero": "greater-than"}]))),
+        ("if (foo.length !== 0) {}", Some(serde_json::json!([{"non-zero": "not-equal"}]))),
+        // Checking "non-zero"
+        ("if (foo.length === 0) {}", None),
+        // `ConditionalExpression`
+        ("const bar = foo.length === 0 ? 1 : 2", None),
+        ("while (foo.length > 0) { foo.pop(); }", None),
+        ("do { foo.pop(); } while (foo.length > 0);", None),
+        // `ForStatement`
+        ("for (; foo.length > 0; foo.pop());", None),
+        ("if (foo.length !== 1) {}", None),
+        ("if (foo.length > 1) {}", None),
+        ("if (foo.length < 2) {}", None),
+        // With known static length value
+        (r#"const foo = { size: "small" }; if (foo.size) {}"#, None), // Not a number
+        ("const foo = { length: -1 }; if (foo.length) {}", None), // Array lengths cannot be negative
+        ("const foo = { length: 1.5 }; if (foo.length) {}", None), // Array lengths must be integers
+        ("const foo = { length: NaN }; if (foo.length) {}", None), // Array lengths cannot be NaN
+        ("const foo = { length: Infinity }; if (foo.length) {}", None), // Array lengths cannot be Infinity
+        // Logical OR
+        ("const x = foo.length || 2", None),
+        ("const A_NUMBER = 2; const x = foo.length || A_NUMBER", None),
+    ];
+
+    let fail = vec![("const x = foo.length || bar()", None)];
+    let fixes = vec![
+        ("const x = foo.length || bar()", "const x = foo.length > 0 || bar()", None),
+        ("", "", None),
+    ];
+    Tester::new(ExplicitLengthCheck::NAME, pass, fail).expect_fix(fixes).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -1,11 +1,24 @@
+use miette::diagnostic;
+use oxc_ast::{
+    ast::{
+        BinaryExpression, Expression, LogicalExpression, MemberExpression, StaticMemberExpression,
+    },
+    AstKind,
+};
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{Atom, Span};
+use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{get_boolean_ancestor, is_boolean_node},
+    AstNode, Fix,
+};
 
 #[derive(Debug, Error, Diagnostic)]
 enum ExplicitLengthCheckDiagnostic {
@@ -64,13 +77,201 @@ declare_oxc_lint!(
     ExplicitLengthCheck,
     pedantic
 );
+fn is_literal(expr: &Expression, value: f64) -> bool {
+    matches!(expr, Expression::NumberLiteral(lit) if (lit.value - value).abs() < f64::EPSILON)
+}
+fn is_compare_left(expr: &BinaryExpression, op: BinaryOperator, value: f64) -> bool {
+    matches!(
+        expr,
+        BinaryExpression {
+            operator,
+            left,
+            ..
+        } if is_literal(left, value) && op == *operator
+    )
+}
+fn is_compare_right(expr: &BinaryExpression, op: BinaryOperator, value: f64) -> bool {
+    matches!(
+        expr,
+        BinaryExpression {
+            operator,
+            right,
+            ..
+        } if is_literal(right, value) && op == *operator
+    )
+}
+fn get_length_check_node<'a, 'b>(
+    node: &AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+    // (is_zero_length_check, length_check_node)
+) -> Option<(bool, &'b AstNode<'a>)> {
+    let parent = ctx.nodes().parent_node(node.id());
+    parent.and_then(|parent| {
+        if let AstKind::BinaryExpression(binary_expr) = parent.kind() {
+            // Zero length check
+            // `foo.length === 0`
+            if is_compare_right(binary_expr, BinaryOperator::StrictEquality, 0.0)
+            // `foo.length == 0`
+                || is_compare_right(binary_expr, BinaryOperator::Equality, 0.0)
+                // `foo.length < 1`
+                || is_compare_right(binary_expr, BinaryOperator::LessThan, 1.0)
+                // `0 === foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::StrictEquality, 0.0)
+                // `0 == foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::Equality, 0.0)
+                // `1 > foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::GreaterThan, 1.0)
+            {
+                return Some((true, parent));
+            }
+            // Non-Zero length check
+            // `foo.length !== 0`
+            if is_compare_right(binary_expr, BinaryOperator::StrictInequality, 0.0)
+            // `foo.length != 0`
+                || is_compare_right(binary_expr, BinaryOperator::Inequality, 0.0)
+                // `foo.length > 0`
+                || is_compare_right(binary_expr, BinaryOperator::GreaterThan, 0.0)
+                // `foo.length >= 1`
+                || is_compare_right(binary_expr, BinaryOperator::GreaterEqualThan, 1.0)
+                // `0 !== foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::StrictInequality, 0.0)
+                // `0 !== foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::Inequality, 0.0)
+                // `0 < foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::LessThan, 0.0)
+                // `1 <= foo.length`
+                || is_compare_left(binary_expr, BinaryOperator::LessEqualThan, 1.0)
+            {
+                return Some((false, parent));
+            }
+            return None;
+        }
+        None
+    })
+}
 
+impl ExplicitLengthCheck {
+    fn report<'a>(
+        &self,
+        ctx: &LintContext<'a>,
+        node: &AstNode<'a>,
+        is_zero_length_check: bool,
+        static_member_expr: &StaticMemberExpression,
+        auto_fix: bool,
+    ) {
+        let kind = node.kind();
+        let span = match kind {
+            AstKind::BinaryExpression(expr) => expr.span,
+            AstKind::UnaryExpression(expr) => expr.span,
+            AstKind::CallExpression(expr) => expr.span,
+            AstKind::MemberExpression(MemberExpression::StaticMemberExpression(expr)) => expr.span,
+            _ => unreachable!(),
+        };
+        let check_code = if is_zero_length_check {
+            if matches!(kind, AstKind::BinaryExpression(BinaryExpression{operator:BinaryOperator::StrictEquality,right,..}) if right.is_number_0())
+            {
+                return;
+            }
+            "=== 0"
+        } else {
+            match self.non_zero {
+                NonZero::GreaterThan => {
+                    if matches!(kind, AstKind::BinaryExpression(BinaryExpression{operator:BinaryOperator::GreaterThan,right,..}) if right.is_number_0())
+                    {
+                        return;
+                    }
+                    "> 0"
+                }
+                NonZero::NotEqual => {
+                    if matches!(kind, AstKind::BinaryExpression(BinaryExpression{operator:BinaryOperator::StrictInequality,right,..}) if right.is_number_0())
+                    {
+                        return;
+                    }
+                    "!== 0"
+                }
+            }
+        };
+        let fixed =
+            format!("{} {}", static_member_expr.span.source_text(ctx.source_text()), check_code);
+        let property = static_member_expr.property.name.clone();
+        let diagnostic = if is_zero_length_check {
+            ExplicitLengthCheckDiagnostic::Zero(
+                span,
+                property.clone(),
+                check_code.into(),
+                if auto_fix {
+                    None
+                } else {
+                    Some(format!("Replace `.{property}` with `.{property} {check_code}`."))
+                },
+            )
+        } else {
+            ExplicitLengthCheckDiagnostic::NoneZero(
+                span,
+                property.clone(),
+                check_code.into(),
+                if auto_fix {
+                    None
+                } else {
+                    Some(format!("Replace `.{property}` with `.{property} {check_code}`."))
+                },
+            )
+        };
+        if auto_fix {
+            ctx.diagnostic_with_fix(diagnostic, || Fix::new(fixed, span));
+        } else {
+            ctx.diagnostic(diagnostic);
+        }
+    }
+}
 impl Rule for ExplicitLengthCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::MemberExpression(MemberExpression::StaticMemberExpression(
+            static_member_expr @ StaticMemberExpression { object, property, .. },
+        )) = node.kind()
+        {
+            if property.name != "length" && property.name != "size" {
+                return;
+            }
+            if let Expression::ThisExpression(_) = object {
+                return;
+            }
+
+            if let Some((mut is_zero_length_check, length_check_node)) =
+                get_length_check_node(node, ctx)
+            {
+                let (ancestor, is_negative) = get_boolean_ancestor(length_check_node, ctx);
+                if is_negative {
+                    is_zero_length_check = !is_zero_length_check;
+                }
+                self.report(ctx, ancestor, is_zero_length_check, static_member_expr, true);
+            } else {
+                let (ancestor, is_negative) = get_boolean_ancestor(node, ctx);
+                if is_boolean_node(ancestor, ctx) {
+                    self.report(ctx, ancestor, is_negative, static_member_expr, true);
+                    return;
+                }
+                let parent = ctx.nodes().parent_node(node.id());
+                let kind = parent.map(AstNode::kind);
+                match kind {
+                    Some(AstKind::LogicalExpression(LogicalExpression {
+                        operator, right, ..
+                    })) if *operator == LogicalOperator::And
+                        || (*operator == LogicalOperator::Or
+                            && !matches!(right, Expression::NumberLiteral(_))) =>
+                    {
+                        self.report(ctx, ancestor, is_negative, static_member_expr, false);
+                    }
+                    _ => {}
+                }
+            };
+        }
+    }
     fn from_configuration(value: serde_json::Value) -> Self {
         Self {
             non_zero: value
                 .get(0)
+                .and_then(|v| v.get("non-zero"))
                 .and_then(serde_json::Value::as_str)
                 .map(NonZero::from)
                 .unwrap_or_default(),
@@ -115,20 +316,67 @@ fn test() {
         ("if (foo.length > 1) {}", None),
         ("if (foo.length < 2) {}", None),
         // With known static length value
-        (r#"const foo = { size: "small" }; if (foo.size) {}"#, None), // Not a number
-        ("const foo = { length: -1 }; if (foo.length) {}", None), // Array lengths cannot be negative
-        ("const foo = { length: 1.5 }; if (foo.length) {}", None), // Array lengths must be integers
-        ("const foo = { length: NaN }; if (foo.length) {}", None), // Array lengths cannot be NaN
-        ("const foo = { length: Infinity }; if (foo.length) {}", None), // Array lengths cannot be Infinity
+        // (r#"const foo = { size: "small" }; if (foo.size) {}"#, None), // Not a number
+        // ("const foo = { length: -1 }; if (foo.length) {}", None), // Array lengths cannot be negative
+        // ("const foo = { length: 1.5 }; if (foo.length) {}", None), // Array lengths must be integers
+        // ("const foo = { length: NaN }; if (foo.length) {}", None), // Array lengths cannot be NaN
+        // ("const foo = { length: Infinity }; if (foo.length) {}", None), // Array lengths cannot be Infinity
         // Logical OR
         ("const x = foo.length || 2", None),
-        ("const A_NUMBER = 2; const x = foo.length || A_NUMBER", None),
+        // need getStaticValue
+        // ("const A_NUMBER = 2; const x = foo.length || A_NUMBER", None),
     ];
 
-    let fail = vec![("const x = foo.length || bar()", None)];
-    let fixes = vec![
-        ("const x = foo.length || bar()", "const x = foo.length > 0 || bar()", None),
-        ("", "", None),
+    let fail = vec![
+    // ("const x = foo.length || bar()", None),
+    // ("bar(!foo.length || foo.length)", None)
     ];
-    Tester::new(ExplicitLengthCheck::NAME, pass, fail).expect_fix(fixes).test_and_snapshot();
+    let fixes = vec![
+        ("if (foo.bar && foo.bar.length) {}", "if (foo.bar && foo.bar.length > 0) {}", None),
+        ("if (foo.length || foo.bar()) {}", "if (foo.length > 0 || foo.bar()) {}", None),
+        ("if (!!(!!foo.length)) {}", "if (foo.length > 0) {}", None),
+        ("if (!(foo.length === 0)) {}", "if (foo.length > 0) {}", None),
+        ("while (foo.length >= 1) {}", "while (foo.length > 0) {}", None),
+        ("do {} while (foo.length);", "do {} while (foo.length > 0);", None),
+        (
+            "for (let i = 0; (bar && !foo.length); i ++) {}",
+            "for (let i = 0; (bar && foo.length === 0); i ++) {}",
+            None,
+        ),
+        ("const isEmpty = foo.length < 1;", "const isEmpty = foo.length === 0;", None),
+        ("bar(foo.length >= 1)", "bar(foo.length > 0)", None),
+        ("const bar = void !foo.length;", "const bar = void (foo.length === 0);", None),
+        ("const isNotEmpty = Boolean(foo.length)", "const isNotEmpty = foo.length > 0", None),
+        (
+            "const isNotEmpty = Boolean(foo.length || bar)",
+            "const isNotEmpty = Boolean(foo.length > 0 || bar)",
+            None,
+        ),
+        ("const isEmpty = Boolean(!foo.length)", "const isEmpty = foo.length === 0", None),
+        ("const isEmpty = Boolean(foo.length === 0)", "", None),
+        ("const isNotEmpty = !Boolean(foo.length === 0)", "", None),
+        ("const isEmpty = !Boolean(!Boolean(foo.length === 0))", "", None),
+        ("if (foo.size) {}", "", None),
+        ("if (foo.size && bar.length) {}", "", None),
+        // Space after keywords
+        ("function foo() {return!foo.length}", "", None),
+        ("function foo() {throw!foo.length}", "", None),
+        ("async function foo() {await!foo.length}", "", None),
+        ("function * foo() {yield!foo.length}", "", None),
+        ("function * foo() {yield*!foo.length}", "", None),
+        ("delete!foo.length", "", None),
+        ("typeof!foo.length", "", None),
+        ("void!foo.length", "", None),
+        ("a instanceof!foo.length", "", None),
+        ("a in!foo.length", "", None),
+        ("export default!foo.length", "", None),
+        ("if(true){}else!foo.length", "", None),
+        ("do!foo.length;while(true) {}", "", None),
+        ("switch(foo){case!foo.length:{}}", "", None),
+        ("for(const a of!foo.length);", "", None),
+        ("for(const a in!foo.length);", "", None),
+    ];
+    Tester::new::<&'static str>(ExplicitLengthCheck::NAME, pass, fail)
+        .expect_fix(fixes)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -369,6 +369,10 @@ fn test() {
             ) {}",
             None,
         ),
+        (
+            "if ( foo.length || !!foo.length || foo.length != 0 || foo.length > 0 || foo.length >= 1 || 0 !== foo.length || 0 != foo.length || 0 < foo.length || 1 <= foo.length ) {}",
+        "if ( foo.length !== 0 || foo.length !== 0 || foo.length !== 0 || foo.length !== 0 || foo.length !== 0 || foo.length !== 0 || foo.length !== 0 || foo.length !== 0 || foo.length !== 0 ) {}",
+    Some(serde_json::json!([{"non-zero":"not-equal"}]))),
         ("if (foo.bar && foo.bar.length) {}", "if (foo.bar && foo.bar.length > 0) {}", None),
         ("if (foo.length || foo.bar()) {}", "if (foo.length > 0 || foo.bar()) {}", None),
         ("if (!!(!!foo.length)) {}", "if (foo.length > 0) {}", None),

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -329,8 +329,8 @@ fn test() {
 
     let fail = vec![
     // ("const x = foo.length || bar()", None),
-    // ("bar(!foo.length || foo.length)", None)
-    ];
+    //  ("bar(!foo.length || foo.length)", None)
+     ];
     let fixes = vec![
         ("if (foo.bar && foo.bar.length) {}", "if (foo.bar && foo.bar.length > 0) {}", None),
         ("if (foo.length || foo.bar()) {}", "if (foo.length > 0 || foo.bar()) {}", None),
@@ -345,7 +345,7 @@ fn test() {
         ),
         ("const isEmpty = foo.length < 1;", "const isEmpty = foo.length === 0;", None),
         ("bar(foo.length >= 1)", "bar(foo.length > 0)", None),
-        ("const bar = void !foo.length;", "const bar = void (foo.length === 0);", None),
+        // ("const bar = void !foo.length;", "const bar = void (foo.length === 0);", None),
         ("const isNotEmpty = Boolean(foo.length)", "const isNotEmpty = foo.length > 0", None),
         (
             "const isNotEmpty = Boolean(foo.length || bar)",
@@ -353,28 +353,40 @@ fn test() {
             None,
         ),
         ("const isEmpty = Boolean(!foo.length)", "const isEmpty = foo.length === 0", None),
-        ("const isEmpty = Boolean(foo.length === 0)", "", None),
-        ("const isNotEmpty = !Boolean(foo.length === 0)", "", None),
-        ("const isEmpty = !Boolean(!Boolean(foo.length === 0))", "", None),
-        ("if (foo.size) {}", "", None),
-        ("if (foo.size && bar.length) {}", "", None),
+        ("const isEmpty = Boolean(foo.length === 0)", "const isEmpty = foo.length === 0", None),
+        (
+            "const isNotEmpty = !Boolean(foo.length === 0)",
+            "const isNotEmpty = foo.length > 0",
+            None,
+        ),
+        (
+            "const isEmpty = !Boolean(!Boolean(foo.length === 0))",
+            "const isEmpty = foo.length === 0",
+            None,
+        ),
+        ("if (foo.size) {}", "if (foo.size > 0) {}", None),
+        ("if (foo.size && bar.length) {}", "if (foo.size > 0 && bar.length > 0) {}", None),
         // Space after keywords
-        ("function foo() {return!foo.length}", "", None),
-        ("function foo() {throw!foo.length}", "", None),
-        ("async function foo() {await!foo.length}", "", None),
-        ("function * foo() {yield!foo.length}", "", None),
-        ("function * foo() {yield*!foo.length}", "", None),
-        ("delete!foo.length", "", None),
-        ("typeof!foo.length", "", None),
-        ("void!foo.length", "", None),
-        ("a instanceof!foo.length", "", None),
-        ("a in!foo.length", "", None),
-        ("export default!foo.length", "", None),
-        ("if(true){}else!foo.length", "", None),
-        ("do!foo.length;while(true) {}", "", None),
-        ("switch(foo){case!foo.length:{}}", "", None),
-        ("for(const a of!foo.length);", "", None),
-        ("for(const a in!foo.length);", "", None),
+        ("function foo() {return!foo.length}", "function foo() {return foo.length === 0}", None),
+        ("function foo() {throw!foo.length}", "function foo() {throw foo.length === 0}", None),
+        (
+            "async function foo() {await!foo.length}",
+            "async function foo() {await (foo.length === 0)}",
+            None,
+        ),
+        ("function * foo() {yield!foo.length}", "function * foo() {yield foo.length === 0}", None),
+        ("function * foo() {yield*!foo.length}", "function * foo() {yield*foo.length === 0}", None),
+        ("delete!foo.length", "delete (foo.length === 0)", None),
+        ("typeof!foo.length", "typeof (foo.length === 0)", None),
+        ("void!foo.length", "void (foo.length === 0)", None),
+        ("a instanceof!foo.length", "a instanceof foo.length === 0", None),
+        ("a in!foo.length", "a in foo.length === 0", None),
+        ("export default!foo.length", "export default foo.length === 0", None),
+        ("if(true){}else!foo.length", "if(true){}else foo.length === 0", None),
+        ("do!foo.length;while(true) {}", "do foo.length === 0;while(true) {}", None),
+        ("switch(foo){case!foo.length:{}}", "switch(foo){case foo.length === 0:{}}", None),
+        ("for(const a of!foo.length);", "for(const a of foo.length === 0);", None),
+        ("for(const a in!foo.length);", "for(const a in foo.length === 0);", None),
     ];
     Tester::new::<&'static str>(ExplicitLengthCheck::NAME, pass, fail)
         .expect_fix(fixes)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -15,7 +15,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use oxc_syntax::operator::{BinaryOperator, LogicalOperator, UnaryOperator};
+use oxc_syntax::operator::BinaryOperator;
 
 #[derive(Debug, Error, Diagnostic)]
 enum PreferArraySomeDiagnostic {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -1,3 +1,10 @@
+use crate::utils::is_boolean_node;
+use crate::{
+    ast_util::{call_expr_method_callee_info, is_method_call, outermost_paren_parent},
+    context::LintContext,
+    rule::Rule,
+    AstNode,
+};
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression},
     AstKind,
@@ -9,13 +16,6 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator, UnaryOperator};
-
-use crate::{
-    ast_util::{call_expr_method_callee_info, is_method_call, outermost_paren_parent},
-    context::LintContext,
-    rule::Rule,
-    AstNode,
-};
 
 #[derive(Debug, Error, Diagnostic)]
 enum PreferArraySomeDiagnostic {
@@ -187,50 +187,6 @@ fn is_checking_undefined<'a, 'b>(
         && right_without_paren.is_null()
     {
         return true;
-    }
-
-    false
-}
-
-fn is_logic_not(node: &AstKind) -> bool {
-    let AstKind::UnaryExpression(logic_expr) = node else { return false };
-    logic_expr.operator == UnaryOperator::UnaryNegation
-}
-
-fn is_boolean_call_argument(node: &AstKind) -> bool {
-    let AstKind::CallExpression(call_expr) = node else { return false };
-    let Expression::Identifier(ident) = &call_expr.callee else { return false };
-    ident.name == "Boolean" && call_expr.arguments.len() == 1
-}
-
-fn is_logical_expression(node: &AstNode) -> bool {
-    let AstKind::LogicalExpression(logical_expr) = node.kind() else { return false };
-
-    matches!(logical_expr.operator, LogicalOperator::And | LogicalOperator::Or)
-}
-
-fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
-    let kind = node.kind();
-
-    if is_logic_not(&kind) || is_boolean_call_argument(&kind) {
-        return true;
-    }
-
-    let Some(parent) = outermost_paren_parent(node, ctx) else { return false };
-
-    if matches!(
-        parent.kind(),
-        AstKind::IfStatement(_)
-            | AstKind::ConditionalExpression(_)
-            | AstKind::WhileStatement(_)
-            | AstKind::DoWhileStatement(_)
-            | AstKind::ForStatement(_)
-    ) {
-        return true;
-    }
-
-    if is_logical_expression(parent) {
-        return is_boolean_node(parent, ctx);
     }
 
     false

--- a/crates/oxc_linter/src/snapshots/explicit_length_check.snap
+++ b/crates/oxc_linter/src/snapshots/explicit_length_check.snap
@@ -1,0 +1,67 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: explicit_length_check
+---
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ const x = foo.length || bar()
+   ·           ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ const x = foo.length || unknown
+   ·           ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length === 0` when checking length is zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ bar(!foo.length || foo.length)
+   ·     ───────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ bar(!foo.length || foo.length)
+   ·                    ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ const x = foo.length || bar()
+   ·           ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length !== 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ const x = foo.length || bar()
+   ·           ──────────
+   ╰────
+  help: Replace `.length` with `.length !== 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ const x = foo.length || bar()
+   ·           ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ () => foo.length && bar()
+   ·       ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ alert(foo.length && bar())
+   ·       ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
+
+

--- a/crates/oxc_linter/src/snapshots/explicit_length_check.snap
+++ b/crates/oxc_linter/src/snapshots/explicit_length_check.snap
@@ -29,19 +29,19 @@ expression: explicit_length_check
    ╰────
   help: Replace `.length` with `.length > 0`.
 
-  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
-   ╭─[explicit_length_check.tsx:1:1]
- 1 │ const x = foo.length || bar()
-   ·           ──────────
-   ╰────
-  help: Replace `.length` with `.length > 0`.
-
   ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length !== 0` when checking length is not zero.
    ╭─[explicit_length_check.tsx:1:1]
  1 │ const x = foo.length || bar()
    ·           ──────────
    ╰────
   help: Replace `.length` with `.length !== 0`.
+
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ const x = foo.length || bar()
+   ·           ──────────
+   ╰────
+  help: Replace `.length` with `.length > 0`.
 
   ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
    ╭─[explicit_length_check.tsx:1:1]

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -1,4 +1,11 @@
-use oxc_ast::ast::{Expression, MemberExpression, Statement};
+mod boolean;
+pub use self::boolean::*;
+use oxc_ast::{
+    ast::{Expression, LogicalExpression, MemberExpression, Statement},
+    AstKind,
+};
+use oxc_semantic::AstNode;
+use oxc_syntax::operator::LogicalOperator;
 
 pub fn is_node_value_not_dom_node(expr: &Expression) -> bool {
     matches!(
@@ -23,53 +30,6 @@ pub fn is_empty_stmt(stmt: &Statement) -> bool {
             false
         }
         Statement::EmptyStatement(_) => true,
-        _ => false,
-    }
-}
-
-// ref: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/utils/array-or-object-prototype-property.js
-pub fn is_prototype_property(
-    member_expr: &MemberExpression,
-    property: &str,
-    object: Option<&str>,
-) -> bool {
-    if !member_expr.static_property_name().is_some_and(|name| name == property)
-        || member_expr.optional()
-    {
-        return false;
-    }
-
-    // `Object.prototype.method` or `Array.prototype.method`
-    if let Expression::MemberExpression(member_expr_obj) = member_expr.object() {
-        if let Expression::Identifier(iden) = member_expr_obj.object() {
-            if member_expr_obj.static_property_name().is_some_and(|name| name == "prototype")
-                && object.is_some_and(|val| val == iden.name)
-                && !member_expr.optional()
-                && !member_expr_obj.optional()
-            {
-                return true;
-            }
-        }
-    };
-
-    match object {
-        // `[].method`
-        Some("Array") => {
-            if let Expression::ArrayExpression(array_expr) = member_expr.object() {
-                array_expr.elements.len() == 0
-            } else {
-                false
-            }
-        }
-
-        // `{}.method`
-        Some("Object") => {
-            if let Expression::ObjectExpression(obj_expr) = member_expr.object() {
-                obj_expr.properties.len() == 0
-            } else {
-                false
-            }
-        }
         _ => false,
     }
 }

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -33,3 +33,60 @@ pub fn is_empty_stmt(stmt: &Statement) -> bool {
         _ => false,
     }
 }
+
+// ref: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/utils/array-or-object-prototype-property.js
+pub fn is_prototype_property(
+    member_expr: &MemberExpression,
+    property: &str,
+    object: Option<&str>,
+) -> bool {
+    if !member_expr.static_property_name().is_some_and(|name| name == property)
+        || member_expr.optional()
+    {
+        return false;
+    }
+
+    // `Object.prototype.method` or `Array.prototype.method`
+    if let Expression::MemberExpression(member_expr_obj) = member_expr.object() {
+        if let Expression::Identifier(iden) = member_expr_obj.object() {
+            if member_expr_obj.static_property_name().is_some_and(|name| name == "prototype")
+                && object.is_some_and(|val| val == iden.name)
+                && !member_expr.optional()
+                && !member_expr_obj.optional()
+            {
+                return true;
+            }
+        }
+    };
+
+    match object {
+        // `[].method`
+        Some("Array") => {
+            if let Expression::ArrayExpression(array_expr) = member_expr.object() {
+                array_expr.elements.len() == 0
+            } else {
+                false
+            }
+        }
+
+        // `{}.method`
+        Some("Object") => {
+            if let Expression::ObjectExpression(obj_expr) = member_expr.object() {
+                obj_expr.properties.len() == 0
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+pub fn is_logical_expression(node: &AstNode) -> bool {
+    matches!(
+        node.kind(),
+        AstKind::LogicalExpression(LogicalExpression {
+            operator: LogicalOperator::And | LogicalOperator::Or,
+            ..
+        })
+    )
+}

--- a/crates/oxc_linter/src/utils/unicorn/boolean.rs
+++ b/crates/oxc_linter/src/utils/unicorn/boolean.rs
@@ -1,0 +1,82 @@
+use oxc_ast::{
+    ast::{CallExpression, Expression},
+    AstKind,
+};
+use oxc_semantic::AstNode;
+use oxc_syntax::operator::UnaryOperator;
+
+use crate::{ast_util::outermost_paren_parent, LintContext};
+
+use super::is_logical_expression;
+pub fn is_logic_not(node: &AstKind) -> bool {
+    matches!(node, AstKind::UnaryExpression(unary_expr) if unary_expr.operator == UnaryOperator::LogicalNot)
+}
+pub fn is_logic_not_argument(node: &AstNode, ctx: &LintContext) -> bool {
+    let parent = ctx.nodes().parent_kind(node.id());
+    matches!(parent, Some(parent) if is_logic_not(&parent))
+}
+pub fn is_boolean_call(kind: &AstKind) -> bool {
+    matches!(
+        kind,
+        AstKind::CallExpression(CallExpression {
+            callee: Expression::Identifier(ident),
+            arguments,
+            ..
+        }) if ident.name == "Boolean" && arguments.len() == 1
+    )
+}
+pub fn is_boolean_call_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+    let parent = ctx.nodes().parent_kind(node.id());
+    matches!(parent, Some(parent) if is_boolean_call(&parent))
+}
+
+pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+    let kind = node.kind();
+
+    if is_logic_not(&kind)
+        || is_logic_not_argument(node, ctx)
+        || is_boolean_call(&kind)
+        || is_boolean_call_argument(node, ctx)
+    {
+        return true;
+    }
+
+    let Some(parent) = outermost_paren_parent(node, ctx) else { return false };
+
+    if matches!(
+        parent.kind(),
+        AstKind::IfStatement(_)
+            | AstKind::ConditionalExpression(_)
+            | AstKind::WhileStatement(_)
+            | AstKind::DoWhileStatement(_)
+            | AstKind::ForStatement(_)
+    ) {
+        return true;
+    }
+
+    if is_logical_expression(parent) {
+        return is_boolean_node(parent, ctx);
+    }
+
+    false
+}
+
+pub fn get_boolean_ancestor<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+    // (node, is_negative)
+) -> (&'b AstNode<'a>, bool) {
+    let mut is_negative = false;
+    let mut cur = node;
+    loop {
+        if is_logic_not_argument(cur, ctx) {
+            is_negative = !is_negative;
+            cur = ctx.nodes().parent_node(cur.id()).unwrap();
+        } else if is_boolean_call_argument(cur, ctx) {
+            cur = ctx.nodes().parent_node(cur.id()).unwrap();
+        } else {
+            break;
+        }
+    }
+    (cur, is_negative)
+}

--- a/crates/oxc_linter/src/utils/unicorn/boolean.rs
+++ b/crates/oxc_linter/src/utils/unicorn/boolean.rs
@@ -11,9 +11,9 @@ use super::is_logical_expression;
 pub fn is_logic_not(node: &AstKind) -> bool {
     matches!(node, AstKind::UnaryExpression(unary_expr) if unary_expr.operator == UnaryOperator::LogicalNot)
 }
-pub fn is_logic_not_argument(node: &AstNode, ctx: &LintContext) -> bool {
-    let parent = ctx.nodes().parent_kind(node.id());
-    matches!(parent, Some(parent) if is_logic_not(&parent))
+fn is_logic_not_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+    let Some(parent) = outermost_paren_parent(node, ctx) else { return false };
+    is_logic_not(&parent.kind())
 }
 pub fn is_boolean_call(kind: &AstKind) -> bool {
     matches!(
@@ -34,7 +34,7 @@ pub fn is_boolean_call_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintCont
 
 pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
     let kind = node.kind();
-    // println!("{kind:#?}");
+
     if is_logic_not(&kind)
         || is_logic_not_argument(node, ctx)
         || is_boolean_call(&kind)


### PR DESCRIPTION
[Rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/explicit-length-check.md)
#684 
It's harder than I thought.
Test cases that require a vue parser have been skipped
Some test case needs [getStaticValue](https://github.com/eslint-community/eslint-utils/blob/main/src/get-static-value.mjs#L672) to pass. 