### PR TITLE
refactor: remove global allocator from non-user facing apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,10 +1409,8 @@ dependencies = [
  "encoding_rs",
  "encoding_rs_io",
  "futures",
- "jemallocator",
  "lazy_static",
  "miette",
- "mimalloc",
  "oxc_allocator",
  "oxc_ast",
  "oxc_codegen",
@@ -1538,8 +1536,6 @@ version = "0.7.0"
 dependencies = [
  "insta",
  "itertools 0.12.1",
- "jemallocator",
- "mimalloc",
  "num-bigint",
  "num-traits",
  "oxc_allocator",
@@ -1561,8 +1557,6 @@ dependencies = [
  "brotlic",
  "flate2",
  "humansize",
- "jemallocator",
- "mimalloc",
  "oxc_allocator",
  "oxc_codegen",
  "oxc_minifier",
@@ -1638,8 +1632,6 @@ dependencies = [
 name = "oxc_prettier_conformance"
 version = "0.0.0"
 dependencies = [
- "jemallocator",
- "mimalloc",
  "oxc_allocator",
  "oxc_ast",
  "oxc_parser",
@@ -1739,8 +1731,6 @@ name = "oxc_transform_conformance"
 version = "0.0.0"
 dependencies = [
  "indexmap",
- "jemallocator",
- "mimalloc",
  "oxc_allocator",
  "oxc_codegen",
  "oxc_diagnostics",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -38,9 +38,3 @@ oxc_codegen = { workspace = true }
 insta     = { workspace = true }
 walkdir   = { workspace = true }
 pico-args = { workspace = true }
-
-[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dev-dependencies]
-mimalloc = { workspace = true }

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -8,14 +8,6 @@ use oxc_span::SourceType;
 
 use pico_args::Arguments;
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 // Instruction:
 // create a `test.js`,
 // run `cargo run -p oxc_minifier --example minifier`

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -49,9 +49,3 @@ encoding_rs    = "0.8.33"
 encoding_rs_io = "0.1.7"
 serde_yaml     = "0.9.31"
 similar        = "2.4.0"
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { workspace = true }

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use oxc_coverage::AppArgs;
 use pico_args::Arguments;
 

--- a/tasks/minsize/Cargo.toml
+++ b/tasks/minsize/Cargo.toml
@@ -27,9 +27,3 @@ flate2           = { workspace = true }
 
 humansize = "2.1.3"
 brotlic   = "0.8.2"
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { workspace = true }

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use std::{
     fs::File,
     io::{self, Write},

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -26,9 +26,3 @@ oxc_ast          = { workspace = true }
 
 walkdir   = { workspace = true }
 pico-args = { workspace = true }
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { workspace = true }

--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -1,11 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use oxc_prettier_conformance::{TestRunner, TestRunnerOptions};
 use pico_args::Arguments;
 

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -35,9 +35,3 @@ serde      = { workspace = true }
 walkdir    = { workspace = true }
 pico-args  = { workspace = true }
 indexmap   = { workspace = true }
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { workspace = true }

--- a/tasks/transform_conformance/src/main.rs
+++ b/tasks/transform_conformance/src/main.rs
@@ -1,13 +1,5 @@
 mod ts_fixtures;
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use oxc_transform_conformance::{TestRunner, TestRunnerOptions};
 use pico_args::Arguments;
 use ts_fixtures::TypeScriptFixtures;


### PR DESCRIPTION
The runtime performance gains does not out weight the compilation speed from
building the custom allocators, which takes about a minute to build on
slower machines.