### PR TITLE
fix(lsp): make the server available in nvim-lspconfig

### DIFF
--- a/editors/vscode/server/src/main.rs
+++ b/editors/vscode/server/src/main.rs
@@ -113,6 +113,7 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
+        debug!("{:?}", &params.settings);
         let changed_options = match serde_json::from_value::<Options>(params.settings) {
             Ok(option) => option,
             Err(err) => {
@@ -173,7 +174,7 @@ impl LanguageServer for Backend {
         if self.is_ignored(&params.text_document.uri).await {
             return;
         }
-        self.handle_file_update(params.text_document.uri, None).await;
+        self.handle_file_update(params.text_document.uri, None, None).await;
     }
 
     /// When the document changed, it may not be written to disk, so we should
@@ -188,7 +189,7 @@ impl LanguageServer for Backend {
             return;
         }
         let content = params.content_changes.first().map(|c| c.text.clone());
-        self.handle_file_update(params.text_document.uri, content).await;
+        self.handle_file_update(params.text_document.uri, content, Some(params.text_document.version)).await;
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
@@ -199,7 +200,7 @@ impl LanguageServer for Backend {
         if self.is_ignored(&params.text_document.uri).await {
             return;
         }
-        self.handle_file_update(params.text_document.uri, None).await;
+        self.handle_file_update(params.text_document.uri, None, Some(params.text_document.version)).await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
@@ -304,7 +305,7 @@ impl Backend {
         .await;
     }
 
-    async fn handle_file_update(&self, uri: Url, content: Option<String>) {
+    async fn handle_file_update(&self, uri: Url, content: Option<String>, version: Option<i32>) {
         if let Some(Some(root_uri)) = self.root_uri.get() {
             self.server_linter.make_plugin(root_uri);
             if let Some(diagnostics) = self.server_linter.run_single(root_uri, &uri, content) {

--- a/editors/vscode/server/src/main.rs
+++ b/editors/vscode/server/src/main.rs
@@ -113,7 +113,6 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
-        debug!("{:?}", &params.settings);
         let changed_options = match serde_json::from_value::<Options>(params.settings) {
             Ok(option) => option,
             Err(err) => {

--- a/editors/vscode/server/src/main.rs
+++ b/editors/vscode/server/src/main.rs
@@ -189,7 +189,12 @@ impl LanguageServer for Backend {
             return;
         }
         let content = params.content_changes.first().map(|c| c.text.clone());
-        self.handle_file_update(params.text_document.uri, content, Some(params.text_document.version)).await;
+        self.handle_file_update(
+            params.text_document.uri,
+            content,
+            Some(params.text_document.version),
+        )
+        .await;
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
@@ -200,7 +205,8 @@ impl LanguageServer for Backend {
         if self.is_ignored(&params.text_document.uri).await {
             return;
         }
-        self.handle_file_update(params.text_document.uri, None, Some(params.text_document.version)).await;
+        self.handle_file_update(params.text_document.uri, None, Some(params.text_document.version))
+            .await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {


### PR DESCRIPTION
1. It seems that nvim-lspconfig diagnostics handler require **version** of **document**, now we can use 
`oxc_vscode` language server in neomvin with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) 

![image](https://github.com/oxc-project/oxc/assets/17974631/6b147333-341f-4226-a466-2b3d17b77215)

