### PR TITLE
perf(parser): lex JSX strings with `memchr`

### DIFF
--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -25,6 +25,13 @@ static SINGLE_QUOTE_STRING_END_TABLE: SafeByteMatchTable =
 /// `$table` must only match `$delimiter`, '\', '\r' or '\n'.
 macro_rules! handle_string_literal {
     ($lexer:ident, $delimiter:expr, $table:ident) => {{
+        debug_assert!($delimiter.is_ascii());
+
+        if $lexer.context == LexerContext::JsxAttributeValue {
+            // SAFETY: Caller guarantees `$delimiter` is ASCII, and next char is ASCII
+            return $lexer.read_jsx_string_literal($delimiter);
+        }
+
         // Skip opening quote.
         // SAFETY: Caller guarantees next byte is ASCII, so safe to advance past it.
         let after_opening_quote = $lexer.source.position().add(1);
@@ -158,30 +165,18 @@ impl<'a> Lexer<'a> {
     /// # SAFETY
     /// Next character must be `"`.
     pub(super) unsafe fn read_string_literal_double_quote(&mut self) -> Kind {
-        if self.context == LexerContext::JsxAttributeValue {
-            // SAFETY: Caller guarantees next char is `"`
-            self.source.next_byte_unchecked();
-            self.read_jsx_string_literal('"')
-        } else {
-            // SAFETY: Caller guarantees next char is `"`, which is ASCII.
-            // b'"' is an ASCII byte. `DOUBLE_QUOTE_STRING_END_TABLE` is a `SafeByteMatchTable`.
-            unsafe { handle_string_literal!(self, b'"', DOUBLE_QUOTE_STRING_END_TABLE) }
-        }
+        // SAFETY: Caller guarantees next char is `"`, which is ASCII.
+        // b'"' is an ASCII byte. `DOUBLE_QUOTE_STRING_END_TABLE` is a `SafeByteMatchTable`.
+        unsafe { handle_string_literal!(self, b'"', DOUBLE_QUOTE_STRING_END_TABLE) }
     }
 
     /// Read string literal delimited with `'`.
     /// # SAFETY
     /// Next character must be `'`.
     pub(super) unsafe fn read_string_literal_single_quote(&mut self) -> Kind {
-        if self.context == LexerContext::JsxAttributeValue {
-            // SAFETY: Caller guarantees next char is `'`
-            self.source.next_byte_unchecked();
-            self.read_jsx_string_literal('\'')
-        } else {
-            // SAFETY: Caller guarantees next char is `"`, which is ASCII.
-            // b'\'' is an ASCII byte. `SINGLE_QUOTE_STRING_END_TABLE` is a `SafeByteMatchTable`.
-            unsafe { handle_string_literal!(self, b'\'', SINGLE_QUOTE_STRING_END_TABLE) }
-        }
+        // SAFETY: Caller guarantees next char is `'`, which is ASCII.
+        // b'\'' is an ASCII byte. `SINGLE_QUOTE_STRING_END_TABLE` is a `SafeByteMatchTable`.
+        unsafe { handle_string_literal!(self, b'\'', SINGLE_QUOTE_STRING_END_TABLE) }
     }
 
     /// Save the string if it is escaped


### PR DESCRIPTION
Simplify lexing JSX string attributes. As the search is purely for 1 byte value (the closing quote), and so doesn't require a byte table, use `memchr`.

This change doesn't really register on benchmarks, but it's one step closer to removing `AutoCow`, and transitioning all the searches in the lexer to byte-by-byte.