### PR TITLE
fix(prettier): Correctly print export declaration

### DIFF
--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -1062,14 +1062,16 @@ impl<'a> Format<'a> for ImportAttribute {
 impl<'a> Format<'a> for ExportNamedDeclaration<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
-        parts.push(module::print_module_specifiers(
-            p,
-            &self.specifiers,
-            /* include_default */ false,
-            /* include_namespace */ false,
-        ));
         if let Some(decl) = &self.declaration {
+            parts.push(ss!(" "));
             parts.push(decl.format(p));
+        } else {
+            parts.push(module::print_module_specifiers(
+                p,
+                &self.specifiers,
+                /* include_default */ false,
+                /* include_namespace */ false,
+            ));
         }
         Doc::Array(parts)
     }


### PR DESCRIPTION
Before this PR:
<img width="912" alt="image" src="https://github.com/oxc-project/oxc/assets/7829098/78605f25-3320-4bed-8a31-3ffa7604cdc7">
https://oxc-project.github.io/oxc/playground/?code=3YCAAICUgICAgICAgICyHorESipoTXBToMuz4zZHvH%2B4MPS3Y6F%2FfvvogA%3D%3D