### PR TITLE
fix(linter): fix plugin name parsing when reading config file

### DIFF
--- a/crates/oxc_linter/fixtures/eslint_config.json
+++ b/crates/oxc_linter/fixtures/eslint_config.json
@@ -15,6 +15,8 @@
             {
                 "null": "ignore"
             }
-        ]
+        ],
+        "@typescript-eslint/ban-types": "error",
+        "jsx-a11y/alt-text": "warn"
     }
 }

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -211,9 +211,11 @@ fn parse_rule_name(name: &str) -> (&str, &str) {
     if let Some((category, name)) = name.split_once('/') {
         let category = category.trim_start_matches('@');
 
-        // if it matches typescript-eslint, map it to typescript
         let category = match category {
+            // if it matches typescript-eslint, map it to typescript
             "typescript-eslint" => "typescript",
+            // plugin name in RuleEnum is in snake_case
+            "jsx-a11y" => "jsx_a11y",
             _ => category,
         };
 

--- a/crates/oxc_linter/src/config/snapshots/oxc_linter__config__test__parse_rules.snap
+++ b/crates/oxc_linter/src/config/snapshots/oxc_linter__config__test__parse_rules.snap
@@ -36,4 +36,16 @@ expression: rules
             ],
         ),
     ),
+    (
+        "typescript",
+        "ban-types",
+        Deny,
+        None,
+    ),
+    (
+        "jsx_a11y",
+        "alt-text",
+        Warn,
+        None,
+    ),
 ]


### PR DESCRIPTION
This PR fixes the plugin parsing logic when reading a config file.

Specifically, the plugin names defined in `RuleEnum`s use snake-case ("jsx_a11y") while in the config file they are written as "jsx-a11y". This inconsistency causes some rules to be filtered out.

I tested the change with the config json file provided in #1969.
- Before the change: `Finished in 21ms on 1 file with 157 rules using 8 threads.`
- After the change: `Finished in 23ms on 1 file with 178 rules using 8 threads.`

Related issue: #1969 