### PR TITLE
perf(linter) reduce the number of diagnostics for no_sparse_arrays

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_sparse_arrays.snap
+++ b/crates/oxc_linter/src/snapshots/no_sparse_arrays.snap
@@ -2,17 +2,62 @@
 source: crates/oxc_linter/src/tester.rs
 expression: no_sparse_arrays
 ---
-  ⚠ eslint(no-sparse-arrays): Unexpected comma in middle of array
+  × eslint(no-sparse-arrays): Unexpected comma in middle of array
    ╭─[no_sparse_arrays.tsx:1:1]
  1 │ var a = [,];
    ·          ▲
+   ·          ╰── unexpected comma
    ╰────
   help: remove the comma or insert `undefined`
 
-  ⚠ eslint(no-sparse-arrays): Unexpected comma in middle of array
+  × eslint(no-sparse-arrays): Unexpected comma in middle of array
    ╭─[no_sparse_arrays.tsx:1:1]
  1 │ var a = [ 1,, 2];
    ·             ▲
+   ·             ╰── unexpected comma
+   ╰────
+  help: remove the comma or insert `undefined`
+
+  × eslint(no-sparse-arrays): Unexpected comma in middle of array
+   ╭─[no_sparse_arrays.tsx:1:1]
+ 1 │ var a = [ 1,,,, 2];
+   ·             ▲▲▲
+   ·             ││╰── unexpected comma
+   ·             │╰── unexpected comma
+   ·             ╰── unexpected comma
+   ╰────
+  help: remove the comma or insert `undefined`
+
+  × eslint(no-sparse-arrays): 30 unexpected commas in middle of array
+   ╭─[no_sparse_arrays.tsx:1:1]
+ 1 │ var a = [ 1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,, 2];
+   ·         ──────────────────┬──────────────────
+   ·                           ╰── the array here
+   ╰────
+  help: remove the comma or insert `undefined`
+
+  × eslint(no-sparse-arrays): 83 unexpected commas in middle of array
+   ╭─[no_sparse_arrays.tsx:1:1]
+ 1 │ var a = [ 1, , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , ,  2];
+   ·         ▲
+   ·         ╰── the array starting here
+   ╰────
+  help: remove the comma or insert `undefined`
+
+  × eslint(no-sparse-arrays): 82 unexpected commas in middle of array
+   ╭─[no_sparse_arrays.tsx:1:1]
+ 1 │ var a = [ 1, , , , , , , , , , , , , , , , , , , , , , , , , , hello, , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , ,  2];
+   ·         ▲
+   ·         ╰── the array starting here
+   ╰────
+  help: remove the comma or insert `undefined`
+
+  × eslint(no-sparse-arrays): 81 unexpected commas in middle of array
+   ╭─[no_sparse_arrays.tsx:1:1]
+ 1 │ var a = [ 1, , , , , , , , , , , , , , , , , , , , , , , , , ,
+   ·         ▲
+   ·         ╰── the array starting here
+ 2 │         
    ╰────
   help: remove the comma or insert `undefined`
 


### PR DESCRIPTION
Partially address #1879

See there for more info. but tldr:

Printing a lot of diagnostics takes a lot of time - a lot longer than it takes to create them

we speed up printing by producing less diagnostics.

we do this by making `no-sparse-arrays` report 1x per array instead of 1x per violation.

This does have the overhead of now every ArrayElement is processed 2x (1x when we loop through in the rule, 1x when we loop through the ast). But the perf reduction is negligble compared to the per production of producing thousands of diagnostics vs 1 diagnostic.

This means that linting nodejs/node now takes ~1.5 seconds vs ~2:30 previously