### PR TITLE
feat(transformer): duplicate keys

### DIFF
--- a/crates/oxc_transformer/src/es2015/duplicate_keys.rs
+++ b/crates/oxc_transformer/src/es2015/duplicate_keys.rs
@@ -31,6 +31,10 @@ impl<'a> DuplicateKeys<'a> {
                 continue;
             };
 
+            if obj_property.computed {
+                continue;
+            }
+
             if let Some(name) = &obj_property.key.static_name() {
                 let mut is_duplicate = false;
 

--- a/crates/oxc_transformer/src/es2015/duplicate_keys.rs
+++ b/crates/oxc_transformer/src/es2015/duplicate_keys.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashSet, rc::Rc};
 
 use oxc_ast::{ast::*, AstBuilder};
-use oxc_span::{Atom, GetSpan};
+use oxc_span::{Atom, SPAN};
 
 use crate::options::{TransformOptions, TransformTarget};
 
@@ -60,12 +60,9 @@ impl<'a> DuplicateKeys<'a> {
 
                 if is_duplicate {
                     obj_property.computed = true;
-
-                    let str_expr = self.ast.literal_string_expression(StringLiteral {
-                        span: obj_property.key.span(),
-                        value: name.as_str().into(),
-                    });
-                    obj_property.key = PropertyKey::Expression(str_expr);
+                    let string_literal = StringLiteral::new(SPAN, name.as_str().into());
+                    let expr = self.ast.literal_string_expression(string_literal);
+                    obj_property.key = PropertyKey::Expression(expr);
                 }
             }
         }

--- a/crates/oxc_transformer/src/es2015/duplicate_keys.rs
+++ b/crates/oxc_transformer/src/es2015/duplicate_keys.rs
@@ -1,0 +1,26 @@
+use std::rc::Rc;
+
+use oxc_ast::{ast::*, AstBuilder};
+use oxc_span::GetSpan;
+
+use crate::options::{TransformOptions, TransformTarget};
+
+/// ES2015: Duplicate Keys
+///
+/// References:
+/// * <https://babeljs.io/docs/babel-plugin-transform-duplicate-keys>
+/// * <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-duplicate-keys>
+pub struct DuplicateKeys<'a> {
+    ast: Rc<AstBuilder<'a>>,
+}
+
+impl<'a> DuplicateKeys<'a> {
+    pub fn new(ast: Rc<AstBuilder<'a>>, options: &TransformOptions) -> Option<Self> {
+        (options.target < TransformTarget::ES2015 || options.shorthand_properties)
+            .then(|| Self { ast })
+    }
+
+    pub fn transform_object_expression<'b>(&mut self, obj_expr: &mut ObjectExpression) {
+        
+    }
+}

--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -1,9 +1,9 @@
+mod duplicate_keys;
 mod function_name;
 mod shorthand_properties;
 mod template_literals;
-mod duplicate_keys;
 
+pub use duplicate_keys::DuplicateKeys;
 pub use function_name::FunctionName;
 pub use shorthand_properties::ShorthandProperties;
 pub use template_literals::TemplateLiterals;
-pub use duplicate_keys::DuplicateKeys;

--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -1,7 +1,9 @@
 mod function_name;
 mod shorthand_properties;
 mod template_literals;
+mod duplicate_keys;
 
 pub use function_name::FunctionName;
 pub use shorthand_properties::ShorthandProperties;
 pub use template_literals::TemplateLiterals;
+pub use duplicate_keys::DuplicateKeys;

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -65,6 +65,7 @@ pub struct Transformer<'a> {
     es2015_function_name: Option<FunctionName<'a>>,
     es2015_shorthand_properties: Option<ShorthandProperties<'a>>,
     es2015_template_literals: Option<TemplateLiterals<'a>>,
+    es2015_duplicate_keys: Option<DuplicateKeys<'a>>,
     es3_property_literal: Option<PropertyLiteral<'a>>,
 }
 
@@ -101,6 +102,7 @@ impl<'a> Transformer<'a> {
             es2015_function_name: FunctionName::new(Rc::clone(&ast), ctx.clone(), &options),
             es2015_shorthand_properties: ShorthandProperties::new(Rc::clone(&ast), &options),
             es2015_template_literals: TemplateLiterals::new(Rc::clone(&ast), &options),
+            es2015_duplicate_keys: DuplicateKeys::new(Rc::clone(&ast), &options),
             // other
             es3_property_literal: PropertyLiteral::new(Rc::clone(&ast), &options),
             react_jsx: ReactJsx::new(Rc::clone(&ast), ctx.clone(), options)
@@ -189,6 +191,7 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
 
     fn visit_object_expression(&mut self, expr: &mut ObjectExpression<'a>) {
         self.es2015_function_name.as_mut().map(|t| t.transform_object_expression(expr));
+        self.es2015_duplicate_keys.as_mut().map(|t| t.transform_object_expression(expr));
 
         for property in expr.properties.iter_mut() {
             self.visit_object_property_kind(property);

--- a/crates/oxc_transformer/src/options.rs
+++ b/crates/oxc_transformer/src/options.rs
@@ -26,6 +26,7 @@ pub struct TransformOptions {
     pub template_literals: bool,
     pub property_literals: bool,
     pub babel_8_breaking: Option<bool>,
+    pub duplicate_keys: bool
 }
 
 /// See <https://www.typescriptlang.org/tsconfig#target>

--- a/crates/oxc_transformer/src/options.rs
+++ b/crates/oxc_transformer/src/options.rs
@@ -20,13 +20,13 @@ pub struct TransformOptions {
     // es2016
     pub exponentiation_operator: bool,
     // es2015
+    pub duplicate_keys: bool,
     pub function_name: bool,
     pub shorthand_properties: bool,
     pub sticky_regex: bool,
     pub template_literals: bool,
     pub property_literals: bool,
     pub babel_8_breaking: Option<bool>,
-    pub duplicate_keys: bool
 }
 
 /// See <https://www.typescriptlang.org/tsconfig#target>

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,4 +1,4 @@
-Passed: 270/1103
+Passed: 277/1111
 
 # All Passed:
 * babel-plugin-transform-numeric-separator
@@ -771,6 +771,9 @@ Passed: 270/1103
 * default/template-revision/input.js
 * loose/ignoreToPrimitiveHint/input.js
 * loose/mutableTemplateObject/input.js
+
+# babel-plugin-transform-duplicate-keys (7/8)
+* combination/dupes/input.js
 
 # babel-plugin-transform-typescript (66/158)
 * class/abstract-class-decorated/input.ts

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -78,6 +78,7 @@ const CASES: &[&str] = &[
     "babel-plugin-transform-sticky-regex",
     "babel-plugin-transform-unicode-regex",
     "babel-plugin-transform-template-literals",
+    "babel-plugin-transform-duplicate-keys",
     // ES3
     "babel-plugin-transform-property-literals",
     // TypeScript

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -111,6 +111,7 @@ pub trait TestCase {
             sticky_regex: options.get_plugin("transform-sticky-regex").is_some(),
             template_literals: options.get_plugin("transform-template-literals").is_some(),
             property_literals: options.get_plugin("transform-property-literals").is_some(),
+            duplicate_keys: options.get_plugin("transform-duplicate_keys").is_some()
         }
     }
 

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -111,7 +111,7 @@ pub trait TestCase {
             sticky_regex: options.get_plugin("transform-sticky-regex").is_some(),
             template_literals: options.get_plugin("transform-template-literals").is_some(),
             property_literals: options.get_plugin("transform-property-literals").is_some(),
-            duplicate_keys: options.get_plugin("transform-duplicate_keys").is_some()
+            duplicate_keys: options.get_plugin("transform-duplicate-keys").is_some(),
         }
     }
 


### PR DESCRIPTION
Try to implement [duplicate-keys](https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-duplicate-keys) for #974.
Left a failed test case which requires [computed-properties](https://babeljs.io/docs/babel-plugin-transform-computed-properties) to be implemented.