### PR TITLE
refactor(parser): remove `TokenValue::BigInt` from `Token`

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -236,7 +236,7 @@ impl<'a> Parser<'a> {
     pub(crate) fn checkpoint(&self) -> ParserCheckpoint<'a> {
         ParserCheckpoint {
             lexer: self.lexer.checkpoint(),
-            cur_token: self.token.clone(),
+            cur_token: self.token,
             prev_span_end: self.prev_token_end,
             errors_pos: self.errors.len(),
         }

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -5,7 +5,7 @@ use oxc_span::Span;
 
 use super::kind::Kind;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Token<'a> {
     /// Token Kind
     pub kind: Kind,
@@ -38,16 +38,15 @@ impl<'a> Token<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum TokenValue<'a> {
     None,
     Number(f64),
-    BigInt(num_bigint::BigInt),
     String(&'a str),
     RegExp(RegExp<'a>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct RegExp<'a> {
     pub pattern: &'a str,
     pub flags: RegExpFlags,
@@ -64,13 +63,6 @@ impl<'a> TokenValue<'a> {
         match self {
             Self::Number(s) => *s,
             _ => unreachable!("expected number!"),
-        }
-    }
-
-    pub fn as_bigint(&self) -> num_bigint::BigInt {
-        match self {
-            Self::BigInt(s) => s.clone(),
-            _ => unreachable!("expected bigint!"),
         }
     }
 


### PR DESCRIPTION
This PR partially fixes #1803 and is part of #1880.

BigInt is removed from the `Token` value, so that the token size can be
reduced once we removed all the variants.

`Token` is now also `Copy`, which removes all the `clone` and `drop` calls.

This yields 5% performance improvement for the parser.