### PR TITLE
fix(linter): Don't check for multiple bits at once.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -90,7 +90,7 @@ enum ErrorKind {
 }
 
 fn check_regex(regexp_lit: &RegExpLiteral) -> Option<ErrorKind> {
-    if regexp_lit.regex.flags.contains(RegExpFlags::I | RegExpFlags::M) {
+    if regexp_lit.regex.flags.contains(RegExpFlags::I) || regexp_lit.regex.flags.contains(RegExpFlags::M) {
         return None;
     }
 
@@ -131,6 +131,7 @@ fn test() {
         r"foo()()",
         r"if (foo.match(/^foo/)) {}",
         r"if (/^foo/.exec(foo)) {}",
+        r"/^http/i.test(uri)",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -90,7 +90,9 @@ enum ErrorKind {
 }
 
 fn check_regex(regexp_lit: &RegExpLiteral) -> Option<ErrorKind> {
-    if regexp_lit.regex.flags.contains(RegExpFlags::I) || regexp_lit.regex.flags.contains(RegExpFlags::M) {
+    if regexp_lit.regex.flags.contains(RegExpFlags::I)
+        || regexp_lit.regex.flags.contains(RegExpFlags::M)
+    {
         return None;
     }
 


### PR DESCRIPTION
Fixes: #1687

The check

```rs
    if regexp_lit.regex.flags.contains(RegExpFlags::I | RegExpFlags::M) {
        return None;
    }
```

checks for _both_ `I` and `M` being set. To catch them individually we need:

```rs
    if regexp_lit.regex.flags.contains(RegExpFlags::I) || regexp_lit.regex.flags.contains(RegExpFlags::M) {
        return None;
    }
```