### PR TITLE
fix(semantic): jsx reference with an incorrect node id

### DIFF
--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{ast::JSXElementName, AstKind};
+use oxc_ast::AstKind;
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
@@ -95,8 +95,10 @@ impl Rule for Namespace {
                             }
                         }
 
-                        AstKind::JSXOpeningElement(element) => {
-                            if let JSXElementName::MemberExpression(expr) = &element.name {
+                        AstKind::JSXMemberExpressionObject(_) => {
+                            if let Some(AstKind::JSXMemberExpression(expr)) =
+                                ctx.nodes().parent_kind(node.id())
+                            {
                                 check_binding_exported(&expr.property.name, expr.property.span);
                             }
                         }

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -51,7 +51,7 @@ impl Rule for InlineScriptId {
         'references_loop: for reference in
             ctx.semantic().symbol_references(specifier.local.symbol_id.get().unwrap())
         {
-            let node = ctx.nodes().get_node(reference.node_id());
+            let Some(node) = ctx.nodes().parent_node(reference.node_id()) else { return };
 
             let AstKind::JSXElementName(_) = node.kind() else { continue };
             let parent_node = ctx.nodes().parent_node(node.id()).unwrap();

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -65,7 +65,7 @@ impl Rule for NoScriptComponentInHead {
         for reference in
             ctx.semantic().symbol_references(default_import.local.symbol_id.get().unwrap())
         {
-            let node = ctx.nodes().get_node(reference.node_id());
+            let Some(node) = ctx.nodes().parent_node(reference.node_id()) else { return };
 
             let AstKind::JSXElementName(_) = node.kind() else { continue };
             let parent_node = ctx.nodes().parent_node(node.id()).unwrap();

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -65,7 +65,7 @@ impl Rule for NoTitleInDocumentHead {
         for reference in
             ctx.semantic().symbol_references(default_import.local.symbol_id.get().unwrap())
         {
-            let node = ctx.nodes().get_node(reference.node_id());
+            let Some(node) = ctx.nodes().parent_node(reference.node_id()) else { return };
 
             let AstKind::JSXElementName(_) = node.kind() else { continue };
             let parent_node = ctx.nodes().parent_node(node.id()).unwrap();


### PR DESCRIPTION
The get kind from the node id should be `JSXIdentifier`, but now it's `JSXOpeningElement`.