### PR TITLE
perf(linter): initialize `LintContext` for each rule

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -153,7 +153,6 @@ pub struct FixedContent {
     pub range: Range,
 }
 
-#[derive(Debug)]
 pub struct IsolatedLintHandler {
     linter: Arc<Linter>,
 }
@@ -375,7 +374,6 @@ fn offset_to_position(offset: usize, source_text: &str) -> Option<Position> {
     Some(Position::new(line as u32, column as u32))
 }
 
-#[derive(Debug)]
 pub struct ServerLinter {
     linter: Arc<Linter>,
 }

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -27,7 +27,6 @@ use tower_lsp::lsp_types::{
 };
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-#[derive(Debug)]
 struct Backend {
     client: Client,
     root_uri: OnceCell<Option<Url>>,

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1,7 +1,9 @@
-use oxc_ast::TriviasMap;
-use oxc_span::Span;
 use rust_lapper::{Interval, Lapper};
 use rustc_hash::FxHashMap;
+
+use oxc_ast::TriviasMap;
+use oxc_semantic::Semantic;
+use oxc_span::Span;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum DisabledRule<'a> {
@@ -24,6 +26,16 @@ pub struct DisableDirectives<'a> {
     disable_all_comments: Vec<Span>,
     /// All comments that disable one or more specific rules
     disable_rule_comments: Vec<DisableRuleComment<'a>>,
+}
+
+impl<'a> Default for DisableDirectives<'a> {
+    fn default() -> Self {
+        Self {
+            intervals: Lapper::new(vec![]),
+            disable_all_comments: vec![],
+            disable_rule_comments: vec![],
+        }
+    }
 }
 
 impl<'a> DisableDirectives<'a> {
@@ -62,10 +74,10 @@ pub struct DisableDirectivesBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> DisableDirectivesBuilder<'a, 'b> {
-    pub fn new(source_text: &'a str, trivias: &'b TriviasMap) -> Self {
+    pub fn from_semantic(semantic: &'b Semantic<'a>) -> Self {
         Self {
-            source_text,
-            trivias,
+            source_text: semantic.source_text(),
+            trivias: semantic.trivias(),
             intervals: Lapper::new(vec![]),
             disable_all_start: None,
             disable_start_map: FxHashMap::default(),


### PR DESCRIPTION
This removes the mutation within the tight loop of each rule run.