### PR TITLE
Refactor: Tidy functions used to read identifier characters

### DIFF
--- a/crates/oxc_syntax/src/identifier.rs
+++ b/crates/oxc_syntax/src/identifier.rs
@@ -97,17 +97,22 @@ pub static ASCII_CONTINUE: Align64<[bool; 128]> = Align64([
     XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, __, __, __, __, __, // 7
 ]);
 
+/// Section 12.7 Detect `IdentifierStartChar`
+#[inline]
+pub fn is_identifier_start(c: char) -> bool {
+    if c.is_ascii() {
+        return is_identifier_start_ascii(c);
+    }
+    is_identifier_start_unicode(c)
+}
+
 #[inline]
 pub fn is_identifier_start_ascii(c: char) -> bool {
     ASCII_START.0[c as usize]
 }
 
-/// Section 12.7 Detect `IdentifierStartChar`
 #[inline]
-pub fn is_identifier_start_all(c: char) -> bool {
-    if c.is_ascii() {
-        return is_identifier_start_ascii(c);
-    }
+pub fn is_identifier_start_unicode(c: char) -> bool {
     is_id_start_unicode(c)
 }
 
@@ -116,12 +121,22 @@ pub fn is_identifier_start_all(c: char) -> bool {
 #[inline]
 pub fn is_identifier_part(c: char) -> bool {
     if c.is_ascii() {
-        return ASCII_CONTINUE.0[c as usize];
+        return is_identifier_part_ascii(c);
     }
+    is_identifier_part_unicode(c)
+}
+
+#[inline]
+pub fn is_identifier_part_ascii(c: char) -> bool {
+    ASCII_CONTINUE.0[c as usize]
+}
+
+#[inline]
+pub fn is_identifier_part_unicode(c: char) -> bool {
     is_id_continue_unicode(c) || c == ZWNJ || c == ZWJ
 }
 
 pub fn is_identifier_name(name: &str) -> bool {
     let mut chars = name.chars();
-    chars.next().is_some_and(is_identifier_start_all) && chars.all(is_identifier_part)
+    chars.next().is_some_and(is_identifier_start) && chars.all(is_identifier_part)
 }

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -11,8 +11,6 @@ pub mod scope;
 pub mod symbol;
 pub mod xml_entities;
 
-pub use unicode_id_start;
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum NumberBase {
     Float,

--- a/crates/oxc_transformer/src/es2015/function_name.rs
+++ b/crates/oxc_transformer/src/es2015/function_name.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use oxc_ast::{ast::*, AstBuilder};
 use oxc_semantic::ScopeId;
 use oxc_span::{Atom, Span};
+use oxc_syntax::identifier::is_identifier_part;
 use oxc_syntax::operator::AssignmentOperator;
-use oxc_syntax::unicode_id_start::is_id_continue;
 // use regex::Regex;
 
 use crate::context::TransformerCtx;
@@ -162,7 +162,7 @@ fn create_valid_identifier(
     // }
 
     let id = Atom::from(
-        atom.chars().map(|c| if is_id_continue(c) { c } else { '-' }).collect::<String>(),
+        atom.chars().map(|c| if is_identifier_part(c) { c } else { '-' }).collect::<String>(),
     );
 
     let id = if id == "" {

--- a/crates/oxc_transformer/src/utils.rs
+++ b/crates/oxc_transformer/src/utils.rs
@@ -3,7 +3,7 @@ use std::mem;
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_span::{Atom, Span};
-use oxc_syntax::unicode_id_start::{is_id_continue, is_id_start};
+use oxc_syntax::identifier::is_identifier_name;
 
 use crate::context::TransformerCtx;
 
@@ -128,26 +128,6 @@ pub const KEYWORDS: phf::Set<&str> = phf::phf_set![
     "void",
     "delete",
 ];
-
-/// https://github.com/babel/babel/blob/ff3481746a830e0e94626de4c4cb075ea5f2f5dc/packages/babel-helper-validator-identifier/src/identifier.ts#L85-L109
-pub fn is_identifier_name(name: &Atom) -> bool {
-    let string = name.as_str();
-    if string.is_empty() {
-        return false;
-    }
-    let mut is_first = true;
-    for ch in string.chars() {
-        if is_first {
-            is_first = false;
-            if !is_id_start(ch) {
-                return false;
-            }
-        } else if !is_id_continue(ch) {
-            return false;
-        }
-    }
-    true
-}
 
 pub fn is_valid_identifier(name: &Atom, reserved: bool) -> bool {
     if reserved && (KEYWORDS.contains(name.as_str()) || is_strict_reserved_word(name, true)) {


### PR DESCRIPTION
Just refactoring, related to functions in `oxc_syntax::identifier`, aiming to make the code a bit clearer. I had found it a bit confusing when trying to familiarise myself with the codebase.

Aims:

1. Consistent naming convention for `is_identifier_start`, `is_identifier_part`, and their variants.
2. Do not re-export `unicode_id_start` crate from `oxc_syntax`. It's confusing having 2 exports which do the same (or *almost* the same) from the same crate.
3. Use these functions with standardized names everywhere.

I've split into 4 commits as the changes affect different crates, but they're all on a similar theme. I'm not sure if you'd prefer this as 4 separate PRs, or if that'd be overkill.