### PR TITLE
feat(cli): disallow path pointing to parent directories

### DIFF
--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -129,9 +129,19 @@ pub struct LintOptions {
     pub config: Option<PathBuf>,
 
     /// Single file, single path or list of paths
-    #[bpaf(positional("PATH"), many)]
+    #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE))]
     pub paths: Vec<PathBuf>,
 }
+
+fn validate_paths(paths: &Vec<PathBuf>) -> bool {
+    if paths.is_empty() {
+        true
+    } else {
+        paths.iter().all(|p| p.components().next() != Some(std::path::Component::ParentDir))
+    }
+}
+
+const PATHS_ERROR_MESSAGE: &str = "PATH cannot start with \"..\"";
 
 // This is formatted according to
 // <https://docs.rs/bpaf/latest/bpaf/params/struct.NamedArg.html#method.help>
@@ -333,6 +343,19 @@ mod lint_options {
             options.paths,
             [PathBuf::from("foo"), PathBuf::from("bar"), PathBuf::from("baz")]
         );
+    }
+
+    #[test]
+    fn no_parent_path() {
+        match lint_command().run_inner(&["../parent_dir"]) {
+            Ok(_) => panic!("Should not allow parent dir"),
+            Err(err) => match err {
+                bpaf::ParseFailure::Stderr(doc) => {
+                    assert_eq!("`../parent_dir`: PATH cannot start with \"..\"", format!("{doc}"));
+                }
+                _ => unreachable!(),
+            },
+        }
     }
 
     #[test]


### PR DESCRIPTION
Linting parent directories introduces undefined behavior because
the intention is not clear. This is a future proof precaution.

closes #1887