### PR TITLE
Remove redundant code from lexer

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -321,8 +321,6 @@ impl<'a> Lexer<'a> {
     /// Read each char and set the current token
     /// Whitespace and line terminators are skipped
     fn read_next_token(&mut self) -> Kind {
-        self.current.token.start = self.offset();
-
         loop {
             let offset = self.offset();
             self.current.token.start = offset;
@@ -1587,8 +1585,7 @@ const BTO: ByteHandler = |lexer| {
 // \
 const ESC: ByteHandler = |lexer| {
     let mut builder = AutoCow::new(lexer);
-    let c = lexer.consume_char();
-    builder.push_matching(c);
+    lexer.consume_char();
     builder.force_allocation_without_current_ascii_char(lexer);
     lexer.identifier_unicode_escape_sequence(&mut builder, true);
     let text = lexer.identifier_name(builder);


### PR DESCRIPTION
Just removes a couple of lines of redundant code from the lexer.

A note on the 2nd one:

```rs
let mut builder = AutoCow::new(lexer);
let c = lexer.consume_char();
builder.push_matching(c);
```

`push_matching()` is a no-op unless `force_allocation_without_current_ascii_char()` has already been called. Here the `AutoCow` has just been freshly created, so we know it hasn't.