### PR TITLE
fix(parser): Binding is not allowed to be optional in VariableDeclarator

### DIFF
--- a/crates/oxc_parser/src/context.rs
+++ b/crates/oxc_parser/src/context.rs
@@ -44,6 +44,9 @@ bitflags! {
         ///   * ambient variable declaration => `declare var $: any`
         ///   * ambient class declaration => `declare class C { foo(); } , etc..`
         const Ambient = 1 << 5;
+
+        /// Binding is not allowed as optional
+        const Required = 1 << 6;
     }
 }
 
@@ -82,6 +85,11 @@ impl Context {
     #[inline]
     pub(crate) fn has_ambient(self) -> bool {
         self.contains(Self::Ambient)
+    }
+
+    #[inline]
+    pub(crate) fn has_required(self) -> bool {
+        self.contains(Self::Required)
     }
 
     #[inline]

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -21,8 +21,9 @@ impl<'a> Parser<'a> {
             _ => self.parse_binding_pattern_identifier(),
         }?;
         if self.ts_enabled() {
-            let optional = self.eat(Kind::Question);
-            let (type_annotation, definite) = self.parse_ts_variable_annotation()?;
+            let optional = if self.ctx.has_required() { false } else { self.eat(Kind::Question) };
+            let (type_annotation, definite) =
+                self.without_context(Context::Required, Parser::parse_ts_variable_annotation)?;
             Ok((self.ast.binding_pattern(kind, type_annotation, optional), definite))
         } else {
             Ok((self.ast.binding_pattern(kind, None, false), false))

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 
-use crate::{diagnostics, lexer::Kind, Parser, StatementContext};
+use crate::{context::Context, diagnostics, lexer::Kind, Parser, StatementContext};
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]
 pub enum VariableDeclarationParent {
@@ -93,8 +93,7 @@ impl<'a> Parser<'a> {
         kind: VariableDeclarationKind,
     ) -> Result<VariableDeclarator<'a>> {
         let span = self.start_span();
-
-        let (id, definite) = self.parse_binding()?;
+        let (id, definite) = self.with_context(Context::Required, Parser::parse_binding)?;
 
         let init =
             self.eat(Kind::Eq).then(|| self.parse_assignment_expression_base()).transpose()?;

--- a/tasks/coverage/misc/fail/oxc-2253.js
+++ b/tasks/coverage/misc/fail/oxc-2253.js
@@ -1,0 +1,2 @@
+// 1. BindingIdentifier
+const a? = "A"

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 10/10 (100.00%)
 Positive Passed: 10/10 (100.00%)
-Negative Passed: 5/5 (100.00%)
+Negative Passed: 6/6 (100.00%)
   × Unexpected token
    ╭─[fail/oxc-169.js:1:1]
  1 │ 1<(V=82<<t-j0<(V=$<LBI<(V=ut<I<(V=$<LBI<(V=uIV=82<<t-j0<(V=$<LBI<(V=ut<I<(V=$<LBI<(V<II>
@@ -22,6 +22,21 @@ Negative Passed: 5/5 (100.00%)
    ·        ─
  3 │ }
    ╰────
+
+  × Missing initializer in const declaration
+   ╭─[fail/oxc-2253.js:1:1]
+ 1 │ // 1. BindingIdentifier
+ 2 │ const a? = "A"
+   ·       ─
+   ╰────
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[fail/oxc-2253.js:1:1]
+ 1 │ // 1. BindingIdentifier
+ 2 │ const a? = "A"
+   ·        ▲
+   ╰────
+  help: Try insert a semicolon here
 
   × Empty parenthesized expression
    ╭─[fail/oxc-232.js:1:1]


### PR DESCRIPTION
fix: #2253

I'm not sure what the best way to fix this bug is. I try to add a `Context::Require` to fix it. This is the first time I've changed the parser's code.

I can always close this PR if there is a better solution.