### PR TITLE
feat(ast): remove generator property from ArrowFunction

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1827,7 +1827,6 @@ pub struct ArrowExpression<'a> {
     pub span: Span,
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
     pub expression: bool,
-    pub generator: bool,
     pub r#async: bool,
     pub params: Box<'a, FormalParameters<'a>>,
     /// See `expression` for whether this arrow expression returns an expression.

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -407,7 +407,6 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         expression: bool,
-        generator: bool,
         r#async: bool,
         params: Box<'a, FormalParameters<'a>>,
         body: Box<'a, FunctionBody<'a>>,
@@ -417,7 +416,6 @@ impl<'a> AstBuilder<'a> {
         Expression::ArrowExpression(self.alloc(ArrowExpression {
             span,
             expression,
-            generator,
             r#async,
             params,
             body,

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -85,9 +85,7 @@ impl Rule for ArrayCallbackReturn {
         let (function_body, always_explicit_return) = match node.kind() {
             // Async, generator, and single expression arrow functions
             // always have explicit return value
-            AstKind::ArrowExpression(arrow) => {
-                (&arrow.body, arrow.r#async || arrow.generator || arrow.expression)
-            }
+            AstKind::ArrowExpression(arrow) => (&arrow.body, arrow.r#async || arrow.expression),
             AstKind::Function(function) => {
                 if let Some(body) = &function.body {
                     (body, function.r#async || function.generator)

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -50,11 +50,7 @@ impl Rule for RequireYield {
             {
                 func.id.as_ref().map_or_else(|| kind.span(), |ident| ident.span)
             }
-            AstKind::ArrowExpression(arrow)
-                if arrow.generator && !arrow.body.statements.is_empty() =>
-            {
-                arrow.span
-            }
+            AstKind::ArrowExpression(arrow) if !arrow.body.statements.is_empty() => arrow.span,
             _ => return,
         };
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -56,8 +56,7 @@ impl Rule for PreferNativeCoercionFunctions {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ArrowExpression(arrow_expr) => {
-                if arrow_expr.r#async || arrow_expr.generator || arrow_expr.params.items.len() == 0
-                {
+                if arrow_expr.r#async || arrow_expr.params.items.len() == 0 {
                     return;
                 }
 

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -253,7 +253,6 @@ impl<'a> Parser<'a> {
         Ok(self.ast.arrow_expression(
             self.end_span(span),
             expression,
-            false,
             r#async,
             params,
             body,
@@ -519,7 +518,6 @@ impl<'a> Parser<'a> {
         Ok(self.ast.arrow_expression(
             self.end_span(span),
             expression,
-            false,
             r#async,
             params,
             body,

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -127,7 +127,7 @@ impl<'a> ArrowFunctions<'a> {
                 FunctionType::FunctionExpression,
                 SPAN,
                 None,
-                arrow_expr.generator,
+                false,
                 arrow_expr.r#async,
                 None,
                 self.ast.copy(&arrow_expr.params),

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -88,7 +88,6 @@ impl<'a> ClassStaticBlock<'a> {
                         SPAN,
                         false,
                         false,
-                        false,
                         params,
                         function_body,
                         None,

--- a/crates/oxc_transformer/src/proposals/decorators.rs
+++ b/crates/oxc_transformer/src/proposals/decorators.rs
@@ -429,7 +429,6 @@ impl<'a> Decorators<'a> {
                                 SPAN,
                                 true,
                                 false,
-                                false,
                                 params,
                                 ast.function_body(
                                     SPAN,
@@ -472,7 +471,6 @@ impl<'a> Decorators<'a> {
                                 ast.arrow_expression(
                                     SPAN,
                                     true,
-                                    false,
                                     false,
                                     params,
                                     ast.function_body(

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -535,7 +535,7 @@ impl<'a> TypeScript<'a> {
         let statements = self.transform_ts_enum_members(&mut decl.body.members, &enum_name);
         let body = self.ast.function_body(decl.body.span, self.ast.new_vec(), statements);
 
-        let callee = self.ast.arrow_expression(SPAN, false, false, false, params, body, None, None);
+        let callee = self.ast.arrow_expression(SPAN, false, false, params, body, None, None);
 
         // })(Foo || {});
         let mut arguments = self.ast.new_vec();


### PR DESCRIPTION
ArrowFunction doesn't support generator. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
