### PR TITLE
fix(linter): explicit-length-check inside ternary

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -348,6 +348,8 @@ fn test() {
         // need getStaticValue
         // ("const A_NUMBER = 2; const x = foo.length || A_NUMBER", None),
         ("class A { a(){ if(this.length); while(!this.size || foo);}}", None),
+        // Use of .size but not in conditional "test" position
+        ("const totalCount = tests.reduce((count, test) => count + (test.enabled ? test.maxSize : test.size), 0)", None),
     ];
 
     let fail = vec![
@@ -361,7 +363,10 @@ fn test() {
         ("const x = foo.length || bar()", None),
         ("() => foo.length && bar()", None),
         ("alert(foo.length && bar())", None),
+        // Use of .size in conditional "test" position
+        ("let foo = arr.length ? 'non-empty' : 'empty'", None),
     ];
+
     let fixes = vec![
         (
             r"if ( !!!( !foo.length && foo.length == 0 && foo.length < 1 && 0 === foo.length && 0 == foo.length && 1 > foo.length ) ||

--- a/crates/oxc_linter/src/snapshots/explicit_length_check.snap
+++ b/crates/oxc_linter/src/snapshots/explicit_length_check.snap
@@ -64,4 +64,10 @@ expression: explicit_length_check
    ╰────
   help: Replace `.length` with `.length > 0`.
 
+  ⚠ eslint-plugin-unicorn(explicit-length-check): Use `.length > 0` when checking length is not zero.
+   ╭─[explicit_length_check.tsx:1:1]
+ 1 │ let foo = arr.length ? 'non-empty' : 'empty'
+   ·           ──────────
+   ╰────
+
 


### PR DESCRIPTION
Fixes #2156 by checking that the length/size check is in the "test" part of a conditional (aka ternary).

I stole the technique from here https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs#L172-L175 - there might be potential for re-use as this one looks a bit more sophisticated? I didn't bother trying though, sorry!

I see there is already [an example in `pass` for conditional with the length/size check in the test part](https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs#L331) but not in `fail` so I added one.

Hope it's all OK but shout if anything needs changing 😄 