### PR TITLE
fix(linter): Rename react_perf/jsx_no_new_function_as_props to jsx_no_new_function_as_prop

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -170,7 +170,7 @@ mod react {
 mod react_perf {
     pub mod jsx_no_jsx_as_prop;
     pub mod jsx_no_new_array_as_prop;
-    pub mod jsx_no_new_function_as_props;
+    pub mod jsx_no_new_function_as_prop;
     pub mod jsx_no_new_object_as_prop;
 }
 
@@ -524,7 +524,7 @@ oxc_macros::declare_all_lint_rules! {
     react::require_render_return,
     react_perf::jsx_no_jsx_as_prop,
     react_perf::jsx_no_new_array_as_prop,
-    react_perf::jsx_no_new_function_as_props,
+    react_perf::jsx_no_new_function_as_prop,
     react_perf::jsx_no_new_object_as_prop,
     import::default,
     import::no_named_as_default_member,

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -20,12 +20,12 @@ use crate::{
 };
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("eslint-plugin-react-perf(jsx-no-new-function-as-props): JSX attribute values should not contain functions created in the same scope.")]
+#[error("eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.")]
 #[diagnostic(severity(warning), help(r"simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array)."))]
-struct JsxNoNewFunctionAsPropsDiagnostic(#[label] pub Span);
+struct JsxNoNewFunctionAsPropDiagnostic(#[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
-pub struct JsxNoNewFunctionAsProps;
+pub struct JsxNoNewFunctionAsProp;
 
 declare_oxc_lint!(
     /// ### What it does
@@ -40,11 +40,11 @@ declare_oxc_lint!(
     /// // Good
     /// <Item callback={this.props.callback} />
     /// ```
-    JsxNoNewFunctionAsProps,
+    JsxNoNewFunctionAsProp,
     correctness
 );
 
-impl Rule for JsxNoNewFunctionAsProps {
+impl Rule for JsxNoNewFunctionAsProp {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXElement(jsx_elem) = node.kind() {
             check_jsx_element(jsx_elem, ctx);
@@ -61,7 +61,7 @@ fn check_jsx_element<'a>(jsx_elem: &JSXElement<'a>, ctx: &LintContext<'a>) {
                 ..
             })) => {
                 if let Some(span) = check_expression(expr) {
-                    ctx.diagnostic(JsxNoNewFunctionAsPropsDiagnostic(span));
+                    ctx.diagnostic(JsxNoNewFunctionAsPropDiagnostic(span));
                 }
             }
             _ => {}
@@ -139,7 +139,7 @@ fn test() {
         r"<Item prop={this.props.callback || (this.props.cb ? this.props.cb : function(){})} />",
     ];
 
-    Tester::new(JsxNoNewFunctionAsProps::NAME, pass, fail)
+    Tester::new(JsxNoNewFunctionAsProp::NAME, pass, fail)
         .with_react_perf_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jsx_no_new_function_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_no_new_function_as_prop.snap
@@ -1,0 +1,68 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: jsx_no_new_function_as_prop
+---
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item prop={function(){return true}} />
+   ·             ───────────────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item prop={() => true} />
+   ·             ──────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item prop={new Function('a', 'alert(a)')}/>
+   ·             ─────────────────────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item prop={Function()}/>
+   ·             ──────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item onClick={this.clickHandler.bind(this)} />
+   ·                ────────────────────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item callback={this.props.callback || function() {}} />
+   ·                                        ─────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item callback={this.props.callback ? this.props.callback : function() {}} />
+   ·                                                             ─────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item prop={this.props.callback || this.props.callback ? this.props.callback : function(){}} />
+   ·                                                                                ────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:1]
+ 1 │ <Item prop={this.props.callback || (this.props.cb ? this.props.cb : function(){})} />
+   ·                                                                     ────────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+


### PR DESCRIPTION
s/props/prop/

> https://github.com/cvazac/eslint-plugin-react-perf/blob/master/docs/rules/jsx-no-new-function-as-prop.md

Sorry, I overlooked this in #2169 😨 