### PR TITLE
feat(linter): support overriding oxlint rules by eslint config

### DIFF
--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -320,7 +320,7 @@ mod test {
         let args = &["-c", "fixtures/eslintrc_off/eslintrc.json", "fixtures/eslintrc_off/test.js"];
         let result = test(args);
         assert_eq!(result.number_of_files, 1);
-        assert_eq!(result.number_of_warnings, 0);
+        assert_eq!(result.number_of_warnings, 1); // triggered by no_empty_file
         assert_eq!(result.number_of_errors, 0);
     }
 

--- a/crates/oxc_linter/src/config/snapshots/oxc_linter__config__test__parse_rules.snap
+++ b/crates/oxc_linter/src/config/snapshots/oxc_linter__config__test__parse_rules.snap
@@ -3,17 +3,17 @@ source: crates/oxc_linter/src/config/mod.rs
 expression: rules
 ---
 [
-    (
-        "eslint",
-        "no-console",
-        Allow,
-        None,
-    ),
-    (
-        "eslint",
-        "no-bitwise",
-        Deny,
-        Some(
+    ESLintRuleConfig {
+        plugin_name: "eslint",
+        rule_name: "no-console",
+        severity: Allow,
+        config: None,
+    },
+    ESLintRuleConfig {
+        plugin_name: "eslint",
+        rule_name: "no-bitwise",
+        severity: Deny,
+        config: Some(
             Array [
                 Object {
                     "allow": Array [
@@ -22,12 +22,12 @@ expression: rules
                 },
             ],
         ),
-    ),
-    (
-        "eslint",
-        "eqeqeq",
-        Deny,
-        Some(
+    },
+    ESLintRuleConfig {
+        plugin_name: "eslint",
+        rule_name: "eqeqeq",
+        severity: Deny,
+        config: Some(
             Array [
                 String("always"),
                 Object {
@@ -35,17 +35,17 @@ expression: rules
                 },
             ],
         ),
-    ),
-    (
-        "typescript",
-        "ban-types",
-        Deny,
-        None,
-    ),
-    (
-        "jsx_a11y",
-        "alt-text",
-        Warn,
-        None,
-    ),
+    },
+    ESLintRuleConfig {
+        plugin_name: "typescript",
+        rule_name: "ban-types",
+        severity: Deny,
+        config: None,
+    },
+    ESLintRuleConfig {
+        plugin_name: "jsx_a11y",
+        rule_name: "alt-text",
+        severity: Warn,
+        config: None,
+    },
 ]

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -18,7 +18,7 @@ mod rules;
 mod service;
 mod utils;
 
-use std::{self, fs, io::Write, rc::Rc, time::Duration};
+use std::{io::Write, rc::Rc, time::Duration};
 
 use oxc_diagnostics::Report;
 pub(crate) use oxc_semantic::AstNode;
@@ -166,14 +166,6 @@ impl Linter {
 
     pub fn get_settings(&self) -> LintSettings {
         self.settings.clone()
-    }
-    #[allow(unused)]
-    fn read_rules_configuration() -> Option<serde_json::Map<String, serde_json::Value>> {
-        fs::read_to_string(".eslintrc.json")
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .and_then(|v: serde_json::Value| v.get("rules").cloned())
-            .and_then(|v| v.as_object().cloned())
     }
 
     pub fn print_rules<W: Write>(writer: &mut W) {


### PR DESCRIPTION
Previously if .eslintrc.json contains 

```
{
  "rules": {
    "no-empty": "off"
  }
}
```

Then no rules will be enabled.

---

This PR changes how we configure oxlint's rules.

The rules will start with the categories we apply, and then merge all the configurations stated in the `rules` field.

For example, if we begin with `-D correctness` with 80 rules, then

* `"no-empty-file": "off"` will remove the rule, yielding 79 rules
* `"no-empty": "error"` (restriction) will add the rule, yield 81 rules
* ""no-empty": ["error", { "allowEmptyCatch": true }]` add the rule's configuration


