### PR TITLE
feat(semantic): add ReferenceFlag::MemberModified for MemberExpression assign

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1847,7 +1847,7 @@ impl<'a> SemanticBuilder<'a> {
                 ) => {
                     break;
                 }
-                (_, AstKind::ParenthesizedExpression(_)) => {
+                (_, AstKind::ParenthesizedExpression(_) | AstKind::MemberExpression(_)) => {
                     // continue up tree
                 }
                 _ => {

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -57,6 +57,11 @@ impl Reference {
         self.flag.is_write()
     }
 
+    /// Returns `true` if the identifier was member modified to. This is not mutually
+    pub fn is_member_modified(&self) -> bool {
+        self.flag.is_member_modified()
+    }
+
     pub fn is_type(&self) -> bool {
         self.flag.is_type()
     }

--- a/crates/oxc_semantic/tests/symbols.rs
+++ b/crates/oxc_semantic/tests/symbols.rs
@@ -94,7 +94,14 @@ fn test_member_expression_reference() {
         "
         const a = { b: { c: 1 } };
         a.b.c = 2;
+        a.b ++
+        console.log(a.b = 1);
     ",
     );
-    test.has_root_symbol("a").has_number_of_references(1).has_number_of_writes(1).test();
+    test.has_root_symbol("a")
+        .has_number_of_references(3)
+        .has_number_of_reads(3)
+        .has_number_of_writes(0)
+        .has_number_of_member_modified(3)
+        .test();
 }

--- a/crates/oxc_semantic/tests/symbols.rs
+++ b/crates/oxc_semantic/tests/symbols.rs
@@ -87,3 +87,14 @@ fn test_types_simple() {
         .has_number_of_references(1)
         .test();
 }
+
+#[test]
+fn test_member_expression_reference() {
+    let test = SemanticTester::ts(
+        "
+        const a = { b: { c: 1 } };
+        a.b.c = 2;
+    ",
+    );
+    test.has_root_symbol("a").has_number_of_references(1).has_number_of_writes(1).test();
+}

--- a/crates/oxc_semantic/tests/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/util/symbol_tester.rs
@@ -105,6 +105,10 @@ impl<'a> SymbolTester<'a> {
         self.has_number_of_references_where(ref_count, Reference::is_write)
     }
 
+    pub fn has_number_of_member_modified(self, ref_count: usize) -> Self {
+        self.has_number_of_references_where(ref_count, Reference::is_member_modified)
+    }
+
     pub fn has_number_of_references(self, ref_count: usize) -> Self {
         self.has_number_of_references_where(ref_count, |_| true)
     }

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -32,6 +32,8 @@ bitflags! {
         const Write = 1 << 1;
         // Used in type definitions.
         const Type = 1 << 2;
+        // Used in member modification, e.g `a.b = 1`.
+        const MemberModified = 1 << 3;
         const ReadWrite = Self::Read.bits() | Self::Write.bits();
     }
 }
@@ -62,6 +64,11 @@ impl ReferenceFlag {
     /// The identifier is written to. It may also be read from.
     pub const fn is_write(&self) -> bool {
         self.intersects(Self::Write)
+    }
+
+    /// The identifier is property modified to. It may also be read from.
+    pub const fn is_member_modified(&self) -> bool {
+        self.intersects(Self::MemberModified)
     }
 
     /// The identifier is only written to. It is not read from in this reference.


### PR DESCRIPTION
Looks like we need to add a new `ReferenceFlag` to represent this change.