### PR TITLE
feat(parser): recover from `async x [newline] => x`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -326,3 +326,8 @@ pub struct UsingDeclarationsMustBeInitialized(#[label] pub Span);
 #[error("TS1089: `static` modifier cannot appear on a constructor declaration.")]
 #[diagnostic()]
 pub struct StaticConstructor(#[label] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("No line break is allowed before '=>'.")]
+#[diagnostic()]
+pub struct NoLineBreakIsAllowedBeforeArrow(#[label] pub Span);

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1003,9 +1003,12 @@ impl<'a> ParserImpl<'a> {
             && self.peek_kind().is_binding_identifier()
             && !self.peek_token().is_on_new_line
             && self.nth_at(2, Kind::Arrow)
-            && !self.nth(2).is_on_new_line
         {
             self.bump_any(); // bump async
+            let arrow_token = self.peek_token();
+            if arrow_token.is_on_new_line {
+                self.error(diagnostics::NoLineBreakIsAllowedBeforeArrow(arrow_token.span()));
+            }
             self.parse_single_param_function_expression(span, true, false)
         } else {
             self.parse_assignment_expression()

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -4994,13 +4994,12 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ╰────
   help: Try insert a semicolon here
 
-  × Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[es2017/async-functions/newline-before-arrow/input.js:1:6]
+  × No line break is allowed before '=>'.
+   ╭─[es2017/async-functions/newline-before-arrow/input.js:2:1]
  1 │ async x
-   ·      ─
  2 │ => x
+   · ──
    ╰────
-  help: Try insert a semicolon here
 
   × Constructor can't be an async method
    ╭─[es2017/async-functions/no-constructor/input.js:2:9]

--- a/tasks/prettier_conformance/prettier.snap.md
+++ b/tasks/prettier_conformance/prettier.snap.md
@@ -1,4 +1,4 @@
-Compatibility: 236/562 (41.99%)
+Compatibility: 237/562 (42.17%)
 
 # Failed
 
@@ -31,9 +31,6 @@ Compatibility: 236/562 (41.99%)
 * arrows/issue-1389-curry.js
 * arrows/long-call-no-args.js
 * arrows/parens.js
-
-### arrows/newline-before-arrow
-* arrows/newline-before-arrow/newline-before-arrow.js
 
 ### assignment
 * assignment/binaryish.js


### PR DESCRIPTION
```javascript
async x
=> x
```

Babel recovers and displays "No line break is allowed before '=>'