### PR TITLE
chore(benchmark): add radix-ui.jsx as a real world jsx example

### DIFF
--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -45,8 +45,10 @@ impl TestFiles {
         let files = [
             // TypeScript syntax (2.81MB)
             "https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts",
-            // Realword tsx (1.0M)
+            // Real world app tsx (1.0M)
             "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx",
+            // Real world content-heavy app jsx (3K)
+            "https://raw.githubusercontent.com/radix-ui/website/main/components/marketing/AdoptionSection.tsx",
             // Heavy with classes (554K)
             "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
             // ES5 (3.9M)
@@ -80,7 +82,12 @@ impl TestFile {
 
         let segments = url.path_segments().ok_or_else(|| "lib url has no segments".to_string())?;
 
-        let filename = segments.last().ok_or_else(|| "lib url has no segments".to_string())?;
+        let mut filename = segments.last().ok_or_else(|| "lib url has no segments".to_string())?;
+
+        // Radix-ui example file has ext `.tsx`, but only actually contains JSX
+        if filename == "AdoptionSection.tsx" {
+            filename = "AdoptionSection.jsx";
+        }
 
         let file = project_root().join("target").join(filename);
 

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -48,7 +48,7 @@ impl TestFiles {
             // Real world app tsx (1.0M)
             "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx",
             // Real world content-heavy app jsx (3K)
-            "https://raw.githubusercontent.com/radix-ui/website/main/components/marketing/AdoptionSection.tsx",
+            "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx",
             // Heavy with classes (554K)
             "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
             // ES5 (3.9M)
@@ -82,12 +82,7 @@ impl TestFile {
 
         let segments = url.path_segments().ok_or_else(|| "lib url has no segments".to_string())?;
 
-        let mut filename = segments.last().ok_or_else(|| "lib url has no segments".to_string())?;
-
-        // Radix-ui example file has ext `.tsx`, but only actually contains JSX
-        if filename == "AdoptionSection.tsx" {
-            filename = "AdoptionSection.jsx";
-        }
+        let filename = segments.last().ok_or_else(|| "lib url has no segments".to_string())?;
 
         let file = project_root().join("target").join(filename);
 


### PR DESCRIPTION
Following #2297, this adds another benchmark.

This one is from radix-ui website. I've chosen this particular file because it differs from the other benchmark sources in 3 ways:

1. JSX not TSX (despite the file extension).
2. Contains no logic, only JSX component hierarchy, and content text.
3. Very small (60 LOC).

The last is particularly important, I think. Often developers will be working on small files (single component per file convention). And some possible directions for the parser (SIMD etc) involve optimizing chewing through chunks of text, with a de-opt at the end to process the final batch of bytes. If that imposes a penalty on short files, this benchmark will surface it.