### PR TITLE
feat(linter): add support for same rule name but different plugin names

### DIFF
--- a/crates/oxc_cli/fixtures/typescript_eslint/eslintrc.json
+++ b/crates/oxc_cli/fixtures/typescript_eslint/eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-loss-of-precision": "off",
+    "@typescript-eslint/no-loss-of-precision": "error"
+  }
+}

--- a/crates/oxc_cli/fixtures/typescript_eslint/test.js
+++ b/crates/oxc_cli/fixtures/typescript_eslint/test.js
@@ -1,0 +1,1 @@
+9007199254740993 // no-loss-of-precision

--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -364,6 +364,19 @@ mod test {
     }
 
     #[test]
+    fn typescript_eslint() {
+        let args = &[
+            "-c",
+            "fixtures/typescript_eslint/eslintrc.json",
+            "fixtures/typescript_eslint/test.js",
+        ];
+        let result = test(args);
+        assert_eq!(result.number_of_files, 1);
+        assert_eq!(result.number_of_warnings, 1);
+        assert_eq!(result.number_of_errors, 0);
+    }
+
+    #[test]
     fn lint_vue_file() {
         let args = &["fixtures/vue/debugger.vue"];
         let result = test(args);

--- a/crates/oxc_linter/src/options.rs
+++ b/crates/oxc_linter/src/options.rs
@@ -104,8 +104,12 @@ pub enum AllowWarnDeny {
 }
 
 impl AllowWarnDeny {
-    pub fn is_enabled(self) -> bool {
+    pub fn is_warn_deny(self) -> bool {
         self != Self::Allow
+    }
+
+    pub fn is_allow(self) -> bool {
+        self == Self::Allow
     }
 }
 


### PR DESCRIPTION
e.g.

```
{
  "rules": {
    "semi": "off",
    "@typescript-eslint/semi": "error"
  }
}
```

closes #1975