### PR TITLE
ensure numbers without a raw are allocated during codegen

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -947,7 +947,7 @@ fn need_space_before_dot<const MINIFY: bool>(bytes: &[u8], p: &mut Codegen<{ MIN
 impl<'a, const MINIFY: bool> Gen<MINIFY> for NumberLiteral<'a> {
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
-        if MINIFY {
+        if MINIFY || self.raw == "" {
             p.print_space_before_identifier();
             let abs_value = self.value.abs();
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -947,7 +947,7 @@ fn need_space_before_dot<const MINIFY: bool>(bytes: &[u8], p: &mut Codegen<{ MIN
 impl<'a, const MINIFY: bool> Gen<MINIFY> for NumberLiteral<'a> {
     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
-        if MINIFY || self.raw == "" {
+        if MINIFY || self.raw.is_empty() {
             p.print_space_before_identifier();
             let abs_value = self.value.abs();
 


### PR DESCRIPTION
This was incorrectly using raw for dynamically generated numbers like in the minifier ( https://github.com/oxc-project/oxc/blob/6e0bd52af13e2add37a2bf444eedc02814f7082b/crates/oxc_minifier/src/compressor/fold.rs#L280 ).

This ensures they are dynamically generated during codegen.

This does not investigate why `just example minifier` does not take the `if MINIFY` branch.