### PR TITLE
fix(parser): restore regex flag parsing

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -872,17 +872,17 @@ impl<'a> Lexer<'a> {
             self.current.chars.next();
             if !ch.is_ascii_lowercase() {
                 self.error(diagnostics::RegExpFlag(ch, self.current_offset()));
-                break;
+                continue;
             }
             let flag = if let Ok(flag) = RegExpFlags::try_from(ch) {
                 flag
             } else {
                 self.error(diagnostics::RegExpFlag(ch, self.current_offset()));
-                break;
+                continue;
             };
             if flags.contains(flag) {
                 self.error(diagnostics::RegExpFlagTwice(ch, self.current_offset()));
-                break;
+                continue;
             }
             flags |= flag;
         }


### PR DESCRIPTION
As discussed in https://github.com/oxc-project/oxc/pull/1999#issuecomment-1888916383, this PR restores some of regex parsing behavior to as it was prior to #1926.