### PR TITLE
fix(parser): remove erroneous debug assertion

### DIFF
--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -162,22 +162,7 @@ impl<'a> Source<'a> {
     pub(super) fn position(&self) -> SourcePosition<'a> {
         // SAFETY: Creating a `SourcePosition` from current position of `Source` is always valid,
         // if caller has upheld safety conditions of other unsafe methods of this type.
-        let pos = unsafe { SourcePosition::new(self.ptr) };
-
-        // SAFETY: `pos.read()`'s contract is upheld by:
-        // * The preceding checks that `pos.ptr` >= `self.start` and < `self.end`.
-        // * `Source`'s invariants guarantee that `self.start` - `self.end` contains allocated memory.
-        // * `Source::new` takes an immutable ref `&str`, guaranteeing that the memory `pos.ptr`
-        //   addresses cannot be aliased by a `&mut` ref as long as `Source` exists.
-        // * `SourcePosition` can only live as long as the `&str` underlying `Source`.
-        debug_assert!(
-            pos.ptr >= self.start
-                && pos.ptr <= self.end
-                // SAFETY: See above
-                && (pos.ptr == self.end || !is_utf8_cont_byte(unsafe { pos.read() }))
-        );
-
-        pos
+        unsafe { SourcePosition::new(self.ptr) }
     }
 
     /// Move current position.


### PR DESCRIPTION
This was a bit of a whoopsie in last batch of PRs. This assertion shouldn't be there, because all reads are now via `source.position().read()`, so this assertion says "you can only read some byte values".

Only reason it didn't blow up conformance tests is that they run in release mode.

Sorry. Please merge soon as you can and cover my shame!