### PR TITLE
perf(semantic): just need to find the AstKind::FormalParameter in is_in_formal_parameters

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -1089,7 +1089,7 @@ fn check_unary_expression<'a>(
 fn is_in_formal_parameters<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) -> bool {
     for node_id in ctx.nodes.ancestors(node.id()).skip(1) {
         match ctx.nodes.kind(node_id) {
-            AstKind::FormalParameters(_) => return true,
+            AstKind::FormalParameter(_) => return true,
             AstKind::Program(_) | AstKind::Function(_) | AstKind::ArrowExpression(_) => break,
             _ => {}
         }


### PR DESCRIPTION
A bit of performance improvement
<img width="894" alt="image" src="https://github.com/oxc-project/oxc/assets/29533304/ed687532-df83-4bd8-a893-059e41c8adf3">
