### PR TITLE
fix(linter): fix a typo in no_redeclare message

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -35,7 +35,7 @@ struct NoRedeclareAsBuiltiInDiagnostic(
 struct NoRedeclareBySyntaxDiagnostic(
     Atom,
     #[label("'{0}' is already defined by a variable declaration.")] pub Span,
-    #[label("It can not be redeclare here.")] pub Span,
+    #[label("It cannot be redeclared here.")] pub Span,
 );
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
You can also compare with the wording here https://eslint.org/docs/latest/rules/no-redeclare