### PR TITLE
chore: add some useful informantion log

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/editors/vscode/dist/*.js"],
 			"env": {
-        "SERVER_PATH_DEV": "${workspaceRoot}/target/debug/oxc_language_server"
+        "SERVER_PATH_DEV": "${workspaceRoot}/target/debug/oxc_language_server",
+        "RUST_LOG": "debug"
       }
 		}
 	]

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -6,7 +6,7 @@ mod walk;
 use crate::linter::{DiagnosticReport, ServerLinter};
 use globset::Glob;
 use ignore::gitignore::Gitignore;
-use log::{debug, error};
+use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -87,7 +87,8 @@ impl LanguageServer for Backend {
         });
 
         if let Some(value) = options {
-            debug!("initialize: {:?}", value);
+            info!("initialize: {:?}", value);
+            info!("language server version: {:?}", env!("CARGO_PKG_VERSION"));
             *self.options.lock().await = value;
         }
         Ok(InitializeResult {

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -105,7 +105,7 @@ export async function activate(context: ExtensionContext) {
     options: {
       env: {
         ...process.env,
-        RUST_LOG: "debug",
+        RUST_LOG: process.env.RUST_LOG || "info",
       },
     },
   };


### PR DESCRIPTION
1. Use `log::info` to print some informantion that we want to display in release mode, 
2. Add config to switch back `debug` log level in development mode.