### PR TITLE
fix(linter): allow eslintrc to add rule when overriding

### DIFF
--- a/crates/oxc_cli/fixtures/no_undef/eslintrc.json
+++ b/crates/oxc_cli/fixtures/no_undef/eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-undef": "warn"
+  }
+}

--- a/crates/oxc_cli/fixtures/no_undef/test.js
+++ b/crates/oxc_cli/fixtures/no_undef/test.js
@@ -1,0 +1,1 @@
+console.log()

--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -325,6 +325,15 @@ mod test {
     }
 
     #[test]
+    fn eslintrc_no_undef() {
+        let args = &["-c", "fixtures/no_undef/eslintrc.json", "fixtures/no_undef/test.js"];
+        let result = test(args);
+        assert_eq!(result.number_of_files, 1);
+        assert_eq!(result.number_of_warnings, 1);
+        assert_eq!(result.number_of_errors, 0);
+    }
+
+    #[test]
     fn no_empty_allow_empty_catch() {
         let args = &[
             "-c",

--- a/crates/oxc_linter/src/options.rs
+++ b/crates/oxc_linter/src/options.rs
@@ -199,7 +199,7 @@ impl LintOptions {
         }
 
         if let Some(config) = &config {
-            config.override_rules(&mut rules);
+            config.override_rules(&mut rules, &all_rules);
         }
 
         let mut rules = rules.into_iter().collect::<Vec<_>>();


### PR DESCRIPTION
Fix a bug introduced in https://github.com/oxc-project/oxc/pull/1966. Ideally, the rules in eslintrc should be merged into final rules as described:

> The rules will start with the categories we apply, and then merge all the configurations stated in the rules field.
>
> For example, if we begin with -D correctness with 80 rules, then
>
> "no-empty-file": "off" will remove the rule, yielding 79 rules
> "no-empty": "error" (restriction) will add the rule, yield 81 rules
> ""no-empty": ["error", { "allowEmptyCatch": true }]` add the rule's configuration

However, the implementation did not include the newly added rules in the eslintrc. As a test case and example, I added a new fixture to `﻿crates/oxc_cli/fixtures/no_undef`. No warn or deny will be found without this PR.

This is my first Rust PR ever. Any nitpicking suggestions are welcome. Thanks! 😊