### PR TITLE
refactor(semantic): shrink the AstNode size from 32 to 24 bytes

### DIFF
--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, path::Path, rc::Rc};
 use oxc_diagnostics::Error;
 use oxc_formatter::{Formatter, FormatterOptions};
 use oxc_semantic::{AstNodes, JSDocComment, ScopeTree, Semantic, SymbolTable};
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 
 use crate::{
     disable_directives::{DisableDirectives, DisableDirectivesBuilder},
@@ -125,6 +125,10 @@ impl<'a> LintContext<'a> {
 
     /* JSDoc */
     pub fn jsdoc(&self, node: &AstNode<'a>) -> Option<JSDocComment<'a>> {
-        self.semantic().jsdoc().get_by_node(node)
+        let node_flags = self.nodes().node_flags(node.id());
+        if !node_flags.has_jsdoc() {
+            return None;
+        }
+        self.semantic().jsdoc().get_by_span(node.kind().span())
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -98,7 +98,7 @@ fn resolve_global_binding<'a, 'b: 'a>(
             },
             |binding_id| {
                 let decl = nodes.get_node(symbols.get_declaration(binding_id));
-                let decl_scope = decl.scope_id();
+                let decl_scope = ctx.nodes().scope_id(decl.id());
                 match decl.kind() {
                     AstKind::VariableDeclarator(parent_decl) => {
                         if !parent_decl.id.kind.is_binding_identifier() {
@@ -135,9 +135,8 @@ impl Rule for NoObjCalls {
         match callee {
             Expression::Identifier(ident) => {
                 // handle new Math(), Math(), etc
-                if let Some(top_level_reference) =
-                    resolve_global_binding(ident, node.scope_id(), ctx)
-                {
+                let scope_id = ctx.nodes().scope_id(node.id());
+                if let Some(top_level_reference) = resolve_global_binding(ident, scope_id, ctx) {
                     if is_global_obj(&top_level_reference) {
                         ctx.diagnostic(NoObjCallsDiagnostic(ident.name.clone(), span));
                     }

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -42,8 +42,12 @@ declare_oxc_lint!(
 impl Rule for NoSetterReturn {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ReturnStatement(stmt) = node.kind() else { return };
-        if stmt.argument.is_some() && ctx.scopes().get_flags(node.scope_id()).is_set_accessor() {
-            ctx.diagnostic(NoSetterReturnDiagnostic(stmt.span));
+
+        if stmt.argument.is_some() {
+            let scope_id = ctx.nodes().scope_id(node.id());
+            if ctx.scopes().get_flags(scope_id).is_set_accessor() {
+                ctx.diagnostic(NoSetterReturnDiagnostic(stmt.span));
+            }
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -39,7 +39,8 @@ impl Rule for RequireYield {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let kind = node.kind();
 
-        if node.flags().has_yield() {
+        let node_flags = ctx.nodes().node_flags(node.id());
+        if node_flags.has_yield() {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -39,7 +39,8 @@ declare_oxc_lint!(
 impl Rule for NoAmd {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // not in top level
-        if node.scope_id() != ctx.scopes().root_scope_id() {
+        let scope_id = ctx.nodes().scope_id(node.id());
+        if scope_id != ctx.scopes().root_scope_id() {
             return;
         }
         if let AstKind::CallExpression(call_expr) = node.kind() {

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -109,7 +109,7 @@ impl MaxExpects {
         };
 
         if ident.name == "expect" {
-            let position = node.scope_id().index();
+            let position = ctx.nodes().scope_id(node.id()).index();
 
             if let Some(count) = count_map.get(&position) {
                 if count > &self.max {

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -189,7 +189,8 @@ fn handle_jest_set_time_out<'a>(
         };
 
         if expr.property.name == "setTimeout" {
-            if !scopes.get_flags(parent_node.scope_id()).is_top() {
+            let scope_id = ctx.nodes().scope_id(parent_node.id());
+            if !scopes.get_flags(scope_id).is_top() {
                 ctx.diagnostic(NoGlobalSetTimeoutDiagnostic(member_expr.span()));
             }
 

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -58,10 +58,9 @@ impl Rule for NoRenderReturnValue {
                             ));
                         }
 
-                        let is_arrow_function = ctx
-                            .scopes()
-                            .get_flags(parent_node.scope_id())
-                            .contains(ScopeFlags::Arrow);
+                        let scope_id = ctx.nodes().scope_id(parent_node.id());
+                        let is_arrow_function =
+                            ctx.scopes().get_flags(scope_id).contains(ScopeFlags::Arrow);
 
                         if is_arrow_function {
                             for node_id in ctx.nodes().ancestors(parent_node.id()).skip(1) {

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -52,8 +52,9 @@ impl Rule for ReactInJsxScope {
             return;
         }
 
+        let scope_id = ctx.nodes().scope_id(node.id());
         if !scope
-            .ancestors(node.scope_id())
+            .ancestors(scope_id)
             .any(|v| scope.get_bindings(v).iter().any(|(k, _)| k == react_name))
         {
             ctx.diagnostic(ReactInJsxScopeDiagnostic(node_span));

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
@@ -63,7 +63,9 @@ impl Rule for ConsistentTypeExports {
             if export_named_declaration.export_kind == ImportOrExportKind::Type {
                 return;
             }
-            check_export_named_declaration(node.scope_id(), export_named_declaration, ctx);
+
+            let scope_id = ctx.nodes().scope_id(node.id());
+            check_export_named_declaration(scope_id, export_named_declaration, ctx);
         }
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -45,7 +45,8 @@ impl Rule for NoUnsafeDeclarationMerging {
         match node.kind() {
             AstKind::Class(decl) => {
                 if let Some(ident) = decl.id.as_ref() {
-                    for (_, symbol_id) in ctx.semantic().scopes().get_bindings(node.scope_id()) {
+                    let scope_id = ctx.nodes().scope_id(node.id());
+                    for (_, symbol_id) in ctx.semantic().scopes().get_bindings(scope_id) {
                         if let AstKind::TSInterfaceDeclaration(scope_interface) =
                             get_symbol_kind(*symbol_id, ctx)
                         {
@@ -55,7 +56,8 @@ impl Rule for NoUnsafeDeclarationMerging {
                 }
             }
             AstKind::TSInterfaceDeclaration(decl) => {
-                for (_, symbol_id) in ctx.semantic().scopes().get_bindings(node.scope_id()) {
+                let scope_id = ctx.nodes().scope_id(node.id());
+                for (_, symbol_id) in ctx.semantic().scopes().get_bindings(scope_id) {
                     if let AstKind::Class(scope_class) = get_symbol_kind(*symbol_id, ctx) {
                         if let Some(scope_class_ident) = scope_class.id.as_ref() {
                             check_and_diagnostic(&decl.id, scope_class_ident, ctx);
@@ -126,7 +128,7 @@ fn test() {
          			interface Foo {
          			  props: string;
          			}
-        
+
          			function bar() {
          			  return class Foo {};
          			}
@@ -138,7 +140,7 @@ fn test() {
          			interface Foo {
          			  props: string;
          			}
-        
+
          			(function bar() {
          			  class Foo {}
          			})();
@@ -150,7 +152,7 @@ fn test() {
          			declare global {
          			  interface Foo {}
          			}
-        
+
          			class Foo {}
          			    ",
             None,

--- a/crates/oxc_query/src/vertex.rs
+++ b/crates/oxc_query/src/vertex.rs
@@ -302,9 +302,8 @@ impl<'a> Vertex<'a> {
             hash_of_node == wanted_node_hash
         });
 
-        adapter.semantic.scopes().get_flags(
-            found.expect("an arrowexpression or function should always be in the ast if we can have the struct of it").scope_id(),
-        )
+        let node = found.expect("an arrowexpression or function should always be in the ast if we can have the struct of it");
+        adapter.semantic.scopes().get_flags(adapter.semantic.nodes().scope_id(node.id()))
     }
 
     pub fn function_parameter(&self) -> VertexIterator<'a, Vertex<'a>> {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -202,10 +202,11 @@ impl<'a> SemanticBuilder<'a> {
         if self.jsdoc.retrieve_jsdoc_comment(kind) {
             flags |= NodeFlags::JSDoc;
         }
-        let ast_node = AstNode::new(kind, self.current_scope_id, flags);
+        let ast_node = AstNode::new(kind);
         let parent_node_id =
             if matches!(kind, AstKind::Program(_)) { None } else { Some(self.current_node_id) };
-        self.current_node_id = self.nodes.add_node(ast_node, parent_node_id);
+        self.current_node_id =
+            self.nodes.add_node(ast_node, parent_node_id, self.current_scope_id, flags);
     }
 
     fn pop_ast_node(&mut self) {
@@ -221,7 +222,7 @@ impl<'a> SemanticBuilder<'a> {
 
     pub fn set_function_node_flag(&mut self, flag: NodeFlags) {
         if let Some(current_function) = self.function_stack.last() {
-            *self.nodes.get_node_mut(*current_function).flags_mut() |= flag;
+            *self.nodes.get_node_flags_mut(*current_function) |= flag;
         }
     }
 

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -177,7 +177,8 @@ fn check_identifier<'a>(name: &Atom, span: Span, node: &AstNode<'a>, ctx: &Seman
             return ctx.error(ReservedKeyword(name.clone(), span));
         }
         // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
-        if ctx.scope.get_flags(node.scope_id()).is_class_static_block() {
+        let scope_id = ctx.nodes.scope_id(node.id());
+        if ctx.scope.get_flags(scope_id).is_class_static_block() {
             return ctx.error(ClassStatickBlockAwait(span));
         }
     }
@@ -413,7 +414,8 @@ fn check_directive<'a>(directive: &Directive, node: &AstNode<'a>, ctx: &Semantic
         return;
     }
 
-    if !ctx.scope.get_flags(node.scope_id()).is_function() {
+    let scope_id = ctx.nodes.scope_id(node.id());
+    if !ctx.scope.get_flags(scope_id).is_function() {
         return;
     }
 
@@ -518,7 +520,8 @@ fn check_meta_property<'a>(prop: &MetaProperty, node: &AstNode<'a>, ctx: &Semant
         "new" => {
             if prop.property.name == "target" {
                 let mut in_function_scope = false;
-                for scope_id in ctx.scope.ancestors(node.scope_id()) {
+                let node_scope_id = ctx.nodes.scope_id(node.id());
+                for scope_id in ctx.scope.ancestors(node_scope_id) {
                     let flags = ctx.scope.get_flags(scope_id);
                     // In arrow functions, new.target is inherited from the surrounding scope.
                     if flags.contains(ScopeFlags::Arrow) {
@@ -1144,7 +1147,8 @@ fn check_await_expression<'a>(
         ctx.error(AwaitOrYieldInParameter("await", expr.span));
     }
     // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
-    if ctx.scope.get_flags(node.scope_id()).is_class_static_block() {
+    let scope_id = ctx.nodes.scope_id(node.id());
+    if ctx.scope.get_flags(scope_id).is_class_static_block() {
         let start = expr.span.start;
         ctx.error(ClassStatickBlockAwait(Span::new(start, start + 5)));
     }

--- a/crates/oxc_semantic/src/jsdoc/mod.rs
+++ b/crates/oxc_semantic/src/jsdoc/mod.rs
@@ -3,11 +3,10 @@ mod builder;
 use std::{cell::OnceCell, collections::BTreeMap};
 
 pub use builder::JSDocBuilder;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 
 use self::parser::JSDocParser;
 pub use self::parser::JSDocTag;
-use crate::AstNode;
 
 mod parser;
 
@@ -27,14 +26,6 @@ pub struct JSDocComment<'a> {
 impl<'a> JSDoc<'a> {
     pub fn new(docs: BTreeMap<Span, JSDocComment<'a>>) -> Self {
         Self { docs }
-    }
-
-    pub fn get_by_node<'b>(&'b self, node: &AstNode<'a>) -> Option<JSDocComment<'a>> {
-        if !node.flags().has_jsdoc() {
-            return None;
-        }
-        let span = node.kind().span();
-        self.get_by_span(span)
     }
 
     pub fn get_by_span<'b>(&'b self, span: Span) -> Option<JSDocComment<'a>> {


### PR DESCRIPTION
https://github.com/oxc-project/oxc/blob/e741b8fec42582c8501bb733d21e403f595fb870/crates/oxc_linter/src/lib.rs#L145-L150

This is running inside a tight loop, shrink the ast node size should theoretically improve performance?