### PR TITLE
perf(semantic): remove redeclare_variables

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
 };
 use oxc_span::{Atom, SourceType};
 
-use crate::{scope::ScopeFlags, symbol::SymbolFlags, SemanticBuilder, VariableInfo};
+use crate::{scope::ScopeFlags, symbol::SymbolFlags, SemanticBuilder};
 
 pub trait Binder {
     fn bind(&self, _builder: &mut SemanticBuilder) {}
@@ -60,11 +60,6 @@ impl<'a> Binder for VariableDeclarator<'a> {
                     builder.check_redeclaration(*scope_id, span, name, excludes, true)
                 {
                     ident.symbol_id.set(Some(symbol_id));
-                    builder.add_redeclared_variables(VariableInfo {
-                        name: ident.name.clone(),
-                        span: ident.span,
-                        symbol_id,
-                    });
                     return;
                 }
             }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -36,18 +36,6 @@ struct UnusedLabels<'a> {
     labels: Vec<AstNodeId>,
 }
 
-#[derive(Debug, Clone)]
-pub struct VariableInfo {
-    pub name: Atom,
-    pub span: Span,
-    pub symbol_id: SymbolId,
-}
-
-#[derive(Debug)]
-pub struct RedeclareVariables {
-    pub variables: Vec<VariableInfo>,
-}
-
 pub struct SemanticBuilder<'a> {
     pub source_text: &'a str,
 
@@ -86,7 +74,7 @@ pub struct SemanticBuilder<'a> {
 
     check_syntax_error: bool,
 
-    redeclare_variables: RedeclareVariables,
+    // redeclare_variables: RedeclareVariables,
     pub class_table_builder: ClassTableBuilder,
 }
 
@@ -120,7 +108,7 @@ impl<'a> SemanticBuilder<'a> {
             unused_labels: UnusedLabels { scopes: vec![], curr_scope: 0, labels: vec![] },
             jsdoc: JSDocBuilder::new(source_text, &trivias),
             check_syntax_error: false,
-            redeclare_variables: RedeclareVariables { variables: vec![] },
+            // redeclare_variables: RedeclareVariables { variables: vec![] },
             class_table_builder: ClassTableBuilder::new(),
         }
     }
@@ -179,7 +167,7 @@ impl<'a> SemanticBuilder<'a> {
             module_record: Arc::clone(&self.module_record),
             jsdoc: self.jsdoc.build(),
             unused_labels: self.unused_labels.labels,
-            redeclare_variables: self.redeclare_variables.variables,
+            // redeclare_variables: self.redeclare_variables.variables,
         };
         SemanticBuilderReturn { semantic, errors: self.errors.into_inner() }
     }
@@ -196,7 +184,7 @@ impl<'a> SemanticBuilder<'a> {
             module_record: Arc::new(ModuleRecord::default()),
             jsdoc: self.jsdoc.build(),
             unused_labels: self.unused_labels.labels,
-            redeclare_variables: self.redeclare_variables.variables,
+            // redeclare_variables: self.redeclare_variables.variables,
         }
     }
 
@@ -253,7 +241,7 @@ impl<'a> SemanticBuilder<'a> {
     ) -> SymbolId {
         if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
             self.symbols.union_flag(symbol_id, includes);
-            self.add_redeclared_variables(VariableInfo { name: name.clone(), span, symbol_id });
+            // self.add_redeclared_variables(VariableInfo { name: name.clone(), span, symbol_id });
             return symbol_id;
         }
 
@@ -346,9 +334,9 @@ impl<'a> SemanticBuilder<'a> {
         }
     }
 
-    pub fn add_redeclared_variables(&mut self, variable: VariableInfo) {
-        self.redeclare_variables.variables.push(variable);
-    }
+    // pub fn add_redeclared_variables(&mut self, variable: VariableInfo) {
+    //     self.redeclare_variables.variables.push(variable);
+    // }
 }
 
 impl<'a> Visit<'a> for SemanticBuilder<'a> {

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -24,7 +24,6 @@ pub use oxc_syntax::{
 };
 
 pub use crate::{
-    builder::VariableInfo,
     node::{AstNode, AstNodeId, AstNodes, NodeFlags},
     reference::{Reference, ReferenceFlag, ReferenceId},
     scope::ScopeTree,
@@ -51,8 +50,7 @@ pub struct Semantic<'a> {
     jsdoc: JSDoc<'a>,
 
     unused_labels: Vec<AstNodeId>,
-
-    redeclare_variables: Vec<VariableInfo>,
+    // redeclare_variables: Vec<VariableInfo>,
 }
 
 impl<'a> Semantic<'a> {
@@ -130,9 +128,9 @@ impl<'a> Semantic<'a> {
         self.scopes().root_unresolved_references().contains_key(&ident.name)
     }
 
-    pub fn redeclare_variables(&self) -> &Vec<VariableInfo> {
-        &self.redeclare_variables
-    }
+    // pub fn redeclare_variables(&self) -> &Vec<VariableInfo> {
+    //     &self.redeclare_variables
+    // }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I think we should remove the property used by a single rule

Now just a test