### PR TITLE
fix: default visitor should visit prop init at `visit_object_property`

### DIFF
--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -804,6 +804,9 @@ pub trait VisitMut<'a>: Sized {
         self.enter_node(kind);
         self.visit_property_key(&mut prop.key);
         self.visit_expression(&mut prop.value);
+        if let Some(init) = &mut prop.init {
+            self.visit_expression(init);
+        }
         self.leave_node(kind);
     }
 


### PR DESCRIPTION

The `visit_object_property` should visit `prop.int` node.