### PR TITLE
perf(linter/react): find class node by symbols in get_parent_es6_component

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -121,7 +121,7 @@ impl Rule for NoStringRefs {
                 if matches!(member_expr.object(), Expression::ThisExpression(_))
                     && member_expr.static_property_name() == Some("refs")
                     && (get_parent_es5_component(node, ctx).is_some()
-                        || get_parent_es6_component(node, ctx).is_some())
+                        || get_parent_es6_component(ctx).is_some())
                 {
                     ctx.diagnostic(NoStringRefsDiagnostic::ThisRefsDeprecated(member_expr.span()));
                 }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -39,6 +39,10 @@ impl SymbolTable {
         self.spans.iter_enumerated().map(|(symbol_id, _)| symbol_id)
     }
 
+    pub fn iter_rev(&self) -> impl Iterator<Item = SymbolId> + '_ {
+        self.spans.iter_enumerated().rev().map(|(symbol_id, _)| symbol_id)
+    }
+
     pub fn get_symbol_id_from_span(&self, span: &Span) -> Option<SymbolId> {
         self.spans
             .iter_enumerated()


### PR DESCRIPTION
This way we can get the class node faster. But I don't know if this is a good way. In `eslint-plugin-react`, they get class node by scope. But oxc cannot do the same way