### PR TITLE
refactor(ast): update TSImportType parameter to argument

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -776,7 +776,7 @@ pub struct TSImportType<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub is_type_of: bool,
-    pub parameter: TSType<'a>,
+    pub argument: TSType<'a>,
     pub qualifier: Option<TSTypeName<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1650,14 +1650,14 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         is_type_of: bool,
-        parameter: TSType<'a>,
+        argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> TSType<'a> {
         TSType::TSImportType(self.alloc(TSImportType {
             span,
             is_type_of,
-            parameter,
+            argument,
             qualifier,
             type_parameters,
         }))

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -762,7 +762,7 @@ impl<'a> ParserImpl<'a> {
         let is_type_of = self.eat(Kind::Typeof);
         self.expect(Kind::Import)?;
         self.expect(Kind::LParen)?;
-        let parameter = self.parse_ts_type()?;
+        let argument = self.parse_ts_type()?;
         self.expect(Kind::RParen)?;
 
         let qualifier = if self.eat(Kind::Dot) { Some(self.parse_ts_type_name()?) } else { None };
@@ -772,7 +772,7 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.ts_import_type(
             self.end_span(span),
             is_type_of,
-            parameter,
+            argument,
             qualifier,
             type_parameters,
         ))


### PR DESCRIPTION
In typescript it's named argument, so we should keep it consistent
https://github.com/microsoft/TypeScript/blob/64d2eeea7b9c7f1a79edf42cb99f302535136a2e/src/compiler/types.ts#L2180
