### PR TITLE
refactor(parser): remove extraneous code from regex parsing

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -870,10 +870,6 @@ impl<'a> Lexer<'a> {
 
         while let Some(ch @ ('$' | '_' | 'a'..='z' | 'A'..='Z' | '0'..='9')) = self.peek() {
             self.current.chars.next();
-            if !ch.is_ascii_lowercase() {
-                self.error(diagnostics::RegExpFlag(ch, self.current_offset()));
-                continue;
-            }
             let flag = if let Ok(flag) = RegExpFlags::try_from(ch) {
                 flag
             } else {


### PR DESCRIPTION
This PR removes some code in parsing regexp flags which is extraneous:

```rs
if !ch.is_ascii_lowercase() {
  self.error(diagnostics::RegExpFlag(ch, self.current_offset()));
  continue;
}
```

Which is followed by:

```rs
let flag = if let Ok(flag) = RegExpFlags::try_from(ch) {
  flag
} else {
  self.error(diagnostics::RegExpFlag(ch, self.current_offset()));
  continue;
};
```

`!ch.is_ascii_lowercase()` is equivalent to `ch < 'a' || ch > 'z'`. The compiler implements `RegExpFlags::try_from(ch)` as `ch < 'd' || ch > 'y'` and then a jump table. So `ch.is_ascii_lowercase()` does nothing that `RegExpFlags::try_from(ch)` doesn't do already.

https://godbolt.org/z/51GPPY9nx

(this PR built on top of #2007 for ease)