### PR TITLE
refactor(parser): remove `TokenValue::Number` from `Token`

### DIFF
--- a/crates/oxc_parser/src/lexer/number.rs
+++ b/crates/oxc_parser/src/lexer/number.rs
@@ -2,13 +2,18 @@
 //! code copied from [jsparagus](https://github.com/mozilla-spidermonkey/jsparagus/blob/master/crates/parser/src/numeric_value.rs)
 
 use num_bigint::BigInt;
+use std::borrow::Cow;
 
 use super::kind::Kind;
 
 // the string passed in has `_` removed from the lexer
 pub fn parse_int(s: &str, kind: Kind) -> Result<f64, &'static str> {
+    if kind == Kind::Decimal {
+        return parse_float(s);
+    }
+    let s = if s.contains('_') { Cow::Owned(s.replace('_', "")) } else { Cow::Borrowed(s) };
+    let s = s.as_ref();
     match kind {
-        Kind::Decimal => parse_float(s),
         Kind::Binary => Ok(parse_binary(&s[2..])),
         Kind::Octal => {
             let s = if s.starts_with("0o") || s.starts_with("0O") {
@@ -24,6 +29,7 @@ pub fn parse_int(s: &str, kind: Kind) -> Result<f64, &'static str> {
 }
 
 pub fn parse_float(s: &str) -> Result<f64, &'static str> {
+    let s = if s.contains('_') { Cow::Owned(s.replace('_', "")) } else { Cow::Borrowed(s) };
     s.parse::<f64>().map_err(|_| "invalid float")
 }
 

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -26,9 +26,7 @@ pub struct Token<'a> {
 
 #[cfg(target_pointer_width = "64")]
 mod size_asserts {
-    use oxc_index::assert_eq_size;
-
-    assert_eq_size!(super::Token, [u8; 40]);
+    oxc_index::assert_eq_size!(super::Token, [u8; 32]);
 }
 
 impl<'a> Token<'a> {
@@ -40,7 +38,6 @@ impl<'a> Token<'a> {
 #[derive(Debug, Copy, Clone)]
 pub enum TokenValue<'a> {
     None,
-    Number(f64),
     String(&'a str),
 }
 
@@ -51,17 +48,10 @@ impl<'a> Default for TokenValue<'a> {
 }
 
 impl<'a> TokenValue<'a> {
-    pub fn as_number(&self) -> f64 {
-        match self {
-            Self::Number(s) => *s,
-            _ => unreachable!("expected number!"),
-        }
-    }
-
     pub fn get_string(&self) -> Option<&str> {
         match self {
             Self::String(s) => Some(s),
-            _ => None,
+            Self::None => None,
         }
     }
 }


### PR DESCRIPTION
This PR is part of #1880.

Token size is reduced from 40 to 32 bytes.