### PR TITLE
feat(semantic): allow reserved keyword defined in ts module block

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -179,6 +179,10 @@ pub const STRICT_MODE_NAMES: Set<&'static str> = phf_set! {
 };
 
 fn check_identifier<'a>(name: &Atom, span: Span, node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
+    // ts module block allows revered keywords
+    if ctx.current_scope_flags().is_ts_module_block() {
+        return;
+    }
     if *name == "await" {
         // It is a Syntax Error if the goal symbol of the syntactic grammar is Module and the StringValue of IdentifierName is "await".
         if ctx.source_type.is_module() {

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -52,6 +52,10 @@ impl ScopeFlags {
         self.contains(Self::ClassStaticBlock)
     }
 
+    pub fn is_ts_module_block(&self) -> bool {
+        self.contains(Self::TsModuleBlock)
+    }
+
     pub fn is_var(&self) -> bool {
         self.intersects(Self::Var)
     }

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -3956,14 +3956,6 @@ Expect to Parse: "conformance/externalModules/topLevelAwait.2.ts"
    ╰────
 
   × The keyword 'await' is reserved
-   ╭─[conformance/externalModules/topLevelAwait.2.ts:3:1]
- 3 │ 
- 4 │ declare namespace foo { const await: any; }
-   ·                               ─────
- 5 │ 
-   ╰────
-
-  × The keyword 'await' is reserved
    ╭─[conformance/externalModules/topLevelAwait.2.ts:6:1]
  6 │ // await allowed in import=namespace when not a module
  7 │ import await = foo.await;
@@ -15632,14 +15624,6 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  7 │ // await disallowed in import=namespace when in a module
  8 │ import await = foo.await;
    ·        ─────
-   ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[conformance/externalModules/topLevelAwaitErrors.12.ts:4:1]
- 4 │ export {};
- 5 │ declare namespace foo { const await: any; }
-   ·                               ─────
- 6 │ 
    ╰────
 
   × The keyword 'await' is reserved


### PR DESCRIPTION
https://www.typescriptlang.org/play?target=99#code/PTAEAEBcEMCcHMCmkBcpEGcB2iAekAoECAWwHsATAVwBtE1MAmABkcYBpMd8CiwAHKgCNQAYzJYMkUAGUAKgCUAkgGE5AfQCyAeQAiAUXUA5AIKb9MtDOQAeAGQByKdEgBLUaCmwAfKAC8oPwAFgBm6hjIAISgAN58oAkJAESuJPx0JIhYkBhJ7PGJoCnZiLAh0KKIeQWJSXSQ1cSFSfwVANbQSI1gzfywrgBuLlX5TbV9ZJCIolMU3YVFgkI07vPNzm6ia7UAnq6INHOjYAC+ANy8ePxksNIx5wQU0zRwiKBY0JkYrZWgIWRkWKgAgJcSSaSpdKITLZDBoaBYHZnYGgiRSQLCFaieGI5EgsRoiElMoVeigBFIlGgIawUD1HGU-Fg9E-DpIBl41HgwL9IZTDlMwk8ybTWYCrnojbucUE7l7A4UAUnAhAA