### PR TITLE
fix(semantic): add export symbol flag to identifiers in export declarations

### DIFF
--- a/crates/oxc_semantic/src/class/mod.rs
+++ b/crates/oxc_semantic/src/class/mod.rs
@@ -2,4 +2,4 @@ mod builder;
 mod table;
 
 pub use builder::ClassTableBuilder;
-pub use table::ClassTable;
+pub use table::{ClassTable, Element};

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -18,7 +18,7 @@ use std::{rc::Rc, sync::Arc};
 pub use petgraph;
 
 pub use builder::{SemanticBuilder, SemanticBuilderReturn};
-use class::ClassTable;
+pub use class::{ClassTable, Element};
 pub use jsdoc::{JSDoc, JSDocComment, JSDocTag};
 use oxc_ast::{ast::IdentifierReference, AstKind, TriviasMap};
 use oxc_span::SourceType;

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -119,13 +119,11 @@ impl ScopeTree {
     }
 
     /// Resolve a symbol binding by name.
-    /// 
+    ///
     /// Symbols are resolved by searching up the scope tree, starting at
     /// the specified scope.
     pub fn resolve_binding(&self, scope_id: ScopeId, name: &Atom) -> Option<SymbolId> {
-        self.ancestors(scope_id)
-            .filter_map(|scope_id| self.get_binding(scope_id, name))
-            .next()
+        self.ancestors(scope_id).find_map(|scope_id| self.get_binding(scope_id, name))
     }
 
     pub fn get_node_id(&self, scope_id: ScopeId) -> AstNodeId {

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -99,7 +99,7 @@ impl ScopeTree {
         self.parent_ids[scope_id]
     }
 
-    /// Get a variable binding by name that was declared in the top-level scope
+    /// Get a variable binding by name that was declared in the top-level scope.
     pub fn get_root_binding(&self, name: &Atom) -> Option<SymbolId> {
         self.get_binding(self.root_scope_id(), name)
     }
@@ -108,12 +108,24 @@ impl ScopeTree {
         self.bindings[scope_id].get(name).is_some()
     }
 
+    /// Get a symbol binding by name in a scope. Does not search parent scopes.
     pub fn get_binding(&self, scope_id: ScopeId, name: &Atom) -> Option<SymbolId> {
         self.bindings[scope_id].get(name).copied()
     }
 
+    /// Get all symbol bindings in a scope.
     pub fn get_bindings(&self, scope_id: ScopeId) -> &Bindings {
         &self.bindings[scope_id]
+    }
+
+    /// Resolve a symbol binding by name.
+    /// 
+    /// Symbols are resolved by searching up the scope tree, starting at
+    /// the specified scope.
+    pub fn resolve_binding(&self, scope_id: ScopeId, name: &Atom) -> Option<SymbolId> {
+        self.ancestors(scope_id)
+            .filter_map(|scope_id| self.get_binding(scope_id, name))
+            .next()
     }
 
     pub fn get_node_id(&self, scope_id: ScopeId) -> AstNodeId {

--- a/crates/oxc_semantic/tests/classes.rs
+++ b/crates/oxc_semantic/tests/classes.rs
@@ -21,7 +21,8 @@ fn test_class_simple() {
     .has_class("Foo")
     .has_number_of_elements(5)
     .has_method("a")
-    .has_property("privateProperty");
+    .has_private_property("privateProperty")
+    .has_property("publicProperty");
 }
 
 #[test]

--- a/crates/oxc_semantic/tests/modules.rs
+++ b/crates/oxc_semantic/tests/modules.rs
@@ -2,7 +2,7 @@ mod util;
 
 use oxc_semantic::SymbolFlags;
 use oxc_span::Atom;
-use oxc_syntax::module_record::{self, ExportLocalName, NameSpan};
+use oxc_syntax::module_record::ExportLocalName;
 pub use util::SemanticTester;
 
 #[test]
@@ -42,24 +42,19 @@ fn test_named_exports() {
 
 #[test]
 fn test_default_export() {
-    // SemanticTester::js(
-    //     "
-    //     export default function foo(a, b) {
-    //         let c = a + b;
-    //         return c / 2
-    //     }
-    //     ",
-    // ).has_some_symbol("foo")
-    // .contains_flags(SymbolFlags::Export | SymbolFlags::Function | SymbolFlags::BlockScopedVariable)
-    // .is_exported()
-    // .test();
-
     let tester = SemanticTester::js(
         "
         const foo = 1;
         export default foo;
         ",
     );
+    tester
+        .has_root_symbol("foo")
+        .is_exported()
+        .contains_flags(
+            SymbolFlags::BlockScopedVariable | SymbolFlags::Export | SymbolFlags::ConstVariable,
+        )
+        .test();
     let semantic = tester.build();
     let module_record = semantic.module_record();
 
@@ -67,12 +62,8 @@ fn test_default_export() {
 
     assert!(module_record.export_default.is_some());
     assert!(module_record.local_export_entries.len() == 1);
-    let foo = &module_record.local_export_entries[0];
+    let local_exports = &module_record.local_export_entries[0];
     assert!(
-        matches!(&foo.local_name, ExportLocalName::Name(namespan) if namespan.name() == &"foo")
+        matches!(&local_exports.local_name, ExportLocalName::Name(namespan) if namespan.name() == &"foo")
     );
-    // .has_some_symbol("foo")
-    // .contains_flags(SymbolFlags::Export | SymbolFlags::BlockScopedVariable)
-    // .is_exported()
-    // .test();
 }

--- a/crates/oxc_semantic/tests/symbols.rs
+++ b/crates/oxc_semantic/tests/symbols.rs
@@ -23,6 +23,12 @@ fn test_class_simple() {
         .has_root_symbol("Foo")
         .has_number_of_reads(1)
         .test();
+
+    SemanticTester::js("class Foo {}; export default Foo")
+        .has_root_symbol("Foo")
+        .is_exported()
+        .contains_flags(SymbolFlags::Class | SymbolFlags::Export)
+        .test();
 }
 
 #[test]

--- a/crates/oxc_semantic/tests/util/mod.rs
+++ b/crates/oxc_semantic/tests/util/mod.rs
@@ -1,7 +1,10 @@
 mod class_tester;
 mod expect;
 mod symbol_tester;
-use std::{path::{Path, PathBuf}, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use itertools::Itertools;
 use oxc_allocator::Allocator;
@@ -37,9 +40,15 @@ impl<'a> SemanticTester<'a> {
     }
 
     pub fn new(source_text: &'a str, source_type: SourceType) -> Self {
-        Self { allocator: Allocator::default(), source_type, source_text, source_path: PathBuf::new() }
+        Self {
+            allocator: Allocator::default(),
+            source_type,
+            source_text,
+            source_path: PathBuf::new(),
+        }
     }
 
+    #[must_use]
     pub fn with_source_path<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.source_path = path.as_ref().to_path_buf();
         self

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -69,7 +69,12 @@ pub struct ModuleRecord {
 impl std::fmt::Debug for ModuleRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // recursively formatting loaded modules can crash when the module graph is cyclic
-        let loaded_modules = self.loaded_modules.iter().map(|entry| (entry.key().to_string())).reduce(|acc, key| format!("{}, {}", acc, key)).unwrap_or_default();
+        let loaded_modules = self
+            .loaded_modules
+            .iter()
+            .map(|entry| (entry.key().to_string()))
+            .reduce(|acc, key| format!("{acc}, {key}"))
+            .unwrap_or_default();
         let loaded_modules = format!("{{ {loaded_modules} }}");
         f.debug_struct("ModuleRecord")
             .field("resolved_absolute_path", &self.resolved_absolute_path)

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -66,6 +66,27 @@ pub struct ModuleRecord {
     pub export_default_duplicated: Vec<Span>,
 }
 
+impl std::fmt::Debug for ModuleRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // recursively formatting loaded modules can crash when the module graph is cyclic
+        let loaded_modules = self.loaded_modules.iter().map(|entry| (entry.key().to_string())).reduce(|acc, key| format!("{}, {}", acc, key)).unwrap_or_default();
+        let loaded_modules = format!("{{ {loaded_modules} }}");
+        f.debug_struct("ModuleRecord")
+            .field("resolved_absolute_path", &self.resolved_absolute_path)
+            .field("requested_modules", &self.requested_modules)
+            .field("loaded_modules", &loaded_modules)
+            .field("import_entries", &self.import_entries)
+            .field("local_export_entries", &self.local_export_entries)
+            .field("indirect_export_entries", &self.indirect_export_entries)
+            .field("star_export_entries", &self.star_export_entries)
+            .field("exported_bindings", &self.exported_bindings)
+            .field("exported_bindings_duplicated", &self.exported_bindings_duplicated)
+            .field("export_default", &self.export_default)
+            .field("export_default_duplicated", &self.export_default_duplicated)
+            .finish()
+    }
+}
+
 impl ModuleRecord {
     pub fn new(resolved_absolute_path: PathBuf) -> Self {
         Self { resolved_absolute_path, ..Self::default() }


### PR DESCRIPTION
# What This PR Does

Consider the following code:
```js
export function foo() {}
function bar () {}
class Baz {}

export { bar }
export default Baz
```

Since symbol flags are added at the time of declaration, `bar` and `Baz` never get flagged with `SymbolFlags::Export`. This PR checks identifiers referenced inside `ExportNamedDeclaration`s and `ExportDefaultDeclaration`s, adding export flags to all resolvable symbols.

## Other Changes
- test(semantic): improvements to class and symbol testers (including better diagnostics)
- feat(semantic): implement `Debug` for `ModuleRecord` (in a non-crashing way)
