### PR TITLE
perf(parser): reduce `Token` size from 16 to 12 bytes

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -4,8 +4,6 @@ use oxc_span::Span;
 
 use super::kind::Kind;
 
-pub type EscapedId = std::num::NonZeroU32;
-
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Token {
     /// Token Kind
@@ -20,14 +18,15 @@ pub struct Token {
     /// Indicates the token is on a newline
     pub is_on_new_line: bool,
 
-    /// A index handle to `Lexer::escaped_strings` or `Lexer::escaped_templates`
-    /// See https://floooh.github.io/2018/06/17/handles-vs-pointers.html for some background reading
-    pub escaped_id: Option<EscapedId>,
+    /// True if the identifier / string / template kinds has escaped strings.
+    /// The escaped strings are saved in [Lexer::escaped_strings] and [Lexer::escaped_templates] by
+    /// [Token::start]
+    pub escaped: bool,
 }
 
 #[cfg(target_pointer_width = "64")]
 mod size_asserts {
-    oxc_index::assert_eq_size!(super::Token, [u8; 16]);
+    oxc_index::assert_eq_size!(super::Token, [u8; 12]);
 }
 
 impl Token {
@@ -36,6 +35,6 @@ impl Token {
     }
 
     pub fn escaped(&self) -> bool {
-        self.escaped_id.is_some()
+        self.escaped
     }
 }


### PR DESCRIPTION
I also had to change how the string for private identifiers are built, otherwise they will always be allocated.