### PR TITLE
ci: use miri to parser detect memory leak

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -17,8 +17,9 @@ jobs:
 
       - name: Install Miri
         run: |
-          rustup component add miri
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
           cargo miri setup
 
       - name: Test with Miri
-        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
+        run: cargo miri test -p oxc_parser

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -316,6 +316,17 @@ mod test {
         }
     }
 
+    #[test]
+    fn memory_leak() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        let sources = ["2n", ";'1234567890123456789012345678901234567890'"];
+        for source in sources {
+            let ret = Parser::new(&allocator, source, source_type).parse();
+            assert!(!ret.program.body.is_empty());
+        }
+    }
+
     // Source with length u32::MAX + 1 fails to parse
     #[test]
     fn overlong_source() {


### PR DESCRIPTION
We'll merge this and then eventually turn it on as a nightly check, it's a manual run for now.