### PR TITLE
Better source line and column numbers

### DIFF
--- a/crates/oxc_diagnostics/src/graphic_reporter.rs
+++ b/crates/oxc_diagnostics/src/graphic_reporter.rs
@@ -400,13 +400,23 @@ impl GraphicalReportHandler {
             self.theme.characters.hbar,
         )?;
 
+        let (source_line, source_col) = labels
+            .iter()
+            .find_map(|hl| {
+                lines
+                    .iter()
+                    .find(|line| line.span_applies(hl) && line.span_line_only(hl))
+                    .map(|line| (line.line_number, self.visual_offset(line, hl.offset()) + 1))
+            })
+            .unwrap_or_else(|| (contents.line() + 1, contents.column() + 1));
+
         if let Some(source_name) = contents.name() {
             let source_name = source_name.style(self.theme.styles.link);
-            writeln!(f, "[{}:{}:{}]", source_name, contents.line() + 1, contents.column() + 1)?;
+            writeln!(f, "[{}:{}:{}]", source_name, source_line, source_col)?;
         } else if lines.len() <= 1 {
             writeln!(f, "{}", self.theme.characters.hbar.to_string().repeat(3))?;
         } else {
-            writeln!(f, "[{}:{}]", contents.line() + 1, contents.column() + 1)?;
+            writeln!(f, "[{}:{}]", source_line, source_col)?;
         }
 
         // Now it's time for the fun part--actually rendering everything!


### PR DESCRIPTION
Attempt to improve the graphical reporter source file **line number** and **column number** .

Currently `oxlint` renders the **line number** as the first line in the snippet **column number** is always `1` AFAICT. Example of current version on VS Code repo:

![image](https://github.com/oxc-project/oxc/assets/37007/196947c0-35cf-4bf3-9c4d-656e4b2c7184)

This means that when CTRL-clicking on the source-file:line:col "link" it takes me to the wrong place.

This PR is an attempt to improve things by getting closer to the source of the issue. Here is my version again on VS Code:

![image](https://github.com/oxc-project/oxc/assets/37007/9adfb14d-c8ee-4aaa-8ed8-be66b69507fb)

I'm a bit worried that none of the tests failed though - would that be expected?

Also the approach feels naïve and there may be several cases it won't work for, or won't work quite so well. Specifically it's just finding the first labelled-span, but I'm guessing in some cases that could be providing context, rather than the thing the user would want to change.

As before I'm no expert and any feedback is very much appreciated.

Also in my local testing, VS Code is still a bit unpredictable - even with the correct line + col it will always go to the correct line number but doesn't always go to the correct column 🤷 But that's not our issue 😄 
