### PR TITLE
fix(diagnostics): always print without considering the `--max-warnings` option

### DIFF
--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -113,12 +113,6 @@ impl DiagnosticService {
                     else if self.quiet {
                         continue;
                     }
-
-                    if let Some(max_warnings) = self.max_warnings {
-                        if self.warnings_count() > max_warnings {
-                            continue;
-                        }
-                    }
                 }
 
                 let mut err = String::new();


### PR DESCRIPTION
closes #1958

`--max-warnings` is only used to control the exit code, it does not
affect diagnostic printing.