### PR TITLE
feat(parser/napi): add flexbuffer to AST transfer (2x speedup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +731,19 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flexbuffers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d14128f06405808ce75bfebe11e9b0f9da18719ede6d7bdb1702d6bfe0f7e8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "num_enum",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1389,6 +1408,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1778,7 @@ dependencies = [
 name = "oxc_napi_parser"
 version = "0.0.0"
 dependencies = [
+ "flexbuffers",
  "miette",
  "napi",
  "napi-build",
@@ -1746,6 +1787,7 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_span",
+ "serde",
  "serde_json",
  "tokio",
 ]
@@ -2171,6 +2213,16 @@ dependencies = [
  "ctor 0.1.26",
  "difference",
  "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2835,6 +2887,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,6 +3457,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -26,7 +26,9 @@ oxc_parser    = { workspace = true }
 oxc_ast       = { workspace = true, features = ["serde"] }
 oxc_span      = { workspace = true }
 
+serde = { workspace = true }
 serde_json = { workspace = true }
+flexbuffers = { version = "2.0.0" }
 miette     = { workspace = true, features = ["fancy-no-backtrace"] }
 
 tokio       = { workspace = true }

--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -34,6 +34,11 @@ export function parseWithoutReturn(sourceText: string, options?: ParserOptions |
  */
 export function parseSync(sourceText: string, options?: ParserOptions | undefined | null): ParseResult
 /**
+ * Returns a binary AST in flexbuffers format.
+ * This is a POC API. Error handling is not done yet.
+ */
+export function parseSyncBuffer(sourceText: string, options?: ParserOptions | undefined | null): Buffer
+/**
  * # Panics
  *
  * * Tokio crashes

--- a/napi/parser/index.js
+++ b/napi/parser/index.js
@@ -252,8 +252,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { parseWithoutReturn, parseSync, parseAsync } = nativeBinding
+const { parseWithoutReturn, parseSync, parseSyncBuffer, parseAsync } = nativeBinding
 
 module.exports.parseWithoutReturn = parseWithoutReturn
 module.exports.parseSync = parseSync
+module.exports.parseSyncBuffer = parseSyncBuffer
 module.exports.parseAsync = parseAsync

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -6,7 +6,8 @@
     "test": "node test.mjs"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^2.15.2"
+    "@napi-rs/cli": "^2.15.2",
+    "flatbuffers": "^23.5.26"
   },
   "engines": {
     "node": ">=14.*"

--- a/napi/parser/pnpm-lock.yaml
+++ b/napi/parser/pnpm-lock.yaml
@@ -4,6 +4,9 @@ devDependencies:
   '@napi-rs/cli':
     specifier: ^2.15.2
     version: 2.15.2
+  flatbuffers:
+    specifier: ^23.5.26
+    version: 23.5.26
 
 packages:
 
@@ -11,4 +14,8 @@ packages:
     resolution: {integrity: sha512-80tBCtCnEhAmFtB9oPM0FL74uW7fAmtpeqjvERH7Q1z/aZzCAs/iNfE7U3ehpwg9Q07Ob2Eh/+1guyCdX/p24w==}
     engines: {node: '>= 10'}
     hasBin: true
+    dev: true
+
+  /flatbuffers@23.5.26:
+    resolution: {integrity: sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==}
     dev: true

--- a/napi/parser/test_buffer.js
+++ b/napi/parser/test_buffer.js
@@ -1,0 +1,32 @@
+const oxc = require('./index');
+const assert = require('assert');
+const flexbuffers = require('flatbuffers/js/flexbuffers');
+const file = require('fs').readFileSync(__dirname + '/index.js', 'utf8');
+
+function testBuffer() {
+  const buffer = oxc.parseSyncBuffer(file);
+  const ref = flexbuffers.toReference(buffer.buffer);
+  assert(ref.isMap());
+  assert.equal(ref.get('type').stringValue(), 'Program');
+  const body = ref.get('body');
+  assert(body.isVector());
+}
+
+function testJSON() {
+  const ret = oxc.parseSync(file);
+  const program = JSON.parse(ret.program);
+  assert(typeof program === 'object');
+  assert.equal(program.type, 'Program');
+  assert(Array.isArray(program.body));
+}
+
+function benchmark(func, time) {
+  console.time(func.name);
+  for (let i = 0; i < time; i++) {
+    func();
+  }
+  console.timeEnd(func.name)
+}
+
+benchmark(testJSON, 10000);
+benchmark(testBuffer, 10000);


### PR DESCRIPTION
Hi! I have created a proof of concept of improving using oxc in JavaScript. The method is not polished but it provides valuable insights for future direction!

Feel free to close~ It is for reference only :)

# Context 

This is a proof of concept implementation of passing binary AST to JavaScript. JavaScript can selectively read flexbuffers-based AST nodes on demand to avoid the deserialization toll.  More context [here](https://dev.to/herrington_darkholme/benchmark-typescript-parsers-demystify-rust-tooling-performance-2go8).

# Changes

* Add a `parseSyncBuffer` napi method to return a binary AST from Rust to JavaScript. The AST is in flexbuffer format.
* Add a `test_buffer.js` to test usage of flexbuffers in JavaScript. It is in cjs format because flexbuffers does not support ESM :/ 

# Result
Some preliminary results, for reference only.

```
~ node test_buffer.js
testJSON: 4.043s
testBuffer: 2.395s
```

Buffer based API is 100% faster than JSON.

# Future Ideas
* Flexbuffers itself is slow. A better binary protocol is desired!
* Using binary reader to traverse AST is undesirable. A proxy-based API to emulate object behavior will be nice. 