### PR TITLE
refactor(ast): improve simple_assignment_target_identifier and simple_assignment_target_member_expression method

### DIFF
--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -86,7 +86,6 @@ impl<'a> AstBuilder<'a> {
     ) -> AssignmentTarget<'a> {
         let ident = IdentifierReference::new(Span::default(), "".into());
         let dummy = self.simple_assignment_target_identifier(ident);
-        let dummy = AssignmentTarget::SimpleAssignmentTarget(dummy);
         mem::replace(target, dummy)
     }
 
@@ -454,15 +453,19 @@ impl<'a> AstBuilder<'a> {
     pub fn simple_assignment_target_identifier(
         &self,
         ident: IdentifierReference,
-    ) -> SimpleAssignmentTarget<'a> {
-        SimpleAssignmentTarget::AssignmentTargetIdentifier(self.alloc(ident))
+    ) -> AssignmentTarget<'a> {
+        AssignmentTarget::SimpleAssignmentTarget(
+            SimpleAssignmentTarget::AssignmentTargetIdentifier(self.alloc(ident)),
+        )
     }
 
     pub fn simple_assignment_target_member_expression(
         &self,
         expr: MemberExpression<'a>,
-    ) -> SimpleAssignmentTarget<'a> {
-        SimpleAssignmentTarget::MemberAssignmentTarget(self.alloc(expr))
+    ) -> AssignmentTarget<'a> {
+        AssignmentTarget::SimpleAssignmentTarget(SimpleAssignmentTarget::MemberAssignmentTarget(
+            self.alloc(expr),
+        ))
     }
 
     pub fn await_expression(&self, span: Span, argument: Expression<'a>) -> Expression<'a> {

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -140,12 +140,7 @@ impl<'a> ExponentiationOperator<'a> {
                         )
                     }
                 };
-                (
-                    AssignmentTarget::SimpleAssignmentTarget(
-                        self.ast.simple_assignment_target_member_expression(reference),
-                    ),
-                    uid,
-                )
+                (self.ast.simple_assignment_target_member_expression(reference), uid)
             }
             _ => return None,
         };
@@ -231,7 +226,6 @@ impl<'a> ExponentiationOperator<'a> {
         let ident = self.create_new_var(&expr);
         // Add new reference `_name = name` to nodes
         let target = self.ast.simple_assignment_target_identifier(ident.clone());
-        let target = AssignmentTarget::SimpleAssignmentTarget(target);
         let op = AssignmentOperator::Assign;
         nodes.push(self.ast.assignment_expression(Span::default(), op, target, expr));
         self.ast.identifier_reference_expression(ident)

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -76,9 +76,7 @@ impl<'a> NullishCoalescingOperator<'a> {
         } else {
             let ident = self.create_new_var(&logical_expr.left);
             reference = self.ast.identifier_reference_expression(ident.clone());
-            let left = AssignmentTarget::SimpleAssignmentTarget(
-                self.ast.simple_assignment_target_identifier(ident),
-            );
+            let left = self.ast.simple_assignment_target_identifier(ident);
             let right = self.ast.copy(&logical_expr.left);
             assignment =
                 self.ast.assignment_expression(SPAN, AssignmentOperator::Assign, left, right);

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -63,7 +63,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
         //               ^ left_expr
 
         let left_expr: Expression<'a>;
-        let assign_target: SimpleAssignmentTarget<'a>;
+        let assign_target: AssignmentTarget<'_>;
 
         // TODO: refactor this block, add tests, cover private identifier
         match &assignment_expr.left {
@@ -81,9 +81,8 @@ impl<'a> LogicalAssignmentOperators<'a> {
                             if let Some(ident) = self.maybe_generate_memoised(&static_expr.object) {
                                 let right = self.ast.copy(&static_expr.object);
                                 let mut expr = self.ast.copy(static_expr);
-                                let target = AssignmentTarget::SimpleAssignmentTarget(
-                                    self.ast.simple_assignment_target_identifier(ident.clone()),
-                                );
+                                let target =
+                                    self.ast.simple_assignment_target_identifier(ident.clone());
                                 expr.object =
                                     self.ast.assignment_expression(SPAN, op, target, right);
                                 left_expr = self.ast.member_expression(
@@ -102,9 +101,10 @@ impl<'a> LogicalAssignmentOperators<'a> {
                                         self.ast.copy(static_expr),
                                     ),
                                 );
-                                assign_target = SimpleAssignmentTarget::MemberAssignmentTarget(
-                                    self.ast.copy(member_expr),
-                                );
+                                assign_target =
+                                    self.ast.simple_assignment_target_member_expression(
+                                        self.ast.copy(member_expr),
+                                    );
                             };
                         }
                         // `a[b.y] &&= c;` ->
@@ -117,16 +117,13 @@ impl<'a> LogicalAssignmentOperators<'a> {
 
                                 let right = self.ast.copy(&computed_expr.object);
                                 let mut expr = self.ast.copy(computed_expr);
-                                let target = AssignmentTarget::SimpleAssignmentTarget(
-                                    self.ast.simple_assignment_target_identifier(ident.clone()),
-                                );
+                                let target =
+                                    self.ast.simple_assignment_target_identifier(ident.clone());
                                 expr.object =
                                     self.ast.assignment_expression(SPAN, op, target, right);
                                 if let Some(property_ident) = &property_ident {
-                                    let left = AssignmentTarget::SimpleAssignmentTarget(
-                                        self.ast.simple_assignment_target_identifier(
-                                            property_ident.clone(),
-                                        ),
+                                    let left = self.ast.simple_assignment_target_identifier(
+                                        property_ident.clone(),
                                     );
                                     let right = self.ast.copy(&computed_expr.expression);
                                     expr.expression =
@@ -159,10 +156,8 @@ impl<'a> LogicalAssignmentOperators<'a> {
                                 // expr.object =
                                 // self.ast.assignment_expression(span, op, target, right);
                                 if let Some(property_ident) = &property_ident {
-                                    let left = AssignmentTarget::SimpleAssignmentTarget(
-                                        self.ast.simple_assignment_target_identifier(
-                                            property_ident.clone(),
-                                        ),
+                                    let left = self.ast.simple_assignment_target_identifier(
+                                        property_ident.clone(),
                                     );
                                     let right = self.ast.copy(&computed_expr.expression);
                                     expr.expression =
@@ -196,7 +191,6 @@ impl<'a> LogicalAssignmentOperators<'a> {
         };
 
         let assign_op = AssignmentOperator::Assign;
-        let assign_target = AssignmentTarget::SimpleAssignmentTarget(assign_target);
         let right = self.ast.move_expression(&mut assignment_expr.right);
         let right = self.ast.assignment_expression(SPAN, assign_op, assign_target, right);
 

--- a/crates/oxc_transformer/src/proposals/decorators.rs
+++ b/crates/oxc_transformer/src/proposals/decorators.rs
@@ -224,12 +224,10 @@ impl<'a> Decorators<'a> {
 
         {
             // insert _classDecs = decorators;
-            let left = AssignmentTarget::SimpleAssignmentTarget(
-                self.ast.simple_assignment_target_identifier(IdentifierReference::new(
-                    SPAN,
-                    class_decs_name.clone(),
-                )),
-            );
+            let left = self.ast.simple_assignment_target_identifier(IdentifierReference::new(
+                SPAN,
+                class_decs_name.clone(),
+            ));
 
             let right =
                 self.ast.array_expression(
@@ -296,19 +294,15 @@ impl<'a> Decorators<'a> {
 
             let mut elements = self.ast.new_vec();
             elements.push(Some(AssignmentTargetMaybeDefault::AssignmentTarget(
-                AssignmentTarget::SimpleAssignmentTarget(
-                    self.ast.simple_assignment_target_identifier(IdentifierReference::new(
-                        SPAN, class_name,
-                    )),
-                ),
+                self.ast.simple_assignment_target_identifier(IdentifierReference::new(
+                    SPAN, class_name,
+                )),
             )));
             elements.push(Some(AssignmentTargetMaybeDefault::AssignmentTarget(
-                AssignmentTarget::SimpleAssignmentTarget(
-                    self.ast.simple_assignment_target_identifier(IdentifierReference::new(
-                        SPAN,
-                        init_class_name.clone(),
-                    )),
-                ),
+                self.ast.simple_assignment_target_identifier(IdentifierReference::new(
+                    SPAN,
+                    init_class_name.clone(),
+                )),
             )));
             let left = self
                 .ast
@@ -364,9 +358,7 @@ impl<'a> Decorators<'a> {
             self.top_statements
                 .push(Statement::Declaration(Declaration::VariableDeclaration(decl)));
 
-            let left = AssignmentTarget::SimpleAssignmentTarget(
-                self.ast.simple_assignment_target_identifier(class_identifier.clone()),
-            );
+            let left = self.ast.simple_assignment_target_identifier(class_identifier.clone());
             let right = self.ast.class_expression(self.ast.copy(class));
             let new_expr =
                 self.ast.assignment_expression(SPAN, AssignmentOperator::Assign, left, right);

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -390,9 +390,7 @@ impl<'a> TypeScript<'a> {
 
                 self.ast.computed_member(SPAN, obj, expr, false)
             };
-            let left = AssignmentTarget::SimpleAssignmentTarget(
-                self.ast.simple_assignment_target_member_expression(member_expr),
-            );
+            let left = self.ast.simple_assignment_target_member_expression(member_expr);
             let mut expr =
                 self.ast.assignment_expression(SPAN, AssignmentOperator::Assign, left, init);
 
@@ -405,9 +403,7 @@ impl<'a> TypeScript<'a> {
                     ));
                     self.ast.computed_member(SPAN, obj, expr, false)
                 };
-                let left = AssignmentTarget::SimpleAssignmentTarget(
-                    self.ast.simple_assignment_target_member_expression(member_expr),
-                );
+                let left = self.ast.simple_assignment_target_member_expression(member_expr);
                 let right = self
                     .ast
                     .literal_string_expression(StringLiteral::new(SPAN, member_name.clone()));
@@ -741,12 +737,10 @@ impl<'a> TypeScript<'a> {
 
         let arguments = {
             let right = {
-                let left = AssignmentTarget::SimpleAssignmentTarget(
-                    self.ast.simple_assignment_target_identifier(IdentifierReference::new(
-                        SPAN,
-                        name.clone(),
-                    )),
-                );
+                let left = self.ast.simple_assignment_target_identifier(IdentifierReference::new(
+                    SPAN,
+                    name.clone(),
+                ));
                 let right = self.ast.object_expression(SPAN, self.ast.new_vec(), None);
                 self.ast.parenthesized_expression(
                     SPAN,


### PR DESCRIPTION
Based on current usage, I think returning AssignmentTarget is better.
