### PR TITLE
feat(ast): remove serde skip for symbol_id and reference_id

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -307,15 +307,13 @@ impl IdentifierName {
 
 /// Identifier Reference
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct IdentifierReference {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_id: Cell<Option<ReferenceId>>,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_flag: ReferenceFlag,
 }
 
@@ -334,13 +332,12 @@ impl IdentifierReference {
 
 /// Binding Identifier
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct BindingIdentifier {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub symbol_id: Cell<Option<SymbolId>>,
 }
 

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -26,7 +26,6 @@ oxc_diagnostics = { workspace = true }
 oxc_index       = { workspace = true }
 oxc_allocator   = { workspace = true }
 
-bitflags   = { workspace = true }
 indexmap   = { workspace = true }
 itertools  = { workspace = true }
 phf        = { workspace = true, features = ["macros"] }
@@ -50,5 +49,5 @@ rustc-hash        = { workspace = true }
 
 [features]
 default = []
-serde   = ["dep:serde", "oxc_span/serde", "oxc_syntax/serde", "oxc_index/serde"]
+serde   = ["dep:serde", "oxc_span/serde", "oxc_syntax/serde"]
 wasm    = ["dep:tsify", "dep:wasm-bindgen"]

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -7,7 +7,11 @@ use itertools::Itertools;
 use oxc_ast::{ast::*, AstKind, Trivias, TriviasMap, Visit};
 use oxc_diagnostics::Error;
 use oxc_span::{Atom, SourceType, Span};
-use oxc_syntax::{module_record::ModuleRecord, operator::AssignmentOperator};
+use oxc_syntax::{
+    module_record::ModuleRecord,
+    node::{AstNodeId, NodeFlags},
+    operator::AssignmentOperator,
+};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -21,7 +25,7 @@ use crate::{
     jsdoc::JSDocBuilder,
     label::LabelBuilder,
     module_record::ModuleRecordBuilder,
-    node::{AstNode, AstNodeId, AstNodes, NodeFlags},
+    node::{AstNode, AstNodes},
     pg::replicate_tree_to_leaves,
     reference::{Reference, ReferenceFlag, ReferenceId},
     scope::{ScopeFlags, ScopeId, ScopeTree},

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::{
         ObjectPropertyAccessAssignmentValue, Register, UnaryExpressioneAssignmentValue,
         UpdateAssignmentValue,
     },
-    node::{AstNode, AstNodeId, AstNodes, NodeFlags},
+    node::{AstNode, AstNodeId, AstNodes},
     reference::{Reference, ReferenceFlag, ReferenceId},
     scope::ScopeTree,
     symbol::SymbolTable,

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,49 +1,9 @@
-use bitflags::bitflags;
 use oxc_ast::AstKind;
-use oxc_index::{define_index_type, IndexVec};
+use oxc_index::IndexVec;
 
 use crate::scope::ScopeId;
 
-define_index_type! {
-    pub struct AstNodeId = usize;
-}
-
-#[cfg_attr(
-    all(feature = "serde", feature = "wasm"),
-    wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
-)]
-const TS_APPEND_CONTENT: &'static str = r#"
-export type AstNodeId = number;
-export type NodeFlags = {
-    JSDoc: 1,
-    Class: 2,
-    HasYield: 4
-};
-"#;
-
-bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct NodeFlags: u8 {
-        const JSDoc    = 1 << 0; // If the Node has a JSDoc comment attached
-        const Class    = 1 << 1; // If Node is inside a class
-        const HasYield = 1 << 2; // If function has yield statement
-
-    }
-}
-
-impl NodeFlags {
-    pub fn has_jsdoc(&self) -> bool {
-        self.contains(Self::JSDoc)
-    }
-
-    pub fn has_class(&self) -> bool {
-        self.contains(Self::Class)
-    }
-
-    pub fn has_yield(&self) -> bool {
-        self.contains(Self::HasYield)
-    }
-}
+pub use oxc_syntax::node::{AstNodeId, NodeFlags};
 
 /// Semantic node contains all the semantic information about an ast node.
 #[derive(Debug, Clone, Copy)]

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -34,5 +34,5 @@ tsify        = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 [features]
 default = []
-serde   = ["dep:serde", "bitflags/serde"]
+serde   = ["dep:serde", "bitflags/serde", "oxc_index/serde"]
 wasm    = ["dep:tsify", "dep:wasm-bindgen"]

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -4,6 +4,7 @@ pub mod assumptions;
 pub mod class;
 pub mod identifier;
 pub mod module_record;
+pub mod node;
 pub mod operator;
 pub mod precedence;
 pub mod reference;

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -1,0 +1,43 @@
+use bitflags::bitflags;
+use oxc_index::define_index_type;
+
+define_index_type! {
+    pub struct AstNodeId = usize;
+}
+
+#[cfg_attr(
+    all(feature = "serde", feature = "wasm"),
+    wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
+)]
+const TS_APPEND_CONTENT: &'static str = r#"
+export type AstNodeId = number;
+export type NodeFlags = {
+    JSDoc: 1,
+    Class: 2,
+    HasYield: 4
+};
+"#;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct NodeFlags: u8 {
+        const JSDoc    = 1 << 0; // If the Node has a JSDoc comment attached
+        const Class    = 1 << 1; // If Node is inside a class
+        const HasYield = 1 << 2; // If function has yield statement
+
+    }
+}
+
+impl NodeFlags {
+    pub fn has_jsdoc(&self) -> bool {
+        self.contains(Self::JSDoc)
+    }
+
+    pub fn has_class(&self) -> bool {
+        self.contains(Self::Class)
+    }
+
+    pub fn has_yield(&self) -> bool {
+        self.contains(Self::HasYield)
+    }
+}

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -139,7 +139,6 @@ impl Oxc {
             .parse();
         self.save_diagnostics(ret.errors);
 
-        self.ast = ret.program.serialize(&self.serializer)?;
         self.ir = format!("{:#?}", ret.program.body).into();
 
         let program = allocator.alloc(ret.program);
@@ -164,7 +163,10 @@ impl Oxc {
             let linter_ret = Linter::default().run(lint_ctx);
             let diagnostics = linter_ret.into_iter().map(|e| e.error).collect();
             self.save_diagnostics(diagnostics);
+        } else {
+            semantic_builder.build(program);
         }
+        self.ast = program.serialize(&self.serializer)?;
 
         if run_options.prettier_format() {
             let ret = Parser::new(&allocator, source_text, source_type)


### PR DESCRIPTION
We want to see symbol_id and reference_id in ast