### PR TITLE
Serialize identifiers to ESTree

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -299,7 +299,7 @@ impl<'a> Expression<'a> {
 
 /// Identifier Name
 #[derive(Debug, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct IdentifierName<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
@@ -315,13 +315,15 @@ impl<'a> IdentifierName<'a> {
 
 /// Identifier Reference
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct IdentifierReference<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_id: Cell<Option<ReferenceId>>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_flag: ReferenceFlag,
 }
 
@@ -340,12 +342,13 @@ impl<'a> IdentifierReference<'a> {
 
 /// Binding Identifier
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct BindingIdentifier<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub symbol_id: Cell<Option<SymbolId>>,
 }
 
@@ -364,7 +367,7 @@ impl<'a> BindingIdentifier<'a> {
 
 /// Label Identifier
 #[derive(Debug, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct LabelIdentifier<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -15,6 +15,18 @@ use serde::Serialize;
 #[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
+#[cfg_attr(
+    all(feature = "serde", feature = "wasm"),
+    wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
+)]
+#[allow(dead_code)]
+const TS_APPEND_CONTENT: &'static str = r#"
+export interface BindingIdentifier extends Span { type: "Identifier", name: Atom }
+export interface IdentifierReference extends Span { type: "Identifier", name: Atom }
+export interface IdentifierName extends Span { type: "Identifier", name: Atom }
+export interface LabelIdentifier extends Span { type: "Identifier", name: Atom }
+"#;
+
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename_all = "camelCase"))]
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
@@ -298,11 +310,9 @@ impl<'a> Expression<'a> {
 }
 
 /// Identifier Name
+// See serializer in serialize.rs
 #[derive(Debug, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
-#[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct IdentifierName<'a> {
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
 }
@@ -314,16 +324,12 @@ impl<'a> IdentifierName<'a> {
 }
 
 /// Identifier Reference
+// See serializer in serialize.rs
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
-#[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct IdentifierReference<'a> {
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_id: Cell<Option<ReferenceId>>,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_flag: ReferenceFlag,
 }
 
@@ -341,14 +347,11 @@ impl<'a> IdentifierReference<'a> {
 }
 
 /// Binding Identifier
+// See serializer in serialize.rs
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
-#[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct BindingIdentifier<'a> {
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub symbol_id: Cell<Option<SymbolId>>,
 }
 
@@ -366,11 +369,9 @@ impl<'a> BindingIdentifier<'a> {
 }
 
 /// Label Identifier
+// See serializer in serialize.rs
 #[derive(Debug, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
-#[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct LabelIdentifier<'a> {
-    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -1,6 +1,12 @@
-use serde::{ser::Serializer, Serialize};
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Serialize,
+};
 
-use crate::ast::{Program, RegExpFlags};
+use crate::ast::{
+    BindingIdentifier, IdentifierName, IdentifierReference, LabelIdentifier, Program, RegExpFlags,
+};
+use oxc_span::{Atom, Span};
 
 pub struct EcmaFormatter;
 
@@ -32,5 +38,57 @@ impl Serialize for RegExpFlags {
         S: Serializer,
     {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+/// Serialize `BindingIdentifier`, `IdentifierReference`, `IdentifierName` and `LabelIdentifier`
+/// to be estree compatible with the `type` set to "Identifier".
+fn serialize_identifier<S: Serializer>(
+    serializer: S,
+    struct_name: &'static str,
+    span: Span,
+    name: &Atom,
+) -> Result<S::Ok, S::Error> {
+    let mut state = serializer.serialize_struct(struct_name, 4)?;
+    state.serialize_field("type", "Identifier")?;
+    state.serialize_field("start", &span.start)?;
+    state.serialize_field("end", &span.end)?;
+    state.serialize_field("name", name)?;
+    state.end()
+}
+
+impl<'a> Serialize for BindingIdentifier<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_identifier(serializer, "BindingIdentifier", self.span, &self.name)
+    }
+}
+
+impl<'a> Serialize for IdentifierReference<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_identifier(serializer, "IdentifierReference", self.span, &self.name)
+    }
+}
+
+impl<'a> Serialize for IdentifierName<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_identifier(serializer, "IdentifierName", self.span, &self.name)
+    }
+}
+
+impl<'a> Serialize for LabelIdentifier<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_identifier(serializer, "LabelIdentifier", self.span, &self.name)
     }
 }


### PR DESCRIPTION
Re #2463 

Do you want to go in this direction?

It can also be seen as a loss for people building other things on top later on (both for merging them and using skipping reference_id).

I'm also quite ok with keeping the AST as close as possible to ESTree without loosing information (align name for 1-1 nodes, camelCase name, string enum, ...) and having a small wrapper to convert to ESTree.

This wrapper could be in a first time in TS and then in Rust. Given that Prettier needs some [very custom AST transformations](https://github.com/prettier/prettier/blob/main/src/language-js/parse/postprocess/index.js), a small wrapper will be needed in that case anyway so I'm fine saying the current AST for identifier is fine as is.

Also this `rename = "Identifier"` doesn't seem to be entirely handled by the wasm-pack, the generated types looks like this:
```ts
export interface Identifier extends Span {
    type: "Identifier";
    name: Atom;
}

export interface Identifier extends Span {
    type: "Identifier";
    name: Atom;
}

export type TSTypePredicateName = IdentifierName | TSThisType;
```

