### PR TITLE
feat(semantic): support scope descendents starting from a certain scope.

### DIFF
--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -86,7 +86,7 @@ impl ManglerBuilder {
         let mut max_slot_for_scope = vec![0; scope_tree.len()];
 
         // Walk the scope tree and compute the slot number for each scope
-        for scope_id in scope_tree.descendants() {
+        for scope_id in scope_tree.descendants_from_root() {
             let bindings = scope_tree.get_bindings(scope_id);
             // The current slot number is continued by the maximum slot from the parent scope
             let parent_max_slot = scope_tree

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -23,7 +23,7 @@ pub struct ScopeTree {
     parent_ids: IndexVec<ScopeId, Option<ScopeId>>,
 
     /// Maps a scope to direct children scopes
-    childs_ids: IndexMap<ScopeId, Vec<ScopeId>>,
+    child_ids: IndexMap<ScopeId, Vec<ScopeId>>,
 
     flags: IndexVec<ScopeId, ScopeFlags>,
     bindings: IndexVec<ScopeId, Bindings>,
@@ -61,7 +61,7 @@ impl ScopeTree {
             }
         }
 
-        add_to_list(&scope_id, &self.childs_ids, &mut list);
+        add_to_list(&scope_id, &self.child_ids, &mut list);
 
         list.into_iter()
     }
@@ -128,10 +128,10 @@ impl ScopeTree {
         _ = self.unresolved_references.push(UnresolvedReferences::default());
 
         if let Some(parent_id) = parent_id {
-            if let Some(children) = self.childs_ids.get_mut(&parent_id) {
+            if let Some(children) = self.child_ids.get_mut(&parent_id) {
                 children.push(scope_id);
             } else {
-                self.childs_ids.insert(parent_id, vec![scope_id]);
+                self.child_ids.insert(parent_id, vec![scope_id]);
             }
         }
 

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -128,14 +128,7 @@ impl ScopeTree {
         _ = self.unresolved_references.push(UnresolvedReferences::default());
 
         if let Some(parent_id) = parent_id {
-            let list = self.child_ids.entry(parent_id).or_default();
-            list.push(scope_id);
-
-            // if let Some(children) = self.child_ids.get_mut(&parent_id) {
-            //     children.push(scope_id);
-            // } else {
-            //     self.child_ids.insert(parent_id, vec![scope_id]);
-            // }
+            self.child_ids.entry(parent_id).or_default().push(scope_id);
         }
 
         scope_id

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::hash::BuildHasherDefault;
 
 use indexmap::IndexMap;
@@ -38,7 +39,23 @@ impl ScopeTree {
         std::iter::successors(Some(scope_id), |scope_id| self.parent_ids[*scope_id])
     }
 
-    pub fn descendants(&self) -> impl Iterator<Item = ScopeId> + '_ {
+    pub fn descendants(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
+        let mut list = vec![];
+        let mut queue = VecDeque::from_iter([scope_id]);
+
+        while let Some(current_id) = queue.pop_front() {
+            for (scope, parent_scope) in self.parent_ids.iter_enumerated() {
+                if parent_scope.as_ref().is_some_and(|parent_id| parent_id == &current_id) {
+                    list.push(scope);
+                    queue.push_back(scope);
+                }
+            }
+        }
+
+        list.into_iter()
+    }
+
+    pub fn descendants_from_root(&self) -> impl Iterator<Item = ScopeId> + '_ {
         self.parent_ids.iter_enumerated().map(|(scope_id, _)| scope_id)
     }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -39,6 +39,18 @@ impl SymbolTable {
         self.spans.iter_enumerated().map(|(symbol_id, _)| symbol_id)
     }
 
+    pub fn get_symbol_id_from_span(&self, span: &Span) -> Option<SymbolId> {
+        self.spans
+            .iter_enumerated()
+            .find_map(|(symbol, inner_span)| if inner_span == span { Some(symbol) } else { None })
+    }
+
+    pub fn get_symbol_id_from_name(&self, name: &Atom) -> Option<SymbolId> {
+        self.names
+            .iter_enumerated()
+            .find_map(|(symbol, inner_name)| if inner_name == name { Some(symbol) } else { None })
+    }
+
     pub fn get_span(&self, symbol_id: SymbolId) -> Span {
         self.spans[symbol_id]
     }
@@ -61,6 +73,14 @@ impl SymbolTable {
 
     pub fn get_scope_id(&self, symbol_id: SymbolId) -> ScopeId {
         self.scope_ids[symbol_id]
+    }
+
+    pub fn get_scope_id_from_span(&self, span: &Span) -> Option<ScopeId> {
+        self.get_symbol_id_from_span(span).map(|symbol_id| self.get_scope_id(symbol_id))
+    }
+
+    pub fn get_scope_id_from_name(&self, name: &Atom) -> Option<ScopeId> {
+        self.get_symbol_id_from_name(name).map(|symbol_id| self.get_scope_id(symbol_id))
     }
 
     pub fn get_declaration(&self, symbol_id: SymbolId) -> AstNodeId {

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -21,6 +21,7 @@ fn main() {
     let source_text = std::fs::read_to_string(path).expect("{name} not found");
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
+
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
     if !ret.errors.is_empty() {
@@ -31,10 +32,8 @@ fn main() {
         return;
     }
 
-    let codegen_options = CodegenOptions;
-    let printed = Codegen::<false>::new(source_text.len(), codegen_options).build(&ret.program);
     println!("Original:\n");
-    println!("{printed}\n");
+    println!("{source_text}\n");
 
     let semantic = SemanticBuilder::new(&source_text, source_type)
         .with_trivias(ret.trivias)
@@ -43,7 +42,7 @@ fn main() {
 
     let program = allocator.alloc(ret.program);
     let transform_options = TransformOptions {
-        target: TransformTarget::ES2015,
+        target: TransformTarget::ES5,
         react_jsx: Some(ReactJsxOptions {
             runtime: Some(ReactJsxRuntimeOption::Valid(ReactJsxRuntime::Classic)),
             ..ReactJsxOptions::default()
@@ -52,7 +51,7 @@ fn main() {
     };
     Transformer::new(&allocator, source_type, semantic, transform_options).build(program).unwrap();
 
-    let printed = Codegen::<false>::new(source_text.len(), codegen_options).build(program);
+    let printed = Codegen::<false>::new(source_text.len(), CodegenOptions).build(program);
     println!("Transformed:\n");
     println!("{printed}");
 }

--- a/crates/oxc_transformer/src/es2015/function_name.rs
+++ b/crates/oxc_transformer/src/es2015/function_name.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 // use lazy_static::lazy_static;
-use oxc_ast::{ast::*, AstBuilder, Visit};
+use oxc_ast::{ast::*, AstBuilder};
 use oxc_semantic::ScopeId;
 use oxc_span::{Atom, Span};
 use oxc_syntax::operator::AssignmentOperator;
@@ -30,8 +30,6 @@ impl<'a> FunctionName<'a> {
         ctx: TransformerCtx<'a>,
         options: &TransformOptions,
     ) -> Option<Self> {
-        // Disabled for now
-        // None
         (options.target < TransformTarget::ES2015 || options.function_name).then(|| Self {
             _ast: ast,
             ctx,
@@ -120,9 +118,6 @@ impl<'a> FunctionName<'a> {
         if let Expression::FunctionExpression(func) = expr {
             let mut count = 0;
 
-            // let mut finder = IdentFinder { id, found: 0 };
-            // finder.visit_expression(expr);
-
             // Check for nested params/vars of the same name
             if let Some(scope_id) = scope_id {
                 let scopes = self.ctx.scopes();
@@ -144,19 +139,6 @@ impl<'a> FunctionName<'a> {
             if func.id.is_none() {
                 func.id = Some(id);
             }
-        }
-    }
-}
-
-struct IdentFinder {
-    id: BindingIdentifier,
-    found: usize,
-}
-
-impl<'a> Visit<'a> for IdentFinder {
-    fn visit_binding_identifier(&mut self, ident: &BindingIdentifier) {
-        if ident.name == self.id.name {
-            self.found += 1;
         }
     }
 }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -98,7 +98,7 @@ impl<'a> Transformer<'a> {
             // es2016
             es2016_exponentiation_operator: ExponentiationOperator::new(Rc::clone(&ast), ctx.clone(), &options),
             // es2015
-            es2015_function_name: FunctionName::new(&ast, &ctx.clone(), &options),
+            es2015_function_name: FunctionName::new(Rc::clone(&ast), ctx.clone(), &options),
             es2015_shorthand_properties: ShorthandProperties::new(Rc::clone(&ast), &options),
             es2015_template_literals: TemplateLiterals::new(Rc::clone(&ast), &options),
             // other


### PR DESCRIPTION
@Boshen 

The `ScopeTree.descendants` function would return all scopes starting from the root, and wasn't truly descendants from a specific scope. To improve this, I've renamed this function to `descendants_from_root` and have introduced a new `descendants` function that does support from a specific scope.

Furthermore, I've introduced helper functions to `SymbolTree` to make reading symbols/scopes easier.

To verify this functionality, I enabled the `function_name` transformer (and fixed it), and ran some example transforms. Here's the input:

```js
let fn;

fn = function (a, b, c) {
  const d = "";
};

const func = function (arg) {
  {
    const value = "";
  }
};

const f = function (f) {};
```

And the output using _the old implementation_. Note that all function names are suffixed with a number, this is incorrect, since it was inheriting far too many scopes.

```js
let fn;
fn = function fn1(a, b, c) {
	const d = '';
};
const func = function func1(arg) {
	{
		const value = '';
	}
};
const f = function f2(f) {
};
```

And here's the output with the new implementation. Note that only `f` is suffixed with a number. That's because it has a shadowed argument of the same name.

```js
let fn;
fn = function fn(a, b, c) {
	const d = '';
};
const func = function func(arg) {
	{
		const value = '';
	}
};
const f = function f1(f) {
};
```