### PR TITLE
up(cli): support --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_cli"
-version = "0.0.0"
+version = "0.5.0"
 dependencies = [
  "bpaf",
  "glob",

--- a/crates/oxc_cli/Cargo.toml
+++ b/crates/oxc_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_cli"
-version                = "0.0.0"
+version                = "0.5.0"
 publish                = false
 authors.workspace      = true
 description.workspace  = true

--- a/crates/oxc_cli/src/command.rs
+++ b/crates/oxc_cli/src/command.rs
@@ -3,7 +3,7 @@ use oxc_linter::AllowWarnDeny;
 use std::{ffi::OsString, path::PathBuf};
 
 #[derive(Debug, Clone, Bpaf)]
-#[bpaf(options)]
+#[bpaf(options, version)]
 pub enum CliCommand {
     /// Lint this repository
     #[bpaf(command)]
@@ -37,7 +37,7 @@ impl CliCommand {
 // <https://docs.rs/bpaf/latest/bpaf/struct.OptionParser.html#method.descr>
 /// Linter for the JavaScript Oxidation Compiler
 #[derive(Debug, Clone, Bpaf)]
-#[bpaf(options)]
+#[bpaf(options, version)]
 pub struct LintCommand {
     #[bpaf(external(lint_options))]
     pub lint_options: LintOptions,
@@ -51,7 +51,7 @@ impl LintCommand {
 
 /// Formatter for the JavaScript Oxidation Compiler
 #[derive(Debug, Clone, Bpaf)]
-#[bpaf(options)]
+#[bpaf(options, version)]
 pub struct FormatCommand {
     #[bpaf(external(format_options))]
     pub format_options: FormatOptions,

--- a/crates/oxc_cli/src/main.rs
+++ b/crates/oxc_cli/src/main.rs
@@ -11,7 +11,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use oxc_cli::{CliCommand, CliRunResult, FormatRunner, LintRunner, Runner};
 
 fn main() -> CliRunResult {
-    let options = oxc_cli::cli_command().fallback_to_usage().run();
+    let options: CliCommand = oxc_cli::cli_command().fallback_to_usage().run();
     options.handle_threads();
     match options {
         CliCommand::Lint(options) => LintRunner::new(options).run(),


### PR DESCRIPTION
Adds support for `--version` to all commands in `oxc_cli`. I've set `oxc_cli`'s version to match the other packages in the monorepo (0.5.0). Let me know if you'd like the version set to some other value.