### PR TITLE
docs: fix oxc-parser README demo error

### DIFF
--- a/npm/oxc-parser/README.md
+++ b/npm/oxc-parser/README.md
@@ -11,7 +11,8 @@ const oxc = require("oxc-parser");
 const assert = require('assert');
 
 function test(ret) {
-  assert(ret.program.body.length == 1);
+  const program = JSON.parse(ret.program);
+  assert(program.body.length == 1);
   assert(ret.errors.length == 0);
 }
 
@@ -31,7 +32,8 @@ import oxc from 'oxc-parser';
 import assert from 'assert';
 
 function test(ret) {
-  assert(ret.program.body.length == 1);
+  const program = JSON.parse(ret.program);
+  assert(program.body.length == 1);
   assert(ret.errors.length == 0);
 }
 


### PR DESCRIPTION
The type of `ret.program` is `string`, it need to parse it first to get the `body`.