### PR TITLE
refactor(parser): reduce `Token` size from 32 to 16 bytes

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub struct ParserCheckpoint<'a> {
     lexer: LexerCheckpoint<'a>,
-    cur_token: Token<'a>,
+    cur_token: Token,
     prev_span_end: u32,
     errors_pos: usize,
 }
@@ -29,8 +29,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Get current token
-    pub(crate) fn cur_token(&self) -> &Token<'a> {
-        &self.token
+    pub(crate) fn cur_token(&self) -> Token {
+        self.token
     }
 
     /// Get current Kind
@@ -47,12 +47,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Get current string
-    pub(crate) fn cur_string(&self) -> Option<&str> {
-        self.cur_token().value.get_string()
+    pub(crate) fn cur_string(&self) -> &'a str {
+        self.lexer.get_string(self.token)
     }
 
     /// Peek next token, returns EOF for final peek
-    pub(crate) fn peek_token(&mut self) -> &Token {
+    pub(crate) fn peek_token(&mut self) -> Token {
         self.lexer.lookahead(1)
     }
 
@@ -67,7 +67,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Peek nth token
-    pub(crate) fn nth(&mut self, n: u8) -> &Token {
+    pub(crate) fn nth(&mut self, n: u8) -> Token {
         if n == 0 {
             return self.cur_token();
         }
@@ -94,7 +94,7 @@ impl<'a> Parser<'a> {
     /// whose code point sequence is the same as a `ReservedWord`.
     #[inline]
     fn test_escaped_keyword(&mut self, kind: Kind) {
-        if self.cur_token().escaped && kind.is_all_keyword() {
+        if self.cur_token().escaped() && kind.is_all_keyword() {
             let span = self.cur_token().span();
             self.error(diagnostics::EscapedKeyword(span));
         }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -50,7 +50,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn at_async_no_new_line(&mut self) -> bool {
-        self.at(Kind::Async) && !self.cur_token().escaped && !self.peek_token().is_on_new_line
+        self.at(Kind::Async) && !self.cur_token().escaped() && !self.peek_token().is_on_new_line
     }
 
     pub(crate) fn parse_function_body(&mut self) -> Result<Box<'a, FunctionBody<'a>>> {

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -127,7 +127,7 @@ impl<'a> Parser<'a> {
             Kind::Const if !(self.ts_enabled() && self.is_at_enum_declaration()) => {
                 self.parse_variable_statement(stmt_ctx)
             }
-            Kind::Let if !self.cur_token().escaped => self.parse_let(stmt_ctx),
+            Kind::Let if !self.cur_token().escaped() => self.parse_let(stmt_ctx),
             Kind::Await
                 if self.peek_kind() == Kind::Using && self.nth_kind(2).is_binding_identifier() =>
             {
@@ -276,7 +276,7 @@ impl<'a> Parser<'a> {
 
         let is_let_of = self.at(Kind::Let) && self.peek_at(Kind::Of);
         let is_async_of =
-            self.at(Kind::Async) && !self.cur_token().escaped && self.peek_at(Kind::Of);
+            self.at(Kind::Async) && !self.cur_token().escaped() && self.peek_at(Kind::Of);
         let expr_span = self.start_span();
 
         if self.at(Kind::RParen) {

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -360,14 +360,15 @@ impl<'a> Parser<'a> {
         }
         // we are at a valid normal Ident or Keyword, let's keep on lexing for `-`
         self.re_lex_jsx_identifier();
-        let name = Atom::from(self.cur_string().unwrap());
         self.bump_any();
-        Ok(self.ast.jsx_identifier(self.end_span(span), name))
+        let span = self.end_span(span);
+        let name = span.source_text(self.source_text);
+        Ok(self.ast.jsx_identifier(span, name.into()))
     }
 
     fn parse_jsx_text(&mut self) -> JSXText {
         let span = self.start_span();
-        let value = Atom::from(self.cur_string().unwrap());
+        let value = Atom::from(self.cur_string());
         self.bump_any();
         self.ast.jsx_text(self.end_span(span), value)
     }

--- a/crates/oxc_parser/src/lexer/string_builder.rs
+++ b/crates/oxc_parser/src/lexer/string_builder.rs
@@ -33,14 +33,14 @@ impl<'a> AutoCow<'a> {
     // and return the reference to it
     pub fn get_mut_string_without_current_ascii_char<'b>(
         &'b mut self,
-        lexer: &'_ Lexer<'a>,
+        lexer: &Lexer<'a>,
     ) -> &'b mut String<'a> {
         self.force_allocation_without_current_ascii_char(lexer);
         self.value.as_mut().unwrap()
     }
 
     // Force allocation of a String, excluding the current ASCII character.
-    pub fn force_allocation_without_current_ascii_char(&mut self, lexer: &'_ Lexer<'a>) {
+    pub fn force_allocation_without_current_ascii_char(&mut self, lexer: &Lexer<'a>) {
         if self.value.is_some() {
             return;
         }

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -4,8 +4,10 @@ use oxc_span::Span;
 
 use super::kind::Kind;
 
+pub type EscapedStringId = std::num::NonZeroU32;
+
 #[derive(Debug, Clone, Copy, Default)]
-pub struct Token<'a> {
+pub struct Token {
     /// Token Kind
     pub kind: Kind,
 
@@ -18,40 +20,22 @@ pub struct Token<'a> {
     /// Indicates the token is on a newline
     pub is_on_new_line: bool,
 
-    /// Is the original string escaped?
-    pub escaped: bool,
-
-    pub value: TokenValue<'a>,
+    /// A index handle to `Lexer::escaped_strings`
+    /// See https://floooh.github.io/2018/06/17/handles-vs-pointers.html for some background reading
+    pub escaped_string_id: Option<EscapedStringId>,
 }
 
 #[cfg(target_pointer_width = "64")]
 mod size_asserts {
-    oxc_index::assert_eq_size!(super::Token, [u8; 32]);
+    oxc_index::assert_eq_size!(super::Token, [u8; 16]);
 }
 
-impl<'a> Token<'a> {
+impl Token {
     pub fn span(&self) -> Span {
         Span::new(self.start, self.end)
     }
-}
 
-#[derive(Debug, Copy, Clone)]
-pub enum TokenValue<'a> {
-    None,
-    String(&'a str),
-}
-
-impl<'a> Default for TokenValue<'a> {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
-impl<'a> TokenValue<'a> {
-    pub fn get_string(&self) -> Option<&str> {
-        match self {
-            Self::String(s) => Some(s),
-            Self::None => None,
-        }
+    pub fn escaped(&self) -> bool {
+        self.escaped_string_id.is_some()
     }
 }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -117,7 +117,7 @@ pub struct Parser<'a> {
     errors: Vec<Error>,
 
     /// The current parsing token
-    token: Token<'a>,
+    token: Token,
 
     /// The end range of the previous token
     prev_token_end: u32,

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -302,13 +302,8 @@ impl<'a> Parser<'a> {
             return self.parse_ts_infer_type();
         }
 
-        let mut operator = None;
-
-        if !self.at(Kind::Str) {
-            if let Some(atom) = self.cur_string() {
-                operator = TSTypeOperator::from_src(atom);
-            }
-        }
+        let operator =
+            if self.at(Kind::Str) { None } else { TSTypeOperator::from_src(self.cur_string()) };
 
         // test ts ts_type_operator
         // type B = keyof A;


### PR DESCRIPTION
Part of #1880

`Token` size is reduced from 32 to 16 bytes by changing the previous
token value `Option<&'a str>` to a u32 index handle.

It would be nice if this handle is eliminated entirely because
the normal case for a string is always `&source_text[token.span.start.token.span.end]`

Unfortunately, JavaScript allows escaped characters to appear in
identifiers, strings and templates. These strings need to be unescaped
for equality checks, i.e. `"\a"  === "a"`.

This leads us to adding a `escaped_strings[]` vec for storing these unescaped and allocated
strings.

Performance regression for adding this vec should be minimal because escaped strings are rare.

Background Reading:

* https://floooh.github.io/2018/06/17/handles-vs-pointers.html