### PR TITLE
refactor(parser): make `Source::set_position` safe

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -255,9 +255,7 @@ impl<'a> ParserImpl<'a> {
         let ParserCheckpoint { lexer, cur_token, prev_span_end, errors_pos: errors_lens } =
             checkpoint;
 
-        // SAFETY: Parser only ever creates a single `Lexer`,
-        // therefore all checkpoints must be created from it.
-        unsafe { self.lexer.rewind(lexer) };
+        self.lexer.rewind(lexer);
         self.token = cur_token;
         self.prev_token_end = prev_span_end;
         self.errors.truncate(errors_lens);

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -153,14 +153,8 @@ impl<'a> Lexer<'a> {
     }
 
     /// Rewinds the lexer to the same state as when the passed in `checkpoint` was created.
-    ///
-    /// # SAFETY
-    /// `checkpoint` must have been created from this `Lexer`.
-    #[allow(clippy::missing_safety_doc)] // Clippy is wrong!
-    pub unsafe fn rewind(&mut self, checkpoint: LexerCheckpoint<'a>) {
+    pub fn rewind(&mut self, checkpoint: LexerCheckpoint<'a>) {
         self.errors.truncate(checkpoint.errors_pos);
-        // SAFETY: Caller guarantees `checkpoint` was created from this `Lexer`,
-        // and therefore `checkpoint.position` was created from `self.source`.
         self.source.set_position(checkpoint.position);
         self.token = checkpoint.token;
         self.lookahead.clear();
@@ -178,10 +172,7 @@ impl<'a> Lexer<'a> {
         let position = self.source.position();
 
         if let Some(lookahead) = self.lookahead.back() {
-            // SAFETY: `self.lookahead` only contains lookaheads created by this `Lexer`.
-            // `self.source` never changes, so `lookahead.position` must have been created
-            // from `self.source`.
-            unsafe { self.source.set_position(lookahead.position) };
+            self.source.set_position(lookahead.position);
         }
 
         for _i in self.lookahead.len()..n {
@@ -197,8 +188,7 @@ impl<'a> Lexer<'a> {
         // read, so that's not possible. So no need to restore `self.token` here.
         // It's already in same state as it was at start of this function.
 
-        // SAFETY: `position` was created above from `self.source`. `self.source` never changes.
-        unsafe { self.source.set_position(position) };
+        self.source.set_position(position);
 
         self.lookahead[n - 1].token
     }
@@ -211,10 +201,7 @@ impl<'a> Lexer<'a> {
     /// Main entry point
     pub fn next_token(&mut self) -> Token {
         if let Some(lookahead) = self.lookahead.pop_front() {
-            // SAFETY: `self.lookahead` only contains lookaheads created by this `Lexer`.
-            // `self.source` never changes, so `lookahead.position` must have been created
-            // from `self.source`.
-            unsafe { self.source.set_position(lookahead.position) };
+            self.source.set_position(lookahead.position);
             return lookahead.token;
         }
         let kind = self.read_next_token();


### PR DESCRIPTION
Make `Source::set_position` a safe function.

This addresses a shortcoming of #2288.

Instead of requiring caller of `Source::set_position` to guarantee that the `SourcePosition` is created from this `Source`, the preceding PRs enforce this guarantee at the type level.

`Source::set_position` is going to be a central API for transitioning the lexer to processing the source as bytes, rather than `char`s (and the anticipated speed-ups that will produce). So making this method safe will remove the need for a *lot* of unsafe code blocks, and boilerplate comments promising "SAFETY: There's only one `Source`", when to the developer, this is blindingly obvious anyway.

So, while splitting the parser into `Parser` and `ParserImpl` (#2339) is an annoying change to have to make, I believe the benefit of this PR justifies it.