### PR TITLE
chore(deps): update `bumpalo` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
 
 [[package]]
 name = "byteorder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ oxc_language_server = { path = "crates/oxc_language_server" }
 assert-unchecked          = { version = "0.1.2" }
 bpaf                      = { version = "0.9.9" }
 bitflags                  = { version = "2.4.2" }
-bumpalo                   = { version = "3.14.0" }
+bumpalo                   = { version = "3.15.0" }
 convert_case              = { version = "0.6.0" }
 criterion                 = { version = "0.5.1", default-features = false }
 crossbeam-channel         = { version = "0.5.11" }

--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -155,8 +155,6 @@ impl<'a> Lexer<'a> {
         let mut str = String::with_capacity_in(capacity, self.allocator);
 
         // Push identifier up this point into `str`
-        // `bumpalo::collections::string::String::push_str` is currently expensive due to
-        // inefficiency in bumpalo's implementation. But best we have right now.
         str.push_str(so_far);
 
         // Process escape and get rest of identifier

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -81,8 +81,6 @@ macro_rules! handle_string_literal_escape {
         let mut str = String::with_capacity_in(capacity, $lexer.allocator);
 
         // Push chunk before `\` into `str`.
-        // `bumpalo::collections::string::String::push_str` is currently expensive due to
-        // inefficiency in bumpalo's implementation. But best we have right now.
         str.push_str(so_far);
 
         'outer: loop {


### PR DESCRIPTION
Latest version of `bumpalo` includes a couple of performance fixes for `String` (e.g. https://github.com/fitzgen/bumpalo/pull/229) which may help the parser a little.