### PR TITLE
feat(tasks): Add @typescript-eslint to lint_rules CI task

### DIFF
--- a/.github/workflows/lint-rules.yml
+++ b/.github/workflows/lint-rules.yml
@@ -27,3 +27,5 @@ jobs:
 
       - name: Update eslint
         run: cargo run -p lint_rules eslint --update
+      - name: Update @typescript-eslint
+        run: cargo run -p lint_rules typescript --update

--- a/tasks/lint_rules/src/generate_list/eslint.rs
+++ b/tasks/lint_rules/src/generate_list/eslint.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 const ORIGINAL_JS_SOURCE_URL: &str =
     "https://raw.githubusercontent.com/eslint/eslint/main/packages/js/src/configs/eslint-all.js";
 
-const UNSUPPORTED_RULES: &[&str] = &["yoda"];
+const UNSUPPORTED_RULES: &[&str] = &[];
 
 pub fn find_to_be_implemented_rules() -> Result<Vec<String>, String> {
     let source_text = super::fetch_plugin_rules_js_string(ORIGINAL_JS_SOURCE_URL)?;

--- a/tasks/lint_rules/src/generate_list/mod.rs
+++ b/tasks/lint_rules/src/generate_list/mod.rs
@@ -3,17 +3,16 @@ use std::collections::HashSet;
 use ureq::Response;
 
 mod eslint;
+mod typescript;
 
 pub fn run(plugin_name: &str) -> Result<String, String> {
-    let (js_source_url, find_to_be_implemented_rules) = match plugin_name {
-        "eslint" => (eslint::ORIGINAL_JS_SOURCE_URL, eslint::find_to_be_implemented_rules),
+    let (rules_to_be_implemented, rules_implemented) = match plugin_name {
+        "eslint" => (eslint::find_to_be_implemented_rules()?, list_implemented_rules("eslint")),
+        "typescript" => {
+            (typescript::find_to_be_implemented_rules()?, list_implemented_rules("typescript"))
+        }
         _ => return Err(format!("😢 Unknown plugin name: {plugin_name}")),
     };
-
-    let js_string = fetch_plugin_rules_js_string(js_source_url)?;
-    let rules_to_be_implemented = find_to_be_implemented_rules(&js_string)?;
-
-    let rules_implemented = list_implemented_rules(plugin_name);
 
     let list = render_markdown_todo_list(&rules_to_be_implemented, &rules_implemented);
     let list = render_markdown_comment(plugin_name, &list);

--- a/tasks/lint_rules/src/generate_list/typescript.rs
+++ b/tasks/lint_rules/src/generate_list/typescript.rs
@@ -6,15 +6,15 @@ use oxc_span::SourceType;
 use std::collections::HashSet;
 
 const ORIGINAL_JS_SOURCE_URL: &str =
-    "https://raw.githubusercontent.com/eslint/eslint/main/packages/js/src/configs/eslint-all.js";
+    "https://raw.githubusercontent.com/typescript-eslint/typescript-eslint/main/packages/eslint-plugin/src/configs/recommended.ts";
 
-const UNSUPPORTED_RULES: &[&str] = &["yoda"];
+const UNSUPPORTED_RULES: &[&str] = &[];
 
 pub fn find_to_be_implemented_rules() -> Result<Vec<String>, String> {
     let source_text = super::fetch_plugin_rules_js_string(ORIGINAL_JS_SOURCE_URL)?;
 
     let allocator = Allocator::default();
-    let source_type = SourceType::default();
+    let source_type = SourceType::default().with_typescript(true);
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
     let program = allocator.alloc(ret.program);
@@ -40,6 +40,13 @@ pub fn find_to_be_implemented_rules() -> Result<Vec<String>, String> {
                 for prop in &obj.properties {
                     if let ObjectPropertyKind::ObjectProperty(prop) = prop {
                         if let Some((name, _)) = prop.key.prop_name() {
+                            // Almost all rules are prefixed, but some are not
+                            // And prefixed and non-prefixed has the same name like `no-unused-vars`
+                            if !name.starts_with("@typescript-eslint/") {
+                                continue;
+                            }
+
+                            let name = name.trim_start_matches("@typescript-eslint/");
                             if unsupported_rules.contains(&name) {
                                 continue;
                             }

--- a/tasks/lint_rules/src/update_comment/mod.rs
+++ b/tasks/lint_rules/src/update_comment/mod.rs
@@ -1,12 +1,15 @@
 use ureq::Response;
 
 const ESLINT_ISSUE_API_URL: &str = "https://api.github.com/repos/oxc-project/oxc/issues/2117";
-// TODO: Restore it after update text is fixed and unsupported list is updated
+const TYPESCRIPT_ISSUE_API_URL: &str = "https://api.github.com/repos/oxc-project/oxc/issues/2117";
+// TODO: Restore these after update text is fixed and unsupported list is updated
 // const ESLINT_ISSUE_API_URL: &str = "https://api.github.com/repos/oxc-project/oxc/issues/479";
+// const TYPESCRIPT_ISSUE_API_URL: &str = "https://api.github.com/repos/oxc-project/oxc/issues/503";
 
 pub fn run(plugin_name: &str, token: &str, comment_body: &str) -> Result<String, String> {
     let api_url = match plugin_name {
         "eslint" => ESLINT_ISSUE_API_URL,
+        "typescript" => TYPESCRIPT_ISSUE_API_URL,
         _ => return Err(format!("😢 Unknown plugin name: {plugin_name}")),
     };
 


### PR DESCRIPTION
Part of #2020

- Add `@typescript-eslint` plugin rules
- w/ refactoring
  - Fix compile errors to add other plugins
  - Remove not intended unsupported rule in `eslint`

(Use #2117 for updating for a while?)