### PR TITLE
refactor(parser): combine token kinds for skipped tokens

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -8,10 +8,7 @@ pub enum Kind {
     Undetermined,
     #[default]
     Eof,
-    WhiteSpace,
-    NewLine,
-    Comment,
-    MultiLineComment,
+    Skip, // Whitespace, line breaks, comments
     // 12.5 Hashbang Comments
     HashbangComment,
     // 12.7.1 identifier
@@ -482,11 +479,8 @@ impl Kind {
         match self {
             Undetermined => "Unknown",
             Eof => "EOF",
-            NewLine => "\n",
-            Comment => "//",
-            MultiLineComment => "/** */",
+            Skip => "Skipped",
             HashbangComment => "#!",
-            WhiteSpace => " ",
             Ident => "Identifier",
             Await => "await",
             Break => "break",


### PR DESCRIPTION
Small optimization to the lexer.

Whitespace, line breaks, and comments are all skipped by `read_next_token()`.

At present there's a different `Kind` for each, and `read_next_token()` decides whether to skip with `matches!(kind, Kind::WhiteSpace | Kind::NewLine | Kind::Comment | Kind::MultiLineComment)`.

These `Kind`s are used for no other purpose, so there seems little reason to differentiate them.

This PR combines them all into `Kind::Skip`, so then the test of whether to skip is reduced to `kind == Kind::Skip`.

Only produces ~0.3% performance bump on parser benchmarks. But, why not?...