### PR TITLE
refactor(parser): mark `ByteHandler`s unsafe

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -1295,7 +1295,7 @@ unsafe fn handle_byte(byte: u8, lexer: &mut Lexer) -> Kind {
     BYTE_HANDLERS[byte as usize](lexer)
 }
 
-type ByteHandler = fn(&mut Lexer<'_>) -> Kind;
+type ByteHandler = unsafe fn(&mut Lexer<'_>) -> Kind;
 
 /// Lookup table mapping any incoming byte to a handler function defined below.
 /// <https://github.com/ratel-rust/ratel-core/blob/master/ratel/src/lexer/mod.rs>


### PR DESCRIPTION
All the ASCII `ByteHandler`s are unsafe to call. I forgot to mark them as unsafe when making that change.

This PR fixes that, and will make it harder for someone to accidentally call one of them without considering the safety invariants.