### PR TITLE
feat(tasks): Re-introduce tasks/lint_rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members  = ["crates/*", "tasks/*", "napi/*"]
+exclude  = ["tasks/lint_rules2"]
 
 [workspace.package]
 authors      = ["Boshen <boshenc@gmail.com>", "Oxc contributors"]

--- a/tasks/lint_rules2/.gitignore
+++ b/tasks/lint_rules2/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/tasks/lint_rules2/README.md
+++ b/tasks/lint_rules2/README.md
@@ -1,0 +1,6 @@
+# tasks/lint_rules2
+
+## FAQ
+
+- Why Node.js? Why not Rust?
+- Why `.cjs`?

--- a/tasks/lint_rules2/README.md
+++ b/tasks/lint_rules2/README.md
@@ -1,6 +1,36 @@
 # tasks/lint_rules2
 
+Task to update implementation progress for each linter plugin.
+
+```sh
+Usage:
+  $ cmd [--target=<pluginName>]... [--update] [--help]
+
+Options:
+  --target, -t: Which plugin to target, multiple allowed
+  --update: Update the issue instead of printing to stdout
+  --help, -h: Print this help message
+```
+
+Environment variables `GITHUB_TOKEN` is required when `--update` is specified.
+
+## Design
+
+- Always install `eslint-plugin-XXX@latest` from npm
+- Load them through ESLint Node.js API
+  - https://eslint.org/docs/latest/integrate/nodejs-api#linter
+- List all their plugin rules(name, depricated, recommended, docs, etc...)
+- List all our implemented rules(name)
+- Combine these lists and render as markdown
+- Update GitHub issue body
+
 ## FAQ
 
-- Why Node.js? Why not Rust?
+- Why is this task written in Node.js? Why not Rust?
+  - Some plugins do not provide static rules list
+    - https://github.com/jest-community/eslint-plugin-jest/
+  - Easiest way to collect the list is just evaluating config file in JavaScript
 - Why `.cjs`?
+  - To keep dependencies as simple as possible
+  - Some plugins only provide their module as CommonJS
+  - So, CommonJS is the only way to go without bundling

--- a/tasks/lint_rules2/README.md
+++ b/tasks/lint_rules2/README.md
@@ -19,7 +19,7 @@ Environment variables `GITHUB_TOKEN` is required when `--update` is specified.
 - Always install `eslint-plugin-XXX@latest` from npm
 - Load them through ESLint Node.js API
   - https://eslint.org/docs/latest/integrate/nodejs-api#linter
-- List all their plugin rules(name, depricated, recommended, docs, etc...)
+- List all their plugin rules(name, deprecated, recommended, docs, etc...)
 - List all our implemented rules(name)
 - Combine these lists and render as markdown
 - Update GitHub issue body

--- a/tasks/lint_rules2/jsconfig.json
+++ b/tasks/lint_rules2/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "module": "node",
+    "moduleResolution": "node",
+    "lib": ["esnext"],
+    "target": "esnext",
+    "strict": true
+  }
+}

--- a/tasks/lint_rules2/package.json
+++ b/tasks/lint_rules2/package.json
@@ -10,6 +10,7 @@
     "eslint": "latest",
     "eslint-plugin-import": "latest",
     "eslint-plugin-jest": "latest",
-    "eslint-plugin-jsdoc": "^48.0.2"
+    "eslint-plugin-jsdoc": "latest",
+    "eslint-plugin-unicorn": "latest"
   }
 }

--- a/tasks/lint_rules2/package.json
+++ b/tasks/lint_rules2/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-import": "latest",
     "eslint-plugin-jest": "latest",
     "eslint-plugin-jsdoc": "latest",
+    "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-unicorn": "latest"
   }
 }

--- a/tasks/lint_rules2/package.json
+++ b/tasks/lint_rules2/package.json
@@ -7,11 +7,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "latest",
     "eslint": "latest",
     "eslint-plugin-import": "latest",
     "eslint-plugin-jest": "latest",
     "eslint-plugin-jsdoc": "latest",
-    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-n": "latest",
     "eslint-plugin-unicorn": "latest"
   }
 }

--- a/tasks/lint_rules2/package.json
+++ b/tasks/lint_rules2/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "name": "lint_rules2",
+  "main": "./src/main.cjs",
+  "version": "0.0.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "eslint": "latest",
+    "eslint-plugin-import": "latest",
+    "eslint-plugin-jest": "latest",
+    "eslint-plugin-jsdoc": "^48.0.2"
+  }
+}

--- a/tasks/lint_rules2/src/eslint-rules.cjs
+++ b/tasks/lint_rules2/src/eslint-rules.cjs
@@ -4,8 +4,15 @@ const { Linter } = require("eslint");
 // Plugins do not provide their type definitions, and also `@types/*` do not exist!
 // Even worse, every plugin has slightly different types in detail...
 //
-// So, we need to normalize recommended and depricated properties manually.
+// So here, we will:
+// - list all rules
+// - normalize recommended and depricated flags
 
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/index.ts
+const {
+  rules: pluginTypeScriptAllRules,
+  configs: pluginTypeScriptConfigs,
+} = require("@typescript-eslint/eslint-plugin");
 // https://github.com/eslint-community/eslint-plugin-n/blob/master/lib/index.js
 const { rules: pluginNAllRules } = require("eslint-plugin-n");
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/index.js
@@ -30,6 +37,24 @@ const { rules: pluginJestAllRules } = require("eslint-plugin-jest");
 
 // All rules including depricated, recommended, etc.
 exports.createESLintLinter = () => new Linter();
+
+/** @param {import("eslint").Linter} linter */
+exports.loadPluginTypeScriptRules = (linter) => {
+  // We want to list all rules but not support type-checked rules
+  const pluginTypeScriptDisableTypeCheckedRules = new Map(
+    Object.entries(pluginTypeScriptConfigs["disable-type-checked"].rules),
+  );
+  for (const [name, rule] of Object.entries(pluginTypeScriptAllRules)) {
+    const prefixedName = `typescript/${name}`;
+
+    if (
+      pluginTypeScriptDisableTypeCheckedRules.has(`@typescript-eslint/${name}`)
+    )
+      continue;
+
+    linter.defineRule(prefixedName, rule);
+  }
+};
 
 /** @param {import("eslint").Linter} linter */
 exports.loadPluginNRules = (linter) => {

--- a/tasks/lint_rules2/src/eslint-rules.cjs
+++ b/tasks/lint_rules2/src/eslint-rules.cjs
@@ -3,7 +3,14 @@ const { Linter } = require("eslint");
 // NOTICE!
 // Plugins do not provide their type definitions, and also `@types/*` do not exist!
 // Even worse, every plugin has slightly different types in detail...
+//
+// So, we need to normalize recommended and depricated properties manually.
 
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/index.js
+const {
+  rules: pluginUnicornAllRules,
+  configs: pluginUnicornConfigs,
+} = require("eslint-plugin-unicorn");
 // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js
 const {
   // @ts-expect-error: Module has no exported member
@@ -23,6 +30,23 @@ const { rules: pluginJestAllRules } = require("eslint-plugin-jest");
 exports.createESLintLinter = () => new Linter();
 
 /** @param {import("eslint").Linter} linter */
+exports.loadPluginUnicornRules = (linter) => {
+  const pluginUnicornRecommendedRules = new Map(
+    Object.entries(pluginUnicornConfigs.recommended.rules),
+  );
+  for (const [name, rule] of Object.entries(pluginUnicornAllRules)) {
+    const prefixedName = `unicorn/${name}`;
+
+    // Some of the rules do not have its property, so we need to mark it manually
+    const recommendedValue = pluginUnicornRecommendedRules.get(prefixedName);
+    // @ts-expect-error: `rule.meta.docs` is possibly `undefined`
+    rule.meta.docs.recommended = recommendedValue && recommendedValue !== "off";
+
+    linter.defineRule(prefixedName, rule);
+  }
+};
+
+/** @param {import("eslint").Linter} linter */
 exports.loadPluginJSDocRules = (linter) => {
   const pluginJSDocRecommendedRules = new Map(
     Object.entries(pluginJSDocConfigs.recommended.rules),
@@ -31,7 +55,8 @@ exports.loadPluginJSDocRules = (linter) => {
     const prefixedName = `jsdoc/${name}`;
 
     // Some of the rules do not have its property, so we need to mark it manually
-    rule.meta.docs.recommended = pluginJSDocRecommendedRules.get(prefixedName) !== "off";
+    rule.meta.docs.recommended =
+      pluginJSDocRecommendedRules.get(prefixedName) !== "off";
 
     linter.defineRule(prefixedName, rule);
   }

--- a/tasks/lint_rules2/src/eslint-rules.cjs
+++ b/tasks/lint_rules2/src/eslint-rules.cjs
@@ -4,7 +4,7 @@ const { Linter } = require("eslint");
 // Plugins do not provide their type definitions, and also `@types/*` do not exist!
 // Even worse, every plugin has slightly different types, different way of configuration in detail...
 //
-// So here, we need to list all rules while normalizing recommended and depricated flags.
+// So here, we need to list all rules while normalizing recommended and deprecated flags.
 // - rule.meta.docs.recommended
 // - rule.meta.deprecated
 
@@ -35,7 +35,7 @@ const {
 // https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts
 const { rules: pluginJestAllRules } = require("eslint-plugin-jest");
 
-// All rules(including depricated, recommended) are loaded initially.
+// All rules(including deprecated, recommended) are loaded initially.
 exports.createESLintLinter = () => new Linter();
 
 /** @param {import("eslint").Linter} linter */

--- a/tasks/lint_rules2/src/eslint-rules.cjs
+++ b/tasks/lint_rules2/src/eslint-rules.cjs
@@ -6,6 +6,8 @@ const { Linter } = require("eslint");
 //
 // So, we need to normalize recommended and depricated properties manually.
 
+// https://github.com/eslint-community/eslint-plugin-n/blob/master/lib/index.js
+const { rules: pluginNAllRules } = require("eslint-plugin-n");
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/index.js
 const {
   rules: pluginUnicornAllRules,
@@ -28,6 +30,16 @@ const { rules: pluginJestAllRules } = require("eslint-plugin-jest");
 
 // All rules including depricated, recommended, etc.
 exports.createESLintLinter = () => new Linter();
+
+/** @param {import("eslint").Linter} linter */
+exports.loadPluginNRules = (linter) => {
+  for (const [name, rule] of Object.entries(pluginNAllRules)) {
+    const prefixedName = `n/${name}`;
+
+    // @ts-expect-error: The types of 'meta.fixable', 'null' is not assignable to type '"code" | "whitespace" | undefined'.
+    linter.defineRule(prefixedName, rule);
+  }
+};
 
 /** @param {import("eslint").Linter} linter */
 exports.loadPluginUnicornRules = (linter) => {

--- a/tasks/lint_rules2/src/eslint-rules.cjs
+++ b/tasks/lint_rules2/src/eslint-rules.cjs
@@ -3,16 +3,20 @@ const { Linter } = require("eslint");
 // NOTICE!
 // Plugins do not provide their type definitions, and also `@types/*` do not exist!
 // Even worse, every plugin has slightly different types in detail...
+
+// https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js
 const {
   // @ts-expect-error: Module has no exported member
   rules: pluginJSDocAllRules,
   // @ts-expect-error: Module has no exported member
   configs: pluginJSDocConfigs,
 } = require("eslint-plugin-jsdoc");
+// https://github.com/import-js/eslint-plugin-import/blob/main/src/index.js
 const {
   rules: pluginImportAllRules,
   configs: pluginImportConfigs,
 } = require("eslint-plugin-import");
+// https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts
 const { rules: pluginJestAllRules } = require("eslint-plugin-jest");
 
 // All rules including depricated, recommended, etc.

--- a/tasks/lint_rules2/src/main.cjs
+++ b/tasks/lint_rules2/src/main.cjs
@@ -1,6 +1,7 @@
 const { parseArgs } = require("node:util");
 const {
   createESLintLinter,
+  loadPluginUnicornRules,
   loadPluginJSDocRules,
   loadPluginImportRules,
   loadPluginJestRules,
@@ -13,7 +14,13 @@ const {
 } = require("./oxlint-rules.cjs");
 const { renderRulesList, renderLayout } = require("./output-markdown.cjs");
 
-const ALL_TARGET_PLUGIN_NAMES = new Set(["eslint", "jsdoc", "import", "jest"]);
+const ALL_TARGET_PLUGIN_NAMES = new Set([
+  "eslint",
+  "unicorn",
+  "jsdoc",
+  "import",
+  "jest",
+]);
 
 const HELP = `
 Usage:
@@ -49,6 +56,7 @@ Options:
   // Load linter and all plugins
   //
   const linter = createESLintLinter();
+  loadPluginUnicornRules(linter);
   loadPluginJSDocRules(linter);
   loadPluginImportRules(linter);
   loadPluginJestRules(linter);

--- a/tasks/lint_rules2/src/main.cjs
+++ b/tasks/lint_rules2/src/main.cjs
@@ -1,6 +1,7 @@
 const { parseArgs } = require("node:util");
 const {
   createESLintLinter,
+  loadPluginTypeScriptRules,
   loadPluginNRules,
   loadPluginUnicornRules,
   loadPluginJSDocRules,
@@ -17,6 +18,7 @@ const { renderRulesList, renderLayout } = require("./output-markdown.cjs");
 
 const ALL_TARGET_PLUGIN_NAMES = new Set([
   "eslint",
+  "typescript",
   "n",
   "unicorn",
   "jsdoc",
@@ -60,6 +62,7 @@ Plugins: ${[...ALL_TARGET_PLUGIN_NAMES].join(", ")}
   // Load linter and all plugins
   //
   const linter = createESLintLinter();
+  loadPluginTypeScriptRules(linter);
   loadPluginNRules(linter);
   loadPluginUnicornRules(linter);
   loadPluginJSDocRules(linter);

--- a/tasks/lint_rules2/src/main.cjs
+++ b/tasks/lint_rules2/src/main.cjs
@@ -1,0 +1,77 @@
+const { parseArgs } = require("node:util");
+const {
+  createESLintLinter,
+  loadPluginJSDocRules,
+  loadPluginImportRules,
+  loadPluginJestRules,
+} = require("./eslint-rules.cjs");
+const {
+  createRuleEntries,
+  readAllImplementedRuleNames,
+  updateNotSupportedStatus,
+  updateImplementedStatus,
+} = require("./oxlint-rules.cjs");
+const { renderRulesList, renderLayout } = require("./output-markdown.cjs");
+
+const ALL_TARGET_PLUGIN_NAMES = new Set(["eslint", "jsdoc", "import", "jest"]);
+
+const HELP = `
+Usage:
+  $ cmd [--target=<pluginName>] [--update] [--help]
+
+Options:
+  --target, -t: Which plugin to target, one of ${[...ALL_TARGET_PLUGIN_NAMES].join(", ")}
+  --update: Update the issue instead of printing to stdout
+  --help, -h: Print this help message
+`;
+
+(async () => {
+  //
+  // Parse arguments
+  //
+  const { values } = parseArgs({
+    options: {
+      target: { type: "string", short: "t", multiple: true },
+      update: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  if (values.help) return console.log(HELP);
+
+  const targetPluginNames = new Set(values.target ?? ALL_TARGET_PLUGIN_NAMES);
+  for (const pluginName of targetPluginNames) {
+    if (!ALL_TARGET_PLUGIN_NAMES.has(pluginName))
+      throw new Error(`Unknown plugin name: ${pluginName}`);
+  }
+
+  //
+  // Load linter and all plugins
+  //
+  const linter = createESLintLinter();
+  loadPluginJSDocRules(linter);
+  loadPluginImportRules(linter);
+  loadPluginJestRules(linter);
+  // TODO: more plugins
+
+  //
+  // Generate entry and update status
+  //
+  const ruleEntries = createRuleEntries(linter.getRules());
+  const implementedRuleNames = await readAllImplementedRuleNames();
+  updateImplementedStatus(ruleEntries, implementedRuleNames);
+  updateNotSupportedStatus(ruleEntries);
+
+  //
+  // Render list and update if necessary
+  //
+  await Promise.allSettled(
+    Array.from(targetPluginNames).map(async (pluginName) => {
+      const listPart = renderRulesList(ruleEntries, pluginName);
+      const content = renderLayout(listPart, pluginName);
+
+      if (!values.update) return console.log(content);
+      // TODO: Update issue
+    }),
+  );
+})();

--- a/tasks/lint_rules2/src/main.cjs
+++ b/tasks/lint_rules2/src/main.cjs
@@ -1,6 +1,7 @@
 const { parseArgs } = require("node:util");
 const {
   createESLintLinter,
+  loadPluginNRules,
   loadPluginUnicornRules,
   loadPluginJSDocRules,
   loadPluginImportRules,
@@ -16,6 +17,7 @@ const { renderRulesList, renderLayout } = require("./output-markdown.cjs");
 
 const ALL_TARGET_PLUGIN_NAMES = new Set([
   "eslint",
+  "n",
   "unicorn",
   "jsdoc",
   "import",
@@ -24,12 +26,14 @@ const ALL_TARGET_PLUGIN_NAMES = new Set([
 
 const HELP = `
 Usage:
-  $ cmd [--target=<pluginName>] [--update] [--help]
+  $ cmd [--target=<pluginName>]... [--update] [--help]
 
 Options:
-  --target, -t: Which plugin to target, one of ${[...ALL_TARGET_PLUGIN_NAMES].join(", ")}
+  --target, -t: Which plugin to target, multiple allowed
   --update: Update the issue instead of printing to stdout
   --help, -h: Print this help message
+
+Plugins: ${[...ALL_TARGET_PLUGIN_NAMES].join(", ")}
 `;
 
 (async () => {
@@ -56,6 +60,7 @@ Options:
   // Load linter and all plugins
   //
   const linter = createESLintLinter();
+  loadPluginNRules(linter);
   loadPluginUnicornRules(linter);
   loadPluginJSDocRules(linter);
   loadPluginImportRules(linter);

--- a/tasks/lint_rules2/src/output-markdown.cjs
+++ b/tasks/lint_rules2/src/output-markdown.cjs
@@ -1,0 +1,53 @@
+/**
+ * @param {import("./oxlint-rules.cjs").RuleEntries} ruleEntries
+ * @param {string} pluginName
+ */
+exports.renderRulesList = (ruleEntries, pluginName) => {
+  /* prettier-ignore */
+  const list = [
+    "| Name | Kind | Status | Docs |",
+    "| :--- | :--: | :----: | :--- |",
+  ];
+
+  for (const [name, entry] of ruleEntries) {
+    if (!name.startsWith(`${pluginName}/`)) continue;
+
+    let kind = "";
+    if (entry.isRecommended) kind += "🍀";
+    if (entry.isDeprecated) kind += "⚠️";
+
+    let status = "";
+    if (entry.isImplemented) status += "✨";
+    if (entry.isNotSupported) status += "🚫";
+
+    list.push(`| ${name} | ${kind} | ${status} | ${entry.docsUrl} |`);
+  }
+
+  return `
+- Kind: 🍀 = recommended | ⚠️ = deprecated
+- Status: ✨ = implemented | 🚫 = not supported
+
+${list.join("\n")}
+`;
+};
+
+/**
+ * @param {string} listPart
+ * @param {string} pluginName
+ */
+exports.renderLayout = (listPart, pluginName) => `
+> [!WARNING]
+> This comment is maintained by CI. Do not edit this comment directly.
+> To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules
+
+## Rules
+${listPart}
+
+## Getting started
+
+\`\`\`sh
+just new-${pluginName}-rule <RULE_NAME>
+\`\`\`
+
+Then register the rule in \`crates/oxc_linter/src/rules.rs\` and also \`declare_all_lint_rules\` at the bottom.
+`;

--- a/tasks/lint_rules2/src/output-markdown.cjs
+++ b/tasks/lint_rules2/src/output-markdown.cjs
@@ -12,6 +12,7 @@ exports.renderRulesList = (ruleEntries, pluginName) => {
   for (const [name, entry] of ruleEntries) {
     if (!name.startsWith(`${pluginName}/`)) continue;
 
+    // These should be exclusive, but show it for sure...
     let kind = "";
     if (entry.isRecommended) kind += "🍀";
     if (entry.isDeprecated) kind += "⚠️";

--- a/tasks/lint_rules2/src/oxlint-rules.cjs
+++ b/tasks/lint_rules2/src/oxlint-rules.cjs
@@ -1,0 +1,96 @@
+const { resolve } = require("node:path");
+const { readFile } = require("node:fs/promises");
+
+/**
+ * @typedef {Map<string, {
+ *   docsUrl: string,
+ *   isDeprecated: boolean,
+ *   isRecommended: boolean,
+ *   isImplemented: boolean,
+ *   isNotSupported: boolean,
+ * }>} RuleEntries
+ */
+
+/** @param {ReturnType<import("eslint").Linter["getRules"]>} loadedAllRules */
+exports.createRuleEntries = (loadedAllRules) => {
+  /** @type {RuleEntries} */
+  const rulesEntry = new Map();
+
+  for (const [name, rule] of loadedAllRules) {
+    // Default eslint rules are not prefixed
+    const prefixedName = name.includes("/") ? name : `eslint/${name}`;
+
+    if (rulesEntry.has(prefixedName))
+      throw new Error(`Duplicate rule: ${name}`);
+
+    const docsUrl = rule.meta?.docs?.url ?? "";
+    const isDeprecated = rule.meta?.deprecated ?? false;
+    const isRecommended = rule.meta?.docs?.recommended ?? false;
+
+    rulesEntry.set(prefixedName, {
+      docsUrl,
+      isDeprecated,
+      isRecommended,
+      // Will be updated later
+      isImplemented: false,
+      isNotSupported: false,
+    });
+  }
+
+  return rulesEntry;
+};
+
+exports.readAllImplementedRuleNames = async () => {
+  const rulesFile = await readFile(
+    resolve("crates/oxc_linter/src/rules.rs"),
+    "utf8",
+  );
+
+  /** @type {Set<string>} */
+  const rules = new Set();
+
+  let found = false;
+  for (const line of rulesFile.split("\n")) {
+    if (line.startsWith("oxc_macros::declare_all_lint_rules!")) {
+      found = true;
+      continue;
+    }
+    if (found && line.startsWith("}")) {
+      return rules;
+    }
+
+    if (found) {
+      const prefixedName = line
+        .trim()
+        .replaceAll(",", "")
+        .replaceAll("::", "/")
+        .replaceAll("_", "-");
+
+      if (prefixedName.startsWith("oxc/")) continue;
+
+      rules.add(prefixedName);
+    }
+  }
+
+  throw new Error("Failed to find the end of the rules list");
+};
+
+const NOT_SUPPORTED_RULE_NAMES = new Set([]);
+/** @param {RuleEntries} ruleEntries */
+exports.updateNotSupportedStatus = (ruleEntries) => {
+  for (const name of NOT_SUPPORTED_RULE_NAMES) {
+    const rule = ruleEntries.get(name);
+    if (rule) rule.isNotSupported = true;
+  }
+};
+
+/**
+ * @param {RuleEntries} ruleEntries
+ * @param {Set<string>} implementedRuleNames
+ */
+exports.updateImplementedStatus = (ruleEntries, implementedRuleNames) => {
+  for (const name of implementedRuleNames) {
+    const rule = ruleEntries.get(name);
+    if (rule) rule.isImplemented = true;
+  }
+};

--- a/tasks/lint_rules2/src/oxlint-rules.cjs
+++ b/tasks/lint_rules2/src/oxlint-rules.cjs
@@ -64,7 +64,9 @@ exports.readAllImplementedRuleNames = async () => {
         .replaceAll("::", "/")
         .replaceAll("_", "-");
 
+      // Ignore no reference rules
       if (prefixedName.startsWith("oxc/")) continue;
+      if (prefixedName.startsWith("deepscan/")) continue;
 
       rules.add(prefixedName);
     }


### PR DESCRIPTION
Part of #2020 

- `tasks/lint_rules2` is a JS rewrite of `tasks/lint_rules`(written in Rust)
  - If no major problems are found here, delete the old ones in next PR
- Why JS? See README file
- For a start, about a half of the supported plugins are implemented

Current markdown output will be posted in next comment. 🔜 