### PR TITLE
fix(linter): add missing typescript-eslint(_) prefix for some errors

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -33,24 +33,24 @@ declare_oxc_lint!(
 
 #[derive(Debug, Diagnostic, Error)]
 pub enum ArrayTypeDiagnostic {
-    #[error("Array type using '{0}{2}[]' is forbidden. Use '{1}<{2}>' instead.")]
+    #[error("typescript-eslint(array-type): Array type using '{0}{2}[]' is forbidden. Use '{1}<{2}>' instead.")]
     #[diagnostic(severity(warning))]
     // readonlyPrefix className type
     Generic(String, String, String, #[label] Span),
 
     #[error(
-        "Array type using '{0}{2}[]' is forbidden for non-simple types. Use '{1}<{2}>' instead."
+        "typescript-eslint(array-type): Array type using '{0}{2}[]' is forbidden for non-simple types. Use '{1}<{2}>' instead."
     )]
     #[diagnostic(severity(warning))]
     // readonlyPrefix className type
     GenericSimple(String, String, String, #[label] Span),
 
-    #[error("Array type using '{1}<{2}>' is forbidden. Use '{0}{2}[]' instead.")]
+    #[error("typescript-eslint(array-type): Array type using '{1}<{2}>' is forbidden. Use '{0}{2}[]' instead.")]
     #[diagnostic(severity(warning))]
     // readonlyPrefix className type
     Array(String, String, String, #[label] Span),
 
-    #[error("Array type using '{1}<{2}>' is forbidden for simple types. Use '{0}{2}[]' instead.")]
+    #[error("typescript-eslint(array-type): Array type using '{1}<{2}>' is forbidden for simple types. Use '{0}{2}[]' instead.")]
     #[diagnostic(severity(warning))]
     // readonlyPrefix className type
     ArraySimple(String, String, String, #[label] Span),

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -10,15 +10,17 @@ use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum BanTsCommentDiagnostic {
-    #[error("Do not use @ts-{0} because it alters compilation errors.")]
+    #[error(
+        "typescript-eslint(ban-ts-comment): Do not use @ts-{0} because it alters compilation errors."
+    )]
     #[diagnostic(severity(warning))]
     Comment(String, #[label] Span),
 
-    #[error("Include a description after the @ts-{0} directive to explain why the @ts-{0} is necessary. The description must be {1} characters or longer.")]
+    #[error("typescript-eslint(ban-ts-comment): Include a description after the @ts-{0} directive to explain why the @ts-{0} is necessary. The description must be {1} characters or longer.")]
     #[diagnostic(severity(warning))]
     CommentRequiresDescription(String, u64, #[label] Span),
 
-    #[error("The description for the @ts-{0} directive must match the {1} format.")]
+    #[error("typescript-eslint(ban-ts-comment): The description for the @ts-{0} directive must match the {1} format.")]
     #[diagnostic(severity(warning))]
     CommentDescriptionNotMatchPattern(String, String, #[label] Span),
 }

--- a/crates/oxc_linter/src/snapshots/array_type.snap
+++ b/crates/oxc_linter/src/snapshots/array_type.snap
@@ -1,358 +1,357 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 150
 expression: array_type
 ---
 
-  ⚠ Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
 
-  ⚠ Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
 
-  ⚠ Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'bigint[]' is forbidden. Use 'Array<bigint>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'bigint[]' is forbidden. Use 'Array<bigint>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: bigint[] = [];
    ·        ────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | bigint)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<bigint>' is forbidden for simple types. Use 'readonly bigint[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<bigint>' is forbidden for simple types. Use 'readonly bigint[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: ReadonlyArray<bigint> = [];
    ·        ─────────────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: (string | bigint)[] = [];
    ·        ───────────────────
    ╰────
 
-  ⚠ Array type using 'readonly bigint[]' is forbidden. Use 'ReadonlyArray<bigint>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly bigint[]' is forbidden. Use 'ReadonlyArray<bigint>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly bigint[] = [];
    ·        ─────────────────
    ╰────
 
-  ⚠ Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let a: readonly (string | bigint)[] = [];
    ·        ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
    ╭─[array_type.tsx:1:15]
  1 │ let a: { foo: Array<Bar> }[] = [];
    ·               ──────────
    ╰────
 
-  ⚠ Array type using 'Bar[]' is forbidden. Use 'Array<Bar>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Bar[]' is forbidden. Use 'Array<Bar>' instead.
    ╭─[array_type.tsx:1:21]
  1 │ let a: Array<{ foo: Bar[] }> = [];
    ·                     ─────
    ╰────
 
-  ⚠ Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
    ╭─[array_type.tsx:1:17]
  1 │ function foo(a: Array<Bar>): Array<Bar> {}
    ·                 ──────────
    ╰────
 
-  ⚠ Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
    ╭─[array_type.tsx:1:30]
  1 │ function foo(a: Array<Bar>): Array<Bar> {}
    ·                              ──────────
    ╰────
 
-  ⚠ Array type using 'Array<undefined>' is forbidden for simple types. Use 'undefined[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<undefined>' is forbidden for simple types. Use 'undefined[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let x: Array<undefined> = [undefined] as undefined[];
    ·        ────────────────
@@ -363,25 +362,25 @@ expression: array_type
  1 │ let y: string[] = <Array<string>>['2'];
    ╰────
 
-  ⚠ Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let z: Array = [3, '4'];
    ·        ─────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:24]
  1 │ let ya = [[1, '2']] as [number, string][];
    ·                        ──────────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
    ╭─[array_type.tsx:1:15]
  1 │ type Arr<T> = Array<T>;
    ·               ────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
    ╭─[array_type.tsx:3:14]
  2 │         interface ArrayClass<T> {
  3 │         foo: Array<T>;
@@ -389,7 +388,7 @@ expression: array_type
  4 │         bar: T[];
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:2:35]
  1 │ 
  2 │         function barFunction(bar: ArrayClass<String>[]) {
@@ -397,25 +396,25 @@ expression: array_type
  3 │         return bar.map(e => e.bar);
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:13]
  1 │ let barVar: ((c: number) => number)[];
    ·             ─────────────────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:17]
  1 │ type barUnion = (string | number | boolean)[];
    ·                 ─────────────────────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:24]
  1 │ type barIntersection = (string & number)[];
    ·                        ───────────────────
    ╰────
 
-  ⚠ Array type using 'Array<undefined>' is forbidden. Use 'undefined[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<undefined>' is forbidden. Use 'undefined[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let x: Array<undefined> = [undefined] as undefined[];
    ·        ────────────────
@@ -426,19 +425,19 @@ expression: array_type
  1 │ let y: string[] = <Array<string>>['2'];
    ╰────
 
-  ⚠ Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let z: Array = [3, '4'];
    ·        ─────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:15]
  1 │ type Arr<T> = Array<T>;
    ·               ────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:3:14]
  2 │         interface ArrayClass<T> {
  3 │         foo: Array<T>;
@@ -446,7 +445,7 @@ expression: array_type
  4 │         bar: T[];
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:2:35]
  1 │ 
  2 │         function fooFunction(foo: Array<ArrayClass<string>>) {
@@ -454,49 +453,49 @@ expression: array_type
  3 │         return foo.map(e => e.foo);
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:13]
  1 │ let fooVar: Array<(c: number) => number>;
    ·             ────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:17]
  1 │ type fooUnion = Array<string | number | boolean>;
    ·                 ────────────────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:24]
  1 │ type fooIntersection = Array<string & number>;
    ·                        ──────────────────────
    ╰────
 
-  ⚠ Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let x: Array;
    ·        ─────
    ╰────
 
-  ⚠ Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let x: Array<>;
    ·        ───────
    ╰────
 
-  ⚠ Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let x: Array;
    ·        ─────
    ╰────
 
-  ⚠ Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
    ╭─[array_type.tsx:1:8]
  1 │ let x: Array<>;
    ·        ───────
    ╰────
 
-  ⚠ Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
    ╭─[array_type.tsx:1:31]
  1 │ let x: Array<number> = [1] as number[];
    ·                               ────────
@@ -507,13 +506,13 @@ expression: array_type
  1 │ let y: string[] = <Array<string>>['2'];
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:24]
  1 │ let ya = [[1, '2']] as [number, string][];
    ·                        ──────────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:4:14]
  3 │         foo: Array<T>;
  4 │         bar: T[];
@@ -521,7 +520,7 @@ expression: array_type
  5 │         baz: Arr<T>;
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:2:35]
  1 │ 
  2 │         function barFunction(bar: ArrayClass<String>[]) {
@@ -529,25 +528,25 @@ expression: array_type
  3 │         return bar.map(e => e.bar);
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:13]
  1 │ let barVar: ((c: number) => number)[];
    ·             ─────────────────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:17]
  1 │ type barUnion = (string | number | boolean)[];
    ·                 ─────────────────────────────
    ╰────
 
-  ⚠ Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
    ╭─[array_type.tsx:1:24]
  1 │ type barIntersection = (string & number)[];
    ·                        ───────────────────
    ╰────
 
-  ⚠ Array type using 'string[]' is forbidden. Use 'Array<string>' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'string[]' is forbidden. Use 'Array<string>' instead.
    ╭─[array_type.tsx:3:24]
  2 │         interface FooInterface {
  3 │         '.bar': { baz: string[] };
@@ -555,13 +554,13 @@ expression: array_type
  4 │         }
    ╰────
 
-  ⚠ Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
    ╭─[array_type.tsx:1:12]
  1 │ const foo: Array<new (...args: any[]) => void> = [];
    ·            ───────────────────────────────────
    ╰────
 
-  ⚠ Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
+  ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
    ╭─[array_type.tsx:1:12]
  1 │ const foo: ReadonlyArray<new (...args: any[]) => void> = [];
    ·            ───────────────────────────────────────────

--- a/crates/oxc_linter/src/snapshots/ban_ts_comment.snap
+++ b/crates/oxc_linter/src/snapshots/ban_ts_comment.snap
@@ -3,19 +3,19 @@ source: crates/oxc_linter/src/tester.rs
 expression: ban_ts_comment
 ---
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error
    ·   ─────────────────
    ╰────
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /* @ts-expect-error */
    ·   ──────────────────
    ╰────
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
  1 │     
  2 │ ╭─▶ /*
@@ -24,25 +24,25 @@ expression: ban_ts_comment
  5 │                 
    ╰────
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /** @ts-expect-error */
    ·   ───────────────────
    ╰────
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: Suppress next line
    ·   ─────────────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /////@ts-expect-error: Suppress next line
    ·   ───────────────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-expect-error because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:5]
  2 │ if (false) {
  3 │   // @ts-expect-error: Unreachable code error
@@ -50,49 +50,49 @@ expression: ban_ts_comment
  4 │   console.log('hello');
    ╰────
 
-  ⚠ Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error
    ·   ─────────────────
    ╰────
 
-  ⚠ Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 10 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 10 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: TODO
    ·   ───────────────────────
    ╰────
 
-  ⚠ Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 25 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: TS1234 because xyz
    ·   ─────────────────────────────────────
    ╰────
 
-  ⚠ The description for the @ts-expect-error directive must match the ^: TS\d+ because .+$ format.
+  ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-expect-error directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: TS1234
    ·   ─────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore
    ·   ───────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore
    ·   ───────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /* @ts-ignore */
    ·   ────────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
  1 │     
  2 │ ╭─▶ /*
@@ -101,25 +101,25 @@ expression: ban_ts_comment
  5 │                 
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /** @ts-ignore */
    ·   ─────────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore: Suppress next line
    ·   ───────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /////@ts-ignore: Suppress next line
    ·   ─────────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-ignore because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-ignore because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:5]
  2 │ if (false) {
  3 │   // @ts-ignore: Unreachable code error
@@ -127,49 +127,49 @@ expression: ban_ts_comment
  4 │   console.log('hello');
    ╰────
 
-  ⚠ Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore
    ·   ───────────
    ╰────
 
-  ⚠ Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore    .
    ·   ────────────────
    ╰────
 
-  ⚠ Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 25 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore: TS1234 because xyz
    ·   ───────────────────────────────
    ╰────
 
-  ⚠ The description for the @ts-ignore directive must match the ^: TS\d+ because .+$ format.
+  ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-ignore directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore: TS1234
    ·   ───────────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck
    ·   ────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck
    ·   ────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /* @ts-nocheck */
    ·   ─────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
  1 │     
  2 │ ╭─▶ /*
@@ -178,25 +178,25 @@ expression: ban_ts_comment
  5 │                 
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /** @ts-nocheck */
    ·   ──────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck: Suppress next line
    ·   ────────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /////@ts-nocheck: Suppress next line
    ·   ──────────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-nocheck because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:5]
  2 │ if (false) {
  3 │   // @ts-nocheck: Unreachable code error
@@ -204,37 +204,37 @@ expression: ban_ts_comment
  4 │   console.log('hello');
    ╰────
 
-  ⚠ Include a description after the @ts-nocheck directive to explain why the @ts-nocheck is necessary. The description must be 3 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-nocheck directive to explain why the @ts-nocheck is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck
    ·   ────────────
    ╰────
 
-  ⚠ Include a description after the @ts-nocheck directive to explain why the @ts-nocheck is necessary. The description must be 25 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-nocheck directive to explain why the @ts-nocheck is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck: TS1234 because xyz
    ·   ────────────────────────────────
    ╰────
 
-  ⚠ The description for the @ts-nocheck directive must match the ^: TS\d+ because .+$ format.
+  ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-nocheck directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck: TS1234
    ·   ────────────────────
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check
    ·   ──────────
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /* @ts-check */
    ·   ───────────
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
  1 │     
  2 │ ╭─▶ /*
@@ -243,25 +243,25 @@ expression: ban_ts_comment
  5 │                 
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /** @ts-check */
    ·   ────────────
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check: Suppress next line
    ·   ──────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /////@ts-check: Suppress next line
    ·   ────────────────────────────────
    ╰────
 
-  ⚠ Do not use @ts-check because it alters compilation errors.
+  ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:5]
  2 │ if (false) {
  3 │   // @ts-check: Unreachable code error
@@ -269,19 +269,19 @@ expression: ban_ts_comment
  4 │   console.log('hello');
    ╰────
 
-  ⚠ Include a description after the @ts-check directive to explain why the @ts-check is necessary. The description must be 3 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-check directive to explain why the @ts-check is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check
    ·   ──────────
    ╰────
 
-  ⚠ Include a description after the @ts-check directive to explain why the @ts-check is necessary. The description must be 25 characters or longer.
+  ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-check directive to explain why the @ts-check is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check: TS1234 because xyz
    ·   ──────────────────────────────
    ╰────
 
-  ⚠ The description for the @ts-check directive must match the ^: TS\d+ because .+$ format.
+  ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-check directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check: TS1234
    ·   ──────────────────


### PR DESCRIPTION
Running latest on one of my projects these warnings jumped out at me because they were "anonymous" vs the others.

This PR just adds the usual rule-name prefix to the errors where it was missing