### PR TITLE
refactor(semantic): check duplicate parameters in Binder of FormalParameters

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -118,8 +118,8 @@ fn test() {
         r"array.forEach(({foo}, index = foo) => {})",
         r"array.forEach((element, {bar = element}) => {})",
         r"array.forEach(({foo}, {bar = foo}) => {})",
-        r"foo.forEach(function(element, element) {})",
-        r"foo.forEach(function element(element, element) {})",
+        r"foo.forEach(function(element, element1) {})",
+        r"foo.forEach(function element(element, element1) {})",
         r"this._listeners.forEach((listener: () => void) => listener());",
         r"return foo.forEach(element => {bar(element)});",
     ];

--- a/crates/oxc_linter/src/snapshots/no_array_for_each.snap
+++ b/crates/oxc_linter/src/snapshots/no_array_for_each.snap
@@ -74,14 +74,14 @@ expression: no_array_for_each
 
   ⚠ eslint-plugin-unicorn(no-array-for-each): Do not use `Array#forEach`
    ╭─[no_array_for_each.tsx:1:1]
- 1 │ foo.forEach(function(element, element) {})
+ 1 │ foo.forEach(function(element, element1) {})
    ·     ───────
    ╰────
   help: Replace it with a for` loop. For loop is faster, more readable, and you can use `break` or `return` to exit early.
 
   ⚠ eslint-plugin-unicorn(no-array-for-each): Do not use `Array#forEach`
    ╭─[no_array_for_each.tsx:1:1]
- 1 │ foo.forEach(function element(element, element) {})
+ 1 │ foo.forEach(function element(element, element1) {})
    ·     ───────
    ╰────
   help: Replace it with a for` loop. For loop is faster, more readable, and you can use `break` or `return` to exit early.

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -1,12 +1,14 @@
+use oxc_ast::syntax_directed_operations::BoundNames;
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, AstKind};
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
 };
-use oxc_span::{GetSpan, Span};
+use oxc_span::{Atom, GetSpan, Span};
+use rustc_hash::FxHashMap;
 
-use crate::{builder::SemanticBuilder, AstNode};
+use crate::{builder::SemanticBuilder, diagnostics::Redeclaration, AstNode};
 
 pub struct EarlyErrorTypeScript;
 
@@ -18,9 +20,25 @@ impl EarlyErrorTypeScript {
         #[allow(clippy::single_match)]
         match kind {
             AstKind::SimpleAssignmentTarget(target) => check_simple_assignment_target(target, ctx),
+            AstKind::FormalParameters(params) => check_formal_parameters(params, ctx),
             _ => {}
         }
     }
+}
+
+fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>) {
+    if !params.is_empty() && params.kind == FormalParameterKind::Signature {
+        check_duplicate_bound_names(params, ctx);
+    }
+}
+
+fn check_duplicate_bound_names<T: BoundNames>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
+    let mut idents: FxHashMap<Atom, Span> = FxHashMap::default();
+    bound_names.bound_names(&mut |ident| {
+        if let Some(old_span) = idents.insert(ident.name.clone(), ident.span) {
+            ctx.error(Redeclaration(ident.name.clone(), old_span, ident.span));
+        }
+    });
 }
 
 fn check_simple_assignment_target<'a>(

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -14105,9 +14105,9 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
     ╭─[language/expressions/function/param-duplicated-strict-3.js:21:1]
  21 │ 
  22 │ (function (param, param, param) { });
-    ·                   ──┬──  ──┬──
-    ·                     │      ╰── It can not be redeclared here
-    ·                     ╰── `param` has already been declared here
+    ·            ──┬──         ──┬──
+    ·              │             ╰── It can not be redeclared here
+    ·              ╰── `param` has already been declared here
     ╰────
 
   × Identifier `param` has already been declared
@@ -14141,9 +14141,9 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
     ╭─[language/expressions/function/param-duplicated-strict-body-3.js:20:1]
  20 │ 
  21 │ (function (param, param, param) { 'use strict'; });
-    ·                   ──┬──  ──┬──
-    ·                     │      ╰── It can not be redeclared here
-    ·                     ╰── `param` has already been declared here
+    ·            ──┬──         ──┬──
+    ·              │             ╰── It can not be redeclared here
+    ·              ╰── `param` has already been declared here
     ╰────
 
   × Cannot assign to 'eval' in strict mode
@@ -31683,9 +31683,9 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
     ╭─[language/statements/function/param-duplicated-strict-3.js:21:1]
  21 │ 
  22 │ function _13_1_7_fun(param, param, param) { }
-    ·                             ──┬──  ──┬──
-    ·                               │      ╰── It can not be redeclared here
-    ·                               ╰── `param` has already been declared here
+    ·                      ──┬──         ──┬──
+    ·                        │             ╰── It can not be redeclared here
+    ·                        ╰── `param` has already been declared here
     ╰────
 
   × Identifier `param` has already been declared
@@ -31719,9 +31719,9 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
     ╭─[language/statements/function/param-duplicated-strict-body-3.js:21:1]
  21 │ 
  22 │ function _13_1_28_fun(param, param, param) { 'use strict'; }
-    ·                              ──┬──  ──┬──
-    ·                                │      ╰── It can not be redeclared here
-    ·                                ╰── `param` has already been declared here
+    ·                       ──┬──         ──┬──
+    ·                         │             ╰── It can not be redeclared here
+    ·                         ╰── `param` has already been declared here
     ╰────
 
   × Cannot assign to 'eval' in strict mode

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -5905,9 +5905,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts:5:1]
  5 │ function f2({b}, {b}) { }
  6 │ function f3([c,[c],[[c]]]) { }
-   ·                 ┬    ┬
-   ·                 │    ╰── It can not be redeclared here
-   ·                 ╰── `c` has already been declared here
+   ·              ┬       ┬
+   ·              │       ╰── It can not be redeclared here
+   ·              ╰── `c` has already been declared here
  7 │ function f4({d, d:{d}}) { }
    ╰────
 
@@ -5935,9 +5935,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts:7:1]
  7 │ function f4({d, d:{d}}) { }
  8 │ function f5({e, e: {e}}, {e}, [d,e, [[e]]], ...e) { }
-   ·                     ┬     ┬
-   ·                     │     ╰── It can not be redeclared here
-   ·                     ╰── `e` has already been declared here
+   ·              ┬            ┬
+   ·              │            ╰── It can not be redeclared here
+   ·              ╰── `e` has already been declared here
  9 │ function f6([f, ...f]) { }
    ╰────
 
@@ -5945,9 +5945,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts:7:1]
  7 │ function f4({d, d:{d}}) { }
  8 │ function f5({e, e: {e}}, {e}, [d,e, [[e]]], ...e) { }
-   ·                           ┬      ┬
-   ·                           │      ╰── It can not be redeclared here
-   ·                           ╰── `e` has already been declared here
+   ·              ┬                   ┬
+   ·              │                   ╰── It can not be redeclared here
+   ·              ╰── `e` has already been declared here
  9 │ function f6([f, ...f]) { }
    ╰────
 
@@ -5955,9 +5955,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts:7:1]
  7 │ function f4({d, d:{d}}) { }
  8 │ function f5({e, e: {e}}, {e}, [d,e, [[e]]], ...e) { }
-   ·                                  ┬    ┬
-   ·                                  │    ╰── It can not be redeclared here
-   ·                                  ╰── `e` has already been declared here
+   ·              ┬                        ┬
+   ·              │                        ╰── It can not be redeclared here
+   ·              ╰── `e` has already been declared here
  9 │ function f6([f, ...f]) { }
    ╰────
 
@@ -5965,9 +5965,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts:7:1]
  7 │ function f4({d, d:{d}}) { }
  8 │ function f5({e, e: {e}}, {e}, [d,e, [[e]]], ...e) { }
-   ·                                       ┬        ┬
-   ·                                       │        ╰── It can not be redeclared here
-   ·                                       ╰── `e` has already been declared here
+   ·              ┬                                 ┬
+   ·              │                                 ╰── It can not be redeclared here
+   ·              ╰── `e` has already been declared here
  9 │ function f6([f, ...f]) { }
    ╰────
 
@@ -6035,9 +6035,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts:6:1]
  6 │ function f2({b}, {b}) { }
  7 │ function f3([c, [c], [[c]]]) { }
-   ·                  ┬     ┬
-   ·                  │     ╰── It can not be redeclared here
-   ·                  ╰── `c` has already been declared here
+   ·              ┬         ┬
+   ·              │         ╰── It can not be redeclared here
+   ·              ╰── `c` has already been declared here
  8 │ function f4({d, d: {d}}) { }
    ╰────
 
@@ -6065,9 +6065,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts:8:1]
   8 │ function f4({d, d: {d}}) { }
   9 │ function f5({e, e: {e}}, {e}, [d, e, [[e]]], ...e) { }
-    ·                     ┬     ┬
-    ·                     │     ╰── It can not be redeclared here
-    ·                     ╰── `e` has already been declared here
+    ·              ┬            ┬
+    ·              │            ╰── It can not be redeclared here
+    ·              ╰── `e` has already been declared here
  10 │ function f6([f, ...f]) { }
     ╰────
 
@@ -6075,9 +6075,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts:8:1]
   8 │ function f4({d, d: {d}}) { }
   9 │ function f5({e, e: {e}}, {e}, [d, e, [[e]]], ...e) { }
-    ·                           ┬       ┬
-    ·                           │       ╰── It can not be redeclared here
-    ·                           ╰── `e` has already been declared here
+    ·              ┬                    ┬
+    ·              │                    ╰── It can not be redeclared here
+    ·              ╰── `e` has already been declared here
  10 │ function f6([f, ...f]) { }
     ╰────
 
@@ -6085,9 +6085,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts:8:1]
   8 │ function f4({d, d: {d}}) { }
   9 │ function f5({e, e: {e}}, {e}, [d, e, [[e]]], ...e) { }
-    ·                                   ┬    ┬
-    ·                                   │    ╰── It can not be redeclared here
-    ·                                   ╰── `e` has already been declared here
+    ·              ┬                         ┬
+    ·              │                         ╰── It can not be redeclared here
+    ·              ╰── `e` has already been declared here
  10 │ function f6([f, ...f]) { }
     ╰────
 
@@ -6095,9 +6095,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ╭─[compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts:8:1]
   8 │ function f4({d, d: {d}}) { }
   9 │ function f5({e, e: {e}}, {e}, [d, e, [[e]]], ...e) { }
-    ·                                        ┬        ┬
-    ·                                        │        ╰── It can not be redeclared here
-    ·                                        ╰── `e` has already been declared here
+    ·              ┬                                  ┬
+    ·              │                                  ╰── It can not be redeclared here
+    ·              ╰── `e` has already been declared here
  10 │ function f6([f, ...f]) { }
     ╰────
 
@@ -12342,9 +12342,9 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ╭─[conformance/es6/destructuring/destructuringParameterDeclaration1ES6.ts:96:1]
  96 │ 
  97 │ function e6({x: [number, number, number]}) { }  // error, duplicate identifier;
-    ·                          ───┬──  ───┬──
-    ·                             │       ╰── It can not be redeclared here
-    ·                             ╰── `number` has already been declared here
+    ·                  ───┬──          ───┬──
+    ·                     │               ╰── It can not be redeclared here
+    ·                     ╰── `number` has already been declared here
  98 │ 
     ╰────
 


### PR DESCRIPTION
`check_duplicate_bound_names` will hurt performance