### PR TITLE
feat(linter): add  jsx-a11y settings

### DIFF
--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -4,12 +4,11 @@ use oxc_diagnostics::Error;
 use oxc_formatter::{Formatter, FormatterOptions};
 use oxc_semantic::{AstNodes, JSDocComment, ScopeTree, Semantic, SymbolTable};
 use oxc_span::SourceType;
-use serde_json::Value;
 
 use crate::{
     disable_directives::{DisableDirectives, DisableDirectivesBuilder},
     fixer::{Fix, Message},
-    AstNode,
+    AstNode, LintSettings,
 };
 
 pub struct LintContext<'a> {
@@ -26,11 +25,11 @@ pub struct LintContext<'a> {
 
     file_path: Box<Path>,
 
-    settings: Option<Value>,
+    settings: LintSettings,
 }
 
 impl<'a> LintContext<'a> {
-    pub fn new(file_path: Box<Path>, semantic: &Rc<Semantic<'a>>, settings: Option<Value>) -> Self {
+    pub fn new(file_path: Box<Path>, semantic: &Rc<Semantic<'a>>, settings: LintSettings) -> Self {
         let disable_directives =
             DisableDirectivesBuilder::new(semantic.source_text(), semantic.trivias()).build();
         Self {
@@ -58,7 +57,7 @@ impl<'a> LintContext<'a> {
         &self.disable_directives
     }
 
-    pub fn settings(&self) -> Option<Value> {
+    pub fn settings(&self) -> LintSettings {
         self.settings.clone()
     }
 

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -4,6 +4,7 @@ use oxc_diagnostics::Error;
 use oxc_formatter::{Formatter, FormatterOptions};
 use oxc_semantic::{AstNodes, JSDocComment, ScopeTree, Semantic, SymbolTable};
 use oxc_span::SourceType;
+use serde_json::Value;
 
 use crate::{
     disable_directives::{DisableDirectives, DisableDirectivesBuilder},
@@ -24,10 +25,12 @@ pub struct LintContext<'a> {
     current_rule_name: &'static str,
 
     file_path: Box<Path>,
+
+    settings: Option<Value>,
 }
 
 impl<'a> LintContext<'a> {
-    pub fn new(file_path: Box<Path>, semantic: &Rc<Semantic<'a>>) -> Self {
+    pub fn new(file_path: Box<Path>, semantic: &Rc<Semantic<'a>>, settings: Option<Value>) -> Self {
         let disable_directives =
             DisableDirectivesBuilder::new(semantic.source_text(), semantic.trivias()).build();
         Self {
@@ -37,6 +40,7 @@ impl<'a> LintContext<'a> {
             fix: false,
             current_rule_name: "",
             file_path,
+            settings,
         }
     }
 
@@ -52,6 +56,10 @@ impl<'a> LintContext<'a> {
 
     pub fn disable_directives(&self) -> &DisableDirectives<'a> {
         &self.disable_directives
+    }
+
+    pub fn settings(&self) -> Option<Value> {
+        self.settings.clone()
     }
 
     pub fn source_text(&self) -> &'a str {

--- a/crates/oxc_linter/src/options.rs
+++ b/crates/oxc_linter/src/options.rs
@@ -9,7 +9,7 @@ use crate::{
         ESLintConfig,
     },
     rules::RULES,
-    RuleCategory, RuleEnum,
+    LintSettings, RuleCategory, RuleEnum,
 };
 use oxc_diagnostics::{Error, Report};
 use rustc_hash::FxHashSet;
@@ -145,12 +145,12 @@ const JSX_A11Y_PLUGIN_NAME: &str = "jsx_a11y";
 impl LintOptions {
     /// # Errors
     /// Returns `Err` if there are any errors parsing the configuration file.
-    pub fn derive_rules(&self) -> Result<Vec<RuleEnum>, Report> {
+    pub fn derive_rules_and_settings(&self) -> Result<(Vec<RuleEnum>, LintSettings), Report> {
         let mut rules: FxHashSet<RuleEnum> = FxHashSet::default();
 
         if let Some(path) = &self.config_path {
-            let rules = ESLintConfig::new(path)?.into_rules();
-            return Ok(rules);
+            let (rules, settings) = ESLintConfig::new(path)?.into_rules().get_config();
+            return Ok((rules, settings));
         }
 
         let all_rules = self.get_filtered_rules();
@@ -195,7 +195,7 @@ impl LintOptions {
         let mut rules = rules.into_iter().collect::<Vec<_>>();
         // for stable diagnostics output ordering
         rules.sort_unstable_by_key(RuleEnum::name);
-        Ok(rules)
+        Ok((rules, LintSettings::default()))
     }
 
     // get final filtered rules by reading `self.jest_plugin` and `self.jsx_a11y_plugin`

--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -16,7 +16,6 @@ use oxc_parser::Parser;
 use oxc_resolver::{ResolveOptions, Resolver};
 use oxc_semantic::{ModuleRecord, SemanticBuilder};
 use oxc_span::{SourceType, VALID_EXTENSIONS};
-use serde_json::Value;
 
 use crate::{Fixer, LintContext, Linter, Message};
 
@@ -63,7 +62,6 @@ impl LintService {
         source_text: &'a str,
         check_syntax_errors: bool,
         tx_error: &DiagnosticSender,
-        settings: &Option<Value>,
     ) -> Vec<Message<'a>> {
         self.runtime
             .paths
@@ -78,7 +76,6 @@ impl LintService {
                     source_type,
                     check_syntax_errors,
                     tx_error,
-                    settings.clone(),
                 )
             })
             .collect::<Vec<_>>()
@@ -156,7 +153,7 @@ impl Runtime {
         };
 
         let mut messages =
-            self.process_source(path, &allocator, &source_text, source_type, true, tx_error, None);
+            self.process_source(path, &allocator, &source_text, source_type, true, tx_error);
 
         if self.linter.options().fix {
             let fix_result = Fixer::new(&source_text, messages).fix();
@@ -181,7 +178,6 @@ impl Runtime {
         source_type: SourceType,
         check_syntax_errors: bool,
         tx_error: &DiagnosticSender,
-        settings: Option<Value>,
     ) -> Vec<Message<'a>> {
         let ret = Parser::new(allocator, source_text, source_type)
             .allow_return_outside_function(true)
@@ -241,7 +237,7 @@ impl Runtime {
         let lint_ctx = LintContext::new(
             path.to_path_buf().into_boxed_path(),
             &Rc::new(semantic_ret.semantic),
-            settings,
+            self.linter.get_settings(),
         );
         self.linter.run(lint_ctx)
     }

--- a/crates/oxc_linter/src/snapshots/no_autofocus.snap
+++ b/crates/oxc_linter/src/snapshots/no_autofocus.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 119
+assertion_line: 130
 expression: no_autofocus
 ---
   ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
@@ -56,6 +56,13 @@ expression: no_autofocus
    ╭─[no_autofocus.tsx:1:1]
  1 │ <Foo autoFocus />
    ·      ─────────
+   ╰────
+  help: Remove `autofocus` attribute
+
+  ⚠ eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users
+   ╭─[no_autofocus.tsx:1:1]
+ 1 │ <Button autoFocus />
+   ·         ─────────
    ╰────
   help: Remove `autofocus` attribute
 

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -7,9 +7,8 @@ use oxc_ast::{
     AstKind,
 };
 use oxc_semantic::{AstNode, SymbolFlags};
-use serde_json::Value;
 
-use crate::LintContext;
+use crate::{JsxA11y, LintContext, LintSettings};
 
 pub fn is_create_element_call(call_expr: &CallExpression) -> bool {
     if let Some(member_expr) = call_expr.callee.get_member_expr() {
@@ -171,15 +170,10 @@ pub fn get_element_type(context: &LintContext, element: &JSXOpeningElement) -> O
 
     let mut element_type = String::from(ident.name.as_str());
 
-    if let Some(Value::Object(obj)) = context.settings() {
-        if let Some(Value::Object(jsx_a11y)) = obj.get("jsx-a11y") {
-            if let Some(Value::Object(components)) = jsx_a11y.get("components") {
-                if let Some(val) = components.get(&element_type) {
-                    let b = val.as_str().unwrap();
-                    element_type = String::from(b);
-                }
-            }
-        };
+    let LintSettings { jsx_a11y } = context.settings();
+    let JsxA11y { polymorphic_prop_name: _, components } = jsx_a11y;
+    if let Some(val) = components.get(&element_type) {
+        element_type = String::from(val);
     }
 
     Some(element_type)

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -7,6 +7,7 @@ use oxc_ast::{
     AstKind,
 };
 use oxc_semantic::{AstNode, SymbolFlags};
+use serde_json::Value;
 
 use crate::LintContext;
 
@@ -162,4 +163,24 @@ pub fn get_parent_es6_component<'a, 'b>(ctx: &'b LintContext<'a>) -> Option<&'b 
         }
         None
     })
+}
+pub fn get_element_type(context: &LintContext, element: &JSXOpeningElement) -> Option<String> {
+    let JSXElementName::Identifier(ident) = &element.name else {
+        return None;
+    };
+
+    let mut element_type = String::from(ident.name.as_str());
+
+    if let Some(Value::Object(obj)) = context.settings() {
+        if let Some(Value::Object(jsx_a11y)) = obj.get("jsx-a11y") {
+            if let Some(Value::Object(components)) = jsx_a11y.get("components") {
+                if let Some(val) = components.get(&element_type) {
+                    let b = val.as_str().unwrap();
+                    element_type = String::from(b);
+                }
+            }
+        };
+    }
+
+    Some(element_type)
 }

--- a/crates/oxc_linter_plugin/src/test.rs
+++ b/crates/oxc_linter_plugin/src/test.rs
@@ -49,7 +49,7 @@ fn run_individual_test(
     let semantic = Rc::new(semantic);
 
     let mut lint_ctx =
-        LintContext::new(PathBuf::from(file_path).into_boxed_path(), &Rc::clone(&semantic));
+        LintContext::new(PathBuf::from(file_path).into_boxed_path(), &Rc::clone(&semantic), None);
 
     let result = plugin.lint_file_with_rule(
         &mut lint_ctx,

--- a/crates/oxc_linter_plugin/src/test.rs
+++ b/crates/oxc_linter_plugin/src/test.rs
@@ -48,8 +48,11 @@ fn run_individual_test(
 
     let semantic = Rc::new(semantic);
 
-    let mut lint_ctx =
-        LintContext::new(PathBuf::from(file_path).into_boxed_path(), &Rc::clone(&semantic), LintSettings::default());
+    let mut lint_ctx = LintContext::new(
+        PathBuf::from(file_path).into_boxed_path(),
+        &Rc::clone(&semantic),
+        LintSettings::default(),
+    );
 
     let result = plugin.lint_file_with_rule(
         &mut lint_ctx,

--- a/crates/oxc_linter_plugin/src/test.rs
+++ b/crates/oxc_linter_plugin/src/test.rs
@@ -23,7 +23,7 @@ fn run_individual_test(
 ) -> std::result::Result<Vec<Report>, Vec<Report>> {
     use std::rc::Rc;
 
-    use oxc_linter::LintContext;
+    use oxc_linter::{LintContext, LintSettings};
 
     let file_path = &test.relative_path.last().expect("there to be atleast 1 path part");
     let source_text = &test.code;
@@ -49,7 +49,7 @@ fn run_individual_test(
     let semantic = Rc::new(semantic);
 
     let mut lint_ctx =
-        LintContext::new(PathBuf::from(file_path).into_boxed_path(), &Rc::clone(&semantic), None);
+        LintContext::new(PathBuf::from(file_path).into_boxed_path(), &Rc::clone(&semantic), LintSettings::default());
 
     let result = plugin.lint_file_with_rule(
         &mut lint_ctx,

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -205,7 +205,7 @@ impl Oxc {
             self.save_diagnostics(semantic_ret.errors);
 
             let semantic = Rc::new(semantic_ret.semantic);
-            let lint_ctx = LintContext::new(path.into_boxed_path(), &semantic);
+            let lint_ctx = LintContext::new(path.into_boxed_path(), &semantic, None);
             let linter_ret = Linter::new().run(lint_ctx);
             let diagnostics = linter_ret.into_iter().map(|e| e.error).collect();
             self.save_diagnostics(diagnostics);

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -13,7 +13,7 @@ use oxc::{
     span::SourceType,
     transformer::{TransformOptions, TransformTarget, Transformer},
 };
-use oxc_linter::{LintContext, Linter};
+use oxc_linter::{LintContext, Linter, LintSettings};
 use oxc_prettier::{Prettier, PrettierOptions};
 use oxc_query::{schema, Adapter, SCHEMA_TEXT};
 use oxc_type_synthesis::{synthesize_program, Diagnostic as TypeCheckDiagnostic};
@@ -205,7 +205,7 @@ impl Oxc {
             self.save_diagnostics(semantic_ret.errors);
 
             let semantic = Rc::new(semantic_ret.semantic);
-            let lint_ctx = LintContext::new(path.into_boxed_path(), &semantic, None);
+            let lint_ctx = LintContext::new(path.into_boxed_path(), &semantic, LintSettings::default());
             let linter_ret = Linter::new().run(lint_ctx);
             let diagnostics = linter_ret.into_iter().map(|e| e.error).collect();
             self.save_diagnostics(diagnostics);

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -13,7 +13,7 @@ use oxc::{
     span::SourceType,
     transformer::{TransformOptions, TransformTarget, Transformer},
 };
-use oxc_linter::{LintContext, Linter, LintSettings};
+use oxc_linter::{LintContext, LintSettings, Linter};
 use oxc_prettier::{Prettier, PrettierOptions};
 use oxc_query::{schema, Adapter, SCHEMA_TEXT};
 use oxc_type_synthesis::{synthesize_program, Diagnostic as TypeCheckDiagnostic};
@@ -205,7 +205,8 @@ impl Oxc {
             self.save_diagnostics(semantic_ret.errors);
 
             let semantic = Rc::new(semantic_ret.semantic);
-            let lint_ctx = LintContext::new(path.into_boxed_path(), &semantic, LintSettings::default());
+            let lint_ctx =
+                LintContext::new(path.into_boxed_path(), &semantic, LintSettings::default());
             let linter_ret = Linter::new().run(lint_ctx);
             let diagnostics = linter_ret.into_iter().map(|e| e.error).collect();
             self.save_diagnostics(diagnostics);

--- a/editors/vscode/server/src/linter.rs
+++ b/editors/vscode/server/src/linter.rs
@@ -270,8 +270,11 @@ impl IsolatedLintHandler {
             return Some(Self::wrap_diagnostics(path, &source_text, reports));
         };
 
-        let mut lint_ctx =
-            LintContext::new(path.to_path_buf().into_boxed_path(), &Rc::new(semantic_ret.semantic));
+        let mut lint_ctx = LintContext::new(
+            path.to_path_buf().into_boxed_path(),
+            &Rc::new(semantic_ret.semantic),
+            None,
+        );
         {
             if let Ok(guard) = plugin.read() {
                 if let Some(plugin) = &*guard {

--- a/editors/vscode/server/src/linter.rs
+++ b/editors/vscode/server/src/linter.rs
@@ -13,7 +13,7 @@ use crate::walk::Walk;
 use miette::NamedSource;
 use oxc_allocator::Allocator;
 use oxc_diagnostics::{miette, Error, Severity};
-use oxc_linter::{LintContext, Linter, LintSettings};
+use oxc_linter::{LintContext, LintSettings, Linter};
 use oxc_linter_plugin::{make_relative_path_parts, LinterPlugin};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;

--- a/editors/vscode/server/src/linter.rs
+++ b/editors/vscode/server/src/linter.rs
@@ -13,7 +13,7 @@ use crate::walk::Walk;
 use miette::NamedSource;
 use oxc_allocator::Allocator;
 use oxc_diagnostics::{miette, Error, Severity};
-use oxc_linter::{LintContext, Linter};
+use oxc_linter::{LintContext, Linter, LintSettings};
 use oxc_linter_plugin::{make_relative_path_parts, LinterPlugin};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -273,7 +273,7 @@ impl IsolatedLintHandler {
         let mut lint_ctx = LintContext::new(
             path.to_path_buf().into_boxed_path(),
             &Rc::new(semantic_ret.semantic),
-            None,
+            LintSettings::default(),
         );
         {
             if let Ok(guard) = plugin.read() {

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -38,7 +38,11 @@ fn bench_linter(criterion: &mut Criterion) {
                 let linter = Linter::from_options(lint_options);
                 let semantic = Rc::new(semantic_ret.semantic);
                 b.iter(|| {
-                    linter.run(LintContext::new(PathBuf::from("").into_boxed_path(), &semantic))
+                    linter.run(LintContext::new(
+                        PathBuf::from("").into_boxed_path(),
+                        &semantic,
+                        None,
+                    ))
                 });
             },
         );

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -10,7 +10,7 @@ use std::{path::PathBuf, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, LintContext, LintOptions, Linter};
+use oxc_linter::{AllowWarnDeny, LintContext, LintOptions, Linter, LintSettings};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -41,7 +41,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     linter.run(LintContext::new(
                         PathBuf::from("").into_boxed_path(),
                         &semantic,
-                        None,
+                        LintSettings::default(),
                     ))
                 });
             },

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -10,7 +10,7 @@ use std::{path::PathBuf, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, LintContext, LintOptions, Linter, LintSettings};
+use oxc_linter::{AllowWarnDeny, LintContext, LintOptions, LintSettings, Linter};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;


### PR DESCRIPTION
When we developed linter  for #1141 , we needed to configure some settings for `jsx-a11y`, which was not supported before, but I am trying to support it now.
like this:
```
fn config() -> serde_json::Value {
    serde_json::json!([2,{
        "ignoreNonDOM": true
    }])
}

fn settings() -> serde_json::Value {
    serde_json::json!({
        "jsx-a11y": {
            "components": {
                "Button": "button",
            }
        }
    })
}

let pass = vec![
    ("<Button />", Some(config()), Some(settings())),
];
```