### PR TITLE
perf(parser): faster offset calculation

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -255,7 +255,7 @@ impl<'a> Lexer<'a> {
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
     fn offset(&self) -> u32 {
-        (self.source.len() - self.current.chars.as_str().len()) as u32
+        (self.current.chars.as_str().as_ptr() as usize - self.source.as_ptr() as usize) as u32
     }
 
     /// Get the current unterminated token range

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -255,6 +255,13 @@ impl<'a> Lexer<'a> {
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
     fn offset(&self) -> u32 {
+        // Offset = current position of `chars` relative to start of `source`.
+        // Previously was `self.source.len() - self.current.chars.as_str().len()`,
+        // but that was slower because `std::str::Chars` internally is a current pointer + end pointer,
+        // whereas `&str` internally is a start pointer and len.
+        // So comparing `len()` of the two requires an extra memory read, and addition operation.
+        // https://godbolt.org/z/v46MWddTM
+        // This function is on hot path, so saving even a single instruction makes a measurable difference.
         (self.current.chars.as_str().as_ptr() as usize - self.source.as_ptr() as usize) as u32
     }
 


### PR DESCRIPTION
A faster way to calculate offset in the lexer.

This only moves the needle because it's on the hottest path in the lexer - `Lexer::offset` is called for every token in `Lexer::read_next_token`.