### PR TITLE
build(linter): add new-react-perf rulegen task

### DIFF
--- a/justfile
+++ b/justfile
@@ -105,6 +105,9 @@ new-nextjs-rule name:
 new-jsdoc-rule name:
   cargo run -p rulegen {{name}} jsdoc
 
+new-react-perf-rule name:
+    cargo run -p rulegen {{name}} react-perf
+
 # Sync all submodules with their own remote repos (this is for Boshen updating the submodules)
 sync:
   git submodule update --init --remote

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -47,6 +47,9 @@ const NEXT_JS_TEST_PATH: &str =
 const JSDOC_TEST_PATH: &str =
     "https://raw.githubusercontent.com/gajus/eslint-plugin-jsdoc/main/test/rules/assertions";
 
+const REACT_PERF_TEST_PATH: &str =
+    "https://raw.githubusercontent.com/cvazac/eslint-plugin-react-perf/main/tests/lib/rules";
+
 struct TestCase<'a> {
     source_text: String,
     code: Option<String>,
@@ -413,6 +416,7 @@ pub enum RuleKind {
     Typescript,
     Unicorn,
     React,
+    ReactPerf,
     JSXA11y,
     Oxc,
     DeepScan,
@@ -427,6 +431,7 @@ impl RuleKind {
             "typescript" => Self::Typescript,
             "unicorn" => Self::Unicorn,
             "react" => Self::React,
+            "react-perf" => Self::ReactPerf,
             "jsx-a11y" => Self::JSXA11y,
             "oxc" => Self::Oxc,
             "deepscan" => Self::DeepScan,
@@ -445,6 +450,7 @@ impl Display for RuleKind {
             Self::Jest => write!(f, "eslint-plugin-jest"),
             Self::Unicorn => write!(f, "eslint-plugin-unicorn"),
             Self::React => write!(f, "eslint-plugin-react"),
+            Self::ReactPerf => write!(f, "eslint-plugin-react-perf"),
             Self::JSXA11y => write!(f, "eslint-plugin-jsx-a11y"),
             Self::DeepScan => write!(f, "deepscan"),
             Self::Oxc => write!(f, "oxc"),
@@ -470,6 +476,7 @@ fn main() {
         RuleKind::Typescript => format!("{TYPESCRIPT_ESLINT_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::Unicorn => format!("{UNICORN_TEST_PATH}/{kebab_rule_name}.mjs"),
         RuleKind::React => format!("{REACT_TEST_PATH}/{kebab_rule_name}.js"),
+        RuleKind::ReactPerf => format!("{REACT_PERF_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::JSXA11y => format!("{JSX_A11Y_TEST_PATH}/{kebab_rule_name}-test.js"),
         RuleKind::NextJS => format!("{NEXT_JS_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::JSDoc => format!("{JSDOC_TEST_PATH}/{camel_rule_name}.js"),

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -35,6 +35,7 @@ impl<'a> Template<'a> {
             RuleKind::Typescript => Path::new("crates/oxc_linter/src/rules/typescript"),
             RuleKind::Unicorn => Path::new("crates/oxc_linter/src/rules/unicorn"),
             RuleKind::React => Path::new("crates/oxc_linter/src/rules/react"),
+            RuleKind::ReactPerf => Path::new("crates/oxc_linter/src/rules/react_perf"),
             RuleKind::JSXA11y => Path::new("crates/oxc_linter/src/rules/jsx_a11y"),
             RuleKind::Oxc => Path::new("crates/oxc_linter/src/rules/oxc"),
             RuleKind::DeepScan => Path::new("crates/oxc_linter/src/rules/deepscan"),


### PR DESCRIPTION
Adds a new linter rule generation task, `just new-react-perf-rule`, for incorporating rules from [eslint-plugin-react-perf](https://github.com/cvazac/eslint-plugin-react-perf) into oxc.

Since this library has its own testing utilities and only 4 rules, I didn't bother writing code to port over test cases. If we deem this requisite I'll add this to the rulegen task.