### PR TITLE
fix(parser): fix crash on TSTemplateLiteralType in function return position

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -197,17 +197,6 @@ pub enum TSTypeOperator {
     Readonly,
 }
 
-impl TSTypeOperator {
-    pub fn from_src(src: &str) -> Option<Self> {
-        match src {
-            "keyof" => Some(Self::Keyof),
-            "unique" => Some(Self::Unique),
-            "readonly" => Some(Self::Readonly),
-            _ => None,
-        }
-    }
-}
-
 /// `let myArray: string[] = ["hello", "world"];`
 ///
 /// <https://www.typescriptlang.org/docs/handbook/2/objects.html#the-array-type>

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -302,8 +302,12 @@ impl<'a> Parser<'a> {
             return self.parse_ts_infer_type();
         }
 
-        let operator =
-            if self.at(Kind::Str) { None } else { TSTypeOperator::from_src(self.cur_string()) };
+        let operator = match self.cur_kind() {
+            Kind::KeyOf => Some(TSTypeOperator::Keyof),
+            Kind::Unique => Some(TSTypeOperator::Unique),
+            Kind::Readonly => Some(TSTypeOperator::Readonly),
+            _ => None,
+        };
 
         // test ts ts_type_operator
         // type B = keyof A;

--- a/tasks/coverage/codegen_misc.snap
+++ b/tasks/coverage/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 9/9 (100.00%)
-Positive Passed: 9/9 (100.00%)
+AST Parsed     : 10/10 (100.00%)
+Positive Passed: 10/10 (100.00%)

--- a/tasks/coverage/misc/pass/oxc-2087.ts
+++ b/tasks/coverage/misc/pass/oxc-2087.ts
@@ -1,0 +1,3 @@
+interface Helpers {
+  inspect(): `~~~~\n${string}\n~~~~`;
+}

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 9/9 (100.00%)
-Positive Passed: 9/9 (100.00%)
+AST Parsed     : 10/10 (100.00%)
+Positive Passed: 10/10 (100.00%)
 Negative Passed: 5/5 (100.00%)
   × Unexpected token
    ╭─[fail/oxc-169.js:1:1]


### PR DESCRIPTION
```
interface Helpers {
  inspect(): `~~~~\n${string}\n~~~~`;
}
```