### PR TITLE
ci: run benchmarks on branches called `bench-*`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - bench-*
     paths:
       - '**/*.rs'
       - 'Cargo.lock'


### PR DESCRIPTION
I've recently switched over from hacking on a fork to working directly on upstream, in order to be able to use Graphite.

One thing I miss now is ability to create branches and run CodSpeed on them while developing. Compared to running benches locally, CodSpeed has the advantage of giving you a visual history, showing how each commit you push moves the dials.

This PR makes the benchmarks run for any branch named `bench-*`, in order to enable this workflow on upstream, without having to open a draft PR for every experiment.