### PR TITLE
feat(linter): no-irregular-whitespace rule

### DIFF
--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -1,13 +1,13 @@
 //! Trivias such as comments
 
-use std::collections::BTreeMap;
 use oxc_span::Span;
+use std::collections::BTreeMap;
 
 /// A vec of trivias from the lexer, tupled by (span.start, span.end).
 #[derive(Debug, Default)]
 pub struct Trivias {
     pub comments: Vec<(u32, u32, CommentKind)>,
-    pub whitespaces: Vec<Span>,
+    pub irregular_whitespaces: Vec<Span>,
 }
 
 /// Trivias such as comments
@@ -18,14 +18,14 @@ pub struct Trivias {
 pub struct TriviasMap {
     /// Keyed by span.start
     comments: BTreeMap<u32, Comment>,
-    whitespaces: Vec<Span>,
+    irregular_whitespaces: Vec<Span>,
 }
 
 impl From<Trivias> for TriviasMap {
     fn from(trivias: Trivias) -> Self {
         Self {
             comments: trivias.comments.iter().map(|t| (t.0, Comment::new(t.1, t.2))).collect(),
-            whitespaces: trivias.whitespaces,
+            irregular_whitespaces: trivias.irregular_whitespaces,
         }
     }
 }
@@ -99,8 +99,7 @@ impl TriviasMap {
         self.comments().iter().map(|(start, comment)| (*comment, Span::new(*start, comment.end)))
     }
 
-    pub fn whitespaces(&self) -> &Vec<Span> {
-        &self.whitespaces
+    pub fn irregular_whitespaces(&self) -> &Vec<Span> {
+        &self.irregular_whitespaces
     }
-    
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -5,7 +5,11 @@ use std::collections::BTreeMap;
 use oxc_span::Span;
 
 /// A vec of trivias from the lexer, tupled by (span.start, span.end).
-pub type Trivias = Vec<(u32, u32, CommentKind)>;
+#[derive(Debug, Default)]
+pub struct Trivias {
+    pub comments: Vec<(u32, u32, CommentKind)>,
+    pub whitespaces: Vec<Span>,
+}
 
 /// Trivias such as comments
 ///
@@ -15,11 +19,15 @@ pub type Trivias = Vec<(u32, u32, CommentKind)>;
 pub struct TriviasMap {
     /// Keyed by span.start
     comments: BTreeMap<u32, Comment>,
+    whitespaces: Vec<Span>,
 }
 
 impl From<Trivias> for TriviasMap {
     fn from(trivias: Trivias) -> Self {
-        Self { comments: trivias.iter().map(|t| (t.0, Comment::new(t.1, t.2))).collect() }
+        Self {
+            comments: trivias.comments.iter().map(|t| (t.0, Comment::new(t.1, t.2))).collect(),
+            whitespaces: trivias.whitespaces,
+        }
     }
 }
 

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -1,7 +1,6 @@
 //! Trivias such as comments
 
 use std::collections::BTreeMap;
-
 use oxc_span::Span;
 
 /// A vec of trivias from the lexer, tupled by (span.start, span.end).
@@ -98,5 +97,14 @@ impl TriviasMap {
 
     pub fn comments_spans(&self) -> impl Iterator<Item = (Comment, Span)> + '_ {
         self.comments().iter().map(|(start, comment)| (*comment, Span::new(*start, comment.end)))
+    }
+
+    pub fn whitespaces(&self) -> &Vec<Span> {
+        &self.whitespaces
+    }
+
+    pub fn add_whitespace(&mut self, span: Span) {
+        let whitespace = Span { start: span.start, end: span.end };
+        self.whitespaces.insert(0, whitespace);
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 #[derive(Debug, Default)]
 pub struct Trivias {
     pub comments: Vec<(u32, u32, CommentKind)>,
-    pub whitespaces: Vec<Span>,
+    pub whitespaces: Vec<(u32, u32)>,
 }
 
 /// Trivias such as comments
@@ -25,7 +25,7 @@ impl From<Trivias> for TriviasMap {
     fn from(trivias: Trivias) -> Self {
         Self {
             comments: trivias.comments.iter().map(|t| (t.0, Comment::new(t.1, t.2))).collect(),
-            whitespaces: trivias.whitespaces,
+            whitespaces: trivias.whitespaces.iter().map(|(start, end)| Span::new(*start, *end)).collect()
         }
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -102,9 +102,5 @@ impl TriviasMap {
     pub fn whitespaces(&self) -> &Vec<Span> {
         &self.whitespaces
     }
-
-    pub fn add_whitespace(&mut self, span: Span) {
-        let whitespace = Span { start: span.start, end: span.end };
-        self.whitespaces.insert(0, whitespace);
-    }
+    
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 #[derive(Debug, Default)]
 pub struct Trivias {
     pub comments: Vec<(u32, u32, CommentKind)>,
-    pub whitespaces: Vec<(u32, u32)>,
+    pub whitespaces: Vec<u32>,
 }
 
 /// Trivias such as comments
@@ -18,14 +18,14 @@ pub struct Trivias {
 pub struct TriviasMap {
     /// Keyed by span.start
     comments: BTreeMap<u32, Comment>,
-    whitespaces: Vec<Span>,
+    whitespaces: Vec<u32>,
 }
 
 impl From<Trivias> for TriviasMap {
     fn from(trivias: Trivias) -> Self {
         Self {
             comments: trivias.comments.iter().map(|t| (t.0, Comment::new(t.1, t.2))).collect(),
-            whitespaces: trivias.whitespaces.iter().map(|(start, end)| Span::new(*start, *end)).collect()
+            whitespaces: trivias.whitespaces,
         }
     }
 }
@@ -99,7 +99,7 @@ impl TriviasMap {
         self.comments().iter().map(|(start, comment)| (*comment, Span::new(*start, comment.end)))
     }
 
-    pub fn whitespaces(&self) -> &Vec<Span> {
+    pub fn whitespaces(&self) -> &Vec<u32> {
         &self.whitespaces
     }
     

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 #[derive(Debug, Default)]
 pub struct Trivias {
     pub comments: Vec<(u32, u32, CommentKind)>,
-    pub whitespaces: Vec<u32>,
+    pub whitespaces: Vec<Span>,
 }
 
 /// Trivias such as comments
@@ -18,7 +18,7 @@ pub struct Trivias {
 pub struct TriviasMap {
     /// Keyed by span.start
     comments: BTreeMap<u32, Comment>,
-    whitespaces: Vec<u32>,
+    whitespaces: Vec<Span>,
 }
 
 impl From<Trivias> for TriviasMap {
@@ -99,7 +99,7 @@ impl TriviasMap {
         self.comments().iter().map(|(start, comment)| (*comment, Span::new(*start, comment.end)))
     }
 
-    pub fn whitespaces(&self) -> &Vec<u32> {
+    pub fn whitespaces(&self) -> &Vec<Span> {
         &self.whitespaces
     }
     

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -393,7 +393,7 @@ impl<'a> Lexer<'a> {
 
     /// Section 12.1 Irregular White Space
     fn skip_irregular_whitespace(&mut self) -> Kind {
-        self.trivia_builder.add_whitespace(self.current.token.start, self.offset());
+        self.trivia_builder.add_whitespace(self.current.token.start);
         Kind::WhiteSpace
     }
 

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -391,6 +391,12 @@ impl<'a> Lexer<'a> {
         Kind::Comment
     }
 
+    /// Section 12.1 Irregular White Space
+    fn skip_irregular_whitespace(&mut self) -> Kind {
+        self.trivia_builder.add_whitespace(self.current.token.start, self.offset());
+        Kind::WhiteSpace
+    }
+
     /// Section 12.4 Multi Line Comment
     fn skip_multi_line_comment(&mut self) -> Kind {
         while let Some(c) = self.current.chars.next() {
@@ -1321,6 +1327,7 @@ const ERR: ByteHandler = |lexer| {
 
 // <TAB> <VT> <FF>
 const SPS: ByteHandler = |lexer| {
+    lexer.skip_irregular_whitespace();
     lexer.consume_char();
     Kind::WhiteSpace
 };

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -358,6 +358,7 @@ impl<'a> Lexer<'a> {
                 Kind::Ident
             }
             c if is_irregular_whitespace(c) => {
+                self.trivia_builder.add_whitespace(self.current.token.start, self.offset());
                 self.consume_char();
                 Kind::WhiteSpace
             }
@@ -393,7 +394,6 @@ impl<'a> Lexer<'a> {
 
     /// Section 12.1 Irregular White Space
     fn skip_irregular_whitespace(&mut self) -> Kind {
-        self.trivia_builder.add_whitespace(self.current.token.start);
         Kind::WhiteSpace
     }
 

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -358,7 +358,8 @@ impl<'a> Lexer<'a> {
                 Kind::Ident
             }
             c if is_irregular_whitespace(c) => {
-                self.trivia_builder.add_whitespace(self.current.token.start, self.offset());
+                self.trivia_builder
+                    .add_irregular_whitespace(self.current.token.start, self.offset());
                 self.consume_char();
                 Kind::WhiteSpace
             }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,4 +1,5 @@
 use oxc_ast::{CommentKind, Trivias};
+use oxc_span::Span;
 
 #[derive(Debug, Default)]
 pub struct TriviaBuilder {
@@ -20,7 +21,7 @@ impl TriviaBuilder {
         self.trivias.comments.push((start + 2, end - 2, CommentKind::MultiLine));
     }
 
-    pub fn add_whitespace(&mut self, index: u32) {
-        self.trivias.whitespaces.push(index);
+    pub fn add_whitespace(&mut self, start: u32, end: u32) {
+        self.trivias.whitespaces.push(Span::new(start, end));
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -20,7 +20,7 @@ impl TriviaBuilder {
         self.trivias.comments.push((start + 2, end - 2, CommentKind::MultiLine));
     }
 
-    pub fn add_whitespace(&mut self, start: u32, end: u32) {
-        self.trivias.whitespaces.push((start, end));
+    pub fn add_whitespace(&mut self, index: u32) {
+        self.trivias.whitespaces.push(index);
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -19,4 +19,8 @@ impl TriviaBuilder {
     pub fn add_multi_line_comment(&mut self, start: u32, end: u32) {
         self.trivias.push((start + 2, end - 2, CommentKind::MultiLine));
     }
+
+    pub fn add_whitespace(&mut self, start: u32, end: u32) {
+        todo!()
+    }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{CommentKind, Trivias};
-use oxc_span::Span;
+// use oxc_span::Span;
 
 #[derive(Debug, Default)]
 pub struct TriviaBuilder {
@@ -22,6 +22,7 @@ impl TriviaBuilder {
     }
 
     pub fn add_whitespace(&mut self, start: u32, end: u32) {
-        self.trivias.whitespaces.push(Span::new(start, end));
+        // self.trivias.whitespaces.push(Span::new(start, end));
+        (start, end);
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -12,12 +12,12 @@ impl TriviaBuilder {
 
     /// skip leading `//`
     pub fn add_single_line_comment(&mut self, start: u32, end: u32) {
-        self.trivias.push((start + 2, end, CommentKind::SingleLine));
+        self.trivias.comments.push((start + 2, end, CommentKind::SingleLine));
     }
 
     /// skip leading `/*` and trailing `*/`
     pub fn add_multi_line_comment(&mut self, start: u32, end: u32) {
-        self.trivias.push((start + 2, end - 2, CommentKind::MultiLine));
+        self.trivias.comments.push((start + 2, end - 2, CommentKind::MultiLine));
     }
 
     pub fn add_whitespace(&mut self, start: u32, end: u32) {

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -21,7 +21,7 @@ impl TriviaBuilder {
         self.trivias.comments.push((start + 2, end - 2, CommentKind::MultiLine));
     }
 
-    pub fn add_whitespace(&mut self, start: u32, end: u32) {
-        self.trivias.whitespaces.push(Span::new(start, end));
+    pub fn add_irregular_whitespace(&mut self, start: u32, end: u32) {
+        self.trivias.irregular_whitespaces.push(Span::new(start, end));
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,4 +1,5 @@
 use oxc_ast::{CommentKind, Trivias};
+use oxc_span::Span;
 
 #[derive(Debug, Default)]
 pub struct TriviaBuilder {
@@ -21,6 +22,6 @@ impl TriviaBuilder {
     }
 
     pub fn add_whitespace(&mut self, start: u32, end: u32) {
-        dbg!(start, end);
+        self.trivias.whitespaces.push(Span::new(start, end));
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -21,6 +21,6 @@ impl TriviaBuilder {
     }
 
     pub fn add_whitespace(&mut self, start: u32, end: u32) {
-        todo!()
+        dbg!(start, end);
     }
 }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,5 +1,4 @@
 use oxc_ast::{CommentKind, Trivias};
-// use oxc_span::Span;
 
 #[derive(Debug, Default)]
 pub struct TriviaBuilder {
@@ -22,7 +21,6 @@ impl TriviaBuilder {
     }
 
     pub fn add_whitespace(&mut self, start: u32, end: u32) {
-        // self.trivias.whitespaces.push(Span::new(start, end));
-        (start, end);
+        self.trivias.whitespaces.push((start, end));
     }
 }

--- a/crates/oxc_prettier/src/lib.rs
+++ b/crates/oxc_prettier/src/lib.rs
@@ -80,7 +80,7 @@ impl<'a> Prettier<'a> {
             allocator,
             source_text,
             options,
-            trivias: trivias.into_iter().peekable(),
+            trivias: trivias.comments.into_iter().peekable(),
             nodes: vec![],
             group_id_builder: GroupIdBuilder::default(),
             args: PrettierArgs::default(),


### PR DESCRIPTION
Parser, trivias and trivias_builder were edited to get all whitespaces. Now Trivias struct store comments and whitespaces Vec. After that, i will implement the no-irregular-whitespace rule.

P.S.: There isn't a way to implement this feature without lose a little bit of performance, comparing with my last PR #1819 to minimax this trouble instead of store the irregular whitespace as Span it was stored as u32, i removed a map iterator and removed too a unused function. If you have a suggestion about it pls give me a feedback.