### PR TITLE
fix(codegen): format new expression + call expression with the correct parentheses

### DIFF
--- a/crates/oxc_codegen/src/context.rs
+++ b/crates/oxc_codegen/src/context.rs
@@ -4,7 +4,8 @@ bitflags! {
     #[derive(Debug, Clone, Copy)]
     pub struct Context: u8 {
         /// [In]
-        const In = 1 << 0;
+        const In          = 1 << 0;
+        const FORBID_CALL = 1 << 1;
     }
 }
 
@@ -21,9 +22,20 @@ impl Context {
     }
 
     #[inline]
+    pub fn has_forbid_call(self) -> bool {
+        self.contains(Self::FORBID_CALL)
+    }
+
+    #[inline]
     #[must_use]
     pub fn and_in(self, include: bool) -> Self {
         self.and(Self::In, include)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn and_forbid_call(self, include: bool) -> Self {
+        self.and(Self::FORBID_CALL, include)
     }
 
     #[inline]

--- a/crates/oxc_codegen/tests/mod.rs
+++ b/crates/oxc_codegen/tests/mod.rs
@@ -108,3 +108,8 @@ fn module_decl() {
     test("import {} from './foo.js' with {}", "import './foo.js' with {\n};\n");
     test("export * from './foo.js' with {}", "export * from './foo.js' with {\n};\n");
 }
+
+#[test]
+fn new_expr() {
+    test("new (foo()).bar();", "new (foo()).bar();\n");
+}


### PR DESCRIPTION
closes #2328