### PR TITLE
fix(parser): error on source larger than 4 GiB

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 #[derive(Debug, Error, Diagnostic)]
 #[error("Source length exceeds 4 GiB limit")]
 #[diagnostic()]
-pub struct OverlongSource(#[label] pub Span);
+pub struct OverlongSource;
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Flow is not supported")]

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -5,6 +5,11 @@ use oxc_diagnostics::{
 use oxc_span::Span;
 
 #[derive(Debug, Error, Diagnostic)]
+#[error("Source length exceeds 4 GiB limit")]
+#[diagnostic()]
+pub struct OverlongSource(#[label] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
 #[error("Flow is not supported")]
 #[diagnostic()]
 pub struct Flow(#[label] pub Span);

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -32,7 +32,7 @@ use self::{
     string_builder::AutoCow,
     trivia_builder::TriviaBuilder,
 };
-use crate::diagnostics;
+use crate::{diagnostics, MAX_LEN};
 
 #[derive(Debug, Clone)]
 pub struct LexerCheckpoint<'a> {
@@ -72,6 +72,11 @@ pub struct Lexer<'a> {
 #[allow(clippy::unused_self)]
 impl<'a> Lexer<'a> {
     pub fn new(allocator: &'a Allocator, source: &'a str, source_type: SourceType) -> Self {
+        // Token's start and end are u32s, so limit for length of source is u32::MAX bytes.
+        // Only a debug assertion is required, as parser checks length of source before calling
+        // this method.
+        debug_assert!(source.len() <= MAX_LEN);
+
         let token = Token {
             // the first token is at the start of file, so is allows on a new line
             is_on_new_line: true,

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -75,7 +75,7 @@ impl<'a> Lexer<'a> {
         // Token's start and end are u32s, so limit for length of source is u32::MAX bytes.
         // Only a debug assertion is required, as parser checks length of source before calling
         // this method.
-        debug_assert!(source.len() <= MAX_LEN);
+        debug_assert!(source.len() <= MAX_LEN, "Source length exceeds MAX_LEN");
 
         let token = Token {
             // the first token is at the start of file, so is allows on a new line

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -241,7 +241,7 @@ impl<'a> Parser<'a> {
     /// Original parsing error is not real - `Parser::new` substituted "\0" as the source text.
     fn overlong_error(&self) -> Option<Error> {
         if self.source_text.len() > MAX_LEN {
-            return Some(diagnostics::OverlongSource(Span::default()).into());
+            return Some(diagnostics::OverlongSource.into());
         }
         None
     }


### PR DESCRIPTION
`Token` and `Span` both represent `start` and `end` as `u32`.

This limits size of source which can be parsed to `u32::MAX`.

https://github.com/oxc-project/oxc/blob/19577709dbcfc9761cfcb1b39ec7f3ebdc810285/crates/oxc_span/src/span.rs#L14-L20

However, this constraint is currently not enforced.

In a release build, code will not panic on arithmetic overflow, so `start`/`end` could wrap around back to zero if source is 4 GiB or more.

That'd produce nonsense spans. But worse, the lexer relies in some places on `self.current.token.start` being correct, so if the value wrapped around, possibly it'd keep rewinding to the start of the source and lexing it again, causing an infinite loop.

In worst case, if for some reason an application's public API used OXC's parser with user-supplied source code (parser-as-a-service!), this could be exploited for denial of service.

This PR adds an assertion to catch this at the start of parsing instead.

This does add an extra instruction, but I imagine the effect will be negligible compared to the work required to parse the code.