### PR TITLE
fix(transformer): always create valid identifiers

### DIFF
--- a/crates/oxc_transformer/src/es2015/function_name.rs
+++ b/crates/oxc_transformer/src/es2015/function_name.rs
@@ -162,7 +162,7 @@ fn create_valid_identifier(
     // }
 
     let id = Atom::from(
-        atom.chars().map(|c| if is_identifier_part(c) { c } else { '-' }).collect::<String>(),
+        atom.chars().map(|c| if is_identifier_part(c) { c } else { '_' }).collect::<String>(),
     );
 
     let id = if id == "" {


### PR DESCRIPTION
I'm not familiar with the transformer, so not 100% sure what this function does. But from the name `create_valid_identifier`, I'm guessing that `-` is a mistake - it's not a valid character to have in identifiers.

If I've misunderstood, please feel free to close this.