### PR TITLE
refactor(semantic): add binder for FormalParameters and RestElement, replacing the binder for FormalParameters

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1648,6 +1648,12 @@ pub enum FormalParameterKind {
     Signature,
 }
 
+impl FormalParameterKind {
+    pub fn is_signature(&self) -> bool {
+        matches!(self, Self::Signature)
+    }
+}
+
 impl<'a> FormalParameters<'a> {
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -86,12 +86,10 @@ impl Rule for NoRedeclare {
                         }
                     }
                 }
-                AstKind::FormalParameters(params) => {
-                    for item in &params.items {
-                        if let BindingPatternKind::BindingIdentifier(ident) = &item.pattern.kind {
-                            if *symbol_table.get_name(variable.symbol_id) == ident.name {
-                                self.report_diagnostic(ctx, variable, ident);
-                            }
+                AstKind::FormalParameter(param) => {
+                    if let BindingPatternKind::BindingIdentifier(ident) = &param.pattern.kind {
+                        if *symbol_table.get_name(variable.symbol_id) == ident.name {
+                            self.report_diagnostic(ctx, variable, ident);
                         }
                     }
                 }

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -89,8 +89,10 @@ impl Rule for NoAccumulatingSpread {
         let reference = symbols.get_reference(reference_id);
         let Some(referenced_symbol_id) = reference.symbol_id() else { return };
         let declaration_id = symbols.get_declaration(referenced_symbol_id);
-        let declaration = ctx.semantic().nodes().get_node(declaration_id);
-        let AstKind::FormalParameters(params) = declaration.kind() else { return };
+        let Some(declaration) = ctx.semantic().nodes().parent_node(declaration_id) else { return };
+        let AstKind::FormalParameters(params) = declaration.kind() else {
+            return;
+        };
 
         // We're only looking for the first parameter, since that's where acc is.
         // Skip non-parameter or non-first-parameter declarations.

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -450,8 +450,11 @@ impl<'a> SemanticBuilder<'a> {
                     &self.nodes,
                 );
             }
-            AstKind::FormalParameters(params) => {
-                params.bind(self);
+            AstKind::RestElement(element) => {
+                element.bind(self);
+            }
+            AstKind::FormalParameter(param) => {
+                param.bind(self);
             }
             AstKind::CatchClause(clause) => {
                 clause.bind(self);


### PR DESCRIPTION
Similar with #2013.

This way we will be able to find the corresponding Ast accurately.

The snapshots look a little strange but the change is expected.