### PR TITLE
fix(codegen): add parenthesis in binary expression by precedence

### DIFF
--- a/crates/oxc_minifier/tests/oxc/precedence.rs
+++ b/crates/oxc_minifier/tests/oxc/precedence.rs
@@ -110,7 +110,7 @@ fn logical_and() {
 fn bitwise_or() {
     test("a | b | c", "a|b|c;");
     test("(a | b) | c", "a|b|c;");
-    test("a | (b | c)", "a|b|c;");
+    test("a | (b | c)", "a|(b|c);");
     test("a | b ^ c", "a|b^c;");
     test("a | (b ^ c)", "a|b^c;");
     test("a | (b && c)", "a|(b&&c);");
@@ -124,7 +124,7 @@ fn bitwise_or() {
 fn bitwise_xor() {
     test("a ^ b ^ c", "a^b^c;");
     test("(a ^ b) ^ c", "a^b^c;");
-    test("a ^ (b ^ c)", "a^b^c;");
+    test("a ^ (b ^ c)", "a^(b^c);");
     test("a | b & c", "a|b&c;");
     test("a | (b & c)", "a|b&c;");
     test("a | (b || c)", "a|(b||c);");
@@ -138,7 +138,7 @@ fn bitwise_xor() {
 fn bitwise_and() {
     test("a & b & c", "a&b&c;");
     test("((a & b) & c) & d", "a&b&c&d;");
-    test("a & (b & (c & d))", "a&b&c&d;");
+    test("a & (b & (c & d))", "a&(b&(c&d));");
     test("a & b == c", "a&b==c;");
     test("a & (b == c)", "a&b==c;");
     test("a == b & c", "a==b&c;");
@@ -152,7 +152,7 @@ fn bitwise_and() {
 #[test]
 fn equality() {
     test("a == b != c === d !== e", "a==b!=c===d!==e;");
-    test("a == (b != (c === (d !== e)))", "a==b!=c===d!==e;");
+    test("a == (b != (c === (d !== e)))", "a==(b!=(c===(d!==e)));");
     test("(((a == b) != c) === d) !== e", "a==b!=c===d!==e;");
     test("a > b == c < d", "a>b==c<d;");
     test("(a > b) == (c < d)", "a>b==c<d;");

--- a/crates/oxc_syntax/src/operator.rs
+++ b/crates/oxc_syntax/src/operator.rs
@@ -222,6 +222,26 @@ impl BinaryOperator {
             Self::Exponential => "**",
         }
     }
+    pub fn lower_precedence(&self) -> Precedence {
+        match self {
+            Self::BitwiseOR => Precedence::LogicalAnd,
+            Self::BitwiseXOR => Precedence::BitwiseOr,
+            Self::BitwiseAnd => Precedence::BitwiseXor,
+            Self::Equality | Self::Inequality | Self::StrictEquality | Self::StrictInequality => {
+                Precedence::BitwiseAnd
+            }
+            Self::LessThan
+            | Self::LessEqualThan
+            | Self::GreaterThan
+            | Self::GreaterEqualThan
+            | Self::Instanceof
+            | Self::In => Precedence::Equality,
+            Self::ShiftLeft | Self::ShiftRight | Self::ShiftRightZeroFill => Precedence::Relational,
+            Self::Addition | Self::Subtraction => Precedence::Shift,
+            Self::Multiplication | Self::Remainder | Self::Division => Precedence::Add,
+            Self::Exponential => Precedence::Multiply,
+        }
+    }
 }
 
 impl GetPrecedence for BinaryOperator {

--- a/crates/oxc_syntax/src/precedence.rs
+++ b/crates/oxc_syntax/src/precedence.rs
@@ -44,6 +44,25 @@ impl Precedence {
     }
 
     pub fn is_right_associative(&self) -> bool {
-        matches!(self, Self::Exponential)
+        matches!(self, Self::Exponential | Self::Conditional | Self::Arrow | Self::Assign)
+    }
+
+    pub fn is_left_associative(&self) -> bool {
+        matches!(
+            self,
+            Self::Member
+                | Self::Multiply
+                | Self::Add
+                | Self::Shift
+                | Self::Relational
+                | Self::Equality
+                | Self::BitwiseAnd
+                | Self::BitwiseXor
+                | Self::BitwiseOr
+                | Self::LogicalAnd
+                | Self::LogicalOr
+                | Self::Coalesce
+                | Self::Comma
+        )
     }
 }


### PR DESCRIPTION
related ESBuild code: https://github.com/evanw/esbuild/blob/f5f8ff895c4665b661ac6a49940e7bb7f012603b/internal/js_printer/js_printer.go#L3348-L3371