### PR TITLE
perf(parser): hint that end of file only happens once

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -376,7 +376,13 @@ impl<'a> Lexer<'a> {
 
             let remaining = self.current.chars.as_str();
             if remaining.is_empty() {
-                return Kind::Eof;
+                // Hint to branch predictor that we only reach the end of file once
+                #[cold]
+                #[inline]
+                fn at_end() -> Kind {
+                    Kind::Eof
+                }
+                return at_end();
             }
 
             let byte = remaining.as_bytes()[0];


### PR DESCRIPTION
Hint to branch predictor that lexer only gets to end of the file once.

I doubt this will actually make any difference. Just posting to see what Codspeed says.
