### PR TITLE
perf(lint/no_var_requires): quicker way to check if the `IdentifierReference` point to a global variable

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -384,10 +384,7 @@ pub fn get_new_expr_ident_name<'a>(new_expr: &'a NewExpression<'a>) -> Option<&'
 
 /// Check if the given [IdentifierReference] is a global reference.
 /// Such as `window`, `document`, `globalThis`, etc.
-pub fn is_global_reference(
-    ident: &IdentifierReference,
-    ctx: &LintContext,
-) -> bool {
+pub fn is_global_reference(ident: &IdentifierReference, ctx: &LintContext) -> bool {
     let symbol_table = ctx.semantic().symbols();
     let Some(reference_id) = ident.reference_id.get() else {
         return false;

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -381,3 +381,29 @@ pub fn get_new_expr_ident_name<'a>(new_expr: &'a NewExpression<'a>) -> Option<&'
 
     Some(ident.name.as_str())
 }
+
+/// Check if the given [IdentifierReference] is a global reference.
+/// Such as `window`, `document`, `globalThis`, etc.
+pub fn is_global_reference(
+    ident: &IdentifierReference,
+    ctx: &LintContext,
+) -> bool {
+    let symbol_table = ctx.semantic().symbols();
+    let Some(reference_id) = ident.reference_id.get() else {
+        return false;
+    };
+    let reference = symbol_table.get_reference(reference_id);
+    reference.symbol_id().is_none()
+}
+
+pub fn is_global_require_call(call_expr: &CallExpression, ctx: &LintContext) -> bool {
+    if call_expr.arguments.len() != 1 {
+        return false;
+    }
+
+    if let Expression::Identifier(id_ref) = &call_expr.callee {
+        id_ref.name == "require" && is_global_reference(id_ref, ctx)
+    } else {
+        false
+    }
+}

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::Expression, AstKind};
+use oxc_ast::AstKind;
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::{get_declaration_of_variable, is_global_require_call}, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::is_global_require_call, context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("typescript-eslint(no-var-requires): Require statement not part of import statement.")]

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::{get_declaration_of_variable, is_global_require_call}, context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("typescript-eslint(no-var-requires): Require statement not part of import statement.")]
@@ -41,7 +41,7 @@ impl Rule for NoVarRequires {
         }
         let AstKind::CallExpression(expr) = node.kind() else { return };
 
-        if expr.is_require_call() && no_local_require_declaration(&expr.callee, ctx) {
+        if is_global_require_call(expr, ctx) {
             // If the parent is an expression statement => this is a top level require()
             // Or, if the parent is a chain expression (require?.()) and
             // the grandparent is an expression statement => this is a top level require()
@@ -68,11 +68,6 @@ impl Rule for NoVarRequires {
             }
         }
     }
-}
-
-fn no_local_require_declaration(expr: &Expression, ctx: &LintContext) -> bool {
-    let Expression::Identifier(ident) = expr else { return true };
-    get_declaration_of_variable(ident, ctx).is_none()
 }
 
 #[test]


### PR DESCRIPTION
The old code use this function to do the checking, which is too much for this simple checking

https://github.com/oxc-project/oxc/blob/ef336cb66b4746073e9d6a2f950d46185fec3cf6/crates/oxc_linter/src/ast_util.rs#L267-L276
