### PR TITLE
fix(cli) skip run lint when `--rules` is passed

### DIFF
--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -14,13 +14,7 @@ pub struct LintRunner {
 
 impl LintRunner {
     fn check_options(&self) -> CliRunResult {
-        let CliLintOptions { filter, misc_options, enable_plugins, config, .. } = &self.options;
-
-        if misc_options.rules {
-            let mut stdout = BufWriter::new(std::io::stdout());
-            Linter::print_rules(&mut stdout);
-            return CliRunResult::None;
-        }
+        let CliLintOptions { filter, enable_plugins, config, .. } = &self.options;
 
         // disallow passing config path and filter at the same time
         if config.is_some() && !filter.is_empty() {
@@ -53,6 +47,12 @@ impl Runner for LintRunner {
     }
 
     fn run(self) -> CliRunResult {
+        if self.options.misc_options.rules {
+            let mut stdout = BufWriter::new(std::io::stdout());
+            Linter::print_rules(&mut stdout);
+            return CliRunResult::None;
+        }
+
         let result = self.check_options();
 
         if !matches!(result, CliRunResult::None) {


### PR DESCRIPTION
not sure if there is a cleaner way to do this.

maybe change `check_options` to return an Option - none if no CliResult, Some if there is a cli result (something was incorrect or the cmd was handled)
