### PR TITLE
perf(parser): faster line comment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ version = "0.6.0"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.4.2",
+ "memchr",
  "miette",
  "num-bigint",
  "ouroboros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ ignore                    = { version = "0.4.22" }
 itertools                 = { version = "0.12.1" }
 jemallocator              = { version = "0.5.4" }
 lazy_static               = { version = "1.4.0" }
+memchr                    = { version = "2.7.1" }
 miette                    = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 mimalloc                  = { version = "0.1.39" }
 num-bigint                = { version = "0.4.4" }

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -28,6 +28,7 @@ oxc_index       = { workspace = true }
 assert-unchecked = { workspace = true }
 bitflags         = { workspace = true }
 rustc-hash       = { workspace = true }
+memchr           = { workspace = true }
 num-bigint       = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Utilizes memchr to find the end of the line comment which _might_ yield performance improvements. Also, adds a new `Source::eat_until_byte3` along with `Source::set_eof` that allows us to naturally integrate memchr-based searches
into the lexer.

Thankfully, memchr does not have any dependencies so this change does not add that much bloat to the binary.