### PR TITLE
fix(ast): implement `GetSpan` for `JSXElement`

### DIFF
--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -294,6 +294,12 @@ impl<'a> GetSpan for JSXElementName<'a> {
     }
 }
 
+impl<'a> GetSpan for JSXElement<'a> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 impl<'a> GetSpan for TSSignature<'a> {
     fn span(&self) -> Span {
         match self {


### PR DESCRIPTION
Title. Just going through some implementation stuff and patching a few API holes.