### PR TITLE
feat(linter): eslint-plugin-jsx-a11y no-aria-hidden-on-focusable

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -236,6 +236,7 @@ mod jsx_a11y {
     pub mod iframe_has_title;
     pub mod img_redundant_alt;
     pub mod no_access_key;
+    pub mod no_aria_hidden_on_focusable;
     pub mod no_autofocus;
     pub mod no_distracting_elements;
     pub mod scope;
@@ -457,6 +458,7 @@ oxc_macros::declare_all_lint_rules! {
     jsx_a11y::iframe_has_title,
     jsx_a11y::img_redundant_alt,
     jsx_a11y::no_access_key,
+    jsx_a11y::no_aria_hidden_on_focusable,
     jsx_a11y::no_autofocus,
     jsx_a11y::scope,
     jsx_a11y::tab_index_no_positive,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -9,8 +9,12 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::rules::jsx_a11y::tab_index_no_positive::parse_jsx_value;
-use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_lowercase, AstNode};
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{has_jsx_prop_lowercase, parse_jsx_value},
+    AstNode,
+};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.")]

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -63,7 +63,7 @@ fn is_aria_hidden_true(attr: &JSXAttributeItem) -> bool {
             None => true,
             _ => false,
         },
-        _ => false,
+        JSXAttributeItem::SpreadAttribute(_) => false,
     }
 }
 
@@ -90,18 +90,16 @@ fn is_focusable(element: &JSXOpeningElement) -> bool {
         _ => return false,
     };
 
-    if let Some(tab_index_prop) = has_jsx_prop_lowercase(element, "tabIndex") {
-        if let JSXAttributeItem::Attribute(attr) = tab_index_prop {
-            if let Some(attr_value) = &attr.value {
-                return parse_jsx_value(attr_value).map_or(false, |num| num >= 0.0);
-            }
+    if let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_lowercase(element, "tabIndex") {
+        if let Some(attr_value) = &attr.value {
+            return parse_jsx_value(attr_value).map_or(false, |num| num >= 0.0);
         }
     }
 
     match tag_name {
         "a" | "area" => has_jsx_prop_lowercase(element, "href").is_some(),
         "button" | "input" | "select" | "textarea" => {
-            !has_jsx_prop_lowercase(element, "disabled").is_some()
+            has_jsx_prop_lowercase(element, "disabled").is_none()
         }
         _ => false,
     }
@@ -112,13 +110,13 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        r#"<div aria-hidden="true" />;"#,
-        r#"<div onClick={() => void 0} aria-hidden="true" />;"#,
-        r#"<img aria-hidden="true" />"#,
-        r#"<a aria-hidden="false" href="" />"#,
-        r#"<button aria-hidden="true" tabIndex="-1" />"#,
-        r#"<button />"#,
-        r#"<a href="/" />"#,
+        "<div aria-hidden=\"true\" />;",
+        "<div onClick={() => void 0} aria-hidden=\"true\" />;",
+        "<img aria-hidden=\"true\" />",
+        "<a aria-hidden=\"false\" href=\"\" />",
+        "<button aria-hidden=\"true\" tabIndex=\"-1\" />",
+        "<button />",
+        "<a href=\"/\" />",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -1,0 +1,180 @@
+use oxc_ast::{
+    ast::{
+        Expression, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXElementName,
+        JSXExpression, JSXExpressionContainer, JSXIdentifier, JSXOpeningElement,
+    },
+    AstKind,
+};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_lowercase, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.")]
+#[diagnostic(severity(warning), help("Remove `aria-hidden=\"true\"` from focusable elements or modify the element to be not focusable."))]
+struct NoAriaHiddenOnFocusableDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoAriaHiddenOnFocusable;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Enforces that `aria-hidden="true"` is not set on focusable elements.
+    ///
+    /// ### Why is this bad?
+    /// `aria-hidden="true"` on focusable elements can lead to confusion or unexpected behavior for screen reader users.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// // Bad
+    /// <div aria-hidden="true" tabIndex="0" />
+    ///
+    /// // Good
+    /// <div aria-hidden="true" />
+    /// ```
+    NoAriaHiddenOnFocusable,
+    correctness
+);
+
+impl Rule for NoAriaHiddenOnFocusable {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else { return };
+        if let Some(aria_hidden_prop) = has_jsx_prop_lowercase(jsx_el, "aria-hidden") {
+            if is_aria_hidden_true(aria_hidden_prop) && is_focusable(jsx_el) {
+                ctx.diagnostic(NoAriaHiddenOnFocusableDiagnostic(jsx_el.span));
+            }
+        }
+    }
+}
+
+fn is_aria_hidden_true(attr: &JSXAttributeItem) -> bool {
+    match attr {
+        JSXAttributeItem::Attribute(attr) => match &attr.value {
+            Some(JSXAttributeValue::StringLiteral(s)) if s.value == "true" => true,
+            None => true,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// Determines if a JSX element is focusable.
+///
+/// According to the [W3C's DOM Level 2 HTML specification](https://www.w3.org/TR/DOM-Level-2-HTML/html.html), the elements that are focusable are:
+/// - `<a>` with an `href` attribute
+/// - `<area>` with an `href` attribute (not handled in this implementation)
+/// - `<button>` unless it is disabled
+/// - `<input>`, `<select>`, `<textarea>` unless they are disabled
+/// - Any element with a `tabIndex` of zero or greater
+///
+/// This function checks the passed `JSXOpeningElement` against these criteria to determine
+/// if it is focusable.
+///
+/// # Arguments
+///
+/// * `element` - A reference to the JSXOpeningElement to check
+///
+/// # Returns
+///
+/// `true` if the element is focusable, `false` otherwise.
+fn is_focusable(element: &JSXOpeningElement) -> bool {
+    let tag_name = match &element.name {
+        JSXElementName::Identifier(JSXIdentifier { name, .. }) => name.as_str(),
+        _ => return false,
+    };
+
+    let has_tab_index = element.attributes.iter().any(|attr| match attr {
+        JSXAttributeItem::Attribute(attr) => match &attr.name {
+            JSXAttributeName::Identifier(JSXIdentifier { name, .. }) => {
+                name.as_str() == "tabIndex" || name.as_str() == "tabindex"
+            }
+            _ => false,
+        },
+        _ => false,
+    });
+
+    if has_tab_index {
+        return element.attributes.iter().any(|attr| match attr {
+            JSXAttributeItem::Attribute(attr) => match &attr.name {
+                JSXAttributeName::Identifier(JSXIdentifier { name, .. })
+                    if (name.as_str() == "tabIndex" || name.as_str() == "tabindex") =>
+                {
+                    match &attr.value {
+                        Some(JSXAttributeValue::StringLiteral(s)) => {
+                            s.value.parse::<i32>().ok().filter(|&num| num >= 0).is_some()
+                        }
+                        Some(JSXAttributeValue::ExpressionContainer(JSXExpressionContainer {
+                            expression: JSXExpression::Expression(expr),
+                            ..
+                        })) => match expr {
+                            Expression::NumberLiteral(num) => num.value as i32 >= 0,
+                            _ => false,
+                        },
+                        _ => false,
+                    }
+                }
+                _ => false,
+            },
+            _ => false,
+        });
+    }
+
+    match tag_name {
+        "a" | "area" => element.attributes.iter().any(|attr| {
+            if let JSXAttributeItem::Attribute(attr) = attr {
+                match &attr.name {
+                    JSXAttributeName::Identifier(JSXIdentifier { name, .. }) => {
+                        name.as_str() == "href"
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }),
+        "button" | "input" | "select" | "textarea" => !element.attributes.iter().any(|attr| {
+            if let JSXAttributeItem::Attribute(attr) = attr {
+                match &attr.name {
+                    JSXAttributeName::Identifier(JSXIdentifier { name, .. }) => {
+                        name.as_str() == "disabled"
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"<div aria-hidden="true" />;"#,
+        r#"<div onClick={() => void 0} aria-hidden="true" />;"#,
+        r#"<img aria-hidden="true" />"#,
+        r#"<a aria-hidden="false" href="" />"#,
+        r#"<button aria-hidden="true" tabIndex="-1" />"#,
+        r#"<button />"#,
+        r#"<a href="/" />"#,
+    ];
+
+    let fail = vec![
+        r#"<div aria-hidden="true" tabIndex="0" />;"#,
+        r#"<input aria-hidden="true" />;"#,
+        r#"<a href="/" aria-hidden="true" />"#,
+        r#"<button aria-hidden="true" />"#,
+        r#"<textarea aria-hidden="true" />"#,
+        r#"<p tabIndex="0" aria-hidden="true">text</p>;"#,
+    ];
+
+    Tester::new_without_config(NoAriaHiddenOnFocusable::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -46,7 +46,9 @@ impl Rule for NoAriaHiddenOnFocusable {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else { return };
         if let Some(aria_hidden_prop) = has_jsx_prop_lowercase(jsx_el, "aria-hidden") {
             if is_aria_hidden_true(aria_hidden_prop) && is_focusable(jsx_el) {
-                ctx.diagnostic(NoAriaHiddenOnFocusableDiagnostic(jsx_el.span));
+                if let JSXAttributeItem::Attribute(boxed_attr) = aria_hidden_prop {
+                    ctx.diagnostic(NoAriaHiddenOnFocusableDiagnostic(boxed_attr.span));
+                }
             }
         }
     }
@@ -66,10 +68,8 @@ fn is_aria_hidden_true(attr: &JSXAttributeItem) -> bool {
 /// Determines if a JSX element is focusable.
 ///
 /// According to the [W3C's DOM Level 2 HTML specification](https://www.w3.org/TR/DOM-Level-2-HTML/html.html), the elements that are focusable are:
-/// - `<a>` with an `href` attribute
-/// - `<area>` with an `href` attribute (not handled in this implementation)
-/// - `<button>` unless it is disabled
-/// - `<input>`, `<select>`, `<textarea>` unless they are disabled
+/// - `<a>`, `<area>` with an `href` attribute
+/// - `<button>`, `<input>`, `<select>`, `<textarea>` unless they are disabled
 /// - Any element with a `tabIndex` of zero or greater
 ///
 /// This function checks the passed `JSXOpeningElement` against these criteria to determine

--- a/crates/oxc_linter/src/rules/jsx_a11y/tab_index_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tab_index_no_positive.rs
@@ -63,7 +63,7 @@ fn check_and_diagnose(attr: &JSXAttributeItem, ctx: &LintContext<'_>) {
     }
 }
 
-fn parse_jsx_value(value: &JSXAttributeValue) -> Result<f64, ()> {
+pub fn parse_jsx_value(value: &JSXAttributeValue) -> Result<f64, ()> {
     match value {
         JSXAttributeValue::StringLiteral(str) => str.value.parse().or(Err(())),
         JSXAttributeValue::ExpressionContainer(JSXExpressionContainer {

--- a/crates/oxc_linter/src/rules/jsx_a11y/tab_index_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tab_index_no_positive.rs
@@ -1,7 +1,4 @@
-use oxc_ast::{
-    ast::{Expression, JSXAttributeItem, JSXAttributeValue, JSXExpression, JSXExpressionContainer},
-    AstKind,
-};
+use oxc_ast::{ast::JSXAttributeItem, AstKind};
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
@@ -9,7 +6,12 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_lowercase, AstNode};
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{has_jsx_prop_lowercase, parse_jsx_value},
+    AstNode,
+};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error(
@@ -60,24 +62,6 @@ fn check_and_diagnose(attr: &JSXAttributeItem, ctx: &LintContext<'_>) {
             }
         }),
         JSXAttributeItem::SpreadAttribute(_) => {}
-    }
-}
-
-pub fn parse_jsx_value(value: &JSXAttributeValue) -> Result<f64, ()> {
-    match value {
-        JSXAttributeValue::StringLiteral(str) => str.value.parse().or(Err(())),
-        JSXAttributeValue::ExpressionContainer(JSXExpressionContainer {
-            expression: JSXExpression::Expression(expression),
-            ..
-        }) => match expression {
-            Expression::StringLiteral(str) => str.value.parse().or(Err(())),
-            Expression::TemplateLiteral(tmpl) => {
-                tmpl.quasis.get(0).unwrap().value.raw.parse().or(Err(()))
-            }
-            Expression::NumberLiteral(num) => Ok(num.value),
-            _ => Err(()),
-        },
-        _ => Err(()),
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/no_aria_hidden_on_focusable.snap
+++ b/crates/oxc_linter/src/snapshots/no_aria_hidden_on_focusable.snap
@@ -1,0 +1,47 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_aria_hidden_on_focusable
+---
+  ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
+   ╭─[no_aria_hidden_on_focusable.tsx:1:1]
+ 1 │ <div aria-hidden="true" tabIndex="0" />;
+   · ───────────────────────────────────────
+   ╰────
+  help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
+
+  ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
+   ╭─[no_aria_hidden_on_focusable.tsx:1:1]
+ 1 │ <input aria-hidden="true" />;
+   · ────────────────────────────
+   ╰────
+  help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
+
+  ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
+   ╭─[no_aria_hidden_on_focusable.tsx:1:1]
+ 1 │ <a href="/" aria-hidden="true" />
+   · ─────────────────────────────────
+   ╰────
+  help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
+
+  ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
+   ╭─[no_aria_hidden_on_focusable.tsx:1:1]
+ 1 │ <button aria-hidden="true" />
+   · ─────────────────────────────
+   ╰────
+  help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
+
+  ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
+   ╭─[no_aria_hidden_on_focusable.tsx:1:1]
+ 1 │ <textarea aria-hidden="true" />
+   · ───────────────────────────────
+   ╰────
+  help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
+
+  ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
+   ╭─[no_aria_hidden_on_focusable.tsx:1:1]
+ 1 │ <p tabIndex="0" aria-hidden="true">text</p>;
+   · ───────────────────────────────────
+   ╰────
+  help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
+
+

--- a/crates/oxc_linter/src/snapshots/no_aria_hidden_on_focusable.snap
+++ b/crates/oxc_linter/src/snapshots/no_aria_hidden_on_focusable.snap
@@ -5,42 +5,42 @@ expression: no_aria_hidden_on_focusable
   ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
    ╭─[no_aria_hidden_on_focusable.tsx:1:1]
  1 │ <div aria-hidden="true" tabIndex="0" />;
-   · ───────────────────────────────────────
+   ·      ──────────────────
    ╰────
   help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
 
   ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
    ╭─[no_aria_hidden_on_focusable.tsx:1:1]
  1 │ <input aria-hidden="true" />;
-   · ────────────────────────────
+   ·        ──────────────────
    ╰────
   help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
 
   ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
    ╭─[no_aria_hidden_on_focusable.tsx:1:1]
  1 │ <a href="/" aria-hidden="true" />
-   · ─────────────────────────────────
+   ·             ──────────────────
    ╰────
   help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
 
   ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
    ╭─[no_aria_hidden_on_focusable.tsx:1:1]
  1 │ <button aria-hidden="true" />
-   · ─────────────────────────────
+   ·         ──────────────────
    ╰────
   help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
 
   ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
    ╭─[no_aria_hidden_on_focusable.tsx:1:1]
  1 │ <textarea aria-hidden="true" />
-   · ───────────────────────────────
+   ·           ──────────────────
    ╰────
   help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
 
   ⚠ eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.
    ╭─[no_aria_hidden_on_focusable.tsx:1:1]
  1 │ <p tabIndex="0" aria-hidden="true">text</p>;
-   · ───────────────────────────────────
+   ·                 ──────────────────
    ╰────
   help: Remove `aria-hidden="true"` from focusable elements or modify the element to be not focusable.
 

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -178,3 +178,21 @@ pub fn get_element_type(context: &LintContext, element: &JSXOpeningElement) -> O
 
     Some(element_type)
 }
+
+pub fn parse_jsx_value(value: &JSXAttributeValue) -> Result<f64, ()> {
+    match value {
+        JSXAttributeValue::StringLiteral(str) => str.value.parse().or(Err(())),
+        JSXAttributeValue::ExpressionContainer(JSXExpressionContainer {
+            expression: JSXExpression::Expression(expression),
+            ..
+        }) => match expression {
+            Expression::StringLiteral(str) => str.value.parse().or(Err(())),
+            Expression::TemplateLiteral(tmpl) => {
+                tmpl.quasis.get(0).unwrap().value.raw.parse().or(Err(()))
+            }
+            Expression::NumberLiteral(num) => Ok(num.value),
+            _ => Err(()),
+        },
+        _ => Err(()),
+    }
+}


### PR DESCRIPTION
Implemented eslint-plugin-jsx-a11y no-aria-hidden-on-focusable as part of #1141 

### Key Points
- Implements `no-aria-hidden-on-focusable` as per the [eslint-plugin-jsx-a11y documentation](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-aria-hidden-on-focusable.md).
- Incorporates HTML's `focus()` API criteria based on the [W3C's DOM Level 2 HTML specification](https://www.w3.org/TR/DOM-Level-2-HTML/html.html) to accurately identify focusable elements.