### PR TITLE
chore(lsp): normalize the lsp naming

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -118,12 +118,12 @@ impl LanguageServer for Backend {
         })
     }
 
-    /// Using pull mode to make client implementation easier
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         let changed_options =
             if let Ok(options) = serde_json::from_value::<Options>(params.settings) {
                 options
             } else {
+                // Fallback if some client didn't took changed configuration in params of `workspace/configuration`
                 let Some(options) = self
                     .client
                     .configuration(vec![ConfigurationItem {

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -132,7 +132,7 @@ impl LanguageServer for Backend {
                     }])
                     .await
                     .ok()
-                    .and_then(|mut config| config.first_mut().map(|first| first.take()))
+                    .and_then(|mut config| config.first_mut().map(serde_json::Value::take))
                     .and_then(|value| serde_json::from_value::<Options>(value).ok())
                 else {
                     error!("Can't fetch `oxc_language_server` configuration");

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -75,7 +75,9 @@ export async function activate(context: ExtensionContext) {
   const toggleEnable = commands.registerCommand(
     OxcCommands.ToggleEnable,
     () => {
-      let enabled = workspace.getConfiguration("oxc_language_server").get("enable");
+      let enabled = workspace
+        .getConfiguration("oxc_language_server")
+        .get("enable");
       let nextState = !enabled;
       workspace
         .getConfiguration("oxc_language_server")
@@ -98,7 +100,6 @@ export async function activate(context: ExtensionContext) {
   const command =
     process.env.SERVER_PATH_DEV ??
     join(context.extensionPath, `./target/release/oxc_language_server${ext}`);
-    console.log(command)
   const run: Executable = {
     command: command!,
     options: {
@@ -125,7 +126,7 @@ export async function activate(context: ExtensionContext) {
       "javascript",
       "typescriptreact",
       "javascriptreact",
-      "vue"
+      "vue",
     ].map((lang) => ({
       language: lang,
       scheme: "file",
@@ -149,8 +150,7 @@ export async function activate(context: ExtensionContext) {
     clientOptions,
   );
   workspace.onDidChangeConfiguration((e) => {
-    console.log(e)
-    let isAffected = e.affectsConfiguration("oxc_language_server")
+    let isAffected = e.affectsConfiguration("oxc_language_server");
     if (!isAffected) {
       return;
     }
@@ -158,7 +158,7 @@ export async function activate(context: ExtensionContext) {
       JSON.stringify(workspace.getConfiguration("oxc_language_server")),
     );
     updateStatsBar(settings.enable);
-    client.sendNotification("workspace/didChangeConfiguration", {settings});
+    client.sendNotification("workspace/didChangeConfiguration", { settings });
   });
 
   function updateStatsBar(enable: boolean) {
@@ -176,8 +176,9 @@ export async function activate(context: ExtensionContext) {
         ? "statusBarItem.activeBackground"
         : "statusBarItem.errorBackground",
     );
-    myStatusBarItem.text = `oxc: ${enable ? "$(check-all)" : "$(circle-slash)"}`;
-
+    myStatusBarItem.text = `oxc: ${
+      enable ? "$(check-all)" : "$(circle-slash)"
+    }`;
 
     myStatusBarItem.backgroundColor = bgColor;
   }

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -18,10 +18,10 @@ import {
 
 import { join } from "node:path";
 
-const languageClientId = "oxc-client";
+const languageClientId = "oxc-vscode";
 const languageClientName = "oxc";
-const outputChannelName = "oxc";
-const traceOutputChannelName = "oxc.trace";
+const outputChannelName = "oxc_language_server";
+const traceOutputChannelName = "oxc_language_server.trace";
 
 const enum OxcCommands {
   RestartServer = "oxc.restartServer",
@@ -75,10 +75,10 @@ export async function activate(context: ExtensionContext) {
   const toggleEnable = commands.registerCommand(
     OxcCommands.ToggleEnable,
     () => {
-      let enabled = workspace.getConfiguration("oxc-client").get("enable");
+      let enabled = workspace.getConfiguration("oxc_language_server").get("enable");
       let nextState = !enabled;
       workspace
-        .getConfiguration("oxc-client")
+        .getConfiguration("oxc_language_server")
         .update("enable", nextState, ConfigurationTarget.Global);
     },
   );
@@ -98,7 +98,7 @@ export async function activate(context: ExtensionContext) {
   const command =
     process.env.SERVER_PATH_DEV ??
     join(context.extensionPath, `./target/release/oxc_language_server${ext}`);
-
+    console.log(command)
   const run: Executable = {
     command: command!,
     options: {
@@ -116,7 +116,7 @@ export async function activate(context: ExtensionContext) {
   // Otherwise the run options are used
   // Options to control the language client
   let clientConfig: any = JSON.parse(
-    JSON.stringify(workspace.getConfiguration("oxc-client")),
+    JSON.stringify(workspace.getConfiguration("oxc_language_server")),
   );
   let clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
@@ -149,13 +149,16 @@ export async function activate(context: ExtensionContext) {
     clientOptions,
   );
   workspace.onDidChangeConfiguration((e) => {
+    console.log(e)
+    let isAffected = e.affectsConfiguration("oxc_language_server")
+    if (!isAffected) {
+      return;
+    }
     let settings: any = JSON.parse(
-      JSON.stringify(workspace.getConfiguration("oxc-client")),
+      JSON.stringify(workspace.getConfiguration("oxc_language_server")),
     );
     updateStatsBar(settings.enable);
-    client.sendNotification("workspace/didChangeConfiguration", {
-      settings,
-    });
+    client.sendNotification("workspace/didChangeConfiguration", {settings});
   });
 
   function updateStatsBar(enable: boolean) {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -62,7 +62,7 @@
       "type": "object",
       "title": "oxc",
       "properties": {
-        "oxc-client.run": {
+        "oxc_language_server.run": {
           "scope": "resource",
           "type": "string",
           "enum": [
@@ -72,12 +72,12 @@
           "default": "onType",
           "description": "Run the linter on save (onSave) or on type (onType)"
         },
-        "oxc-client.enable": {
+        "oxc_language_server.enable": {
           "type": "boolean",
           "default": true,
-          "description": "enable oxc linter"
+          "description": "enable oxc language server"
         },
-        "oxc-client.trace.server": {
+        "oxc_language_server.trace.server": {
           "type": "string",
           "scope": "window",
           "enum": [
@@ -99,7 +99,7 @@
   "scripts": {
     "preinstall": "[ -f icon.png ] || curl https://raw.githubusercontent.com/Boshen/oxc-assets/main/logo-square-min.png --output icon.png",
     "build": "pnpm run server:build:release && pnpm run compile && pnpm run package",
-    "compile": "esbuild client/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node16 --minify",
+    "compile": "esbuild client/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node16 --minify --sourcemap",
     "watch": "pnpm run compile --watch",
     "package": "vsce package --no-dependencies -o oxc_vscode.vsix",
     "install-extension": "code --install-extension oxc_vscode.vsix --force",


### PR DESCRIPTION
1. Fallback logic about `document/didChangeConfiguration`
2. normalize vscode naming
3. change `configuration` section name from `oxc-client` to `oxc_langauge_server`.