### PR TITLE
fix(linter): jsx no undef match scope should check with ancestors

### DIFF
--- a/crates/oxc_linter/src/snapshots/jsx_no_undef.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_no_undef.snap
@@ -44,4 +44,18 @@ expression: jsx_no_undef
    ╰────
   help: 'Unknown' is not defined.
 
+  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+   ╭─[jsx_no_undef.tsx:1:1]
+ 1 │ var React; { const App = null; }; React.render(<App />);
+   ·                                                 ───
+   ╰────
+  help: 'App' is not defined.
+
+  ⚠ eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX
+   ╭─[jsx_no_undef.tsx:1:1]
+ 1 │ var React; enum A { App }; React.render(<App />);
+   ·                                          ───
+   ╰────
+  help: 'App' is not defined.
+
 


### PR DESCRIPTION
when check undef in jsx-no-undef rule, the match one should be scope of current jsx or the ancestors scope of current jsx. cause I just begin to learn rust, I am not sure the code style and performance can be better, if there is any, I would change