### PR TITLE
feat(cli/linter): support .eslintrc.js

### DIFF
--- a/crates/oxc_linter/fixtures/eslint_config.js
+++ b/crates/oxc_linter/fixtures/eslint_config.js
@@ -1,0 +1,21 @@
+module.exports = {
+    rules: {
+        // requires jsonc support
+        'no-console': 'off',
+        'no-bitwise': [
+            'error',
+            {
+                allow: ['~'],
+            },
+        ],
+        eqeqeq: [
+            'error',
+            'always',
+            {
+                null: 'ignore',
+            },
+        ],
+        '@typescript-eslint/ban-types': 'error',
+        'jsx-a11y/alt-text': 'warn',
+    },
+}

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -373,7 +373,8 @@ mod test {
 
     #[test]
     fn test_js_config() {
-        let fixture_path = env::current_dir().unwrap().join("fixtures/eslint_config.js");
+        // double join to use correct separator on windows
+        let fixture_path = env::current_dir().unwrap().join("fixtures").join("eslint_config.js");
         let config = ESLintConfig::new(&fixture_path).unwrap();
         assert!(!config.rules.is_empty());
         assert!(config.rules.iter().any(|rule| rule.rule_name == "no-console"));


### PR DESCRIPTION
Adds support for JavaScript eslint configs. Configs are loaded by running `node` in a subprocess. This is significantly slower than simply parsing a JSON file, but increases compatibility with existing configs and should make migrating to oxc easier.

## Security
Since loading JS configs requires running `node`, this opens the door to RCE attacks. To mitigate threats, node's experimental [Permissions API](https://nodejs.org/docs/latest-v20.x/api/permissions.html) is used when available.