### PR TITLE
refactor(semantic): use LabelBuilder instead of UnusedLabeled

### DIFF
--- a/crates/oxc_semantic/src/label.rs
+++ b/crates/oxc_semantic/src/label.rs
@@ -1,0 +1,156 @@
+use oxc_ast::ast::LabeledStatement;
+use oxc_span::Span;
+use rustc_hash::FxHashSet;
+
+use crate::AstNodeId;
+
+#[derive(Debug)]
+pub struct Label<'a> {
+    id: AstNodeId,
+    pub name: &'a str,
+    pub span: Span,
+    used: bool,
+    /// depth is the number of nested labeled statements
+    depth: usize,
+    /// is accessible means that the label is accessible from the current position
+    is_accessible: bool,
+    /// is_inside_function_or_static_block means that the label is inside a function or static block
+    is_inside_function_or_static_block: bool,
+}
+
+impl<'a> Label<'a> {
+    pub fn new(
+        id: AstNodeId,
+        name: &'a str,
+        span: Span,
+        depth: usize,
+        is_inside_function_or_static_block: bool,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            span,
+            depth,
+            is_inside_function_or_static_block,
+            used: false,
+            is_accessible: true,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct LabelBuilder<'a> {
+    pub labels: Vec<Vec<Label<'a>>>,
+    depth: usize,
+    pub unused_node_ids: FxHashSet<AstNodeId>,
+}
+
+impl<'a> LabelBuilder<'a> {
+    pub fn enter(&mut self, stmt: &'a LabeledStatement<'a>, current_node_id: AstNodeId) {
+        let is_empty = self.labels.last().map_or(false, Vec::is_empty);
+
+        if !self.is_inside_labeled_statement() {
+            self.labels.push(vec![]);
+        }
+
+        self.depth += 1;
+
+        self.labels.last_mut().unwrap_or_else(|| unreachable!()).push(Label::new(
+            current_node_id,
+            stmt.label.name.as_str(),
+            stmt.label.span,
+            self.depth,
+            is_empty,
+        ));
+    }
+
+    pub fn leave(&mut self) {
+        let depth = self.depth;
+
+        // Mark labels at the current depth as inaccessible
+        // ```ts
+        // label: {} // leave here, mark label as inaccessible
+        // break label // So we cannot find label here
+        // ```
+        for label in self.get_accessible_labels_mut() {
+            if depth == label.depth {
+                label.is_accessible = false;
+            }
+        }
+
+        // If depth is 0, move last labels to the front of `labels` and set `depth` to the length of the last labels.
+        // We need to do this because we're currently inside a function or static block
+        while self.depth == 0 {
+            if let Some(last_labels) = self.labels.pop() {
+                if !last_labels.is_empty() {
+                    self.labels.insert(0, last_labels);
+                }
+            }
+            self.depth = self.labels.last().unwrap().len();
+        }
+
+        self.depth -= 1;
+
+        // insert unused labels into `unused_node_ids`
+        if self.depth == 0 {
+            if let Some(labels) = self.labels.last() {
+                for label in labels {
+                    if !label.used {
+                        self.unused_node_ids.insert(label.id);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn enter_function_or_static_block(&mut self) {
+        if self.is_inside_labeled_statement() {
+            self.depth = 0;
+            self.labels.push(vec![]);
+        }
+    }
+
+    pub fn leave_function_or_static_block(&mut self) {
+        if self.is_inside_labeled_statement() {
+            let labels = self.labels.pop().unwrap_or_else(|| unreachable!());
+            if !labels.is_empty() {
+                self.labels.insert(0, labels);
+            }
+            self.depth = self.labels.last().map_or(0, Vec::len);
+        }
+    }
+
+    pub fn is_inside_labeled_statement(&self) -> bool {
+        self.depth != 0 || self.labels.last().is_some_and(Vec::is_empty)
+    }
+
+    pub fn is_inside_function_or_static_block(&self) -> bool {
+        self.labels
+            .last()
+            .is_some_and(|labels| labels.is_empty() || labels[0].is_inside_function_or_static_block)
+    }
+
+    pub fn get_accessible_labels(&self) -> impl DoubleEndedIterator<Item = &Label<'a>> {
+        return self.labels.last().unwrap().iter().filter(|label| label.is_accessible).rev();
+    }
+
+    pub fn get_accessible_labels_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Label<'a>> {
+        return self
+            .labels
+            .last_mut()
+            .unwrap()
+            .iter_mut()
+            .filter(|label| label.is_accessible)
+            .rev();
+    }
+
+    pub fn mark_as_used(&mut self, label: &oxc_ast::ast::LabelIdentifier) {
+        if self.is_inside_labeled_statement() {
+            let label = self.get_accessible_labels_mut().find(|x| x.name == label.name);
+
+            if let Some(label) = label {
+                label.used = true;
+            }
+        }
+    }
+}

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -5,6 +5,7 @@ mod class;
 mod control_flow;
 mod diagnostics;
 mod jsdoc;
+mod label;
 mod module_record;
 mod node;
 pub mod pg;
@@ -27,6 +28,7 @@ pub use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
+use rustc_hash::FxHashSet;
 
 pub use crate::{
     builder::VariableInfo,
@@ -61,7 +63,7 @@ pub struct Semantic<'a> {
 
     jsdoc: JSDoc<'a>,
 
-    unused_labels: Vec<AstNodeId>,
+    unused_labels: FxHashSet<AstNodeId>,
 
     redeclare_variables: Vec<VariableInfo>,
 
@@ -113,7 +115,7 @@ impl<'a> Semantic<'a> {
         &self.symbols
     }
 
-    pub fn unused_labels(&self) -> &Vec<AstNodeId> {
+    pub fn unused_labels(&self) -> &FxHashSet<AstNodeId> {
         &self.unused_labels
     }
 

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -21736,27 +21736,30 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
  24 │     var y=2;
     ╰────
 
-  × Jump target cannot cross function boundary.
+  × Use of undefined label
     ╭─[language/statements/break/S12.8_A5_T1.js:22:1]
  22 │             return;
  23 │         break LABEL_ANOTHER_LOOP;
-    ·               ──────────────────
+    ·               ─────────┬────────
+    ·                        ╰── This label is used, but not defined
  24 │         LABEL_IN_2 : y++;
     ╰────
 
-  × Jump target cannot cross function boundary.
+  × Use of undefined label
     ╭─[language/statements/break/S12.8_A5_T2.js:24:1]
  24 │             return;
  25 │         break IN_DO_FUNC;
-    ·               ──────────
+    ·               ─────┬────
+    ·                    ╰── This label is used, but not defined
  26 │         LABEL_IN_2 : y++;
     ╰────
 
-  × Jump target cannot cross function boundary.
+  × Use of undefined label
     ╭─[language/statements/break/S12.8_A5_T3.js:24:1]
  24 │             return;
  25 │         break LABEL_IN;
-    ·               ────────
+    ·               ────┬───
+    ·                   ╰── This label is used, but not defined
  26 │         LABEL_IN_2 : y++;
     ╰────
 
@@ -28280,11 +28283,12 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
  21 │   }
     ╰────
 
-  × Jump target cannot cross function boundary.
+  × Use of undefined label
     ╭─[language/statements/class/static-init-invalid-undefined-break-target.js:21:1]
  21 │     x: while (false) {
  22 │       break y;
-    ·             ─
+    ·             ┬
+    ·             ╰── This label is used, but not defined
  23 │     }
     ╰────
 

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -18236,11 +18236,12 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  32 │             return toFixed()
     ╰────
 
-  × Jump target cannot cross function boundary.
+  × Use of undefined label
     ╭─[conformance/salsa/plainJSBinderErrors.ts:37:1]
  37 │             label: var x = 1
  38 │             break label
-    ·                   ─────
+    ·                   ──┬──
+    ·                     ╰── This label is used, but not defined
  39 │         }
     ╰────
 


### PR DESCRIPTION
I think `UnusedLabeled` can do more than that.

1. Collect unused label
2. Support check duplication label
3. Support check label in `BreakStatement`
4. Support check label in `ContinueStatement` (Not yet)

But then the `UnusedLabeled` name wouldn't fit, so I renamed it `LabelBuilder` and moved it to `label.rs`