### PR TITLE
feat(tasks): introduce tasks/lint_rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "lint_rules"
+version = "0.0.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_span",
+ "oxc_tasks_common",
+ "ureq",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tasks/lint_rules/Cargo.toml
+++ b/tasks/lint_rules/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name              = "lint_rules"
+version           = "0.0.0"
+publish           = false
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "lint_rules"
+test = false
+
+[dependencies]
+oxc_allocator    = { workspace = true }
+oxc_span         = { workspace = true }
+oxc_ast          = { workspace = true }
+oxc_parser       = { workspace = true }
+oxc_semantic     = { workspace = true }
+oxc_tasks_common = { workspace = true }
+
+# convert_case = { workspace = true }
+# serde        = { workspace = true, features = ["derive"] }
+# regex        = { workspace = true }
+# lazy_static  = { workspace = true }
+ureq         = { workspace = true }
+
+# handlebars = "5.0.0"

--- a/tasks/lint_rules/Cargo.toml
+++ b/tasks/lint_rules/Cargo.toml
@@ -20,10 +20,4 @@ oxc_parser       = { workspace = true }
 oxc_semantic     = { workspace = true }
 oxc_tasks_common = { workspace = true }
 
-# convert_case = { workspace = true }
-# serde        = { workspace = true, features = ["derive"] }
-# regex        = { workspace = true }
-# lazy_static  = { workspace = true }
-ureq         = { workspace = true }
-
-# handlebars = "5.0.0"
+ureq = { workspace = true }

--- a/tasks/lint_rules/src/main.rs
+++ b/tasks/lint_rules/src/main.rs
@@ -1,9 +1,9 @@
-use std::{fs::read_dir, path::Path};
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::ObjectPropertyKind, syntax_directed_operations::PropName, AstKind};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
+use std::{fs::read_dir, path::Path};
 use ureq::Response;
 
 // TODOs:
@@ -92,4 +92,3 @@ fn list_implemented_rules(path: &Path) -> Vec<String> {
 
     rules
 }
-

--- a/tasks/lint_rules/src/main.rs
+++ b/tasks/lint_rules/src/main.rs
@@ -1,0 +1,95 @@
+use std::{fs::read_dir, path::Path};
+use oxc_allocator::Allocator;
+use oxc_ast::{ast::ObjectPropertyKind, syntax_directed_operations::PropName, AstKind};
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::SourceType;
+use ureq::Response;
+
+// TODOs:
+// - Error handling, message
+//   - JS parsing may fail?
+// - Use Result properly
+// - Support other rules
+// - Better AST traversal... :(
+
+const ORIGINAL: &str = "https://raw.githubusercontent.com/eslint/eslint/main/packages/js/src/configs/eslint-recommended.js";
+const OURS_DIR: &str = "crates/oxc_linter/src/rules/eslint";
+
+fn main() {
+    let js_string = fetch_to_be_implemented_rules_js(ORIGINAL).unwrap();
+    let rules_to_be_implemented = find_to_be_implemented_rules(&js_string);
+
+    let rules_implemented = list_implemented_rules(Path::new(OURS_DIR));
+
+    for rule in &rules_to_be_implemented {
+        let mark = if rules_implemented.contains(rule) { "x" } else { " " };
+        println!("- [{mark}] {rule}");
+    }
+}
+
+fn fetch_to_be_implemented_rules_js(url: &str) -> Result<String, String> {
+    let body = oxc_tasks_common::agent().get(url).call().map(Response::into_string);
+
+    match body {
+        Ok(Ok(body)) => Ok(body),
+        Err(err) => {
+            println!("Failed to fetch {ORIGINAL}");
+            Err(err.to_string())
+        }
+        Ok(Err(err)) => {
+            println!("Failed to fetch {ORIGINAL}");
+            Err(err.to_string())
+        }
+    }
+}
+
+fn find_to_be_implemented_rules(source_text: &str) -> Vec<String> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::default();
+    let ret = Parser::new(&allocator, source_text, source_type).parse();
+
+    let program = allocator.alloc(ret.program);
+    let semantic_ret = SemanticBuilder::new(source_text, source_type).build(program);
+
+    let mut rules = vec![];
+    let mut is_rules = false;
+    for node in semantic_ret.semantic.nodes().iter() {
+        if let AstKind::IdentifierName(kind) = node.kind() {
+            if kind.name == "rules" {
+                is_rules = true;
+                continue;
+            }
+        }
+        if is_rules {
+            if let AstKind::ObjectExpression(obj) = node.kind() {
+                for prop in &obj.properties {
+                    if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                        if let Some((name, _)) = prop.key.prop_name() {
+                            rules.push(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    rules
+}
+
+fn list_implemented_rules(path: &Path) -> Vec<String> {
+    let Ok(entries) = read_dir(path) else {
+        println!("Failed to read dir {path:?}");
+        return vec![];
+    };
+
+    let mut rules = vec![];
+    for entry in entries.flatten() {
+        let os_str = entry.file_name();
+        let name = os_str.to_string_lossy().trim_end_matches(".rs").replace('_', "-");
+        rules.push(name);
+    }
+
+    rules
+}
+

--- a/tasks/lint_rules/src/main.rs
+++ b/tasks/lint_rules/src/main.rs
@@ -13,7 +13,8 @@ use ureq::Response;
 // - Support other rules
 // - Better AST traversal... :(
 
-const ORIGINAL: &str = "https://raw.githubusercontent.com/eslint/eslint/main/packages/js/src/configs/eslint-recommended.js";
+const ORIGINAL: &str =
+    "https://raw.githubusercontent.com/eslint/eslint/main/packages/js/src/configs/eslint-all.js";
 const OURS_DIR: &str = "crates/oxc_linter/src/rules/eslint";
 
 fn main() {
@@ -55,12 +56,15 @@ fn find_to_be_implemented_rules(source_text: &str) -> Vec<String> {
     let mut rules = vec![];
     let mut is_rules = false;
     for node in semantic_ret.semantic.nodes().iter() {
-        if let AstKind::IdentifierName(kind) = node.kind() {
-            if kind.name == "rules" {
-                is_rules = true;
-                continue;
+        if let AstKind::ObjectProperty(prop) = node.kind() {
+            if let Some((name, _)) = prop.key.prop_name() {
+                if name == "rules" {
+                    is_rules = true;
+                    continue;
+                }
             }
         }
+
         if is_rules {
             if let AstKind::ObjectExpression(obj) = node.kind() {
                 for prop in &obj.properties {


### PR DESCRIPTION
Part of #2020 

- [x] A new task should be added to tasks/.
- [x] It will pull all our supported plugins from their source,
- [x] compare them against our implemented rules,
- [ ] and generate a markdown file with a tracking list.

<details>
<summary>Current generated list for eslint.all</summary>

```sh
❯ cargo run -p lint_rules
- [ ] accessor-pairs
- [x] array-callback-return
- [ ] arrow-body-style
- [ ] block-scoped-var
- [ ] camelcase
- [ ] capitalized-comments
- [ ] class-methods-use-this
- [ ] complexity
- [ ] consistent-return
- [ ] consistent-this
- [x] constructor-super
- [ ] curly
- [ ] default-case
- [x] default-case-last
- [ ] default-param-last
- [ ] dot-notation
- [x] eqeqeq
- [x] for-direction
- [ ] func-name-matching
- [ ] func-names
- [ ] func-style
- [x] getter-return
- [ ] grouped-accessor-pairs
- [ ] guard-for-in
- [ ] id-denylist
- [ ] id-length
- [ ] id-match
- [ ] init-declarations
- [ ] line-comment-position
- [ ] logical-assignment-operators
- [ ] max-classes-per-file
- [ ] max-depth
- [ ] max-lines
- [ ] max-lines-per-function
- [ ] max-nested-callbacks
- [ ] max-params
- [ ] max-statements
- [ ] multiline-comment-style
- [ ] new-cap
- [ ] no-alert
- [x] no-array-constructor
- [x] no-async-promise-executor
- [ ] no-await-in-loop
- [x] no-bitwise
- [x] no-caller
- [x] no-case-declarations
- [x] no-class-assign
- [x] no-compare-neg-zero
- [x] no-cond-assign
- [x] no-console
- [x] no-const-assign
- [x] no-constant-binary-expression
- [x] no-constant-condition
- [ ] no-constructor-return
- [ ] no-continue
- [x] no-control-regex
- [x] no-debugger
- [x] no-delete-var
- [ ] no-div-regex
- [ ] no-dupe-args
- [x] no-dupe-class-members
- [x] no-dupe-else-if
- [x] no-dupe-keys
- [x] no-duplicate-case
- [ ] no-duplicate-imports
- [ ] no-else-return
- [x] no-empty
- [x] no-empty-character-class
- [ ] no-empty-function
- [x] no-empty-pattern
- [x] no-empty-static-block
- [ ] no-eq-null
- [x] no-eval
- [x] no-ex-assign
- [ ] no-extend-native
- [ ] no-extra-bind
- [x] no-extra-boolean-cast
- [ ] no-extra-label
- [x] no-fallthrough
- [x] no-func-assign
- [x] no-global-assign
- [ ] no-implicit-coercion
- [ ] no-implicit-globals
- [ ] no-implied-eval
- [x] no-import-assign
- [ ] no-inline-comments
- [x] no-inner-declarations
- [ ] no-invalid-regexp
- [ ] no-invalid-this
- [x] no-irregular-whitespace
- [ ] no-iterator
- [ ] no-label-var
- [ ] no-labels
- [ ] no-lone-blocks
- [ ] no-lonely-if
- [ ] no-loop-func
- [x] no-loss-of-precision
- [ ] no-magic-numbers
- [ ] no-misleading-character-class
- [ ] no-multi-assign
- [ ] no-multi-str
- [ ] no-negated-condition
- [ ] no-nested-ternary
- [ ] no-new
- [ ] no-new-func
- [ ] no-new-native-nonconstructor
- [ ] no-new-wrappers
- [ ] no-nonoctal-decimal-escape
- [x] no-obj-calls
- [ ] no-object-constructor
- [ ] no-octal
- [ ] no-octal-escape
- [ ] no-param-reassign
- [ ] no-plusplus
- [ ] no-promise-executor-return
- [ ] no-proto
- [x] no-prototype-builtins
- [x] no-redeclare
- [x] no-regex-spaces
- [ ] no-restricted-exports
- [ ] no-restricted-globals
- [ ] no-restricted-imports
- [ ] no-restricted-properties
- [ ] no-restricted-syntax
- [ ] no-return-assign
- [ ] no-script-url
- [x] no-self-assign
- [x] no-self-compare
- [ ] no-sequences
- [x] no-setter-return
- [ ] no-shadow
- [x] no-shadow-restricted-names
- [x] no-sparse-arrays
- [ ] no-template-curly-in-string
- [ ] no-ternary
- [ ] no-this-before-super
- [ ] no-throw-literal
- [x] no-undef
- [ ] no-undef-init
- [ ] no-undefined
- [ ] no-underscore-dangle
- [ ] no-unexpected-multiline
- [ ] no-unmodified-loop-condition
- [ ] no-unneeded-ternary
- [ ] no-unreachable
- [ ] no-unreachable-loop
- [x] no-unsafe-finally
- [x] no-unsafe-negation
- [x] no-unsafe-optional-chaining
- [ ] no-unused-expressions
- [x] no-unused-labels
- [x] no-unused-private-class-members
- [ ] no-unused-vars
- [ ] no-use-before-define
- [ ] no-useless-assignment
- [ ] no-useless-backreference
- [ ] no-useless-call
- [x] no-useless-catch
- [ ] no-useless-computed-key
- [ ] no-useless-concat
- [ ] no-useless-constructor
- [x] no-useless-escape
- [ ] no-useless-rename
- [ ] no-useless-return
- [x] no-var
- [ ] no-void
- [ ] no-warning-comments
- [ ] no-with
- [ ] object-shorthand
- [ ] one-var
- [ ] operator-assignment
- [ ] prefer-arrow-callback
- [ ] prefer-const
- [ ] prefer-destructuring
- [ ] prefer-exponentiation-operator
- [ ] prefer-named-capture-group
- [ ] prefer-numeric-literals
- [ ] prefer-object-has-own
- [ ] prefer-object-spread
- [ ] prefer-promise-reject-errors
- [ ] prefer-regex-literals
- [ ] prefer-rest-params
- [ ] prefer-spread
- [ ] prefer-template
- [ ] radix
- [ ] require-atomic-updates
- [ ] require-await
- [ ] require-unicode-regexp
- [x] require-yield
- [ ] sort-imports
- [ ] sort-keys
- [ ] sort-vars
- [ ] strict
- [ ] symbol-description
- [ ] unicode-bom
- [x] use-isnan
- [x] valid-typeof
- [ ] vars-on-top
- [ ] yoda
```

</details>