### PR TITLE
refactor(linter): get js code slice from source code

### DIFF
--- a/crates/oxc_linter/src/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/partial_loader/mod.rs
@@ -11,13 +11,13 @@ pub enum PartialLoader {
 }
 
 #[derive(Default)]
-pub struct PartialLoaderValue {
-    pub source_text: String,
+pub struct PartialLoaderValue<'a> {
+    pub source_text: &'a str,
     pub source_type: SourceType,
 }
 
-impl PartialLoaderValue {
-    pub fn from(source_text: String, is_ts: bool, is_jsx: bool) -> Self {
+impl<'a> PartialLoaderValue<'a> {
+    pub fn from(source_text: &'a str, is_ts: bool, is_jsx: bool) -> Self {
         // `module_kind`  should be `ModuleKind::Module` for allow `import`
         let source_type =
             SourceType::default().with_typescript(is_ts).with_module(true).with_jsx(is_jsx);
@@ -26,7 +26,7 @@ impl PartialLoaderValue {
 }
 
 impl PartialLoader {
-    pub fn parse(&self, source_text: &str) -> PartialLoaderValue {
+    pub fn parse<'a>(&self, source_text: &'a str) -> PartialLoaderValue<'a> {
         if matches!(self, Self::Vue) {
             return VuePartialLoader::from(source_text).build();
         }


### PR DESCRIPTION
Has test [nuxt](https://github.com/nuxt/nuxt), [vant](https://github.com/youzan/vant), [elk](https://github.com/elk-zone/elk), [element-plus](https://github.com/element-plus/element-plus), no panic with these repos.