### PR TITLE
WIP: feat(codegen): source map support using `source-map` crate from ezno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -1397,6 +1397,7 @@ dependencies = [
 name = "oxc_codegen"
 version = "0.5.0"
 dependencies = [
+ "base64",
  "bitflags 2.4.1",
  "num-bigint",
  "oxc_allocator",
@@ -1404,6 +1405,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "oxc_syntax",
+ "source-map",
 ]
 
 [[package]]
@@ -2386,6 +2388,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "source-map"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c87aed86fe881b9427c79b2278f2e70b81dac06996dc789de58f2c1d79f7ec"
 
 [[package]]
 name = "spin"

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -27,5 +27,8 @@ oxc_syntax    = { workspace = true }
 bitflags   = { workspace = true }
 num-bigint = { workspace = true }
 
+source-map = "0.14.9"
+base64     = "0.21.7"
+
 [dev-dependencies]
 oxc_parser = { workspace = true }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -8,7 +8,7 @@ use oxc_syntax::{
     NumberBase,
 };
 use oxc_span::GetSpan;
-use source_map::SpanWithSource;
+use source_map::{SpanWithSource, ToString};
 
 use super::{Codegen, Context, Operator, Separator};
 
@@ -83,11 +83,11 @@ fn print_directives_and_statements_with_semicolon_order<const MINIFY: bool>(
             p.print_semicolon_if_needed();
         }
         let span = stmt.span();
-        p.sourcemap.add_mapping(&SpanWithSource {
+        p.code.add_mapping(&SpanWithSource {
             start: span.start,
             end: span.end,
             source: p.source_id
-        }, 0)
+        })
     }
 }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -7,6 +7,8 @@ use oxc_syntax::{
     precedence::{GetPrecedence, Precedence},
     NumberBase,
 };
+use oxc_span::GetSpan;
+use source_map::SpanWithSource;
 
 use super::{Codegen, Context, Operator, Separator};
 
@@ -80,6 +82,12 @@ fn print_directives_and_statements_with_semicolon_order<const MINIFY: bool>(
             stmt.gen(p, ctx);
             p.print_semicolon_if_needed();
         }
+        let span = stmt.span();
+        p.sourcemap.add_mapping(&SpanWithSource {
+            start: span.start,
+            end: span.end,
+            source: p.source_id
+        }, 0)
     }
 }
 


### PR DESCRIPTION
Related:
* https://github.com/oxc-project/oxc/issues/1045
* https://github.com/oxc-project/oxc/discussions/2105

This is far from complete, correct, or usable - but I'm opening the PR anyway to gather feedback and insights on how to implement it.

Work done so far:

* Created [a dev fork of `oxc`](https://github.com/egasimus/oxc/) and established dev workflow / test harness / inner loop [in my downstream repo](https://github.com/hackbg/ganesha/tree/feat/sourcemap).
* Added dependency on `source-map` crate (https://crates.io/crates/source-map, https://github.com/kaleidawave/source-map) and plugged it into `print_directives_and_statements_with_semicolon_order`.
* Replaced `Vec<u8>` in `struct Codegen` with `source_map::StringWithOptionalSourceMap`. (**I know using `String` in `oxc` is bad because allocations**; the `source_map` code would have to be adapted to use `Vec<u8>` instead.)
* Added `base64` to output the encoded sourcemap.
* Tested some (e.g. [test](https://github.com/hackbg/ganesha/blob/1d04135151b0694e0ce5d70501dd8e1cfba2ee59/src/test.rs#L10) -> [result](https://evanw.github.io/source-map-visualization/#NDM3AGNvbnN0IGJheiA9IHsKICAgICAgICBmb286JzEyMycKfTsKY29uc29sZS5sb2coewogICAgICAgIGJhejpiYXoKfSk7CgovLyMgc291cmNlTWFwcGluZ1VSTD1kYXRhOmFwcGxpY2F0aW9uL2pzb247YmFzZTY0LGV5SjJaWEp6YVc5dUlqb3pMQ0p6YjNWeVkyVlNiMjkwSWpvaUlpd2ljMjkxY21ObGN5STZXeUlvZFc1cmJtOTNiaUJ6YjNWeVkyVXBJbDBzSW5OdmRYSmpaWE5EYjI1MFpXNTBJanBiSW5SNWNHVWdSbTl2SUQwZ2MzUnlhVzVuWEc1Y2JtbHVkR1Z5Wm1GalpTQkNZWElnZXlCbWIyODZJRVp2YnlCOVhHNWNibU52Ym5OMElHSmhlam9nUW1GeUlEMGdleUJtYjI4NklGd2lNVEl6WENJZ2ZWeHVYRzVqYjI1emIyeGxMbXh2WnloN1ltRjZmU2xjYmlKZExDSnVZVzFsY3lJNlcxMHNJbTFoY0hCcGJtZHpJam9pUVVGQlFTeEJRVVZCT3p0QlFVVkJPenRCUVVWQkluMD0KMjM2AHsidmVyc2lvbiI6Mywic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiKHVua25vd24gc291cmNlKSJdLCJzb3VyY2VzQ29udGVudCI6WyJ0eXBlIEZvbyA9IHN0cmluZ1xuXG5pbnRlcmZhY2UgQmFyIHsgZm9vOiBGb28gfVxuXG5jb25zdCBiYXo6IEJhciA9IHsgZm9vOiBcIjEyM1wiIH1cblxuY29uc29sZS5sb2coe2Jhen0pXG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsQUFFQTs7QUFFQTs7QUFFQSJ9)) and saw how it doesn't generate the source map correctly at all :sweat_smile: (`source_map` expects you to pass newlines manually, while span start/end in Oxc are byte offsets?)

Next steps:
* Adapt `source_map` code to use `Vec<u8>` instead of string with manual newlines.
* I need to familiarize myself with how the source map format actually works - so far I've only used them.
* Possibly use a const generic to toggle source maps, like with `MINIFY`?
* **Alternate proposal:** I use source maps mostly to get correct line numbers in Node.js stack traces. I know this sounds weird (in the sense that nobody has done it yet?), but what about a codegen mode where TypeScript annotations are replaced with *whitespace* and the compiled code otherwise matches the input 1:1? We already have the span data :thinking:

Anyone got any pointers / opinions / denouncements? :grin: 