### PR TITLE
feat(linter): implement @next/next/no-document-import-in-page

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -284,6 +284,7 @@ mod nextjs {
     pub mod no_assign_module_variable;
     pub mod no_async_client_component;
     pub mod no_css_tags;
+    pub mod no_document_import_in_page;
     pub mod no_head_element;
     pub mod no_head_import_in_document;
     pub mod no_img_element;
@@ -551,4 +552,5 @@ oxc_macros::declare_all_lint_rules! {
     nextjs::no_sync_scripts,
     nextjs::no_title_in_document_head,
     nextjs::no_typos,
+    nextjs::no_document_import_in_page,
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -215,5 +215,5 @@ fn test() {
         ),
     ];
 
-    Tester::new_with_settings(NoDocumentImportInPage::NAME, pass, fail).test_and_snapshot();
+    Tester::new(NoDocumentImportInPage::NAME, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -76,7 +76,7 @@ fn test() {
 			"#,
             None,
             None,
-            Some(PathBuf::from("pages/_document.tsx")),
+            Some(PathBuf::from("pages/_document.js")),
         ),
         (
             r#"import Document from "next/document"
@@ -92,7 +92,7 @@ fn test() {
 			"#,
             None,
             None,
-            Some(PathBuf::from("pages/_document.tsx")),
+            Some(PathBuf::from("pages/_document.js")),
         ),
         (
             r#"import NextDocument from "next/document"
@@ -113,50 +113,50 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-        	    export default class MyDocument extends Document {
-        	      render() {
-        	        return (
-        	          <Html>
-        	          </Html>
-        	        );
-        	      }
-        	    }
+            export default class MyDocument extends Document {
+              render() {
+                return (
+                  <Html>
+                  </Html>
+                );
+              }
+            }
         	"#,
             None,
             None,
-            Some(PathBuf::from("pages/_document.tsx")),
+            Some(PathBuf::from("pages/_document.page.tsx")),
         ),
         (
             r#"import NDocument from "next/document"
 
-        	    export default class Document extends NDocument {
-        	      render() {
-        	        return (
-        	          <Html>
-        	          </Html>
-        	        );
-        	      }
-        	    }
+            export default class Document extends NDocument {
+              render() {
+                return (
+                  <Html>
+                  </Html>
+                );
+              }
+            }
         	"#,
             None,
             None,
-            Some(PathBuf::from("pages/_document.tsx")),
+            Some(PathBuf::from("pages/_document/index.js")),
         ),
         (
             r#"import NDocument from "next/document"
 
-        	    export default class Document extends NDocument {
-        	      render() {
-        	        return (
-        	          <Html>
-        	          </Html>
-        	        );
-        	      }
-        	    }
+            export default class Document extends NDocument {
+              render() {
+                return (
+                  <Html>
+                  </Html>
+                );
+              }
+            }
         	"#,
             None,
             None,
-            Some(PathBuf::from("pages/_document.tsx")),
+            Some(PathBuf::from("pages/_document/index.tsx")),
         ),
         (
             r#"import Document from "next/document"
@@ -172,7 +172,7 @@ fn test() {
         	"#,
             None,
             None,
-            Some(PathBuf::from("src/pages/_document.tsx")),
+            Some(PathBuf::from("pagesapp/src/pages/_document.js")),
         ),
     ];
 
@@ -184,7 +184,7 @@ fn test() {
 			"#,
             None,
             None,
-            Some(PathBuf::from("pages/test.tsx")),
+            Some(PathBuf::from("components/test.js")),
         ),
         (
             r#"import Document from "next/document"
@@ -193,7 +193,7 @@ fn test() {
         	"#,
             None,
             None,
-            Some(PathBuf::from("pages/test.tsx")),
+            Some(PathBuf::from("pages/test.js")),
         ),
         (
             r#"import Document from "next/document"

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -1,0 +1,219 @@
+use oxc_ast::{ast::ModuleDeclaration, AstKind};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("eslint-plugin-next(no-document-import-in-page): `<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-import-in-page")]
+#[diagnostic(
+    severity(warning),
+    help("Prevent importing `next/document` outside of `pages/_document.js`.")
+)]
+struct NoDocumentImportInPageDiagnostic(#[label] pub Span);
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDocumentImportInPage;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Prevent importing `next/document` outside of `pages/_document.js`.
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Example
+    /// ```javascript
+    /// ```
+    NoDocumentImportInPage,
+    correctness
+);
+
+impl Rule for NoDocumentImportInPage {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
+            node.kind()
+        else {
+            return;
+        };
+
+        if import_decl.source.value.as_str() != "next/document" {
+            return;
+        }
+
+        let Some(path) = ctx.file_path().to_str() else { return };
+        let Some(page) = path.split("pages").last() else { return };
+
+        if page.starts_with("/_document") || page.starts_with("\\_document") {
+            return;
+        }
+
+        ctx.diagnostic(NoDocumentImportInPageDiagnostic(import_decl.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            r#"import Document from "next/document"
+			
+			export default class MyDocument extends Document {
+			  render() {
+				return (
+				  <Html>
+				  </Html>
+				);
+			  }
+			}
+			"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/_document.tsx")),
+        ),
+        (
+            r#"import Document from "next/document"
+			
+				export default class MyDocument extends Document {
+				render() {
+					return (
+					<Html>
+					</Html>
+					);
+				}
+				}
+			"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/_document.tsx")),
+        ),
+        (
+            r#"import NextDocument from "next/document"
+
+        	    export default class MyDocument extends NextDocument {
+        	      render() {
+        	        return (
+        	          <Html>
+        	          </Html>
+        	        );
+        	      }
+        	    }
+        	"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/_document.tsx")),
+        ),
+        (
+            r#"import Document from "next/document"
+
+        	    export default class MyDocument extends Document {
+        	      render() {
+        	        return (
+        	          <Html>
+        	          </Html>
+        	        );
+        	      }
+        	    }
+        	"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/_document.tsx")),
+        ),
+        (
+            r#"import NDocument from "next/document"
+
+        	    export default class Document extends NDocument {
+        	      render() {
+        	        return (
+        	          <Html>
+        	          </Html>
+        	        );
+        	      }
+        	    }
+        	"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/_document.tsx")),
+        ),
+        (
+            r#"import NDocument from "next/document"
+
+        	    export default class Document extends NDocument {
+        	      render() {
+        	        return (
+        	          <Html>
+        	          </Html>
+        	        );
+        	      }
+        	    }
+        	"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/_document.tsx")),
+        ),
+        (
+            r#"import Document from "next/document"
+
+        	    export default class MyDocument extends Document {
+        	      render() {
+        	        return (
+        	          <Html>
+        	          </Html>
+        	        );
+        	      }
+        	    }
+        	"#,
+            None,
+            None,
+            Some(PathBuf::from("src/pages/_document.tsx")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            r#"import Document from "next/document"
+
+        	    export const Test = () => <p>Test</p>
+			"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/test.tsx")),
+        ),
+        (
+            r#"import Document from "next/document"
+
+        	    export const Test = () => <p>Test</p>
+        	"#,
+            None,
+            None,
+            Some(PathBuf::from("pages/test.tsx")),
+        ),
+        (
+            r#"import Document from "next/document"
+
+        	    export const Test = () => <p>Test</p>
+			"#,
+            None,
+            None,
+            Some(PathBuf::from("src/pages/user/test.tsx")),
+        ),
+        (
+            r#"import Document from "next/document"
+
+        	    export const Test = () => <p>Test</p>
+			"#,
+            None,
+            None,
+            Some(PathBuf::from("src/pages/user/_document.tsx")),
+        ),
+    ];
+
+    Tester::new_with_settings(NoDocumentImportInPage::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/no_document_import_in_page.snap
+++ b/crates/oxc_linter/src/snapshots/no_document_import_in_page.snap
@@ -1,0 +1,41 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_document_import_in_page
+---
+  ⚠ eslint-plugin-next(no-document-import-in-page): `<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-
+  │ import-in-page
+   ╭─[no_document_import_in_page.tsx:1:1]
+ 1 │ import Document from "next/document"
+   · ────────────────────────────────────
+ 2 │ 
+   ╰────
+  help: Prevent importing `next/document` outside of `pages/_document.js`.
+
+  ⚠ eslint-plugin-next(no-document-import-in-page): `<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-
+  │ import-in-page
+   ╭─[no_document_import_in_page.tsx:1:1]
+ 1 │ import Document from "next/document"
+   · ────────────────────────────────────
+ 2 │ 
+   ╰────
+  help: Prevent importing `next/document` outside of `pages/_document.js`.
+
+  ⚠ eslint-plugin-next(no-document-import-in-page): `<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-
+  │ import-in-page
+   ╭─[no_document_import_in_page.tsx:1:1]
+ 1 │ import Document from "next/document"
+   · ────────────────────────────────────
+ 2 │ 
+   ╰────
+  help: Prevent importing `next/document` outside of `pages/_document.js`.
+
+  ⚠ eslint-plugin-next(no-document-import-in-page): `<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-
+  │ import-in-page
+   ╭─[no_document_import_in_page.tsx:1:1]
+ 1 │ import Document from "next/document"
+   · ────────────────────────────────────
+ 2 │ 
+   ╰────
+  help: Prevent importing `next/document` outside of `pages/_document.js`.
+
+


### PR DESCRIPTION
implement @next/next/no-document-import-in-page
Related issue: https://github.com/oxc-project/oxc/issues/1929

original

- code: https://github.com/vercel/next.js/blob/canary/packages/eslint-plugin-next/src/rules/no-document-import-in-page.ts
- doc: https://nextjs.org/docs/messages/no-document-import-in-page