### PR TITLE
[BREAKING CHANGE] Change `Atom` to `Atom<'a>` to make it safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +304,20 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1645,6 +1668,7 @@ dependencies = [
 name = "oxc_span"
 version = "0.7.0"
 dependencies = [
+ "compact_str",
  "inlinable_string",
  "miette",
  "serde",
@@ -2149,6 +2173,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -79,9 +79,9 @@ pub struct JSXClosingFragment {
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum JSXElementName<'a> {
     /// `<Apple />`
-    Identifier(JSXIdentifier),
+    Identifier(JSXIdentifier<'a>),
     /// `<Apple:Orange />`
-    NamespacedName(Box<'a, JSXNamespacedName>),
+    NamespacedName(Box<'a, JSXNamespacedName<'a>>),
     /// `<Apple.Orange />`
     MemberExpression(Box<'a, JSXMemberExpression<'a>>),
 }
@@ -90,14 +90,14 @@ pub enum JSXElementName<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct JSXNamespacedName {
+pub struct JSXNamespacedName<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub namespace: JSXIdentifier,
-    pub property: JSXIdentifier,
+    pub namespace: JSXIdentifier<'a>,
+    pub property: JSXIdentifier<'a>,
 }
 
-impl std::fmt::Display for JSXNamespacedName {
+impl<'a> std::fmt::Display for JSXNamespacedName<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}", self.namespace.name, self.property.name)
     }
@@ -111,7 +111,7 @@ pub struct JSXMemberExpression<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub object: JSXMemberExpressionObject<'a>,
-    pub property: JSXIdentifier,
+    pub property: JSXIdentifier<'a>,
 }
 
 impl<'a> JSXMemberExpression<'a> {
@@ -127,7 +127,7 @@ impl<'a> JSXMemberExpression<'a> {
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum JSXMemberExpressionObject<'a> {
-    Identifier(JSXIdentifier),
+    Identifier(JSXIdentifier<'a>),
     MemberExpression(Box<'a, JSXMemberExpression<'a>>),
 }
 
@@ -199,8 +199,8 @@ pub struct JSXSpreadAttribute<'a> {
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum JSXAttributeName<'a> {
-    Identifier(JSXIdentifier),
-    NamespacedName(Box<'a, JSXNamespacedName>),
+    Identifier(JSXIdentifier<'a>),
+    NamespacedName(Box<'a, JSXNamespacedName<'a>>),
 }
 
 /// JSX Attribute Value
@@ -208,7 +208,7 @@ pub enum JSXAttributeName<'a> {
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum JSXAttributeValue<'a> {
-    StringLiteral(StringLiteral),
+    StringLiteral(StringLiteral<'a>),
     ExpressionContainer(JSXExpressionContainer<'a>),
     Element(Box<'a, JSXElement<'a>>),
     Fragment(Box<'a, JSXFragment<'a>>),
@@ -217,10 +217,10 @@ pub enum JSXAttributeValue<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct JSXIdentifier {
+pub struct JSXIdentifier<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub name: Atom,
+    pub name: Atom<'a>,
 }
 
 // 1.4 JSX Children
@@ -230,7 +230,7 @@ pub struct JSXIdentifier {
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum JSXChild<'a> {
-    Text(JSXText),
+    Text(JSXText<'a>),
     Element(Box<'a, JSXElement<'a>>),
     Fragment(Box<'a, JSXFragment<'a>>),
     ExpressionContainer(JSXExpressionContainer<'a>),
@@ -249,8 +249,8 @@ pub struct JSXSpreadChild<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct JSXText {
+pub struct JSXText<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub value: Atom,
+    pub value: Atom<'a>,
 }

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -109,15 +109,15 @@ impl<'a> Hash for NumericLiteral<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct BigintLiteral {
+pub struct BigintLiteral<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub raw: Atom,
+    pub raw: Atom<'a>,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub base: BigintBase,
 }
 
-impl BigintLiteral {
+impl<'a> BigintLiteral<'a> {
     pub fn is_zero(&self) -> bool {
         self.raw == "0n"
     }
@@ -126,24 +126,24 @@ impl BigintLiteral {
 #[derive(Debug, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct RegExpLiteral {
+pub struct RegExpLiteral<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     // valid regex is printed as {}
     // invalid regex is printed as null, which we can't implement yet
     pub value: EmptyObject,
-    pub regex: RegExp,
+    pub regex: RegExp<'a>,
 }
 
 #[derive(Debug, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct RegExp {
-    pub pattern: Atom,
+pub struct RegExp<'a> {
+    pub pattern: Atom<'a>,
     pub flags: RegExpFlags,
 }
 
-impl fmt::Display for RegExp {
+impl<'a> fmt::Display for RegExp<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "/{}/{}", self.pattern, self.flags)
     }
@@ -238,14 +238,14 @@ pub struct EmptyObject;
 #[derive(Debug, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct StringLiteral {
+pub struct StringLiteral<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub value: Atom,
+    pub value: Atom<'a>,
 }
 
-impl StringLiteral {
-    pub fn new(span: Span, value: Atom) -> Self {
+impl<'a> StringLiteral<'a> {
+    pub fn new(span: Span, value: Atom<'a>) -> Self {
         Self { span, value }
     }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -27,7 +27,7 @@ export interface TSAbstractMethodDefinition extends Omit<MethodDefinition, 'type
 pub struct TSThisParameter<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub this: IdentifierName,
+    pub this: IdentifierName<'a>,
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
 
@@ -40,7 +40,7 @@ pub struct TSThisParameter<'a> {
 pub struct TSEnumDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub id: BindingIdentifier,
+    pub id: BindingIdentifier<'a>,
     pub members: Vec<'a, TSEnumMember<'a>>,
     /// Valid Modifiers: `const`, `export`, `declare`
     pub modifiers: Modifiers<'a>,
@@ -60,8 +60,8 @@ pub struct TSEnumMember<'a> {
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum TSEnumMemberName<'a> {
-    Identifier(IdentifierName),
-    StringLiteral(StringLiteral),
+    Identifier(IdentifierName<'a>),
+    StringLiteral(StringLiteral<'a>),
     // Invalid Grammar `enum E { [computed] }`
     ComputedPropertyName(Expression<'a>),
     // Invalid Grammar `enum E { 1 }`
@@ -93,9 +93,9 @@ pub enum TSLiteral<'a> {
     BooleanLiteral(Box<'a, BooleanLiteral>),
     NullLiteral(Box<'a, NullLiteral>),
     NumericLiteral(Box<'a, NumericLiteral<'a>>),
-    BigintLiteral(Box<'a, BigintLiteral>),
-    RegExpLiteral(Box<'a, RegExpLiteral>),
-    StringLiteral(Box<'a, StringLiteral>),
+    BigintLiteral(Box<'a, BigintLiteral<'a>>),
+    RegExpLiteral(Box<'a, RegExpLiteral<'a>>),
+    StringLiteral(Box<'a, StringLiteral<'a>>),
     TemplateLiteral(Box<'a, TemplateLiteral<'a>>),
     UnaryExpression(Box<'a, UnaryExpression<'a>>),
 }
@@ -254,7 +254,7 @@ pub struct TSNamedTupleMember<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub element_type: TSType<'a>,
-    pub label: IdentifierName,
+    pub label: IdentifierName<'a>,
     pub optional: bool,
 }
 
@@ -410,12 +410,12 @@ pub struct TSTypeReference<'a> {
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum TSTypeName<'a> {
-    IdentifierReference(Box<'a, IdentifierReference>),
+    IdentifierReference(Box<'a, IdentifierReference<'a>>),
     QualifiedName(Box<'a, TSQualifiedName<'a>>),
 }
 
 impl<'a> TSTypeName<'a> {
-    pub fn get_first_name(name: &TSTypeName) -> IdentifierReference {
+    pub fn get_first_name(name: &TSTypeName<'a>) -> IdentifierReference<'a> {
         match name {
             TSTypeName::IdentifierReference(name) => (*name).clone(),
             TSTypeName::QualifiedName(name) => TSTypeName::get_first_name(&name.left),
@@ -456,7 +456,7 @@ pub struct TSQualifiedName<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub left: TSTypeName<'a>,
-    pub right: IdentifierName,
+    pub right: IdentifierName<'a>,
 }
 
 #[derive(Debug, Hash)]
@@ -474,7 +474,7 @@ pub struct TSTypeParameterInstantiation<'a> {
 pub struct TSTypeParameter<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub name: BindingIdentifier,
+    pub name: BindingIdentifier<'a>,
     pub constraint: Option<TSType<'a>>,
     pub default: Option<TSType<'a>>,
     pub r#in: bool,
@@ -497,7 +497,7 @@ pub struct TSTypeParameterDeclaration<'a> {
 pub struct TSTypeAliasDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub id: BindingIdentifier,
+    pub id: BindingIdentifier<'a>,
     pub type_annotation: TSType<'a>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     /// Valid Modifiers: `declare`, `export`
@@ -546,7 +546,7 @@ pub struct TSClassImplements<'a> {
 pub struct TSInterfaceDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub id: BindingIdentifier,
+    pub id: BindingIdentifier<'a>,
     pub body: Box<'a, TSInterfaceBody<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub extends: Option<Vec<'a, Box<'a, TSInterfaceHeritage<'a>>>>,
@@ -651,7 +651,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 pub struct TSIndexSignatureName<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub name: Atom,
+    pub name: Atom<'a>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
 }
 
@@ -671,7 +671,7 @@ pub struct TSInterfaceHeritage<'a> {
 pub struct TSTypePredicate<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub parameter_name: TSTypePredicateName,
+    pub parameter_name: TSTypePredicateName<'a>,
     pub asserts: bool,
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
@@ -679,8 +679,8 @@ pub struct TSTypePredicate<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged, rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub enum TSTypePredicateName {
-    Identifier(IdentifierName),
+pub enum TSTypePredicateName<'a> {
+    Identifier(IdentifierName<'a>),
     This(TSThisType),
 }
 
@@ -690,7 +690,7 @@ pub enum TSTypePredicateName {
 pub struct TSModuleDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub id: TSModuleDeclarationName,
+    pub id: TSModuleDeclarationName<'a>,
     pub body: TSModuleDeclarationBody<'a>,
     /// The keyword used to define this module declaration
     /// ```text
@@ -718,13 +718,13 @@ pub enum TSModuleDeclarationKind {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub enum TSModuleDeclarationName {
-    Identifier(IdentifierName),
-    StringLiteral(StringLiteral),
+pub enum TSModuleDeclarationName<'a> {
+    Identifier(IdentifierName<'a>),
+    StringLiteral(StringLiteral<'a>),
 }
 
-impl TSModuleDeclarationName {
-    pub fn name(&self) -> &Atom {
+impl<'a> TSModuleDeclarationName<'a> {
+    pub fn name(&self) -> &Atom<'a> {
         match self {
             Self::Identifier(ident) => &ident.name,
             Self::StringLiteral(lit) => &lit.value,
@@ -805,16 +805,16 @@ pub struct TSImportAttributes<'a> {
 pub struct TSImportAttribute<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub name: TSImportAttributeName,
+    pub name: TSImportAttributeName<'a>,
     pub value: Expression<'a>,
 }
 
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub enum TSImportAttributeName {
-    Identifier(IdentifierName),
-    StringLiteral(StringLiteral),
+pub enum TSImportAttributeName<'a> {
+    Identifier(IdentifierName<'a>),
+    StringLiteral(StringLiteral<'a>),
 }
 
 #[derive(Debug, Hash)]
@@ -872,7 +872,7 @@ pub enum TSMappedTypeModifierOperator {
 pub struct TSTemplateLiteralType<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub quasis: Vec<'a, TemplateElement>,
+    pub quasis: Vec<'a, TemplateElement<'a>>,
     pub types: Vec<'a, TSType<'a>>,
 }
 
@@ -912,7 +912,7 @@ pub struct TSTypeAssertion<'a> {
 pub struct TSImportEqualsDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub id: BindingIdentifier,
+    pub id: BindingIdentifier<'a>,
     pub module_reference: Box<'a, TSModuleReference<'a>>,
     pub is_export: bool,
     pub import_kind: ImportOrExportKind,
@@ -923,16 +923,16 @@ pub struct TSImportEqualsDeclaration<'a> {
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub enum TSModuleReference<'a> {
     TypeName(TSTypeName<'a>),
-    ExternalModuleReference(TSExternalModuleReference),
+    ExternalModuleReference(TSExternalModuleReference<'a>),
 }
 
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct TSExternalModuleReference {
+pub struct TSExternalModuleReference<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub expression: StringLiteral,
+    pub expression: StringLiteral<'a>,
 }
 
 #[derive(Debug, Hash)]
@@ -1030,10 +1030,10 @@ pub struct TSExportAssignment<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
-pub struct TSNamespaceExportDeclaration {
+pub struct TSNamespaceExportDeclaration<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub id: IdentifierName,
+    pub id: IdentifierName<'a>,
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -7,12 +7,12 @@ use crate::ast::*;
 #[derive(Debug, Clone, Copy)]
 pub enum AstKind<'a> {
     Program(&'a Program<'a>),
-    Directive(&'a Directive),
-    Hashbang(&'a Hashbang),
+    Directive(&'a Directive<'a>),
+    Hashbang(&'a Hashbang<'a>),
 
     BlockStatement(&'a BlockStatement<'a>),
-    BreakStatement(&'a BreakStatement),
-    ContinueStatement(&'a ContinueStatement),
+    BreakStatement(&'a BreakStatement<'a>),
+    ContinueStatement(&'a ContinueStatement<'a>),
     DebuggerStatement(&'a DebuggerStatement),
     DoWhileStatement(&'a DoWhileStatement<'a>),
     EmptyStatement(&'a EmptyStatement),
@@ -39,21 +39,21 @@ pub enum AstKind<'a> {
 
     UsingDeclaration(&'a UsingDeclaration<'a>),
 
-    IdentifierName(&'a IdentifierName),
-    IdentifierReference(&'a IdentifierReference),
-    BindingIdentifier(&'a BindingIdentifier),
-    LabelIdentifier(&'a LabelIdentifier),
-    PrivateIdentifier(&'a PrivateIdentifier),
+    IdentifierName(&'a IdentifierName<'a>),
+    IdentifierReference(&'a IdentifierReference<'a>),
+    BindingIdentifier(&'a BindingIdentifier<'a>),
+    LabelIdentifier(&'a LabelIdentifier<'a>),
+    PrivateIdentifier(&'a PrivateIdentifier<'a>),
 
     NumericLiteral(&'a NumericLiteral<'a>),
-    StringLiteral(&'a StringLiteral),
+    StringLiteral(&'a StringLiteral<'a>),
     BooleanLiteral(&'a BooleanLiteral),
     NullLiteral(&'a NullLiteral),
-    BigintLiteral(&'a BigintLiteral),
-    RegExpLiteral(&'a RegExpLiteral),
+    BigintLiteral(&'a BigintLiteral<'a>),
+    RegExpLiteral(&'a RegExpLiteral<'a>),
     TemplateLiteral(&'a TemplateLiteral<'a>),
 
-    MetaProperty(&'a MetaProperty),
+    MetaProperty(&'a MetaProperty<'a>),
     Super(&'a Super),
 
     ArrayExpression(&'a ArrayExpression<'a>),
@@ -110,9 +110,9 @@ pub enum AstKind<'a> {
 
     ModuleDeclaration(&'a ModuleDeclaration<'a>),
     ImportDeclaration(&'a ImportDeclaration<'a>),
-    ImportSpecifier(&'a ImportSpecifier),
-    ImportDefaultSpecifier(&'a ImportDefaultSpecifier),
-    ImportNamespaceSpecifier(&'a ImportNamespaceSpecifier),
+    ImportSpecifier(&'a ImportSpecifier<'a>),
+    ImportDefaultSpecifier(&'a ImportDefaultSpecifier<'a>),
+    ImportNamespaceSpecifier(&'a ImportNamespaceSpecifier<'a>),
     ExportDefaultDeclaration(&'a ExportDefaultDeclaration<'a>),
     ExportNamedDeclaration(&'a ExportNamedDeclaration<'a>),
     ExportAllDeclaration(&'a ExportAllDeclaration<'a>),
@@ -127,11 +127,11 @@ pub enum AstKind<'a> {
     JSXExpressionContainer(&'a JSXExpressionContainer<'a>),
     JSXAttributeItem(&'a JSXAttributeItem<'a>),
     JSXSpreadAttribute(&'a JSXSpreadAttribute<'a>),
-    JSXText(&'a JSXText),
-    JSXIdentifier(&'a JSXIdentifier),
+    JSXText(&'a JSXText<'a>),
+    JSXIdentifier(&'a JSXIdentifier<'a>),
     JSXMemberExpression(&'a JSXMemberExpression<'a>),
     JSXMemberExpressionObject(&'a JSXMemberExpressionObject<'a>),
-    JSXNamespacedName(&'a JSXNamespacedName),
+    JSXNamespacedName(&'a JSXNamespacedName<'a>),
 
     // TypeScript
     TSModuleBlock(&'a TSModuleBlock<'a>),
@@ -159,7 +159,7 @@ pub enum AstKind<'a> {
 
     TSImportEqualsDeclaration(&'a TSImportEqualsDeclaration<'a>),
     TSTypeName(&'a TSTypeName<'a>),
-    TSExternalModuleReference(&'a TSExternalModuleReference),
+    TSExternalModuleReference(&'a TSExternalModuleReference<'a>),
     TSQualifiedName(&'a TSQualifiedName<'a>),
 
     TSInterfaceDeclaration(&'a TSInterfaceDeclaration<'a>),
@@ -245,7 +245,7 @@ impl<'a> AstKind<'a> {
         matches!(self, Self::Function(_) | Self::ArrowFunctionExpression(_))
     }
 
-    pub fn identifier_name(self) -> Option<Atom> {
+    pub fn identifier_name(self) -> Option<Atom<'a>> {
         match self {
             Self::BindingIdentifier(ident) => Some(ident.name.clone()),
             Self::IdentifierReference(ident) => Some(ident.name.clone()),

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -76,7 +76,7 @@ impl<'a> GetSpan for Expression<'a> {
     }
 }
 
-impl GetSpan for Directive {
+impl<'a> GetSpan for Directive<'a> {
     fn span(&self) -> Span {
         self.span
     }
@@ -144,7 +144,7 @@ impl<'a> GetSpan for MemberExpression<'a> {
     }
 }
 
-impl GetSpan for ImportAttributeKey {
+impl<'a> GetSpan for ImportAttributeKey<'a> {
     fn span(&self) -> Span {
         match self {
             Self::Identifier(identifier) => identifier.span,
@@ -153,7 +153,7 @@ impl GetSpan for ImportAttributeKey {
     }
 }
 
-impl GetSpan for ModuleExportName {
+impl<'a> GetSpan for ModuleExportName<'a> {
     fn span(&self) -> Span {
         match self {
             Self::Identifier(identifier) => identifier.span,
@@ -191,7 +191,7 @@ impl<'a> GetSpan for Declaration<'a> {
     }
 }
 
-impl GetSpan for TSModuleDeclarationName {
+impl<'a> GetSpan for TSModuleDeclarationName<'a> {
     fn span(&self) -> Span {
         match self {
             Self::Identifier(ident) => ident.span,
@@ -365,7 +365,7 @@ impl<'a> GetSpan for ExportDefaultDeclarationKind<'a> {
     }
 }
 
-impl GetSpan for ImportDeclarationSpecifier {
+impl<'a> GetSpan for ImportDeclarationSpecifier<'a> {
     fn span(&self) -> Span {
         match self {
             Self::ImportSpecifier(specifier) => specifier.span,

--- a/crates/oxc_ast/src/syntax_directed_operations/bound_names.rs
+++ b/crates/oxc_ast/src/syntax_directed_operations/bound_names.rs
@@ -1,16 +1,16 @@
 use crate::ast::*;
 
 /// [`BoundName`](https://tc39.es/ecma262/#sec-static-semantics-boundnames)
-pub trait BoundName {
-    fn bound_name<F: FnMut(&BindingIdentifier)>(&self, f: &mut F);
+pub trait BoundName<'a> {
+    fn bound_name<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F);
 }
 
-pub trait BoundNames {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F);
+pub trait BoundNames<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F);
 }
 
-impl<'a> BoundNames for BindingPattern<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for BindingPattern<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         match &self.kind {
             BindingPatternKind::BindingIdentifier(ident) => ident.bound_names(f),
             BindingPatternKind::ArrayPattern(array) => array.bound_names(f),
@@ -20,14 +20,14 @@ impl<'a> BoundNames for BindingPattern<'a> {
     }
 }
 
-impl BoundNames for BindingIdentifier {
+impl<'a> BoundNames<'a> for BindingIdentifier<'a> {
     fn bound_names<F: FnMut(&Self)>(&self, f: &mut F) {
         f(self);
     }
 }
 
-impl<'a> BoundNames for ArrayPattern<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for ArrayPattern<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         for elem in self.elements.iter().flatten() {
             elem.bound_names(f);
         }
@@ -37,8 +37,8 @@ impl<'a> BoundNames for ArrayPattern<'a> {
     }
 }
 
-impl<'a> BoundNames for ObjectPattern<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for ObjectPattern<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         for p in &self.properties {
             p.value.bound_names(f);
         }
@@ -48,20 +48,20 @@ impl<'a> BoundNames for ObjectPattern<'a> {
     }
 }
 
-impl<'a> BoundNames for AssignmentPattern<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for AssignmentPattern<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         self.left.bound_names(f);
     }
 }
 
-impl<'a> BoundNames for BindingRestElement<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for BindingRestElement<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         self.argument.bound_names(f);
     }
 }
 
-impl<'a> BoundNames for FormalParameters<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for FormalParameters<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         for item in &self.items {
             item.bound_names(f);
         }
@@ -71,8 +71,8 @@ impl<'a> BoundNames for FormalParameters<'a> {
     }
 }
 
-impl<'a> BoundNames for Declaration<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for Declaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         match self {
             Declaration::VariableDeclaration(decl) => decl.bound_names(f),
             Declaration::FunctionDeclaration(func) => func.bound_names(f),
@@ -82,66 +82,66 @@ impl<'a> BoundNames for Declaration<'a> {
     }
 }
 
-impl<'a> BoundNames for VariableDeclaration<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for VariableDeclaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         for declarator in &self.declarations {
             declarator.id.bound_names(f);
         }
     }
 }
 
-impl<'a> BoundNames for UsingDeclaration<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for UsingDeclaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         for declarator in &self.declarations {
             declarator.id.bound_names(f);
         }
     }
 }
 
-impl<'a> BoundName for Function<'a> {
-    fn bound_name<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundName<'a> for Function<'a> {
+    fn bound_name<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         if let Some(ident) = &self.id {
             f(ident);
         }
     }
 }
 
-impl<'a> BoundNames for Function<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for Function<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         self.bound_name(f);
     }
 }
 
-impl<'a> BoundName for Class<'a> {
-    fn bound_name<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundName<'a> for Class<'a> {
+    fn bound_name<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         if let Some(ident) = &self.id {
             f(ident);
         }
     }
 }
 
-impl<'a> BoundNames for Class<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for Class<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         self.bound_name(f);
     }
 }
 
-impl<'a> BoundNames for FormalParameter<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for FormalParameter<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         self.pattern.bound_names(f);
     }
 }
 
-impl<'a> BoundNames for ModuleDeclaration<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for ModuleDeclaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         if let ModuleDeclaration::ImportDeclaration(decl) = &self {
             decl.bound_names(f);
         }
     }
 }
 
-impl<'a> BoundNames for ImportDeclaration<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for ImportDeclaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         if let Some(specifiers) = &self.specifiers {
             for specifier in specifiers {
                 match specifier {
@@ -160,8 +160,8 @@ impl<'a> BoundNames for ImportDeclaration<'a> {
     }
 }
 
-impl<'a> BoundNames for ExportNamedDeclaration<'a> {
-    fn bound_names<F: FnMut(&BindingIdentifier)>(&self, f: &mut F) {
+impl<'a> BoundNames<'a> for ExportNamedDeclaration<'a> {
+    fn bound_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F) {
         if let Some(decl) = &self.declaration {
             decl.bound_names(f);
         }

--- a/crates/oxc_ast/src/syntax_directed_operations/gather_node_parts.rs
+++ b/crates/oxc_ast/src/syntax_directed_operations/gather_node_parts.rs
@@ -2,12 +2,12 @@ use crate::ast::*;
 use oxc_span::Atom;
 
 // TODO: <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L61>
-pub trait GatherNodeParts {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F);
+pub trait GatherNodeParts<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F);
 }
 
-impl<'a> GatherNodeParts for Expression<'a> {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for Expression<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         match self {
             Self::Identifier(ident) => f(ident.name.clone()),
             Self::MemberExpression(expr) => expr.gather(f),
@@ -19,8 +19,8 @@ impl<'a> GatherNodeParts for Expression<'a> {
     }
 }
 
-impl<'a> GatherNodeParts for MemberExpression<'a> {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for MemberExpression<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         match self {
             MemberExpression::ComputedMemberExpression(expr) => {
                 expr.object.gather(f);
@@ -38,8 +38,8 @@ impl<'a> GatherNodeParts for MemberExpression<'a> {
     }
 }
 
-impl<'a> GatherNodeParts for AssignmentTarget<'a> {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for AssignmentTarget<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         match self {
             AssignmentTarget::SimpleAssignmentTarget(t) => t.gather(f),
             AssignmentTarget::AssignmentTargetPattern(_) => {}
@@ -47,8 +47,8 @@ impl<'a> GatherNodeParts for AssignmentTarget<'a> {
     }
 }
 
-impl<'a> GatherNodeParts for SimpleAssignmentTarget<'a> {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for SimpleAssignmentTarget<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         match self {
             Self::AssignmentTargetIdentifier(ident) => ident.gather(f),
             Self::MemberAssignmentTarget(expr) => expr.gather(f),
@@ -57,26 +57,26 @@ impl<'a> GatherNodeParts for SimpleAssignmentTarget<'a> {
     }
 }
 
-impl GatherNodeParts for IdentifierReference {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for IdentifierReference<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         f(self.name.clone());
     }
 }
 
-impl GatherNodeParts for IdentifierName {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for IdentifierName<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         f(self.name.clone());
     }
 }
 
-impl GatherNodeParts for PrivateIdentifier {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for PrivateIdentifier<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         f(self.name.clone());
     }
 }
 
-impl GatherNodeParts for StringLiteral {
-    fn gather<F: FnMut(Atom)>(&self, f: &mut F) {
+impl<'a> GatherNodeParts<'a> for StringLiteral<'a> {
+    fn gather<F: FnMut(Atom<'a>)>(&self, f: &mut F) {
         f(self.value.clone());
     }
 }

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -90,7 +90,7 @@ pub trait Visit<'a>: Sized {
         self.leave_scope();
     }
 
-    fn visit_break_statement(&mut self, stmt: &BreakStatement) {
+    fn visit_break_statement(&mut self, stmt: &BreakStatement<'a>) {
         let kind = AstKind::BreakStatement(self.alloc(stmt));
         self.enter_node(kind);
         if let Some(break_target) = &stmt.label {
@@ -99,7 +99,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_continue_statement(&mut self, stmt: &ContinueStatement) {
+    fn visit_continue_statement(&mut self, stmt: &ContinueStatement<'a>) {
         let kind = AstKind::ContinueStatement(self.alloc(stmt));
         self.enter_node(kind);
         if let Some(continue_target) = &stmt.label {
@@ -323,7 +323,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_directive(&mut self, directive: &Directive) {
+    fn visit_directive(&mut self, directive: &Directive<'a>) {
         let kind = AstKind::Directive(self.alloc(directive));
         self.enter_node(kind);
         self.visit_string_literal(&directive.expression);
@@ -605,7 +605,7 @@ pub trait Visit<'a>: Sized {
         }
     }
 
-    fn visit_meta_property(&mut self, meta: &MetaProperty) {
+    fn visit_meta_property(&mut self, meta: &MetaProperty<'a>) {
         let kind = AstKind::MetaProperty(self.alloc(meta));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1053,7 +1053,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_jsx_identifier(&mut self, ident: &JSXIdentifier) {
+    fn visit_jsx_identifier(&mut self, ident: &JSXIdentifier<'a>) {
         let kind = AstKind::JSXIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1079,7 +1079,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_jsx_namespaced_name(&mut self, name: &JSXNamespacedName) {
+    fn visit_jsx_namespaced_name(&mut self, name: &JSXNamespacedName<'a>) {
         let kind = AstKind::JSXNamespacedName(self.alloc(name));
         self.enter_node(kind);
         self.visit_jsx_identifier(&name.namespace);
@@ -1157,7 +1157,7 @@ pub trait Visit<'a>: Sized {
         self.visit_expression(&child.expression);
     }
 
-    fn visit_jsx_text(&mut self, child: &JSXText) {
+    fn visit_jsx_text(&mut self, child: &JSXText<'a>) {
         let kind = AstKind::JSXText(self.alloc(child));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1179,7 +1179,7 @@ pub trait Visit<'a>: Sized {
         }
     }
 
-    fn visit_binding_identifier(&mut self, ident: &BindingIdentifier) {
+    fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
         let kind = AstKind::BindingIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1231,25 +1231,25 @@ pub trait Visit<'a>: Sized {
 
     /* ----------  Identifier ---------- */
 
-    fn visit_identifier_reference(&mut self, ident: &IdentifierReference) {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
         let kind = AstKind::IdentifierReference(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_private_identifier(&mut self, ident: &PrivateIdentifier) {
+    fn visit_private_identifier(&mut self, ident: &PrivateIdentifier<'a>) {
         let kind = AstKind::PrivateIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_label_identifier(&mut self, ident: &LabelIdentifier) {
+    fn visit_label_identifier(&mut self, ident: &LabelIdentifier<'a>) {
         let kind = AstKind::LabelIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_identifier_name(&mut self, ident: &IdentifierName) {
+    fn visit_identifier_name(&mut self, ident: &IdentifierName<'a>) {
         let kind = AstKind::IdentifierName(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1275,13 +1275,13 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_bigint_literal(&mut self, lit: &BigintLiteral) {
+    fn visit_bigint_literal(&mut self, lit: &BigintLiteral<'a>) {
         let kind = AstKind::BigintLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_string_literal(&mut self, lit: &StringLiteral) {
+    fn visit_string_literal(&mut self, lit: &StringLiteral<'a>) {
         let kind = AstKind::StringLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1299,7 +1299,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_reg_expr_literal(&mut self, lit: &RegExpLiteral) {
+    fn visit_reg_expr_literal(&mut self, lit: &RegExpLiteral<'a>) {
         let kind = AstKind::RegExpLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1346,7 +1346,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_import_declaration_specifier(&mut self, specifier: &ImportDeclarationSpecifier) {
+    fn visit_import_declaration_specifier(&mut self, specifier: &ImportDeclarationSpecifier<'a>) {
         match &specifier {
             ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
                 self.visit_import_specifier(specifier);
@@ -1360,7 +1360,7 @@ pub trait Visit<'a>: Sized {
         }
     }
 
-    fn visit_import_specifier(&mut self, specifier: &ImportSpecifier) {
+    fn visit_import_specifier(&mut self, specifier: &ImportSpecifier<'a>) {
         let kind = AstKind::ImportSpecifier(self.alloc(specifier));
         self.enter_node(kind);
         // TODO: imported
@@ -1368,14 +1368,14 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_import_default_specifier(&mut self, specifier: &ImportDefaultSpecifier) {
+    fn visit_import_default_specifier(&mut self, specifier: &ImportDefaultSpecifier<'a>) {
         let kind = AstKind::ImportDefaultSpecifier(self.alloc(specifier));
         self.enter_node(kind);
         self.visit_binding_identifier(&specifier.local);
         self.leave_node(kind);
     }
 
-    fn visit_import_name_specifier(&mut self, specifier: &ImportNamespaceSpecifier) {
+    fn visit_import_name_specifier(&mut self, specifier: &ImportNamespaceSpecifier<'a>) {
         let kind = AstKind::ImportNamespaceSpecifier(self.alloc(specifier));
         self.enter_node(kind);
         self.visit_binding_identifier(&specifier.local);
@@ -1490,7 +1490,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference) {
+    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
         let kind = AstKind::TSExternalModuleReference(self.alloc(reference));
         self.enter_node(kind);
         self.visit_string_literal(&reference.expression);

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -87,7 +87,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_scope();
     }
 
-    fn visit_break_statement(&mut self, stmt: &mut BreakStatement) {
+    fn visit_break_statement(&mut self, stmt: &mut BreakStatement<'a>) {
         let kind = AstKind::BreakStatement(self.alloc(stmt));
         self.enter_node(kind);
         if let Some(break_target) = &mut stmt.label {
@@ -96,7 +96,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_continue_statement(&mut self, stmt: &mut ContinueStatement) {
+    fn visit_continue_statement(&mut self, stmt: &mut ContinueStatement<'a>) {
         let kind = AstKind::ContinueStatement(self.alloc(stmt));
         self.enter_node(kind);
         if let Some(continue_target) = &mut stmt.label {
@@ -320,7 +320,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_directive(&mut self, directive: &mut Directive) {
+    fn visit_directive(&mut self, directive: &mut Directive<'a>) {
         let kind = AstKind::Directive(self.alloc(directive));
         self.enter_node(kind);
         self.visit_string_literal(&mut directive.expression);
@@ -595,7 +595,7 @@ pub trait VisitMut<'a>: Sized {
         }
     }
 
-    fn visit_meta_property(&mut self, meta: &mut MetaProperty) {
+    fn visit_meta_property(&mut self, meta: &mut MetaProperty<'a>) {
         let kind = AstKind::MetaProperty(self.alloc(meta));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1052,7 +1052,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_jsx_identifier(&mut self, ident: &mut JSXIdentifier) {
+    fn visit_jsx_identifier(&mut self, ident: &mut JSXIdentifier<'a>) {
         let kind = AstKind::JSXIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1078,7 +1078,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_jsx_namespaced_name(&mut self, name: &mut JSXNamespacedName) {
+    fn visit_jsx_namespaced_name(&mut self, name: &mut JSXNamespacedName<'a>) {
         let kind = AstKind::JSXNamespacedName(self.alloc(name));
         self.enter_node(kind);
         self.visit_jsx_identifier(&mut name.namespace);
@@ -1156,13 +1156,13 @@ pub trait VisitMut<'a>: Sized {
         self.visit_expression(&mut child.expression);
     }
 
-    fn visit_jsx_text(&mut self, child: &JSXText) {
+    fn visit_jsx_text(&mut self, child: &JSXText<'a>) {
         let kind = AstKind::JSXText(self.alloc(child));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    /* ----------  Pattern ---------- */
+    /*<'a> ----------  Pattern ---------- */
 
     fn visit_binding_pattern(&mut self, pat: &mut BindingPattern<'a>) {
         match &mut pat.kind {
@@ -1178,7 +1178,7 @@ pub trait VisitMut<'a>: Sized {
         }
     }
 
-    fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier) {
+    fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier<'a>) {
         let kind = AstKind::BindingIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1230,25 +1230,25 @@ pub trait VisitMut<'a>: Sized {
 
     /* ----------  Identifier ---------- */
 
-    fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference) {
+    fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'a>) {
         let kind = AstKind::IdentifierReference(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_private_identifier(&mut self, ident: &mut PrivateIdentifier) {
+    fn visit_private_identifier(&mut self, ident: &mut PrivateIdentifier<'a>) {
         let kind = AstKind::PrivateIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_label_identifier(&mut self, ident: &mut LabelIdentifier) {
+    fn visit_label_identifier(&mut self, ident: &mut LabelIdentifier<'a>) {
         let kind = AstKind::LabelIdentifier(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_identifier_name(&mut self, ident: &mut IdentifierName) {
+    fn visit_identifier_name(&mut self, ident: &mut IdentifierName<'a>) {
         let kind = AstKind::IdentifierName(self.alloc(ident));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1274,13 +1274,13 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_bigint_literal(&mut self, lit: &mut BigintLiteral) {
+    fn visit_bigint_literal(&mut self, lit: &mut BigintLiteral<'a>) {
         let kind = AstKind::BigintLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);
     }
 
-    fn visit_string_literal(&mut self, lit: &mut StringLiteral) {
+    fn visit_string_literal(&mut self, lit: &mut StringLiteral<'a>) {
         let kind = AstKind::StringLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1298,7 +1298,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_reg_expr_literal(&mut self, lit: &mut RegExpLiteral) {
+    fn visit_reg_expr_literal(&mut self, lit: &mut RegExpLiteral<'a>) {
         let kind = AstKind::RegExpLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);
@@ -1345,7 +1345,10 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_import_declaration_specifier(&mut self, specifier: &mut ImportDeclarationSpecifier) {
+    fn visit_import_declaration_specifier(
+        &mut self,
+        specifier: &mut ImportDeclarationSpecifier<'a>,
+    ) {
         match specifier {
             ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
                 self.visit_import_specifier(specifier);
@@ -1359,7 +1362,7 @@ pub trait VisitMut<'a>: Sized {
         }
     }
 
-    fn visit_import_specifier(&mut self, specifier: &mut ImportSpecifier) {
+    fn visit_import_specifier(&mut self, specifier: &mut ImportSpecifier<'a>) {
         let kind = AstKind::ImportSpecifier(self.alloc(specifier));
         self.enter_node(kind);
         // TODO: imported
@@ -1367,14 +1370,14 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_import_default_specifier(&mut self, specifier: &mut ImportDefaultSpecifier) {
+    fn visit_import_default_specifier(&mut self, specifier: &mut ImportDefaultSpecifier<'a>) {
         let kind = AstKind::ImportDefaultSpecifier(self.alloc(specifier));
         self.enter_node(kind);
         self.visit_binding_identifier(&mut specifier.local);
         self.leave_node(kind);
     }
 
-    fn visit_import_name_specifier(&mut self, specifier: &mut ImportNamespaceSpecifier) {
+    fn visit_import_name_specifier(&mut self, specifier: &mut ImportNamespaceSpecifier<'a>) {
         let kind = AstKind::ImportNamespaceSpecifier(self.alloc(specifier));
         self.enter_node(kind);
         self.visit_binding_identifier(&mut specifier.local);
@@ -1488,7 +1491,10 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_ts_external_module_reference(&mut self, reference: &mut TSExternalModuleReference) {
+    fn visit_ts_external_module_reference(
+        &mut self,
+        reference: &mut TSExternalModuleReference<'a>,
+    ) {
         let kind = AstKind::TSExternalModuleReference(self.alloc(reference));
         self.enter_node(kind);
         self.visit_string_literal(&mut reference.expression);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -60,14 +60,14 @@ fn print_directives_and_statements<const MINIFY: bool>(
     );
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for Hashbang {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for Hashbang<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print_str(b"#!");
         p.print_str(self.value.as_bytes());
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for Directive {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for Directive<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         // A Use Strict Directive may not contain an EscapeSequence or LineContinuation.
         // So here should print original `directive` value, the `expression` value is escaped str.
@@ -344,7 +344,7 @@ impl<const MINIFY: bool> Gen<MINIFY> for EmptyStatement {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for ContinueStatement {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for ContinueStatement<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         p.print_indent();
         p.print_str(b"continue");
@@ -356,7 +356,7 @@ impl<const MINIFY: bool> Gen<MINIFY> for ContinueStatement {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for BreakStatement {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for BreakStatement<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         p.print_indent();
         p.print_str(b"break");
@@ -797,7 +797,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for WithClause<'a> {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for ImportAttribute {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for ImportAttribute<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         match &self.key {
             ImportAttributeKey::Identifier(identifier) => {
@@ -838,7 +838,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for ExportNamedDeclaration<'a> {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for ExportSpecifier {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for ExportSpecifier<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         self.local.gen(p, ctx);
         if self.local.name() != self.exported.name() {
@@ -848,7 +848,7 @@ impl<const MINIFY: bool> Gen<MINIFY> for ExportSpecifier {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for ModuleExportName {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for ModuleExportName<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         match self {
             Self::Identifier(identifier) => {
@@ -977,7 +977,7 @@ impl<'a, const MINIFY: bool> GenExpr<MINIFY> for TSAsExpression<'a> {
         }
     }
 }
-impl<const MINIFY: bool> Gen<MINIFY> for IdentifierReference {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for IdentifierReference<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         // if let Some(mangler) = &p.mangler {
         // if let Some(reference_id) = self.reference_id.get() {
@@ -991,19 +991,19 @@ impl<const MINIFY: bool> Gen<MINIFY> for IdentifierReference {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for IdentifierName {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for IdentifierName<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print_str(self.name.as_bytes());
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for BindingIdentifier {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for BindingIdentifier<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print_symbol(self.symbol_id.get(), &self.name);
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for LabelIdentifier {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for LabelIdentifier<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print_str(self.name.as_bytes());
     }
@@ -1130,7 +1130,7 @@ fn print_non_negative_float<const MINIFY: bool>(value: f64, _p: &Codegen<{ MINIF
     result
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for BigintLiteral {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for BigintLiteral<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         if self.raw.contains('_') {
             p.print_str(self.raw.replace('_', "").as_bytes());
@@ -1140,7 +1140,7 @@ impl<const MINIFY: bool> Gen<MINIFY> for BigintLiteral {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for RegExpLiteral {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for RegExpLiteral<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         let last = p.peek_nth(0);
         // Avoid forming a single-line comment or "</script" sequence
@@ -1238,7 +1238,7 @@ fn print_unquoted_str<const MINIFY: bool>(s: &str, quote: char, p: &mut Codegen<
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for StringLiteral {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for StringLiteral<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         let s = self.value.as_str();
         p.wrap_quote(s, |p, quote| {
@@ -1920,7 +1920,7 @@ impl<'a, const MINIFY: bool> GenExpr<MINIFY> for NewExpression<'a> {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for MetaProperty {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for MetaProperty<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         self.meta.gen(p, ctx);
         p.print(b'.');
@@ -1988,7 +1988,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for ClassElement<'a> {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for JSXIdentifier {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for JSXIdentifier<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print_str(self.name.as_bytes());
     }
@@ -2021,7 +2021,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for JSXElementName<'a> {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for JSXNamespacedName {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for JSXNamespacedName<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         self.namespace.gen(p, ctx);
         p.print(b':');
@@ -2145,7 +2145,7 @@ impl<const MINIFY: bool> Gen<MINIFY> for JSXClosingFragment {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for JSXText {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for JSXText<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print_str(self.value.as_bytes());
     }
@@ -2306,7 +2306,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for AccessorProperty<'a> {
     }
 }
 
-impl<const MINIFY: bool> Gen<MINIFY> for PrivateIdentifier {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for PrivateIdentifier<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.print(b'#');
         p.print_str(self.name.as_bytes());

--- a/crates/oxc_js_regex/src/ast.rs
+++ b/crates/oxc_js_regex/src/ast.rs
@@ -1,7 +1,7 @@
 //! [`@eslint-community/regexpp`](https://github.com/eslint-community/regexpp/blob/2e8f1af992fb12eae46a446253e8fa3f6cede92a/src/ast.ts)
 
 use oxc_allocator::{Box, Vec};
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 /// The type which includes all nodes.
 #[derive(Debug)]
@@ -120,7 +120,7 @@ pub struct Group<'a> {
 #[derive(Debug)]
 pub struct CapturingGroup<'a> {
     pub span: Span,
-    pub name: Option<Atom>,
+    pub name: Option<CompactString>,
     pub alternatives: Vec<'a, Alternative<'a>>,
     pub references: Vec<'a, Backreference<'a>>,
 }
@@ -267,8 +267,8 @@ pub enum UnicodePropertyCharacterSet<'a> {
 #[derive(Debug)]
 pub struct CharacterUnicodePropertyCharacterSet {
     pub span: Span,
-    pub key: Atom,
-    pub value: Option<Atom>,
+    pub key: CompactString,
+    pub value: Option<CompactString>,
     pub negate: bool,
 }
 
@@ -276,7 +276,7 @@ pub struct CharacterUnicodePropertyCharacterSet {
 #[derive(Debug)]
 pub struct StringsUnicodePropertyCharacterSet {
     pub span: Span,
-    pub key: Atom,
+    pub key: CompactString,
 }
 
 /// The expression character class.
@@ -360,7 +360,7 @@ pub struct Character {
 #[derive(Debug)]
 pub enum BackreferenceRef {
     Number(i32),
-    Atom(Atom),
+    CompactString(CompactString),
 }
 
 /// The backreference.

--- a/crates/oxc_linter/src/rules/deepscan/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/deepscan/bad_array_method_on_arguments.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -19,7 +19,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
         "The 'arguments' object does not have '{0}()' method. If an array method was intended, consider converting the 'arguments' object to an array or using ES6 rest parameter instead."
     )
 )]
-struct BadArrayMethodOnArgumentsDiagnostic(Atom, #[label] pub Span);
+struct BadArrayMethodOnArgumentsDiagnostic(CompactString, #[label] pub Span);
 
 /// `https://deepscan.io/docs/rules/bad-array-method-on-arguments`
 #[derive(Debug, Default, Clone)]
@@ -61,7 +61,7 @@ impl Rule for BadArrayMethodOnArguments {
             MemberExpression::StaticMemberExpression(expr) => {
                 if ARRAY_METHODS.binary_search(&expr.property.name.as_str()).is_ok() {
                     ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
-                        expr.property.name.clone(),
+                        expr.property.name.to_compact_string(),
                         expr.span,
                     ));
                 }
@@ -71,7 +71,7 @@ impl Rule for BadArrayMethodOnArguments {
                     Expression::StringLiteral(name) => {
                         if ARRAY_METHODS.binary_search(&name.value.as_str()).is_ok() {
                             ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
-                                name.value.clone(),
+                                name.value.to_compact_string(),
                                 expr.span,
                             ));
                         }
@@ -86,7 +86,7 @@ impl Rule for BadArrayMethodOnArguments {
                             {
                                 if ARRAY_METHODS.binary_search(&name).is_ok() {
                                     ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
-                                        Atom::from(name),
+                                        CompactString::from(name),
                                         expr.span,
                                     ));
                                 }

--- a/crates/oxc_linter/src/rules/deepscan/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/deepscan/number_arg_out_of_range.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -17,7 +17,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("The first argument of 'Number.prototype.{0}' should be a number between {1} and {2}")
 )]
-struct NumberArgOutOfRangeDiagnostic(Atom, usize, usize, #[label] pub Span);
+struct NumberArgOutOfRangeDiagnostic(CompactString, usize, usize, #[label] pub Span);
 
 /// `https://deepscan.io/docs/rules/number-arg-out-of-range`
 #[derive(Debug, Default, Clone)]
@@ -52,19 +52,19 @@ impl Rule for NumberArgOutOfRange {
                 match member.static_property_name() {
                     Some(name @ "toString") => {
                         if !(2.0_f64..=36.0_f64).contains(&value) {
-                            let name = Atom::from(name);
+                            let name = CompactString::from(name);
                             ctx.diagnostic(NumberArgOutOfRangeDiagnostic(name, 2, 36, expr.span));
                         }
                     }
                     Some(name @ ("toFixed" | "toExponential")) => {
                         if !(0.0_f64..=20.0_f64).contains(&value) {
-                            let name = Atom::from(name);
+                            let name = CompactString::from(name);
                             ctx.diagnostic(NumberArgOutOfRangeDiagnostic(name, 0, 20, expr.span));
                         }
                     }
                     Some(name @ "toPrecision") => {
                         if !(1.0_f64..=21.0_f64).contains(&value) {
-                            let name = Atom::from(name);
+                            let name = CompactString::from(name);
                             ctx.diagnostic(NumberArgOutOfRangeDiagnostic(name, 1, 21, expr.span));
                         }
                     }

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 use phf::phf_set;
 use serde_json::Value;
 
@@ -28,14 +28,14 @@ enum ArrayCallbackReturnDiagnostic {
         severity(warning),
         help("Array method {0:?} needs to have valid return on all code paths")
     )]
-    ExpectReturn(Atom, #[label] Span),
+    ExpectReturn(CompactString, #[label] Span),
 
     #[error("eslint(array-callback-return): Unexpected return for array method {0}")]
     #[diagnostic(
         severity(warning),
         help("Array method {0} expects no useless return from the function")
     )]
-    ExpectNoReturn(Atom, #[label] Span),
+    ExpectNoReturn(CompactString, #[label] Span),
 }
 
 #[derive(Debug, Default, Clone)]
@@ -243,10 +243,10 @@ const TARGET_METHODS: phf::Set<&'static str> = phf_set! {
     "toSorted",
 };
 
-fn full_array_method_name(array_method: &'static str) -> Atom {
+fn full_array_method_name(array_method: &'static str) -> CompactString {
     match array_method {
-        "from" => Atom::from("Array.from"),
-        s => Atom::from(format!("Array.prototype.{s}")),
+        "from" => CompactString::from("Array.from"),
+        s => CompactString::from(format!("Array.prototype.{s}")),
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-class-assign): Unexpected re-assignment of class {0}")]
 #[diagnostic(severity(warning))]
 struct NoClassAssignDiagnostic(
-    Atom,
+    CompactString,
     #[label("{0} is declared as class here")] pub Span,
     #[label("{0} is re-assigned here")] pub Span,
 );
@@ -45,7 +45,7 @@ impl Rule for NoClassAssign {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(NoClassAssignDiagnostic(
-                        symbol_table.get_name(symbol_id).clone(),
+                        symbol_table.get_name(symbol_id).into(),
                         symbol_table.get_span(symbol_id),
                         reference.span(),
                     ));

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-const-assign): Unexpected re-assignment of const variable {0}")]
 #[diagnostic(severity(warning))]
 struct NoConstAssignDiagnostic(
-    Atom,
+    CompactString,
     #[label("{0} is declared here as const")] pub Span,
     #[label("{0} is re-assigned here")] pub Span,
 );
@@ -44,7 +44,7 @@ impl Rule for NoConstAssign {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(NoConstAssignDiagnostic(
-                        symbol_table.get_name(symbol_id).clone(),
+                        symbol_table.get_name(symbol_id).into(),
                         symbol_table.get_span(symbol_id),
                         reference.span(),
                     ));

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule};
@@ -17,7 +17,7 @@ use crate::{context::LintContext, rule::Rule};
     )
 )]
 struct NoDupeClassMembersDiagnostic(
-    Atom, /*Class member name */
+    CompactString, /*Class member name */
     #[label("{0:?} is previously declared here")] pub Span,
     #[label("{0:?} is re-declared here")] pub Span,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -5,14 +5,14 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-func-assign): '{0}' is a function.")]
 #[diagnostic(severity(warning))]
-struct NoFuncAssignDiagnostic(Atom, #[label("{0} is re-assigned here")] pub Span);
+struct NoFuncAssignDiagnostic(CompactString, #[label("{0} is re-assigned here")] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoFuncAssign;
@@ -42,7 +42,7 @@ impl Rule for NoFuncAssign {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(NoFuncAssignDiagnostic(
-                        symbol_table.get_name(symbol_id).clone(),
+                        symbol_table.get_name(symbol_id).into(),
                         reference.span(),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-global-assign): Read-only global '{0}' should not be modified.")]
 #[diagnostic(severity(warning))]
 struct NoGlobalAssignDiagnostic(
-    Atom,
+    CompactString,
     #[label("Read-only global '{0}' should not be modified.")] pub Span,
 );
 
@@ -20,7 +20,7 @@ pub struct NoGlobalAssign(Box<NoGlobalAssignConfig>);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoGlobalAssignConfig {
-    excludes: Vec<Atom>,
+    excludes: Vec<CompactString>,
 }
 
 impl std::ops::Deref for NoGlobalAssign {
@@ -58,8 +58,8 @@ impl Rule for NoGlobalAssign {
                 .iter()
                 .map(serde_json::Value::as_str)
                 .filter(std::option::Option::is_some)
-                .map(|x| Atom::from(x.unwrap().to_string()))
-                .collect::<Vec<Atom>>(),
+                .map(|x| CompactString::from(x.unwrap()))
+                .collect::<Vec<CompactString>>(),
         }))
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -16,7 +16,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("do not use {0} as a constructor, consider removing the new operator.")
 )]
-struct NoNewWrappersDiagnostic(Atom, #[label] pub Span);
+struct NoNewWrappersDiagnostic(CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNewWrappers;
@@ -47,7 +47,7 @@ impl Rule for NoNewWrappers {
         if (ident.name == "String" || ident.name == "Number" || ident.name == "Boolean")
             && ctx.semantic().is_reference_to_global_variable(ident)
         {
-            ctx.diagnostic(NoNewWrappersDiagnostic(ident.name.clone(), expr.span));
+            ctx.diagnostic(NoNewWrappersDiagnostic(ident.name.to_compact_string(), expr.span));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use oxc_syntax::operator::UnaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-undef): Disallow the use of undeclared variables")]
 #[diagnostic(severity(warning), help("'{0}' is not defined."))]
-struct NoUndefDiagnostic(Atom, #[label] pub Span);
+struct NoUndefDiagnostic(CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUndef {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -4,14 +4,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, fixer::Fix, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-unused-labels): Disallow unused labels")]
 #[diagnostic(severity(warning), help("'{0}:' is defined but never used."))]
-struct NoUnusedLabelsDiagnostic(Atom, #[label] pub Span);
+struct NoUnusedLabelsDiagnostic(CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUnusedLabels;
@@ -51,7 +51,7 @@ impl Rule for NoUnusedLabels {
                 // TODO: Ignore fix where comments exist between label and statement
                 // e.g. A: /* Comment */ function foo(){}
                 ctx.diagnostic_with_fix(
-                    NoUnusedLabelsDiagnostic(stmt.label.name.clone(), stmt.label.span),
+                    NoUnusedLabelsDiagnostic(stmt.label.name.to_compact_string(), stmt.label.span),
                     || Fix::delete(stmt.label.span),
                 );
             }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, AstNodeId, AstNodes};
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use oxc_syntax::class::ElementKind;
 
 use crate::{context::LintContext, rule::Rule};
@@ -14,7 +14,7 @@ use crate::{context::LintContext, rule::Rule};
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-unused-private-class-members): '{0}' is defined but never used.")]
 #[diagnostic(severity(warning))]
-struct NoUnusedPrivateClassMembersDiagnostic(Atom, #[label] pub Span);
+struct NoUnusedPrivateClassMembersDiagnostic(CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUnusedPrivateClassMembers;
@@ -179,7 +179,7 @@ fn test() {
 			}",
         r"class C {
 			    #usedMember;
-			
+
 			    foo() {
 			        bar(this.#usedMember += 1);
 			    }
@@ -192,11 +192,11 @@ fn test() {
 			}",
         r"class C {
 			    #usedInOuterClass;
-			
+
 			    foo() {
 			        return class {};
 			    }
-			
+
 			    bar() {
 			        return this.#usedInOuterClass;
 			    }
@@ -205,7 +205,7 @@ fn test() {
 			    #usedInForInLoop;
 			    method() {
 			        for (const bar in this.#usedInForInLoop) {
-			
+
 			        }
 			    }
 			}",
@@ -213,7 +213,7 @@ fn test() {
 			    #usedInForOfLoop;
 			    method() {
 			        for (const bar of this.#usedInForOfLoop) {
-			
+
 			        }
 			    }
 			}",
@@ -237,7 +237,7 @@ fn test() {
 			}",
         r"class C {
 			    #usedInObjectAssignment;
-			
+
 			    method() {
 			        ({ [this.#usedInObjectAssignment]: a } = foo);
 			    }
@@ -330,18 +330,18 @@ fn test() {
 			}",
         r"class C {
 			    #usedOnlyInIncrement;
-			
+
 			    foo() {
 			        this.#usedOnlyInIncrement++;
 			    }
 			}",
         r"class C {
 			    #unusedInOuterClass;
-			
+
 			    foo() {
 			        return class {
 			            #unusedInOuterClass;
-			
+
 			            bar() {
 			                return this.#unusedInOuterClass;
 			            }
@@ -350,21 +350,21 @@ fn test() {
 			}",
         r"class C {
 			    #unusedOnlyInSecondNestedClass;
-			
+
 			    foo() {
 			        return class {
 			            #unusedOnlyInSecondNestedClass;
-			
+
 			            bar() {
 			                return this.#unusedOnlyInSecondNestedClass;
 			            }
 			        };
 			    }
-			
+
 			    baz() {
 			        return this.#unusedOnlyInSecondNestedClass;
 			    }
-			
+
 			    bar() {
 			        return class {
 			            #unusedOnlyInSecondNestedClass;
@@ -390,7 +390,7 @@ fn test() {
 			    #unusedForInLoop;
 			    method() {
 			        for (this.#unusedForInLoop in bar) {
-			
+
 			        }
 			    }
 			}",
@@ -398,7 +398,7 @@ fn test() {
 			    #unusedForOfLoop;
 			    method() {
 			        for (this.#unusedForOfLoop of bar) {
-			
+
 			        }
 			    }
 			}",
@@ -428,15 +428,15 @@ fn test() {
 			}",
         r"class C {
 			    #usedOnlyInTheSecondInnerClass;
-			
+
 			    method(a) {
 			        return class {
 			            #usedOnlyInTheSecondInnerClass;
-			
+
 			            method2(b) {
 			                foo = b.#usedOnlyInTheSecondInnerClass;
 			            }
-			
+
 			            method3(b) {
 			                foo = b.#usedOnlyInTheSecondInnerClass;
 			            }

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ModuleRecord;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{context::LintContext, rule::Rule};
@@ -15,10 +15,10 @@ use crate::{context::LintContext, rule::Rule};
 enum ExportDiagnostic {
     #[error("eslint-plugin-import(export): Multiple exports of name '{1}'.")]
     #[diagnostic(severity(warning))]
-    MultipleNamedExport(#[label] Span, Atom),
+    MultipleNamedExport(#[label] Span, CompactString),
     #[error("eslint-plugin-import(export): No named exports found in module '{1}'")]
     #[diagnostic(severity(warning))]
-    NoNamedExport(#[label] Span, Atom),
+    NoNamedExport(#[label] Span, CompactString),
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md>
@@ -84,7 +84,7 @@ impl Rule for Export {
 
 fn walk_exported_recursive(
     module_record: &ModuleRecord,
-    result: &mut FxHashSet<Atom>,
+    result: &mut FxHashSet<CompactString>,
     visited: &mut FxHashSet<PathBuf>,
 ) {
     let path = &module_record.resolved_absolute_path;

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -3,14 +3,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(namespace): ")]
 #[diagnostic(severity(warning), help(""))]
-struct NamespaceDiagnostic(Atom, #[label] pub Span);
+struct NamespaceDiagnostic(CompactString, #[label] pub Span);
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -5,14 +5,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(no-amd): Do not use AMD `require` and `define` calls.")]
 #[diagnostic(severity(warning), help("Expected imports instead of AMD {1}()"))]
-struct NoAmdDiagnostic(#[label] pub Span, Atom);
+struct NoAmdDiagnostic(#[label] pub Span, CompactString);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoAmd;
@@ -54,7 +54,10 @@ impl Rule for NoAmd {
 
                 if let Argument::Expression(Expression::ArrayExpression(_)) = call_expr.arguments[0]
                 {
-                    ctx.diagnostic(NoAmdDiagnostic(identifier.span, identifier.name.clone()));
+                    ctx.diagnostic(NoAmdDiagnostic(
+                        identifier.span,
+                        identifier.name.to_compact_string(),
+                    ));
                 }
             }
         }

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -11,7 +11,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use oxc_syntax::module_record::ModuleRecord;
 
 use crate::{context::LintContext, rule::Rule};
@@ -120,7 +120,7 @@ impl Rule for NoCycle {
 #[derive(Debug, Default)]
 struct State {
     traversed: HashSet<PathBuf>,
-    stack: Vec<(Atom, PathBuf)>,
+    stack: Vec<(CompactString, PathBuf)>,
 }
 
 impl NoCycle {

--- a/crates/oxc_linter/src/rules/import/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/import/no_deprecated.rs
@@ -3,14 +3,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(namespace): ")]
 #[diagnostic(severity(warning), help(""))]
-struct NoDeprecatedDiagnostic(Atom, #[label] pub Span);
+struct NoDeprecatedDiagnostic(CompactString, #[label] pub Span);
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-deprecated.md>
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -3,14 +3,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(namespace): ")]
 #[diagnostic(severity(warning), help(""))]
-struct NoUnusedModulesDiagnostic(Atom, #[label] pub Span);
+struct NoUnusedModulesDiagnostic(CompactString, #[label] pub Span);
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, AstNodeId, ReferenceId};
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span};
 
 use crate::{
     context::LintContext,
@@ -236,7 +236,7 @@ fn is_jest_fn_call<'a>(
     parse_jest_fn_call(call_expr, possible_jest_node, ctx).is_some()
 }
 
-fn is_jest_call(name: &Atom) -> bool {
+fn is_jest_call(name: &str) -> bool {
     // handle "jest" | "Jest" | "JEST" | "JEst" to "jest", For example:
     //
     // import { jest as Jest } from "@jest/globals";

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -120,7 +120,7 @@ fn filter_and_process_jest_result<'a>(
     call_expr: &'a CallExpression<'a>,
     possible_jest_node: &PossibleJestNode<'a, '_>,
     ctx: &LintContext<'a>,
-) -> Option<(Span, &'a Atom, JestFnKind, AstNodeId)> {
+) -> Option<(Span, &'a Atom<'a>, JestFnKind, AstNodeId)> {
     let Some(result) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) else {
         return None;
     };

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 
 use crate::{
     context::LintContext,
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jest(no-test-prefixes): Use {0:?} instead.")]
 #[diagnostic(severity(warning))]
-struct NoTestPrefixesDiagnostic(Atom, #[label] pub Span);
+struct NoTestPrefixesDiagnostic(CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoTestPrefixes;
@@ -91,7 +91,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
     });
 }
 
-fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> Atom {
+fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> CompactString {
     let ParsedGeneralJestFnCall { members, name, .. } = jest_fn_call;
 
     let preferred_modifier = if name.starts_with('f') { "only" } else { "skip" };
@@ -103,9 +103,9 @@ fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> Atom {
     let name_slice = &name[1..];
 
     if member_names.is_empty() {
-        Atom::from(format!("{name_slice}.{preferred_modifier}"))
+        CompactString::from(format!("{name_slice}.{preferred_modifier}"))
     } else {
-        Atom::from(format!("{name_slice}.{preferred_modifier}.{member_names}"))
+        CompactString::from(format!("{name_slice}.{preferred_modifier}.{member_names}"))
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 
 use crate::{
     context::LintContext,
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jest(valid-expect): {0:?}")]
 #[diagnostic(severity(warning), help("{1:?}"))]
-struct ValidExpectDiagnostic(pub Atom, pub &'static str, #[label] pub Span);
+struct ValidExpectDiagnostic(CompactString, &'static str, #[label] Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct ValidExpect(Box<ValidExpectConfig>);
@@ -142,7 +142,7 @@ impl ValidExpect {
         let Some(Expression::CallExpression(call_expr)) = jest_fn_call.head.parent else { return };
 
         if call_expr.arguments.len() < self.min_args {
-            let error = Atom::from(format!(
+            let error = CompactString::from(format!(
                 "Expect takes at most {} argument{} ",
                 self.min_args,
                 if self.min_args > 1 { "s" } else { "" }
@@ -152,7 +152,7 @@ impl ValidExpect {
             return;
         }
         if call_expr.arguments.len() > self.max_args {
-            let error = Atom::from(format!(
+            let error = CompactString::from(format!(
                 "Expect requires at least {} argument{} ",
                 self.max_args,
                 if self.max_args > 1 { "s" } else { "" }
@@ -360,24 +360,26 @@ enum Message {
 }
 
 impl Message {
-    fn details(self) -> (Atom, &'static str) {
+    fn details(self) -> (CompactString, &'static str) {
         match self {
             Self::MatcherNotFound => (
-                Atom::from("Expect must have a corresponding matcher call."),
+                CompactString::from("Expect must have a corresponding matcher call."),
                 "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)",
             ),
             Self::MatcherNotCalled => (
-                Atom::from("Matchers must be called to assert."),
+                CompactString::from("Matchers must be called to assert."),
                 "You need call your matcher, e.g. `expect(true).toBe(true)`.",
             ),
-            Self::ModifierUnknown => {
-                (Atom::from("Expect has an unknown modifier."), "Is it a spelling mistake?")
-            }
-            Self::AsyncMustBeAwaited => {
-                (Atom::from("Async assertions must be awaited."), "Add `await` to your assertion.")
-            }
+            Self::ModifierUnknown => (
+                CompactString::from("Expect has an unknown modifier."),
+                "Is it a spelling mistake?",
+            ),
+            Self::AsyncMustBeAwaited => (
+                CompactString::from("Async assertions must be awaited."),
+                "Add `await` to your assertion.",
+            ),
             Self::PromisesWithAsyncAssertionsMustBeAwaited => (
-                Atom::from("Promises which return async assertions must be awaited."),
+                CompactString::from("Promises which return async assertions must be awaited."),
                 "Add `await` to your assertion.",
             ),
         }

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 use regex::Regex;
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jest(valid-title): {0:?}")]
 #[diagnostic(severity(warning), help("{1:?}"))]
-struct ValidTitleDiagnostic(Atom, &'static str, #[label] pub Span);
+struct ValidTitleDiagnostic(CompactString, &'static str, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct ValidTitle(Box<ValidTitleConfig>);
@@ -293,7 +293,7 @@ fn validate_title(
         if let Some(matched) = disallowed_words_reg.find(title) {
             let error = format!("{} is not allowed in test title", matched.as_str());
             ctx.diagnostic(ValidTitleDiagnostic(
-                Atom::from(error),
+                CompactString::from(error),
                 "It is included in the `disallowedWords` of your config file, try to remove it from your title",
                 span,
             ));
@@ -325,8 +325,8 @@ fn validate_title(
         if !regex.is_match(title) {
             let raw_pattern = regex.as_str();
             let message = message.as_ref().map_or_else(
-                || Atom::from(format!("{un_prefixed_name} should match {raw_pattern}")),
-                |message| Atom::from(message.as_str()),
+                || CompactString::from(format!("{un_prefixed_name} should match {raw_pattern}")),
+                |message| CompactString::from(message.as_str()),
             );
             ctx.diagnostic(ValidTitleDiagnostic(
                 message,
@@ -340,8 +340,12 @@ fn validate_title(
         if regex.is_match(title) {
             let raw_pattern = regex.as_str();
             let message = message.as_ref().map_or_else(
-                || Atom::from(format!("{un_prefixed_name} should not match {raw_pattern}")),
-                |message| Atom::from(message.as_str()),
+                || {
+                    CompactString::from(format!(
+                        "{un_prefixed_name} should not match {raw_pattern}"
+                    ))
+                },
+                |message| CompactString::from(message.as_str()),
             );
 
             ctx.diagnostic(ValidTitleDiagnostic(
@@ -382,7 +386,7 @@ impl Message {
     }
     fn diagnostic(&self, ctx: &LintContext, span: Span) {
         let (error, help) = self.detail();
-        ctx.diagnostic(ValidTitleDiagnostic(Atom::from(error), help, span));
+        ctx.diagnostic(ValidTitleDiagnostic(CompactString::from(error), help, span));
     }
 }
 

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -19,7 +19,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
         "Remove the argument and its usage. Alternatively, use the argument in the function body."
     )
 )]
-struct OnlyUsedInRecursionDiagnostic(#[label] pub Span, pub Atom);
+struct OnlyUsedInRecursionDiagnostic(#[label] pub Span, pub CompactString);
 
 #[derive(Debug, Default, Clone)]
 pub struct OnlyUsedInRecursion;
@@ -79,7 +79,10 @@ impl Rule for OnlyUsedInRecursion {
             let BindingPatternKind::BindingIdentifier(arg) = &arg.pattern.kind else { continue };
 
             if is_argument_only_used_in_recursion(function_id, arg, arg_index, ctx) {
-                ctx.diagnostic(OnlyUsedInRecursionDiagnostic(arg.span, arg.name.clone()));
+                ctx.diagnostic(OnlyUsedInRecursionDiagnostic(
+                    arg.span,
+                    arg.name.to_compact_string(),
+                ));
             }
         }
     }

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, CompactString, Span};
 use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -20,7 +20,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("Remove one of the props, or rename them so each prop is distinct.")
 )]
-struct JsxNoDuplicatePropsDiagnostic(Atom, #[label] pub Span, #[label] pub Span);
+struct JsxNoDuplicatePropsDiagnostic(CompactString, #[label] pub Span, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct JsxNoDuplicateProps;
@@ -63,7 +63,7 @@ impl Rule for JsxNoDuplicateProps {
 
             if let Some(old_span) = props.insert(ident.name.clone(), ident.span) {
                 ctx.diagnostic(JsxNoDuplicatePropsDiagnostic(
-                    ident.name.clone(),
+                    ident.name.to_compact_string(),
                     old_span,
                     ident.span,
                 ));

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -10,14 +10,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX")]
 #[diagnostic(severity(warning), help("'{0}' is not defined."))]
-struct JsxNoUndefDiagnostic(Atom, #[label] pub Span);
+struct JsxNoUndefDiagnostic(CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct JsxNoUndef;
@@ -69,7 +69,7 @@ impl Rule for JsxNoUndef {
                         return;
                     }
                 }
-                ctx.diagnostic(JsxNoUndefDiagnostic(ident.name.clone(), ident.span));
+                ctx.diagnostic(JsxNoUndefDiagnostic(ident.name.to_compact_string(), ident.span));
             }
         }
     }

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub enum BanTypesDiagnostic {
     #[error("typescript-eslint(ban-types): Do not use {0:?} as a type. Use \"{1}\" instead")]
     #[diagnostic(severity(warning))]
-    Type(Atom, String, #[label] Span),
+    Type(CompactString, String, #[label] Span),
 
     #[error("typescript-eslint(ban-types): Prefer explicitly define the object shape")]
     #[diagnostic(severity(warning), help("This type means \"any non-nullish value\", which is slightly better than 'unknown', but it's still a broad type"))]
@@ -63,7 +63,7 @@ impl Rule for BanTypes {
                 match name.as_str() {
                     "String" | "Boolean" | "Number" | "Symbol" | "BigInt" => {
                         ctx.diagnostic(BanTypesDiagnostic::Type(
-                            name.clone(),
+                            name.to_compact_string(),
                             name.to_lowercase(),
                             typ.span,
                         ));

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -37,7 +37,7 @@ pub struct NoThisAlias(Box<NoThisAliasConfig>);
 #[derive(Debug, Clone)]
 pub struct NoThisAliasConfig {
     allow_destructuring: bool,
-    allow_names: Vec<Atom>,
+    allow_names: Vec<CompactString>,
 }
 
 impl std::ops::Deref for NoThisAlias {
@@ -83,8 +83,8 @@ impl Rule for NoThisAlias {
             .iter()
             .map(serde_json::Value::as_str)
             .filter(std::option::Option::is_some)
-            .map(|x| Atom::from(x.unwrap().to_string()))
-            .collect::<Vec<Atom>>();
+            .map(|x| CompactString::from(x.unwrap()))
+            .collect::<Vec<CompactString>>();
 
         Self(Box::new(NoThisAliasConfig {
             allow_destructuring: obj
@@ -114,7 +114,7 @@ impl Rule for NoThisAlias {
                 }
 
                 if let BindingPatternKind::BindingIdentifier(identifier) = &decl.id.kind {
-                    if !self.allow_names.contains(&identifier.name) {
+                    if !self.allow_names.iter().any(|s| s.as_str() == identifier.name.as_str()) {
                         ctx.diagnostic(NoThisAliasDiagnostic(identifier.span));
                     }
 
@@ -135,14 +135,18 @@ impl Rule for NoThisAlias {
                     }
                     AssignmentTarget::SimpleAssignmentTarget(pat) => match pat {
                         SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
-                            if !self.allow_names.contains(&id.name) {
+                            if !self.allow_names.iter().any(|s| s.as_str() == id.name.as_str()) {
                                 ctx.diagnostic(NoThisAliasDiagnostic(id.span));
                             }
                         }
                         _ => {
                             if let Some(expr) = pat.get_expression() {
                                 if let Some(id) = expr.get_identifier_reference() {
-                                    if !self.allow_names.contains(&id.name) {
+                                    if !self
+                                        .allow_names
+                                        .iter()
+                                        .any(|s| s.as_str() == id.name.as_str())
+                                    {
                                         ctx.diagnostic(NoThisAliasDiagnostic(id.span));
                                     }
                                 }

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -14,7 +14,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 )]
 #[diagnostic(severity(warning), help("Remove the unnecessary {1:?} constraint"))]
 struct NoUnnecessaryTypeConstraintDiagnostic(
-    Atom,
+    CompactString,
     &'static str,
     #[label] pub Span,
     #[label] pub Span,
@@ -60,7 +60,7 @@ impl Rule for NoUnnecessaryTypeConstraint {
                         _ => continue,
                     };
                     ctx.diagnostic(NoUnnecessaryTypeConstraintDiagnostic(
-                        param.name.name.clone(),
+                        param.name.name.to_compact_string(),
                         value,
                         param.name.span,
                         ty_span,

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -15,7 +15,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[diagnostic(severity(warning))]
 pub enum ErrorMessageDiagnostic {
     #[error("eslint-plugin-unicorn(error-message): Pass a message to the {0:1} constructor.")]
-    MissingMessage(Atom, #[label] Span),
+    MissingMessage(CompactString, #[label] Span),
     #[error("eslint-plugin-unicorn(error-message): Error message should not be an empty string.")]
     EmptyMessage(#[label] Span),
     #[error("eslint-plugin-unicorn(error-message): Error message should be a string.")]
@@ -88,7 +88,7 @@ impl Rule for ErrorMessage {
             Some(v) => v,
             None => {
                 return ctx.diagnostic(ErrorMessageDiagnostic::MissingMessage(
-                    constructor_name.clone(),
+                    constructor_name.to_compact_string(),
                     span,
                 ))
             }

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -10,7 +10,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::{
@@ -24,12 +24,12 @@ use crate::{
 enum ExplicitLengthCheckDiagnostic {
     #[error("eslint-plugin-unicorn(explicit-length-check): Use `.{1} {2}` when checking {1} is not zero.")]
     #[diagnostic(severity(warning))]
-    NoneZero(#[label] Span, Atom, Atom, #[help] Option<String>),
+    NoneZero(#[label] Span, CompactString, CompactString, #[help] Option<String>),
     #[error(
         "eslint-plugin-unicorn(explicit-length-check): Use `.{1} {2}` when checking {1} is zero."
     )]
     #[diagnostic(severity(warning))]
-    Zero(#[label] Span, Atom, Atom, #[help] Option<String>),
+    Zero(#[label] Span, CompactString, CompactString, #[help] Option<String>),
 }
 #[derive(Debug, Default, Clone)]
 enum NonZero {
@@ -218,7 +218,7 @@ impl ExplicitLengthCheck {
         let diagnostic = if is_zero_length_check {
             ExplicitLengthCheckDiagnostic::Zero(
                 span,
-                property.clone(),
+                property.to_compact_string(),
                 check_code.into(),
                 if auto_fix {
                     None
@@ -229,7 +229,7 @@ impl ExplicitLengthCheck {
         } else {
             ExplicitLengthCheckDiagnostic::NoneZero(
                 span,
-                property.clone(),
+                property.to_compact_string(),
                 check_code.into(),
                 if auto_fix {
                     None

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -17,7 +17,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("Reference `this` directly instead of assigning it to a variable.")
 )]
-struct NoThisAssignmentDiagnostic(#[label] pub Span, Atom);
+struct NoThisAssignmentDiagnostic(#[label] pub Span, CompactString);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoThisAssignment;
@@ -78,7 +78,7 @@ impl Rule for NoThisAssignment {
 
                 ctx.diagnostic(NoThisAssignmentDiagnostic(
                     variable_decl.span,
-                    binding_ident.name.clone(),
+                    binding_ident.name.to_compact_string(),
                 ));
             }
             AstKind::AssignmentExpression(assignment_expr) => {
@@ -103,7 +103,7 @@ impl Rule for NoThisAssignment {
 
                 ctx.diagnostic(NoThisAssignmentDiagnostic(
                     assignment_expr.span,
-                    ident.name.clone(),
+                    ident.name.to_compact_string(),
                 ));
             }
             _ => {}

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{CompactString, GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -21,7 +21,7 @@ enum PreferDateNowDiagnostic {
 
     #[error("eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `new Date().{1}()`")]
     #[diagnostic(severity(warning), help("Change to `Date.now()`."))]
-    PreferDateNowOverMethods(#[label] Span, Atom),
+    PreferDateNowOverMethods(#[label] Span, CompactString),
 
     #[error(
         "eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `Number(new Date())`"

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 use phf::phf_map;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
@@ -15,7 +15,7 @@ use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode}
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(prefer-modern-dom-apis): Prefer using `{0}` over `{1}`.")]
 #[diagnostic(severity(warning))]
-struct PreferModernDomApisDiagnostic(pub &'static str, Atom, #[label] pub Span);
+struct PreferModernDomApisDiagnostic(pub &'static str, CompactString, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferModernDomApis;
@@ -91,7 +91,7 @@ impl Rule for PreferModernDomApis {
             if let Some(preferred_method) = DISALLOWED_METHODS.get(method) {
                 ctx.diagnostic(PreferModernDomApisDiagnostic(
                     preferred_method,
-                    Atom::from(method),
+                    CompactString::from(method),
                     member_expr.property.span,
                 ));
 
@@ -111,7 +111,7 @@ impl Rule for PreferModernDomApis {
                     if lit.value == position {
                         ctx.diagnostic(PreferModernDomApisDiagnostic(
                             replacer,
-                            Atom::from(method),
+                            CompactString::from(method),
                             member_expr.property.span,
                         ));
                     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -144,7 +144,7 @@ fn check_function(
     None
 }
 
-fn get_returned_ident<'a>(stmt: &'a Statement, is_arrow: bool) -> Option<&'a Atom> {
+fn get_returned_ident<'a>(stmt: &'a Statement, is_arrow: bool) -> Option<&'a Atom<'a>> {
     if is_arrow {
         if let Statement::ExpressionStatement(expr_stmt) = &stmt {
             return expr_stmt

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -77,14 +77,14 @@ impl Rule for PreferNodeProtocol {
 fn get_static_require_arg<'a>(
     ctx: &LintContext<'a>,
     call: &CallExpression<'a>,
-) -> Option<(Atom, Span)> {
+) -> Option<(Atom<'a>, Span)> {
     let Expression::Identifier(ref id) = call.callee else { return None };
     match call.arguments.as_slice() {
         [Argument::Expression(Expression::StringLiteral(str))] if id.name == "require" => ctx
             .semantic()
             .scopes()
             .root_unresolved_references()
-            .contains_key(&id.name)
+            .contains_key(id.name.as_str())
             .then(|| (str.value.clone(), str.span)),
         _ => None,
     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
@@ -15,7 +15,7 @@ use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, Ast
 enum PreferStringReplaceAllDiagnostic {
     #[error("eslint-plugin-unicorn(prefer-string-replace-all): This pattern can be replaced with `{1}`.")]
     #[diagnostic(severity(warning))]
-    StringLiteral(#[label] Span, Atom),
+    StringLiteral(#[label] Span, CompactString),
     #[error("eslint-plugin-unicorn(prefer-string-replace-all): Prefer `String#replaceAll()` over `String#replace()` when using a regex with the global flag.")]
     #[diagnostic(severity(warning))]
     UseReplaceAll(#[label] Span),
@@ -99,7 +99,7 @@ fn is_reg_exp_with_global_flag<'a>(expr: &'a Expression<'a>) -> bool {
     false
 }
 
-fn get_pattern_replacement<'a>(expr: &'a Expression<'a>) -> Option<Atom> {
+fn get_pattern_replacement<'a>(expr: &'a Expression<'a>) -> Option<CompactString> {
     let Expression::RegExpLiteral(reg_exp_literal) = expr else { return None };
 
     if !reg_exp_literal.regex.flags.contains(RegExpFlags::G) {
@@ -110,7 +110,7 @@ fn get_pattern_replacement<'a>(expr: &'a Expression<'a>) -> Option<Atom> {
         return None;
     }
 
-    Some(reg_exp_literal.regex.pattern.clone())
+    Some(reg_exp_literal.regex.pattern.to_compact_string())
 }
 
 fn is_simple_string(str: &str) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -4,14 +4,14 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(prefer-string-slice): Prefer String#slice() over String#{1}()")]
 #[diagnostic(severity(warning))]
-struct PreferStringSliceDiagnostic(#[label] pub Span, Atom);
+struct PreferStringSliceDiagnostic(#[label] pub Span, CompactString);
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferStringSlice;
@@ -50,7 +50,7 @@ impl Rule for PreferStringSlice {
             _ => return,
         };
 
-        ctx.diagnostic(PreferStringSliceDiagnostic(span, name.clone()));
+        ctx.diagnostic(PreferStringSliceDiagnostic(span, name.to_compact_string()));
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -4,14 +4,14 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(prefer-string-trim-start-end): Prefer `{1}` over `{2}`")]
 #[diagnostic(severity(warning), help("Replace with `{1}`"))]
-struct PreferStringTrimStartEndDiagnostic(#[label] pub Span, Atom, &'static str);
+struct PreferStringTrimStartEndDiagnostic(#[label] pub Span, CompactString, &'static str);
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferStringTrimStartEnd;
@@ -67,7 +67,7 @@ impl Rule for PreferStringTrimStartEnd {
 
         ctx.diagnostic(PreferStringTrimStartEndDiagnostic(
             span,
-            name.clone(),
+            name.to_compact_string(),
             get_replacement(name.as_str()),
         ));
     }

--- a/crates/oxc_linter/src/snapshots/no_unused_private_class_members.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_private_class_members.snap
@@ -63,7 +63,7 @@ expression: no_unused_private_class_members
  1 │ class C {
  2 │                 #usedOnlyInIncrement;
    ·                 ────────────────────
- 3 │             
+ 3 │ 
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInOuterClass' is defined but never used.
@@ -71,7 +71,7 @@ expression: no_unused_private_class_members
  1 │ class C {
  2 │                 #unusedInOuterClass;
    ·                 ───────────────────
- 3 │             
+ 3 │ 
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedOnlyInSecondNestedClass' is defined but never used.
@@ -159,5 +159,5 @@ expression: no_unused_private_class_members
  1 │ class C {
  2 │                 #usedOnlyInTheSecondInnerClass;
    ·                 ──────────────────────────────
- 3 │             
+ 3 │ 
    ╰────

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -134,7 +134,7 @@ pub fn parse_expect_jest_fn_call<'a>(
 
 pub struct PossibleJestNode<'a, 'b> {
     pub node: &'b AstNode<'a>,
-    pub original: Option<&'a Atom>, // if this node is imported from 'jest/globals', this field will be Some(original_name), otherwise None
+    pub original: Option<&'a Atom<'a>>, // if this node is imported from 'jest/globals', this field will be Some(original_name), otherwise None
 }
 
 /// Collect all possible Jest fn Call Expression,
@@ -193,7 +193,7 @@ pub fn collect_possible_jest_call_node<'a, 'b>(
 
 fn collect_ids_referenced_to_import<'a, 'b>(
     ctx: &'b LintContext<'a>,
-) -> Vec<(ReferenceId, Option<&'a Atom>)> {
+) -> Vec<(ReferenceId, Option<&'a Atom<'a>>)> {
     ctx.symbols()
         .resolved_references
         .iter_enumerated()
@@ -220,14 +220,17 @@ fn collect_ids_referenced_to_import<'a, 'b>(
             None
         })
         .flatten()
-        .collect::<Vec<(ReferenceId, Option<&'a Atom>)>>()
+        .collect::<Vec<(ReferenceId, Option<&'a Atom<'a>>)>>()
 }
 
 /// Find name in the Import Declaration, not use name because of lifetime not long enough.
-fn find_original_name<'a>(import_decl: &'a ImportDeclaration<'a>, name: &Atom) -> Option<&'a Atom> {
+fn find_original_name<'a>(
+    import_decl: &'a ImportDeclaration<'a>,
+    name: &str,
+) -> Option<&'a Atom<'a>> {
     import_decl.specifiers.iter().flatten().find_map(|specifier| match specifier {
         ImportDeclarationSpecifier::ImportSpecifier(import_specifier) => {
-            if import_specifier.local.name.as_str() == name.as_str() {
+            if import_specifier.local.name.as_str() == name {
                 return Some(import_specifier.imported.name());
             }
             None

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -271,13 +271,13 @@ fn is_valid_jest_call(members: &[Cow<str>]) -> bool {
 
 fn resolve_to_jest_fn<'a>(
     call_expr: &'a CallExpression<'a>,
-    original: Option<&'a Atom>,
+    original: Option<&'a Atom<'a>>,
 ) -> Option<ResolvedJestFn<'a>> {
     let ident = resolve_first_ident(&call_expr.callee)?;
     Some(ResolvedJestFn { local: &ident.name, original })
 }
 
-fn resolve_first_ident<'a>(expr: &'a Expression) -> Option<&'a IdentifierReference> {
+fn resolve_first_ident<'a>(expr: &'a Expression<'a>) -> Option<&'a IdentifierReference<'a>> {
     match expr {
         Expression::Identifier(ident) => Some(ident),
         Expression::MemberExpression(member_expr) => resolve_first_ident(member_expr.object()),
@@ -333,8 +333,8 @@ impl<'a> ParsedExpectFnCall<'a> {
 }
 
 struct ResolvedJestFn<'a> {
-    pub local: &'a Atom,
-    pub original: Option<&'a Atom>,
+    pub local: &'a Atom<'a>,
+    pub original: Option<&'a Atom<'a>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -388,7 +388,7 @@ impl<'a> KnownMemberExpressionProperty<'a> {
 
 pub enum MemberExpressionElement<'a> {
     Expression(&'a Expression<'a>),
-    IdentName(&'a IdentifierName),
+    IdentName(&'a IdentifierName<'a>),
 }
 
 impl<'a> MemberExpressionElement<'a> {

--- a/crates/oxc_linter/src/utils/nextjs.rs
+++ b/crates/oxc_linter/src/utils/nextjs.rs
@@ -1,4 +1,4 @@
-use oxc_span::Atom;
+use oxc_span::CompactString;
 
 use crate::LintContext;
 
@@ -11,7 +11,7 @@ pub fn is_document_page(file_path: &str) -> bool {
     page.starts_with("/_document") || page.starts_with("\\_document")
 }
 
-pub fn get_next_script_import_local_name<'a>(ctx: &'a LintContext) -> Option<&'a Atom> {
+pub fn get_next_script_import_local_name<'a>(ctx: &'a LintContext) -> Option<&'a CompactString> {
     ctx.semantic().module_record().import_entries.iter().find_map(|entry| {
         if entry.module_request.name().as_str() == "next/script" {
             Some(entry.local_name.name())

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -13,11 +13,11 @@ pub struct Mangler {
 }
 
 impl Mangler {
-    pub fn get_symbol_name(&self, symbol_id: SymbolId) -> &Atom {
+    pub fn get_symbol_name(&self, symbol_id: SymbolId) -> &str {
         self.symbol_table.get_name(symbol_id)
     }
 
-    pub fn get_reference_name(&self, reference_id: ReferenceId) -> Option<&Atom> {
+    pub fn get_reference_name(&self, reference_id: ReferenceId) -> Option<&str> {
         let symbol_id = self.symbol_table.get_reference(reference_id).symbol_id()?;
         Some(self.symbol_table.get_name(symbol_id))
     }
@@ -171,7 +171,7 @@ impl ManglerBuilder {
             // rename the variables
             for (symbol_to_rename, new_name) in symbols_to_rename_with_new_names {
                 for symbol_id in &symbol_to_rename.symbol_ids {
-                    symbol_table.set_name(*symbol_id, new_name.clone());
+                    symbol_table.set_name(*symbol_id, new_name.to_compact_string());
                 }
             }
         }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -80,7 +80,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_function(
         &mut self,
         span: Span,
-        id: Option<BindingIdentifier>,
+        id: Option<BindingIdentifier<'a>>,
         r#async: bool,
         generator: bool,
         func_kind: FunctionKind,
@@ -329,7 +329,7 @@ impl<'a> ParserImpl<'a> {
         kind: FunctionKind,
         r#async: bool,
         generator: bool,
-    ) -> Option<BindingIdentifier> {
+    ) -> Option<BindingIdentifier<'a>> {
         let ctx = self.ctx;
         if kind.is_expression() {
             self.ctx = self.ctx.and_await(r#async).and_yield(generator);

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -5,7 +5,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
     Result,
 };
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{Atom, CompactString, GetSpan, Span};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
 #[error("Identifier `{0}` has already been declared")]
 #[diagnostic()]
 struct Redeclaration(
-    pub Atom,
+    pub CompactString,
     #[label("`{0}` has already been declared here")] pub Span,
     #[label("It can not be redeclared here")] pub Span,
 );
@@ -290,8 +290,8 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
 
 /// [Assert Entries](https://tc39.es/proposal-import-assertions)
 pub struct AssertEntries<'a> {
-    pub elements: Vec<'a, ImportAttribute>,
-    keys: FxHashMap<Atom, Span>,
+    pub elements: Vec<'a, ImportAttribute<'a>>,
+    keys: FxHashMap<Atom<'a>, Span>,
 }
 
 impl<'a> SeparatedList<'a> for AssertEntries<'a> {
@@ -315,7 +315,7 @@ impl<'a> SeparatedList<'a> for AssertEntries<'a> {
         };
 
         if let Some(old_span) = self.keys.get(&key.as_atom()) {
-            p.error(Redeclaration(key.as_atom(), *old_span, key.span()));
+            p.error(Redeclaration(key.as_atom().into_compact_string(), *old_span, key.span()));
         } else {
             self.keys.insert(key.as_atom(), key.span());
         }
@@ -329,7 +329,7 @@ impl<'a> SeparatedList<'a> for AssertEntries<'a> {
 }
 
 pub struct ExportNamedSpecifiers<'a> {
-    pub elements: Vec<'a, ExportSpecifier>,
+    pub elements: Vec<'a, ExportSpecifier<'a>>,
 }
 
 impl<'a> SeparatedList<'a> for ExportNamedSpecifiers<'a> {
@@ -443,7 +443,7 @@ impl<'a> NormalList<'a> for SwitchCases<'a> {
 }
 
 pub struct ImportSpecifierList<'a> {
-    pub import_specifiers: Vec<'a, ImportDeclarationSpecifier>,
+    pub import_specifiers: Vec<'a, ImportDeclarationSpecifier<'a>>,
 }
 
 impl<'a> SeparatedList<'a> for ImportSpecifierList<'a> {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -73,7 +73,7 @@ impl<'a> ParserImpl<'a> {
     // Full Syntax: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#syntax>
     fn parse_import_declaration_specifiers(
         &mut self,
-    ) -> Result<Vec<'a, ImportDeclarationSpecifier>> {
+    ) -> Result<Vec<'a, ImportDeclarationSpecifier<'a>>> {
         let mut specifiers = self.ast.new_vec();
         // import defaultExport from "module-name";
         if self.cur_kind().is_binding_identifier() {
@@ -104,7 +104,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     // import default from "module-name"
-    fn parse_import_default_specifier(&mut self) -> Result<ImportDeclarationSpecifier> {
+    fn parse_import_default_specifier(&mut self) -> Result<ImportDeclarationSpecifier<'a>> {
         let span = self.start_span();
         let local = self.parse_binding_identifier()?;
         Ok(ImportDeclarationSpecifier::ImportDefaultSpecifier(ImportDefaultSpecifier {
@@ -114,7 +114,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     // import * as name from "module-name"
-    fn parse_import_namespace_specifier(&mut self) -> Result<ImportDeclarationSpecifier> {
+    fn parse_import_namespace_specifier(&mut self) -> Result<ImportDeclarationSpecifier<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `*`
         self.expect(Kind::As)?;
@@ -126,7 +126,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     // import { export1 , export2 as alias2 , [...] } from "module-name";
-    fn parse_import_specifiers(&mut self) -> Result<Vec<'a, ImportDeclarationSpecifier>> {
+    fn parse_import_specifiers(&mut self) -> Result<Vec<'a, ImportDeclarationSpecifier<'a>>> {
         let ctx = self.ctx;
         self.ctx = Context::default();
         let specifiers = ImportSpecifierList::parse(self)?.import_specifiers;
@@ -167,7 +167,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_export_namespace(
         &mut self,
-    ) -> Result<Box<'a, TSNamespaceExportDeclaration>> {
+    ) -> Result<Box<'a, TSNamespaceExportDeclaration<'a>>> {
         let span = self.start_span();
         self.expect(Kind::As)?;
         self.expect(Kind::Namespace)?;
@@ -377,7 +377,7 @@ impl<'a> ParserImpl<'a> {
     // ImportSpecifier :
     //   ImportedBinding
     //   ModuleExportName as ImportedBinding
-    pub(crate) fn parse_import_specifier(&mut self) -> Result<ImportSpecifier> {
+    pub(crate) fn parse_import_specifier(&mut self) -> Result<ImportSpecifier<'a>> {
         let specifier_span = self.start_span();
         let peek_kind = self.peek_kind();
         let mut import_kind = ImportOrExportKind::Value;
@@ -414,7 +414,7 @@ impl<'a> ParserImpl<'a> {
     // ModuleExportName :
     //   IdentifierName
     //   StringLiteral
-    pub(crate) fn parse_module_export_name(&mut self) -> Result<ModuleExportName> {
+    pub(crate) fn parse_module_export_name(&mut self) -> Result<ModuleExportName<'a>> {
         match self.cur_kind() {
             Kind::Str => {
                 let literal = self.parse_literal_string()?;

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -14,7 +14,7 @@ impl<'a> ParserImpl<'a> {
     // Section 12
     // The InputElementHashbangOrRegExp goal is used at the start of a Script
     // or Module.
-    pub(crate) fn parse_hashbang(&mut self) -> Option<Hashbang> {
+    pub(crate) fn parse_hashbang(&mut self) -> Option<Hashbang<'a>> {
         if self.cur_kind() == Kind::HashbangComment {
             let span = self.start_span();
             self.bump_any();
@@ -33,7 +33,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_directives_and_statements(
         &mut self,
         is_top_level: bool,
-    ) -> Result<(Vec<'a, Directive>, Vec<'a, Statement<'a>>)> {
+    ) -> Result<(Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>)> {
         let mut directives = self.ast.new_vec();
         let mut statements = self.ast.new_vec();
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -153,7 +153,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_jsx_member_expression(
         &mut self,
         span: Span,
-        object: JSXIdentifier,
+        object: JSXIdentifier<'a>,
     ) -> Result<Box<'a, JSXMemberExpression<'a>>> {
         let mut span = span;
         let mut object = JSXMemberExpressionObject::Identifier(object);
@@ -353,7 +353,7 @@ impl<'a> ParserImpl<'a> {
     ///   `IdentifierStart`
     ///   `JSXIdentifier` `IdentifierPart`
     ///   `JSXIdentifier` [no `WhiteSpace` or Comment here] -
-    fn parse_jsx_identifier(&mut self) -> Result<JSXIdentifier> {
+    fn parse_jsx_identifier(&mut self) -> Result<JSXIdentifier<'a>> {
         let span = self.start_span();
         if !self.at(Kind::Ident) && !self.cur_kind().is_all_keyword() {
             return Err(self.unexpected());
@@ -366,7 +366,7 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.jsx_identifier(span, name.into()))
     }
 
-    fn parse_jsx_text(&mut self) -> JSXText {
+    fn parse_jsx_text(&mut self) -> JSXText<'a> {
         let span = self.start_span();
         let value = Atom::from(self.cur_string());
         self.bump_any();

--- a/crates/oxc_prettier/src/format/block.rs
+++ b/crates/oxc_prettier/src/format/block.rs
@@ -9,7 +9,7 @@ use crate::{
 pub(super) fn print_block<'a>(
     p: &mut Prettier<'a>,
     stmts: &[Statement<'a>],
-    directives: Option<&[Directive]>,
+    directives: Option<&[Directive<'a>]>,
 ) -> Doc<'a> {
     let mut parts = p.vec();
     parts.push(ss!("{"));
@@ -52,7 +52,7 @@ pub(super) fn print_block<'a>(
 pub(super) fn print_block_body<'a>(
     p: &mut Prettier<'a>,
     stmts: &[Statement<'a>],
-    directives: Option<&[Directive]>,
+    directives: Option<&[Directive<'a>]>,
     remove_last_statement_hardline: bool,
     is_root: bool,
 ) -> Option<Doc<'a>> {

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -79,13 +79,13 @@ impl<'a> Format<'a> for Program<'a> {
     }
 }
 
-impl<'a> Format<'a> for Hashbang {
+impl<'a> Format<'a> for Hashbang<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         Doc::Str(self.span.source_text(p.source_text))
     }
 }
 
-impl<'a> Format<'a> for Directive {
+impl<'a> Format<'a> for Directive<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
         parts.push(Doc::Str(string::print_string(
@@ -332,7 +332,7 @@ impl<'a> Format<'a> for DoWhileStatement<'a> {
     }
 }
 
-impl<'a> Format<'a> for ContinueStatement {
+impl<'a> Format<'a> for ContinueStatement<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
         parts.push(ss!("continue"));
@@ -346,7 +346,7 @@ impl<'a> Format<'a> for ContinueStatement {
     }
 }
 
-impl<'a> Format<'a> for BreakStatement {
+impl<'a> Format<'a> for BreakStatement<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
         parts.push(ss!("break"));
@@ -970,7 +970,7 @@ impl<'a> Format<'a> for TSTypeName<'a> {
     }
 }
 
-impl<'a> Format<'a> for TSExternalModuleReference {
+impl<'a> Format<'a> for TSExternalModuleReference<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         array!(p, ss!("require("), format!(p, self.expression), ss!(")"))
     }
@@ -1058,7 +1058,7 @@ impl<'a> Format<'a> for ImportDeclaration<'a> {
     }
 }
 
-impl<'a> Format<'a> for ImportDeclarationSpecifier {
+impl<'a> Format<'a> for ImportDeclarationSpecifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         match self {
             Self::ImportSpecifier(specifier) => specifier.format(p),
@@ -1068,7 +1068,7 @@ impl<'a> Format<'a> for ImportDeclarationSpecifier {
     }
 }
 
-impl<'a> Format<'a> for ImportSpecifier {
+impl<'a> Format<'a> for ImportSpecifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         if self.imported.span() == self.local.span {
             self.local.format(p)
@@ -1078,25 +1078,25 @@ impl<'a> Format<'a> for ImportSpecifier {
     }
 }
 
-impl<'a> Format<'a> for ImportDefaultSpecifier {
+impl<'a> Format<'a> for ImportDefaultSpecifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         self.local.format(p)
     }
 }
 
-impl<'a> Format<'a> for ImportNamespaceSpecifier {
+impl<'a> Format<'a> for ImportNamespaceSpecifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         array!(p, ss!("* as "), self.local.format(p))
     }
 }
 
-impl<'a> Format<'a> for Option<Vec<'a, ImportAttribute>> {
+impl<'a> Format<'a> for Option<Vec<'a, ImportAttribute<'a>>> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }
 }
 
-impl<'a> Format<'a> for ImportAttribute {
+impl<'a> Format<'a> for ImportAttribute<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }
@@ -1126,13 +1126,13 @@ impl<'a> Format<'a> for TSExportAssignment<'a> {
     }
 }
 
-impl<'a> Format<'a> for TSNamespaceExportDeclaration {
+impl<'a> Format<'a> for TSNamespaceExportDeclaration<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }
 }
 
-impl<'a> Format<'a> for ExportSpecifier {
+impl<'a> Format<'a> for ExportSpecifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         if self.exported.span() == self.local.span() {
             self.local.format(p)
@@ -1142,7 +1142,7 @@ impl<'a> Format<'a> for ExportSpecifier {
     }
 }
 
-impl<'a> Format<'a> for ModuleExportName {
+impl<'a> Format<'a> for ModuleExportName<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         match self {
             Self::Identifier(ident) => ident.format(p),
@@ -1227,25 +1227,25 @@ impl<'a> Format<'a> for Expression<'a> {
     }
 }
 
-impl<'a> Format<'a> for IdentifierReference {
+impl<'a> Format<'a> for IdentifierReference<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         wrap!(p, self, IdentifierReference, { p.str(self.name.as_str()) })
     }
 }
 
-impl<'a> Format<'a> for IdentifierName {
+impl<'a> Format<'a> for IdentifierName<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         p.str(self.name.as_str())
     }
 }
 
-impl<'a> Format<'a> for BindingIdentifier {
+impl<'a> Format<'a> for BindingIdentifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         wrap!(p, self, BindingIdentifier, { p.str(self.name.as_str()) })
     }
 }
 
-impl<'a> Format<'a> for LabelIdentifier {
+impl<'a> Format<'a> for LabelIdentifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         p.str(self.name.as_str())
     }
@@ -1336,7 +1336,7 @@ impl<'a> Format<'a> for NumericLiteral<'a> {
     }
 }
 
-impl<'a> Format<'a> for BigintLiteral {
+impl<'a> Format<'a> for BigintLiteral<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let text = self.span.source_text(p.source_text);
         // Perf: avoid a memory allocation from `to_ascii_lowercase`.
@@ -1348,7 +1348,7 @@ impl<'a> Format<'a> for BigintLiteral {
     }
 }
 
-impl<'a> Format<'a> for RegExpLiteral {
+impl<'a> Format<'a> for RegExpLiteral<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
         parts.push(ss!("/"));
@@ -1359,7 +1359,7 @@ impl<'a> Format<'a> for RegExpLiteral {
     }
 }
 
-impl<'a> Format<'a> for StringLiteral {
+impl<'a> Format<'a> for StringLiteral<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         wrap!(p, self, StringLiteral, {
             let raw = &p.source_text[(self.span.start + 1) as usize..(self.span.end - 1) as usize];
@@ -1871,7 +1871,7 @@ impl<'a> Format<'a> for TemplateLiteral<'a> {
     }
 }
 
-impl<'a> Format<'a> for TemplateElement {
+impl<'a> Format<'a> for TemplateElement<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         // TODO: `replaceEndOfLine`
         p.str(self.value.raw.as_str())
@@ -1941,7 +1941,7 @@ impl<'a> Format<'a> for NewExpression<'a> {
     }
 }
 
-impl<'a> Format<'a> for MetaProperty {
+impl<'a> Format<'a> for MetaProperty<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         array![p, format!(p, self.meta), ss!("."), format!(p, self.property)]
     }
@@ -1973,7 +1973,7 @@ impl<'a> Format<'a> for ClassElement<'a> {
     }
 }
 
-impl<'a> Format<'a> for JSXIdentifier {
+impl<'a> Format<'a> for JSXIdentifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }
@@ -1997,7 +1997,7 @@ impl<'a> Format<'a> for JSXElementName<'a> {
     }
 }
 
-impl<'a> Format<'a> for JSXNamespacedName {
+impl<'a> Format<'a> for JSXNamespacedName<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }
@@ -2081,7 +2081,7 @@ impl<'a> Format<'a> for JSXClosingFragment {
     }
 }
 
-impl<'a> Format<'a> for JSXText {
+impl<'a> Format<'a> for JSXText<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }
@@ -2133,7 +2133,7 @@ impl<'a> Format<'a> for AccessorProperty<'a> {
     }
 }
 
-impl<'a> Format<'a> for PrivateIdentifier {
+impl<'a> Format<'a> for PrivateIdentifier<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
         parts.push(ss!("#"));

--- a/crates/oxc_prettier/src/format/template_literal.rs
+++ b/crates/oxc_prettier/src/format/template_literal.rs
@@ -13,7 +13,7 @@ pub enum TemplateLiteralPrinter<'a, 'b> {
 }
 
 impl<'a, 'b> TemplateLiteralPrinter<'a, 'b> {
-    fn quasis(&self) -> &[TemplateElement] {
+    fn quasis(&self) -> &[TemplateElement<'a>] {
         match self {
             Self::TemplateLiteral(template_literal) => &template_literal.quasis,
             Self::TSTemplateLiteralType(template_literal) => &template_literal.quasis,
@@ -31,9 +31,9 @@ impl<'a, 'b> TemplateLiteralPrinter<'a, 'b> {
     }
 }
 
-pub(super) fn print_template_literal<'a>(
+pub(super) fn print_template_literal<'a, 'b>(
     p: &mut Prettier<'a>,
-    template_literal: &TemplateLiteralPrinter<'a, '_>,
+    template_literal: &'b TemplateLiteralPrinter<'a, 'b>,
 ) -> Doc<'a> {
     let mut parts = p.vec();
     parts.push(ss!("`"));

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -68,7 +68,7 @@ impl<'a> Binder for VariableDeclarator<'a> {
                 builder.declare_symbol_on_scope(span, name, current_scope_id, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
             for scope_id in &var_scope_ids {
-                builder.scope.add_binding(*scope_id, name.clone(), symbol_id);
+                builder.scope.add_binding(*scope_id, name.to_compact_string(), symbol_id);
             }
         });
     }
@@ -280,19 +280,19 @@ fn declare_symbol_for_import_specifier(ident: &BindingIdentifier, builder: &mut 
     ident.symbol_id.set(Some(symbol_id));
 }
 
-impl Binder for ImportSpecifier {
+impl<'a> Binder for ImportSpecifier<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         declare_symbol_for_import_specifier(&self.local, builder);
     }
 }
 
-impl Binder for ImportDefaultSpecifier {
+impl<'a> Binder for ImportDefaultSpecifier<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         declare_symbol_for_import_specifier(&self.local, builder);
     }
 }
 
-impl Binder for ImportNamespaceSpecifier {
+impl<'a> Binder for ImportNamespaceSpecifier<'a> {
     fn bind(&self, builder: &mut SemanticBuilder) {
         declare_symbol_for_import_specifier(&self.local, builder);
     }

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -89,11 +89,11 @@ fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>)
     }
 }
 
-fn check_duplicate_bound_names<T: BoundNames>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
-    let mut idents: FxHashMap<Atom, Span> = FxHashMap::default();
+fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
+    let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
     bound_names.bound_names(&mut |ident| {
         if let Some(old_span) = idents.insert(ident.name.clone(), ident.span) {
-            ctx.error(Redeclaration(ident.name.clone(), old_span, ident.span));
+            ctx.error(Redeclaration(ident.name.to_compact_string(), old_span, ident.span));
         }
     });
 }

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -65,7 +65,7 @@ impl ClassTableBuilder {
                 self.classes.add_element(
                     class_id,
                     Element::new(
-                        name,
+                        name.to_compact_string(),
                         property.key.span(),
                         property.r#static,
                         is_private,
@@ -86,7 +86,7 @@ impl ClassTableBuilder {
                 self.classes.add_element(
                     class_id,
                     Element::new(
-                        name,
+                        name.to_compact_string(),
                         property.key.span(),
                         property.r#static,
                         is_private,
@@ -112,7 +112,7 @@ impl ClassTableBuilder {
 
                     let reference = PrivateIdentifierReference::new(
                         current_node_id,
-                        ident.name.clone(),
+                        ident.name.to_compact_string(),
                         ident.span,
                         element_ids,
                     );
@@ -134,7 +134,7 @@ impl ClassTableBuilder {
                 self.classes.add_element(
                     class_id,
                     Element::new(
-                        name,
+                        name.to_compact_string(),
                         method.key.span(),
                         method.r#static,
                         is_private,

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -1,5 +1,5 @@
 use oxc_index::IndexVec;
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, CompactString, Span};
 use oxc_syntax::class::{ClassId, ElementId, ElementKind};
 use rustc_hash::FxHashMap;
 
@@ -7,7 +7,7 @@ use crate::node::AstNodeId;
 
 #[derive(Debug)]
 pub struct Element {
-    pub name: Atom,
+    pub name: CompactString,
     pub span: Span,
     pub is_private: bool,
     pub r#static: bool,
@@ -16,7 +16,7 @@ pub struct Element {
 
 impl Element {
     pub fn new(
-        name: Atom,
+        name: CompactString,
         span: Span,
         r#static: bool,
         is_private: bool,
@@ -29,13 +29,18 @@ impl Element {
 #[derive(Debug)]
 pub struct PrivateIdentifierReference {
     pub id: AstNodeId,
-    pub name: Atom,
+    pub name: CompactString,
     pub span: Span,
     pub element_ids: Vec<ElementId>,
 }
 
 impl PrivateIdentifierReference {
-    pub fn new(id: AstNodeId, name: Atom, span: Span, element_ids: Vec<ElementId>) -> Self {
+    pub fn new(
+        id: AstNodeId,
+        name: CompactString,
+        span: Span,
+        element_ids: Vec<ElementId>,
+    ) -> Self {
         Self { id, name, span, element_ids }
     }
 }
@@ -93,8 +98,8 @@ impl ClassTable {
         element_ids
     }
 
-    pub fn has_private_definition(&self, class_id: ClassId, name: &Atom) -> bool {
-        self.elements[class_id].iter().any(|p| p.is_private && p.name == *name)
+    pub fn has_private_definition(&self, class_id: ClassId, name: &str) -> bool {
+        self.elements[class_id].iter().any(|p| p.is_private && p.name == name)
     }
 
     pub fn declare_class(&mut self, parent_id: Option<ClassId>, ast_node_id: AstNodeId) -> ClassId {

--- a/crates/oxc_semantic/src/control_flow.rs
+++ b/crates/oxc_semantic/src/control_flow.rs
@@ -1,4 +1,4 @@
-use oxc_span::Atom;
+use oxc_span::CompactString;
 use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
 };
@@ -14,8 +14,8 @@ pub enum Register {
 
 #[derive(Debug, Clone)]
 pub enum ObjectPropertyAccessBy {
-    PrivateProperty(Atom),
-    Property(Atom),
+    PrivateProperty(CompactString),
+    Property(CompactString),
     Expression(Register),
 }
 
@@ -139,8 +139,8 @@ pub struct ControlFlowGraph {
     pub basic_blocks_with_continues: Vec<Vec<NodeIndex>>,
     // node indexes of the basic blocks of switch case conditions
     pub switch_case_conditions: Vec<Vec<NodeIndex>>,
-    pub next_label: Option<Atom>,
-    pub label_to_ast_node_ix: Vec<(Atom, AstNodeId)>,
+    pub next_label: Option<CompactString>,
+    pub label_to_ast_node_ix: Vec<(CompactString, AstNodeId)>,
     pub ast_node_to_break_continue: Vec<(AstNodeId, usize, Option<usize>)>,
     pub after_throw_block: Option<NodeIndex>,
 }

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -2,13 +2,13 @@ use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::{self, Error},
 };
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Identifier `{0}` has already been declared")]
 #[diagnostic()]
 pub struct Redeclaration(
-    pub Atom,
+    pub CompactString,
     #[label("`{0}` has already been declared here")] pub Span,
     #[label("It can not be redeclared here")] pub Span,
 );

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -127,7 +127,7 @@ impl<'a> Semantic<'a> {
         let AstKind::IdentifierReference(id) = reference_node.kind() else {
             return false;
         };
-        self.scopes().root_unresolved_references().contains_key(&id.name)
+        self.scopes().root_unresolved_references().contains_key(id.name.as_str())
     }
 
     /// Find which scope a symbol is declared in
@@ -145,7 +145,7 @@ impl<'a> Semantic<'a> {
     }
 
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
-        self.scopes().root_unresolved_references().contains_key(&ident.name)
+        self.scopes().root_unresolved_references().contains_key(ident.name.as_str())
     }
 
     pub fn redeclare_variables(&self) -> &Vec<VariableInfo> {
@@ -212,7 +212,7 @@ mod tests {
         let top_level_a = semantic
             .scopes()
             .iter_bindings()
-            .find(|(_scope_id, _symbol_id, name)| name == &Atom::from("Fn"))
+            .find(|(_scope_id, _symbol_id, name)| name.as_str() == "Fn")
             .unwrap();
         assert_eq!(semantic.symbols.get_scope_id(top_level_a.1), top_level_a.0);
     }

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,4 +1,4 @@
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactString, Span};
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub use oxc_syntax::reference::{ReferenceFlag, ReferenceId};
 pub struct Reference {
     span: Span,
     /// The name of the identifier that was referred to
-    name: Atom,
+    name: CompactString,
     node_id: AstNodeId,
     symbol_id: Option<SymbolId>,
     /// Describes how this referenced is used by other AST nodes. References can
@@ -21,7 +21,7 @@ pub struct Reference {
 }
 
 impl Reference {
-    pub fn new(span: Span, name: Atom, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
+    pub fn new(span: Span, name: CompactString, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
         Self { span, name, node_id, symbol_id: None, flag }
     }
 
@@ -29,7 +29,7 @@ impl Reference {
         self.span
     }
 
-    pub fn name(&self) -> &Atom {
+    pub fn name(&self) -> &CompactString {
         &self.name
     }
 

--- a/crates/oxc_semantic/tests/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/util/symbol_tester.rs
@@ -39,8 +39,11 @@ impl<'a> SymbolTester<'a> {
         semantic: Semantic<'a>,
         target: &str,
     ) -> Self {
-        let symbols_with_target_name: Vec<_> =
-            semantic.scopes().iter_bindings().filter(|(_, _, name)| name == &target).collect();
+        let symbols_with_target_name: Vec<_> = semantic
+            .scopes()
+            .iter_bindings()
+            .filter(|(_, _, name)| name.as_str() == target)
+            .collect();
         let data = match symbols_with_target_name.len() {
             0 => Err(miette!("Could not find declaration for {target}")),
             1 => Ok(symbols_with_target_name.iter().map(|(_, symbol_id, _)| *symbol_id).next().unwrap()),
@@ -139,7 +142,7 @@ impl<'a> SymbolTester<'a> {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
                 let binding = Atom::from(self.target_symbol_name.clone());
-                if self.semantic.module_record().exported_bindings.contains_key(&binding)
+                if self.semantic.module_record().exported_bindings.contains_key(binding.as_str())
                     && self.semantic.scopes().get_root_binding(&binding) == Some(symbol_id)
                 {
                     Ok(symbol_id)

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 [dependencies]
 miette           = { workspace = true }
 inlinable_string = "0.1.15"
+compact_str      = { version = "0.7.1", features = ["serde"] }
 
 tsify        = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -11,3 +11,4 @@ pub use crate::{
     source_type::{Language, LanguageVariant, ModuleKind, SourceType, VALID_EXTENSIONS},
     span::{GetSpan, Span, SPAN},
 };
+pub use compact_str::CompactString;

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -4,8 +4,9 @@ use std::{fmt, hash::BuildHasherDefault, path::PathBuf, sync::Arc};
 
 use dashmap::DashMap;
 use indexmap::IndexMap;
-use oxc_span::{Atom, Span};
 use rustc_hash::{FxHashMap, FxHasher};
+
+use oxc_span::{CompactString, Span};
 
 /// Module Record
 ///
@@ -26,13 +27,13 @@ pub struct ModuleRecord {
     ///   import ModuleSpecifier
     ///   export ExportFromClause FromClause
     /// Keyed by ModuleSpecifier, valued by all node occurrences
-    pub requested_modules: IndexMap<Atom, Vec<Span>, BuildHasherDefault<FxHasher>>,
+    pub requested_modules: IndexMap<CompactString, Vec<Span>, BuildHasherDefault<FxHasher>>,
 
     /// `[[LoadedModules]]`
     ///
     /// A map from the specifier strings used by the module represented by this record to request the importation of a module to the resolved Module Record.
     /// The list does not contain two different Records with the same `[[Specifier]]`.
-    pub loaded_modules: DashMap<Atom, Arc<ModuleRecord>, BuildHasherDefault<FxHasher>>,
+    pub loaded_modules: DashMap<CompactString, Arc<ModuleRecord>, BuildHasherDefault<FxHasher>>,
 
     /// `[[ImportEntries]]`
     ///
@@ -59,7 +60,7 @@ pub struct ModuleRecord {
     /// not including export * as namespace declarations.
     pub star_export_entries: Vec<ExportEntry>,
 
-    pub exported_bindings: FxHashMap<Atom, Span>,
+    pub exported_bindings: FxHashMap<CompactString, Span>,
     pub exported_bindings_duplicated: Vec<NameSpan>,
 
     pub export_default: Option<Span>,
@@ -100,16 +101,16 @@ impl fmt::Debug for ModuleRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NameSpan {
-    name: Atom,
+    name: CompactString,
     span: Span,
 }
 
 impl NameSpan {
-    pub fn new(name: Atom, span: Span) -> Self {
+    pub fn new(name: CompactString, span: Span) -> Self {
         Self { name, span }
     }
 
-    pub fn name(&self) -> &Atom {
+    pub fn name(&self) -> &CompactString {
         &self.name
     }
 

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -7,7 +7,7 @@ use std::{
 use oxc_ast::AstBuilder;
 use oxc_diagnostics::Error;
 use oxc_semantic::{ScopeId, ScopeTree, Semantic, SymbolId, SymbolTable};
-use oxc_span::{Atom, SourceType};
+use oxc_span::{CompactString, SourceType};
 
 #[derive(Clone)]
 pub struct TransformerCtx<'a> {
@@ -37,7 +37,7 @@ impl<'a> TransformerCtx<'a> {
         RefMut::map(self.semantic.borrow_mut(), |semantic| semantic.scopes_mut())
     }
 
-    pub fn add_binding(&self, name: Atom) {
+    pub fn add_binding(&self, name: CompactString) {
         // TODO: use the correct scope and symbol id
         self.scopes_mut().add_binding(ScopeId::new(0), name, SymbolId::new(0));
     }

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -41,7 +41,7 @@ impl<'a> VisitMut<'a> for ArrowFunctions<'a> {
         self.nodes.pop();
     }
 
-    fn visit_jsx_identifier(&mut self, ident: &mut JSXIdentifier) {
+    fn visit_jsx_identifier(&mut self, ident: &mut JSXIdentifier<'a>) {
         let parent_kind = self.nodes.last().unwrap();
         let parent_parent_kind = self.nodes[self.nodes.len() - 2];
         if ident.name == "this"
@@ -69,9 +69,9 @@ impl<'a> ArrowFunctions<'a> {
         })
     }
 
-    fn get_this_name(&self) -> Atom {
+    fn get_this_name(&self) -> Atom<'a> {
         let uid = if self.uid == 1 { String::new() } else { self.uid.to_string() };
-        format!("_this{uid}",).into()
+        self.ast.new_atom(&format!("_this{uid}"))
     }
 
     pub fn transform_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>) {

--- a/crates/oxc_transformer/src/es2015/duplicate_keys.rs
+++ b/crates/oxc_transformer/src/es2015/duplicate_keys.rs
@@ -64,7 +64,7 @@ impl<'a> DuplicateKeys<'a> {
 
                 if is_duplicate {
                     obj_property.computed = true;
-                    let string_literal = StringLiteral::new(SPAN, name.as_str().into());
+                    let string_literal = StringLiteral::new(SPAN, name.clone());
                     let expr = self.ast.literal_string_expression(string_literal);
                     obj_property.key = PropertyKey::Expression(expr);
                 }

--- a/crates/oxc_transformer/src/es2015/function_name.rs
+++ b/crates/oxc_transformer/src/es2015/function_name.rs
@@ -111,7 +111,7 @@ impl<'a> FunctionName<'a> {
     fn transform_expression(
         &mut self,
         expr: &mut Expression<'a>,
-        mut id: BindingIdentifier,
+        mut id: BindingIdentifier<'a>,
         scope_id: Option<ScopeId>,
     ) {
         // function () {} -> function name() {}

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -25,7 +25,7 @@ impl<'a> ClassStaticBlock<'a> {
             return;
         }
 
-        let private_names: HashSet<Atom> = class_body
+        let private_names: HashSet<Atom<'a>> = class_body
             .body
             .iter()
             .filter_map(ClassElement::property_key)
@@ -107,7 +107,7 @@ impl<'a> ClassStaticBlock<'a> {
     }
 }
 
-fn generate_uid(deny_list: &HashSet<Atom>, i: &mut u32) -> Atom {
+fn generate_uid<'a>(deny_list: &HashSet<Atom<'a>>, i: &mut u32) -> Atom<'a> {
     *i += 1;
 
     let mut uid: Atom = if *i == 1 { "_".to_string() } else { format!("_{i}") }.into();

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -72,7 +72,7 @@ pub struct Transformer<'a> {
     // es2020
     es2020_nullish_coalescing_operators: Option<NullishCoalescingOperator<'a>>,
     // es2019
-    es2019_json_strings: Option<JsonStrings>,
+    es2019_json_strings: Option<JsonStrings<'a>>,
     es2019_optional_catch_binding: Option<OptionalCatchBinding<'a>>,
     // es2016
     es2016_exponentiation_operator: Option<ExponentiationOperator<'a>>,
@@ -114,7 +114,7 @@ impl<'a> Transformer<'a> {
             // es2020
             es2020_nullish_coalescing_operators: NullishCoalescingOperator::new(Rc::clone(&ast), ctx.clone(), &options),
             // es2019
-            es2019_json_strings: JsonStrings::new(&options),
+            es2019_json_strings: JsonStrings::new(Rc::clone(&ast), &options),
             es2019_optional_catch_binding: OptionalCatchBinding::new(Rc::clone(&ast), &options),
             // es2016
             es2016_exponentiation_operator: ExponentiationOperator::new(Rc::clone(&ast), ctx.clone(), &options),
@@ -302,7 +302,7 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
         self.leave_node(kind);
     }
 
-    fn visit_directive(&mut self, directive: &mut Directive) {
+    fn visit_directive(&mut self, directive: &mut Directive<'a>) {
         self.es2019_json_strings
             .as_mut()
             .map(|t: &mut JsonStrings| t.transform_directive(directive));

--- a/crates/oxc_transformer/src/react_jsx/mod.rs
+++ b/crates/oxc_transformer/src/react_jsx/mod.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
 };
-use oxc_span::{Atom, GetSpan, Span, SPAN};
+use oxc_span::{Atom, CompactString, GetSpan, Span, SPAN};
 use oxc_syntax::{
     identifier::{is_irregular_whitespace, is_line_terminator},
     xml_entities::XML_ENTITIES,
@@ -58,7 +58,7 @@ pub struct ReactJsx<'a> {
     import_fragment: bool,
     import_create_element: bool,
     require_jsx_runtime: bool,
-    jsx_runtime_importer: Atom,
+    jsx_runtime_importer: CompactString,
     pub babel_8_breaking: Option<bool>,
     default_runtime: ReactJsxRuntime,
 }
@@ -129,9 +129,9 @@ impl<'a> ReactJsx<'a> {
 
         let jsx_runtime_importer =
             if jsx_options.import_source == "react" || default_runtime.is_classic() {
-                Atom::new_inline("react/jsx-runtime")
+                CompactString::from("react/jsx-runtime")
             } else {
-                Atom::from(format!("{}/jsx-runtime", jsx_options.import_source))
+                CompactString::from(format!("{}/jsx-runtime", jsx_options.import_source))
             };
         Some(Self {
             ast,
@@ -209,8 +209,8 @@ impl<'a> ReactJsx<'a> {
         program.body.splice(index..index, imports);
     }
 
-    fn new_string_literal(name: &str) -> StringLiteral {
-        StringLiteral::new(SPAN, name.into())
+    fn new_string_literal(&self, name: &str) -> StringLiteral<'a> {
+        StringLiteral::new(SPAN, self.ast.new_atom(name))
     }
 
     fn add_import<'b>(
@@ -242,7 +242,7 @@ impl<'a> ReactJsx<'a> {
             self.require_jsx_runtime = true;
             self.add_require_statement(
                 "_reactJsxRuntime",
-                Self::new_string_literal(self.jsx_runtime_importer.as_str()),
+                self.new_string_literal(self.jsx_runtime_importer.as_str()),
                 false,
             );
         }
@@ -256,7 +256,7 @@ impl<'a> ReactJsx<'a> {
             self.add_import_statement(
                 "jsx",
                 "_jsx",
-                Self::new_string_literal(self.jsx_runtime_importer.as_str()),
+                self.new_string_literal(self.jsx_runtime_importer.as_str()),
             );
         }
     }
@@ -266,7 +266,7 @@ impl<'a> ReactJsx<'a> {
             self.add_require_jsx_runtime();
         } else if !self.import_jsxs {
             self.import_jsxs = true;
-            let source = Self::new_string_literal(self.jsx_runtime_importer.as_str());
+            let source = self.new_string_literal(self.jsx_runtime_importer.as_str());
             self.add_import_statement("jsxs", "_jsxs", source);
         }
     }
@@ -276,7 +276,7 @@ impl<'a> ReactJsx<'a> {
             self.add_require_jsx_runtime();
         } else if !self.import_fragment {
             self.import_fragment = true;
-            let source = Self::new_string_literal(self.jsx_runtime_importer.as_str());
+            let source = self.new_string_literal(self.jsx_runtime_importer.as_str());
             self.add_import_statement("Fragment", "_Fragment", source);
             self.add_import_jsx();
         }
@@ -289,22 +289,25 @@ impl<'a> ReactJsx<'a> {
             if self.ctx.source_type().is_script() {
                 self.add_require_statement(
                     "_react",
-                    Self::new_string_literal(self.options.import_source.as_ref()),
+                    self.new_string_literal(self.options.import_source.as_ref()),
                     true,
                 );
             } else {
-                let source = Self::new_string_literal(self.options.import_source.as_ref());
+                let source = self.new_string_literal(self.options.import_source.as_ref());
                 self.add_import_statement("createElement", "_createElement", source);
             }
         }
     }
 
-    fn add_import_statement(&mut self, imported: &str, local: &str, source: StringLiteral) {
+    fn add_import_statement(&mut self, imported: &str, local: &str, source: StringLiteral<'a>) {
         let mut specifiers = self.ast.new_vec_with_capacity(1);
         specifiers.push(ImportDeclarationSpecifier::ImportSpecifier(ImportSpecifier {
             span: SPAN,
-            imported: ModuleExportName::Identifier(IdentifierName::new(SPAN, imported.into())),
-            local: BindingIdentifier::new(SPAN, local.into()),
+            imported: ModuleExportName::Identifier(IdentifierName::new(
+                SPAN,
+                self.ast.new_atom(imported),
+            )),
+            local: BindingIdentifier::new(SPAN, self.ast.new_atom(local)),
             import_kind: ImportOrExportKind::Value,
         }));
         let import_statement = self.ast.import_declaration(
@@ -319,7 +322,12 @@ impl<'a> ReactJsx<'a> {
         self.imports.push(decl);
     }
 
-    fn add_require_statement(&mut self, variable_name: &str, source: StringLiteral, front: bool) {
+    fn add_require_statement(
+        &mut self,
+        variable_name: &str,
+        source: StringLiteral<'a>,
+        front: bool,
+    ) {
         let callee = self
             .ast
             .identifier_reference_expression(IdentifierReference::new(SPAN, "require".into()));
@@ -328,7 +336,10 @@ impl<'a> ReactJsx<'a> {
             .new_vec_single(Argument::Expression(self.ast.literal_string_expression(source)));
         let init = self.ast.call_expression(SPAN, callee, arguments, false, None);
         let id = self.ast.binding_pattern(
-            self.ast.binding_pattern_identifier(BindingIdentifier::new(SPAN, variable_name.into())),
+            self.ast.binding_pattern_identifier(BindingIdentifier::new(
+                SPAN,
+                self.ast.new_atom(variable_name),
+            )),
             None,
             false,
         );
@@ -486,8 +497,8 @@ impl<'a> ReactJsx<'a> {
         object_ident_name: &str,
         property_name: &str,
     ) -> Expression<'a> {
-        let property = IdentifierName::new(SPAN, property_name.into());
-        let ident = IdentifierReference::new(SPAN, object_ident_name.into());
+        let property = IdentifierName::new(SPAN, self.ast.new_atom(property_name));
+        let ident = IdentifierReference::new(SPAN, self.ast.new_atom(object_ident_name));
         let object = self.ast.identifier_reference_expression(ident);
         self.ast.static_member_expression(SPAN, object, property, false)
     }
@@ -499,7 +510,7 @@ impl<'a> ReactJsx<'a> {
         let property = callee.next();
         property.map_or_else(
             || {
-                let ident = IdentifierReference::new(SPAN, member.into());
+                let ident = IdentifierReference::new(SPAN, self.ast.new_atom(member));
                 self.ast.identifier_reference_expression(ident)
             },
             |property_name| self.get_static_member_expression(member, property_name),

--- a/crates/oxc_transformer/src/regexp/regexp_flags.rs
+++ b/crates/oxc_transformer/src/regexp/regexp_flags.rs
@@ -53,13 +53,13 @@ impl<'a> RegexpFlags<'a> {
     // `/regex/flags` -> `new RegExp('regex', 'flags')`
     pub fn transform_expression(&self, expr: &mut Expression<'a>) {
         let Expression::RegExpLiteral(literal) = expr else { return };
-        let regex = &literal.regex;
+        let regex = literal.regex.clone();
         if regex.flags.intersection(self.transform_flags).is_empty() {
             return;
         }
         let ident = IdentifierReference::new(SPAN, Atom::from("RegExp"));
         let callee = self.ast.identifier_reference_expression(ident);
-        let pattern = StringLiteral::new(SPAN, Atom::from(regex.pattern.as_str()));
+        let pattern = StringLiteral::new(SPAN, regex.pattern.clone());
         let flags = StringLiteral::new(SPAN, Atom::from(regex.flags.to_string()));
         let pattern_literal = self.ast.literal_string_expression(pattern);
         let flags_literal = self.ast.literal_string_expression(flags);

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -24,9 +24,9 @@ pub struct TypeScript<'a> {
     ast: Rc<AstBuilder<'a>>,
     ctx: TransformerCtx<'a>,
     verbatim_module_syntax: bool,
-    export_name_set: FxHashSet<Atom>,
+    export_name_set: FxHashSet<Atom<'a>>,
     options: TypescriptOptions,
-    namespace_arg_names: FxHashMap<Atom, usize>,
+    namespace_arg_names: FxHashMap<Atom<'a>, usize>,
 }
 
 impl<'a> TypeScript<'a> {
@@ -318,7 +318,7 @@ impl<'a> TypeScript<'a> {
     fn transform_ts_enum_members(
         &self,
         members: &mut Vec<'a, TSEnumMember<'a>>,
-        enum_name: &Atom,
+        enum_name: &Atom<'a>,
     ) -> Vec<'a, Statement<'a>> {
         let mut default_init = self.ast.literal_number_expression(NumericLiteral {
             span: SPAN,
@@ -668,7 +668,7 @@ impl<'a> TypeScript<'a> {
         }
     }
 
-    fn get_namespace_arg_name(&mut self, name: &Atom) -> Atom {
+    fn get_namespace_arg_name(&mut self, name: &Atom<'a>) -> Atom<'a> {
         let count = self.namespace_arg_names.entry(name.clone()).or_insert(0);
         *count += 1;
         format!("_{name}{}", if *count > 1 { count.to_string() } else { String::new() }).into()

--- a/crates/oxc_transformer/src/utils.rs
+++ b/crates/oxc_transformer/src/utils.rs
@@ -25,12 +25,13 @@ pub trait CreateVars<'a> {
         stmts.insert(0, stmt);
     }
 
-    fn create_new_var(&mut self, expr: &Expression<'a>) -> IdentifierReference {
+    fn create_new_var(&mut self, expr: &Expression<'a>) -> IdentifierReference<'a> {
         let name = self.ctx().scopes().generate_uid_based_on_node(expr);
         self.ctx().add_binding(name.clone());
 
         // Add `var name` to scope
         // TODO: hookup symbol id
+        let name = self.ctx().ast.new_atom(name.as_str());
         let binding_identifier = BindingIdentifier::new(Span::default(), name.clone());
         let binding_pattern_kind = self.ctx().ast.binding_pattern_identifier(binding_identifier);
         let binding = self.ctx().ast.binding_pattern(binding_pattern_kind, None, false);
@@ -43,7 +44,10 @@ pub trait CreateVars<'a> {
 
     /// Possibly generate a memoised identifier if it is not static and has consequences.
     /// <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L578>
-    fn maybe_generate_memoised(&mut self, expr: &Expression<'a>) -> Option<IdentifierReference> {
+    fn maybe_generate_memoised(
+        &mut self,
+        expr: &Expression<'a>,
+    ) -> Option<IdentifierReference<'a>> {
         if self.ctx().symbols().is_static(expr) {
             None
         } else {

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -12,7 +12,7 @@ use walkdir::WalkDir;
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_prettier::{Prettier, PrettierOptions};
-use oxc_span::{Atom, SourceType};
+use oxc_span::SourceType;
 use oxc_tasks_common::project_root;
 
 use crate::{
@@ -257,7 +257,7 @@ impl TestRunner {
         path: &Path,
         input: &str,
         prettier_options: PrettierOptions,
-        snapshot_options: &[(Atom, String)],
+        snapshot_options: &[(String, String)],
         snap_content: &str,
     ) -> String {
         let filename = path.file_name().unwrap().to_string_lossy();

--- a/tasks/prettier_conformance/src/runner.rs
+++ b/tasks/prettier_conformance/src/runner.rs
@@ -186,7 +186,7 @@ impl TestRunner {
         path: &Path,
         input: &str,
         prettier_options: PrettierOptions,
-        snapshot_options: &[(Atom, String)],
+        snapshot_options: &[(String, String)],
         snap_content: &str,
     ) -> String {
         let filename = path.file_name().unwrap().to_string_lossy();

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -9,11 +9,11 @@ use oxc_ast::{
 };
 use oxc_parser::Parser;
 use oxc_prettier::{ArrowParens, EndOfLine, PrettierOptions, QuoteProps, TrailingComma};
-use oxc_span::{Atom, GetSpan, SourceType};
+use oxc_span::{GetSpan, SourceType};
 
 #[derive(Default)]
 pub struct SpecParser {
-    pub calls: Vec<(PrettierOptions, Vec<(Atom, String)>)>,
+    pub calls: Vec<(PrettierOptions, Vec<(String, String)>)>,
     source_text: String,
 }
 
@@ -39,7 +39,7 @@ impl VisitMut<'_> for SpecParser {
             return;
         }
         let mut parsers = vec![];
-        let mut snapshot_options = vec![];
+        let mut snapshot_options: Vec<(String, String)> = vec![];
         let mut options = PrettierOptions::default();
 
         if let Some(argument) = expr.arguments.get(1) {
@@ -110,7 +110,7 @@ impl VisitMut<'_> for SpecParser {
                         };
                         if name != "errors" {
                             snapshot_options.push((
-                                name,
+                                name.to_string(),
                                 obj_prop.value.span().source_text(&self.source_text).to_string(),
                             ));
                         }
@@ -120,7 +120,7 @@ impl VisitMut<'_> for SpecParser {
         }
 
         snapshot_options.push((
-            "parsers".into(),
+            "parsers".to_string(),
             format!(
                 "[{}]",
                 parsers.iter().map(|p| format!("\"{p}\"")).collect::<Vec<_>>().join(", ")
@@ -128,7 +128,7 @@ impl VisitMut<'_> for SpecParser {
         ));
 
         if !snapshot_options.iter().any(|item| item.0 == "printWidth") {
-            snapshot_options.push(("printWidth".into(), "80".into()));
+            snapshot_options.push(("printWidth".to_string(), "80".into()));
         }
 
         snapshot_options.sort_by(|a, b| a.0.cmp(&b.0));


### PR DESCRIPTION
Part of #2295

This PR splits the `Atom` type into `Atom<'a>` and `CompactString`.

All the AST node strings now use `Atom<'a>` instead of `Atom` to signify it belongs to the arena.

It is now up to the user to select which form of the string to use.

This PR essentially removes this really unsafe code 

https://github.com/oxc-project/oxc/blob/93742f89e91bc7c45491b6d2b49a134fa65f2b5c/crates/oxc_span/src/atom.rs#L98-L107

which can lead to 
![image](https://github.com/oxc-project/oxc/assets/1430279/8c513c4f-19b0-4b63-b61c-e07c187c95b5)
