### PR TITLE
feat(ast): visit TSModuleReference

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -4,7 +4,7 @@
 //! [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
 
 use oxc_allocator::{Box, Vec};
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, GetSpan, Span};
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
@@ -413,6 +413,15 @@ impl<'a> TSTypeName<'a> {
 
     pub fn is_qualified_name(&self) -> bool {
         matches!(self, Self::QualifiedName(_))
+    }
+}
+
+impl GetSpan for TSTypeName<'_> {
+    fn span(&self) -> Span {
+        match self {
+            TSTypeName::IdentifierReference(ident) => ident.span,
+            TSTypeName::QualifiedName(name) => name.span,
+        }
     }
 }
 

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -152,6 +152,10 @@ pub enum AstKind<'a> {
     TSEnumBody(&'a TSEnumBody<'a>),
 
     TSImportEqualsDeclaration(&'a TSImportEqualsDeclaration<'a>),
+    TSTypeName(&'a TSTypeName<'a>),
+    TSExternalModuleReference(&'a TSExternalModuleReference),
+    TSQualifiedName(&'a TSQualifiedName<'a>),
+
     TSInterfaceDeclaration(&'a TSInterfaceDeclaration<'a>),
     TSModuleDeclaration(&'a TSModuleDeclaration<'a>),
     TSTypeAliasDeclaration(&'a TSTypeAliasDeclaration<'a>),
@@ -456,6 +460,9 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::TSEnumBody(x) => x.span,
 
             Self::TSImportEqualsDeclaration(x) => x.span,
+            Self::TSTypeName(x) => x.span(),
+            Self::TSExternalModuleReference(x) => x.span,
+            Self::TSQualifiedName(x) => x.span,
             Self::TSInterfaceDeclaration(x) => x.span,
             Self::TSModuleDeclaration(x) => x.span,
             Self::TSTypeAliasDeclaration(x) => x.span,
@@ -633,6 +640,9 @@ impl<'a> AstKind<'a> {
             Self::TSEnumMember(_) => "TSEnumMember".into(),
 
             Self::TSImportEqualsDeclaration(_) => "TSImportEqualsDeclaration".into(),
+            Self::TSTypeName(_) => "TSTypeName".into(),
+            Self::TSExternalModuleReference(_) => "TSExternalModuleReference".into(),
+            Self::TSQualifiedName(_) => "TSQualifiedName".into(),
             Self::TSInterfaceDeclaration(_) => "TSInterfaceDeclaration".into(),
             Self::TSModuleDeclaration(_) => "TSModuleDeclaration".into(),
             Self::TSTypeAliasDeclaration(_) => "TSTypeAliasDeclaration".into(),

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -8624,6 +8624,38 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  16 │ 
     ╰────
 
+  × The keyword 'public' is reserved
+    ╭─[compiler/strictModeReservedWord.ts:16:1]
+ 16 │ 
+ 17 │     var b: public.bar;
+    ·            ──────
+ 18 │ 
+    ╰────
+
+  × The keyword 'private' is reserved
+    ╭─[compiler/strictModeReservedWord.ts:18:1]
+ 18 │ 
+ 19 │     function foo(x: private.x) { }
+    ·                     ───────
+ 20 │     function foo1(x: private.package.x) { }
+    ╰────
+
+  × The keyword 'private' is reserved
+    ╭─[compiler/strictModeReservedWord.ts:19:1]
+ 19 │     function foo(x: private.x) { }
+ 20 │     function foo1(x: private.package.x) { }
+    ·                      ───────
+ 21 │     function foo2(x: private.package.protected) { }
+    ╰────
+
+  × The keyword 'private' is reserved
+    ╭─[compiler/strictModeReservedWord.ts:20:1]
+ 20 │     function foo1(x: private.package.x) { }
+ 21 │     function foo2(x: private.package.protected) { }
+    ·                      ───────
+ 22 │     let b: interface.package.implements.B;
+    ╰────
+
   × Identifier `b` has already been declared
     ╭─[compiler/strictModeReservedWord.ts:16:1]
  16 │ 
@@ -8637,6 +8669,14 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  22 │     let b: interface.package.implements.B;
     ·         ┬
     ·         ╰── It can not be redeclared here
+ 23 │     ublic();
+    ╰────
+
+  × The keyword 'interface' is reserved
+    ╭─[compiler/strictModeReservedWord.ts:21:1]
+ 21 │     function foo2(x: private.package.protected) { }
+ 22 │     let b: interface.package.implements.B;
+    ·            ─────────
  23 │     ublic();
     ╰────
 

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -863,9 +863,10 @@ Passed: 298/1179
 * imports/elide-injected/input.ts
 * imports/elide-no-import-specifiers/input.ts
 * imports/elide-preact/input.ts
-* imports/elide-type-referenced-in-imports-equal-no/input.ts
+* imports/elide-react/input.ts
 * imports/elision/input.ts
 * imports/elision-locations/input.ts
+* imports/elision-qualifiedname/input.ts
 * imports/elision-rename/input.ts
 * imports/enum-id/input.ts
 * imports/enum-value/input.ts
@@ -881,7 +882,6 @@ Passed: 298/1179
 * imports/type-only-export-specifier-2/input.ts
 * imports/type-only-import-specifier-3/input.ts
 * imports/type-only-import-specifier-4/input.ts
-* namespace/alias/input.ts
 * namespace/ambient-module-nested/input.ts
 * namespace/ambient-module-nested-exported/input.ts
 * namespace/canonical/input.ts


### PR DESCRIPTION
### Failed cases:

* https://github.com/babel/babel/blob/7c29fbc4db7809d24789235b0597e7e8dd61c4ae/packages/babel-plugin-transform-typescript/test/fixtures/imports/elision-qualifiedname/input.ts
* https://github.com/babel/babel/blob/7c29fbc4db7809d24789235b0597e7e8dd61c4ae/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-react/input.ts

We need to distinguish whether a reference is a type or a js variable
