### PR TITLE
perf(linter): precompute `rule.name()`

### DIFF
--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -73,6 +73,7 @@ impl<'a> LintContext<'a> {
         &self.file_path
     }
 
+    #[inline]
     pub fn with_rule_name(&mut self, name: &'static str) {
         self.current_rule_name = name;
     }


### PR DESCRIPTION
enum static dispatch has become slow because there are 200 enum variants