### PR TITLE
feat(vscode): use icon to represent enabled status

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -172,7 +172,9 @@ export async function activate(context: ExtensionContext) {
         ? "statusBarItem.activeBackground"
         : "statusBarItem.errorBackground",
     );
-    myStatusBarItem.text = `oxc: ${enable ? "on" : "off"}`;
+    myStatusBarItem.text = `oxc: ${enable ? "$(check-all)" : "$(circle-slash)"}`;
+
+
     myStatusBarItem.backgroundColor = bgColor;
   }
   updateStatsBar(clientConfig.enable);


### PR DESCRIPTION

use Icon represents the status of enabled.
- disabled: 
![image](https://github.com/oxc-project/oxc/assets/17974631/5aa80c13-6fc3-4340-b423-986a216cabf6)
- enabled: 
![image](https://github.com/oxc-project/oxc/assets/17974631/31cacfe6-1dab-4715-a20c-d3e8d85acf5f)
