### PR TITLE
feat(linter): eslint-plugin-jsx-a11y no-distracting-elements rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -237,9 +237,9 @@ mod jsx_a11y {
     pub mod img_redundant_alt;
     pub mod no_access_key;
     pub mod no_autofocus;
+    pub mod no_distracting_elements;
     pub mod scope;
     pub mod tab_index_no_positive;
-    pub mod no_distracting_elements;
 }
 
 mod oxc {

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -239,6 +239,7 @@ mod jsx_a11y {
     pub mod no_autofocus;
     pub mod scope;
     pub mod tab_index_no_positive;
+    pub mod no_distracting_elements;
 }
 
 mod oxc {
@@ -459,6 +460,7 @@ oxc_macros::declare_all_lint_rules! {
     jsx_a11y::no_autofocus,
     jsx_a11y::scope,
     jsx_a11y::tab_index_no_positive,
+    jsx_a11y::no_distracting_elements,
     oxc::const_comparisons,
     oxc::double_comparisons,
     oxc::no_accumulating_spread,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstKind, ast::JSXElementName};
+use oxc_ast::{ast::JSXElementName, AstKind};
 use oxc_diagnostics::thiserror::Error;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
@@ -25,8 +25,8 @@ declare_oxc_lint!(
     ///
     /// ### Why is this necessary?
     ///
-    /// Elements that can be visually distracting can cause accessibility issues with visually impaired users. 
-    /// Such elements are most likely deprecated, and should be avoided. By default, <marquee> and <blink> elements are visually distracting. 
+    /// Elements that can be visually distracting can cause accessibility issues with visually impaired users.
+    /// Such elements are most likely deprecated, and should be avoided. By default, <marquee> and <blink> elements are visually distracting.
     ///
     /// ### What it checks
     ///
@@ -85,5 +85,7 @@ fn test() {
         (r"<blink foo={undefined} />", None),
     ];
 
-    Tester::new(NoDistractingElements::NAME, pass, fail).with_jsx_a11y_plugin(true).test_and_snapshot();
+    Tester::new(NoDistractingElements::NAME, pass, fail)
+        .with_jsx_a11y_plugin(true)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -1,0 +1,89 @@
+use oxc_ast::{AstKind, ast::JSXElementName};
+use oxc_diagnostics::thiserror::Error;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::AstNode;
+use oxc_span::Span;
+
+use oxc_diagnostics::miette::{self, Diagnostic};
+
+use crate::{rule::Rule, LintContext};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated."
+)]
+#[diagnostic(severity(warning), help("Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects."))]
+struct NoDistractingElementsDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDistractingElements;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces that no distracting elements are used.
+    ///
+    /// ### Why is this necessary?
+    ///
+    /// Elements that can be visually distracting can cause accessibility issues with visually impaired users. 
+    /// Such elements are most likely deprecated, and should be avoided. By default, <marquee> and <blink> elements are visually distracting. 
+    ///
+    /// ### What it checks
+    ///
+    /// This rule checks for marquee and blink element.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// // Bad
+    /// <marquee />
+    /// <marquee {...props} />
+    /// <marquee lang={undefined} />
+    /// <blink />
+    /// <blink {...props} />
+    /// <blink foo={undefined} />
+    ///
+    /// // Good
+    /// <div />
+    /// <Marquee />
+    /// <Blink />
+    /// ```
+    NoDistractingElements,
+    correctness
+);
+
+impl Rule for NoDistractingElements {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else { return };
+        let JSXElementName::Identifier(iden) = &jsx_el.name else { return };
+
+        let name = iden.name.as_str();
+
+        if let "marquee" | "blink" = name {
+            ctx.diagnostic(NoDistractingElementsDiagnostic(iden.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r"<div />", None),
+        (r"<Marquee />", None),
+        (r"<div marquee />", None),
+        (r"<Blink />", None),
+        (r"<div blink />", None),
+    ];
+
+    let fail = vec![
+        (r"<marquee />", None),
+        (r"<marquee {...props} />", None),
+        (r"<marquee lang={undefined} />", None),
+        (r"<blink />", None),
+        (r"<blink {...props} />", None),
+        (r"<blink foo={undefined} />", None),
+    ];
+
+    Tester::new(NoDistractingElements::NAME, pass, fail).with_jsx_a11y_plugin(true).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/no_distracting_elements.snap
+++ b/crates/oxc_linter/src/snapshots/no_distracting_elements.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 144
+expression: no_distracting_elements
+---
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+   ╭─[no_distracting_elements.tsx:1:1]
+ 1 │ <marquee />
+   ·  ───────
+   ╰────
+  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+   ╭─[no_distracting_elements.tsx:1:1]
+ 1 │ <marquee {...props} />
+   ·  ───────
+   ╰────
+  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+   ╭─[no_distracting_elements.tsx:1:1]
+ 1 │ <marquee lang={undefined} />
+   ·  ───────
+   ╰────
+  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+   ╭─[no_distracting_elements.tsx:1:1]
+ 1 │ <blink />
+   ·  ─────
+   ╰────
+  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+   ╭─[no_distracting_elements.tsx:1:1]
+ 1 │ <blink {...props} />
+   ·  ─────
+   ╰────
+  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+
+  ⚠ eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.
+   ╭─[no_distracting_elements.tsx:1:1]
+ 1 │ <blink foo={undefined} />
+   ·  ─────
+   ╰────
+  help: Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.
+
+


### PR DESCRIPTION
Implemented eslint-plugin-jsx-a11y no-distracting-elements as part of https://github.com/oxc-project/oxc/issues/1141 porting recommended rules.

Doc: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-distracting-elements.md
Test: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__tests__/src/rules/no-distracting-elements-test.js