### PR TITLE
refactor(semantic): improve ClassTable implmention and merge properties and methods to elements

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -294,8 +294,7 @@ fn check_private_identifier_outside_class(ident: &PrivateIdentifier, ctx: &Seman
 fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
     if let Some(class_id) = ctx.class_table_builder.current_class_id {
         ctx.class_table_builder.classes.iter_private_identifiers(class_id).for_each(|reference| {
-            if reference.property_id.is_none()
-                && reference.method_ids.is_empty()
+            if reference.element_ids.is_empty()
                 && !ctx.class_table_builder.classes.ancestors(class_id).skip(1).any(|class_id| {
                     ctx.class_table_builder
                         .classes

--- a/crates/oxc_semantic/tests/classes.rs
+++ b/crates/oxc_semantic/tests/classes.rs
@@ -19,8 +19,25 @@ fn test_class_simple() {
     ",
     )
     .has_class("Foo")
-    .has_number_of_methods(3)
-    .has_number_of_properties(2)
+    .has_number_of_elements(5)
     .has_method("a")
     .has_property("privateProperty");
+}
+
+#[test]
+fn test_class_with_ts() {
+    SemanticTester::ts(
+        "
+      class Foo {
+        accessor ap = 1;
+        accessor #pap = 1;
+        constructor() {} // this method is skip
+      }
+        
+    ",
+    )
+    .has_class("Foo")
+    .has_number_of_elements(2)
+    .has_accessor("ap")
+    .has_accessor("pap");
 }

--- a/crates/oxc_semantic/tests/util/class_tester.rs
+++ b/crates/oxc_semantic/tests/util/class_tester.rs
@@ -28,28 +28,33 @@ impl<'a> ClassTester<'a> {
         }
     }
 
-    pub fn has_number_of_properties(&self, len: usize) -> &Self {
-        let property_len = self.semantic.classes().properties[self.class_id].len();
-        debug_assert!(property_len == len, "Expected {len} properties, found {property_len}");
-        self
-    }
-
-    pub fn has_number_of_methods(&self, len: usize) -> &Self {
-        let method_len = self.semantic.classes().methods[self.class_id].len();
-        debug_assert!(method_len == len, "Expected `{len}` methods, found {method_len}");
+    pub fn has_number_of_elements(&self, len: usize) -> &Self {
+        let element_len = self.semantic.classes().elements[self.class_id].len();
+        debug_assert!(element_len == len, "Expected {len} elements, found {element_len}");
         self
     }
 
     pub fn has_property(&self, name: &str) -> &Self {
-        let property =
-            self.semantic.classes().properties[self.class_id].iter().find(|p| p.name == name);
+        let property = self.semantic.classes().elements[self.class_id]
+            .iter()
+            .find(|p| p.kind.is_property() && p.name == name);
         debug_assert!(property.is_some(), "Expected property `{name}` not found");
         self
     }
 
     pub fn has_method(&self, name: &str) -> &Self {
-        let method = self.semantic.classes().methods[self.class_id].iter().find(|m| m.name == name);
+        let method = self.semantic.classes().elements[self.class_id]
+            .iter()
+            .find(|m| m.kind.is_method() && m.name == name);
         debug_assert!(method.is_some(), "Expected method `{name}` not found");
+        self
+    }
+
+    pub fn has_accessor(&self, name: &str) -> &Self {
+        let method = self.semantic.classes().elements[self.class_id]
+            .iter()
+            .find(|m| m.kind.is_accessor() && m.name == name);
+        debug_assert!(method.is_some(), "Expected accessor `{name}` not found");
         self
     }
 }

--- a/crates/oxc_syntax/src/class.rs
+++ b/crates/oxc_syntax/src/class.rs
@@ -1,11 +1,32 @@
+use bitflags::bitflags;
 use oxc_index::define_index_type;
 
 define_index_type! {
     pub struct ClassId = u32;
 }
 define_index_type! {
-    pub struct PropertyId = u32;
+    pub struct ElementId = u32;
 }
-define_index_type! {
-    pub struct MethodId = u32;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct ElementKind: u8 {
+        const Accessor = 0;
+        const Method = 1;
+        const Property = 2;
+    }
+}
+
+impl ElementKind {
+    pub fn is_property(self) -> bool {
+        self.contains(Self::Property)
+    }
+
+    pub fn is_method(self) -> bool {
+        self.contains(Self::Method)
+    }
+
+    pub fn is_accessor(self) -> bool {
+        self.contains(Self::Accessor)
+    }
 }

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1,6 +1,6 @@
 parser_typescript Summary:
 AST Parsed     : 5201/5205 (99.92%)
-Positive Passed: 5192/5205 (99.75%)
+Positive Passed: 5194/5205 (99.79%)
 Negative Passed: 1023/4859 (21.05%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
@@ -3880,39 +3880,6 @@ Expect to Parse: "compiler/withStatementInternalComments.ts"
    ·       ────
    ╰────
 
-Expect to Parse: "conformance/classes/propertyMemberDeclarations/autoAccessor2.ts"
-  × Private field 'a' must be declared in an enclosing class
-    ╭─[conformance/classes/propertyMemberDeclarations/autoAccessor2.ts:9:1]
-  9 │     constructor() {
- 10 │         this.#a = 3;
-    ·              ──
- 11 │         this.#b = 4;
-    ╰────
-
-  × Private field 'b' must be declared in an enclosing class
-    ╭─[conformance/classes/propertyMemberDeclarations/autoAccessor2.ts:10:1]
- 10 │         this.#a = 3;
- 11 │         this.#b = 4;
-    ·              ──
- 12 │     }
-    ╰────
-
-  × Private field 'c' must be declared in an enclosing class
-    ╭─[conformance/classes/propertyMemberDeclarations/autoAccessor2.ts:14:1]
- 14 │     static {
- 15 │         this.#c = 5;
-    ·              ──
- 16 │         this.#d = 6;
-    ╰────
-
-  × Private field 'd' must be declared in an enclosing class
-    ╭─[conformance/classes/propertyMemberDeclarations/autoAccessor2.ts:15:1]
- 15 │         this.#c = 5;
- 16 │         this.#d = 6;
-    ·              ──
- 17 │     }
-    ╰────
-
 Expect to Parse: "conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts"
   × Classes may not have a static property named prototype
     ╭─[conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:55:1]
@@ -3969,23 +3936,6 @@ Expect to Parse: "conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJ
  68 │ with (_) {
     · ────
  69 │     var y = _;
-    ╰────
-
-Expect to Parse: "conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts"
-  × Private field 'field1' must be declared in an enclosing class
-    ╭─[conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts:14:1]
- 14 │     static {
- 15 │         this.#field1;
-    ·              ───────
- 16 │         this.#field1 = 1;
-    ╰────
-
-  × Private field 'field1' must be declared in an enclosing class
-    ╭─[conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts:15:1]
- 15 │         this.#field1;
- 16 │         this.#field1 = 1;
-    ·              ───────
- 17 │     }
     ╰────
 
 Expect to Parse: "conformance/esDecorators/esDecorators-preservesThis.ts"


### PR DESCRIPTION
close: #1828

Storing `PropertyDefinition` and `MethodyDefinition` separately doesn't seem like a good way to do it, since we may have other `ClassElement` properties to check in the future. So I removed the `properties` and `methods` properties and added `elements` instead.