### PR TITLE
refactor(parser): remove `TokenValue::RegExp` from `Token`

### DIFF
--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -163,8 +163,13 @@ impl<'a> AstBuilder<'a> {
         TemplateElementValue { raw, cooked }
     }
 
-    pub fn reg_exp_literal(&self, span: Span, pattern: Atom, flags: RegExpFlags) -> RegExpLiteral {
-        RegExpLiteral { span, value: EmptyObject, regex: RegExp { pattern, flags } }
+    pub fn reg_exp_literal(
+        &self,
+        span: Span,
+        pattern: &'a str,
+        flags: RegExpFlags,
+    ) -> RegExpLiteral {
+        RegExpLiteral { span, value: EmptyObject, regex: RegExp { pattern: pattern.into(), flags } }
     }
 
     pub fn literal_string_expression(&self, literal: StringLiteral) -> Expression<'a> {

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -1,6 +1,5 @@
 //! Token
 
-use oxc_ast::ast::RegExpFlags;
 use oxc_span::Span;
 
 use super::kind::Kind;
@@ -29,7 +28,7 @@ pub struct Token<'a> {
 mod size_asserts {
     use oxc_index::assert_eq_size;
 
-    assert_eq_size!(super::Token, [u8; 48]);
+    assert_eq_size!(super::Token, [u8; 40]);
 }
 
 impl<'a> Token<'a> {
@@ -43,13 +42,6 @@ pub enum TokenValue<'a> {
     None,
     Number(f64),
     String(&'a str),
-    RegExp(RegExp<'a>),
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct RegExp<'a> {
-    pub pattern: &'a str,
-    pub flags: RegExpFlags,
 }
 
 impl<'a> Default for TokenValue<'a> {
@@ -63,13 +55,6 @@ impl<'a> TokenValue<'a> {
         match self {
             Self::Number(s) => *s,
             _ => unreachable!("expected number!"),
-        }
-    }
-
-    pub fn as_regex(&self) -> &RegExp<'a> {
-        match self {
-            Self::RegExp(regex) => regex,
-            _ => unreachable!("expected regex!"),
         }
     }
 

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -1144,6 +1144,12 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
  2 │ /
    ╰────
 
+  × Unexpected token
+   ╭─[core/uncategorised/380/input.js:1:1]
+ 1 │ var x = /
+ 2 │ /
+   ╰────
+
   × Unterminated string
    ╭─[core/uncategorised/381/input.js:1:1]
  1 │ var x = "
@@ -1523,6 +1529,12 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ╭─[core/uncategorised/441/input.js:1:1]
  1 │ /a\
    · ────
+ 2 │ /
+   ╰────
+
+  × Unexpected token
+   ╭─[core/uncategorised/441/input.js:1:1]
+ 1 │ /a\
  2 │ /
    ╰────
 
@@ -7967,6 +7979,11 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
  2 │ /
    ╰────
 
+  × Unexpected token
+   ╭─[esprima/invalid-syntax/migrated_0040/input.js:2:1]
+ 2 │ /
+   ╰────
+
   × Invalid Unicode escape sequence
    ╭─[esprima/invalid-syntax/migrated_0041/input.js:1:1]
  1 │ var x = /[a-z]/\ux
@@ -8138,6 +8155,11 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ╭─[esprima/invalid-syntax/migrated_0062/input.js:1:1]
  1 │ var x = /
    ·         ──
+ 2 │ /
+   ╰────
+
+  × Unexpected token
+   ╭─[esprima/invalid-syntax/migrated_0062/input.js:2:1]
  2 │ /
    ╰────
 
@@ -8678,6 +8700,11 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ╭─[esprima/invalid-syntax/migrated_0157/input.js:1:1]
  1 │ /a\
    · ────
+ 2 │ /
+   ╰────
+
+  × Unexpected token
+   ╭─[esprima/invalid-syntax/migrated_0157/input.js:2:1]
  2 │ /
    ╰────
 

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -18251,11 +18251,21 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
     · ─
     ╰────
 
+  × Unexpected token
+    ╭─[language/line-terminators/invalid-regexp-cr.js:18:1]
+ 18 │ /
+    ╰────
+
   × Unterminated regular expression
     ╭─[language/line-terminators/invalid-regexp-lf.js:16:1]
  16 │ 
  17 │ /
     · ──
+ 18 │ /
+    ╰────
+
+  × Unexpected token
+    ╭─[language/line-terminators/invalid-regexp-lf.js:18:1]
  18 │ /
     ╰────
 
@@ -18266,11 +18276,21 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
     · ──
     ╰────
 
+  × Unexpected token
+    ╭─[language/line-terminators/invalid-regexp-ls.js:17:1]
+ 17 │ / /
+    ╰────
+
   × Unterminated regular expression
     ╭─[language/line-terminators/invalid-regexp-ps.js:16:1]
  16 │ 
  17 │ / /
     · ──
+    ╰────
+
+  × Unexpected token
+    ╭─[language/line-terminators/invalid-regexp-ps.js:17:1]
+ 17 │ / /
     ╰────
 
   × Unterminated string
@@ -31535,6 +31555,11 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
  16 │ 
  17 │ function __func(){/ ABC}
     ·                   ───────
+    ╰────
+
+  × Expected `}` but found `EOF`
+    ╭─[language/statements/function/invalid-function-body-1.js:17:1]
+ 17 │ function __func(){/ ABC}
     ╰────
 
   × Unexpected token

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -17136,6 +17136,11 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ·     ────────────
    ╰────
 
+  × Expected `)` but found `EOF`
+   ╭─[conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts:1:1]
+ 1 │ foo(/notregexp);
+   ╰────
+
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity7.ts:1:1]
  1 │ (a/8


### PR DESCRIPTION
This PR is part of #1880.

`Token` size is reduced from 48 to 40 bytes.

To reconstruct the regex pattern and flags within the parser , the regex string is
re-parsed from the end by reading all valid flags.

In order to make things work nicely, the lexer will no longer recover
from a invalid regex.
