### PR TITLE
refactor(parser): remove start params for `byte_search` macro arms

### DIFF
--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -69,11 +69,11 @@ impl<'a> Lexer<'a> {
                     })
                 }
             },
-            handle_match: |_next_byte, _start| {
+            handle_match: |_next_byte| {
                 self.token.is_on_new_line = true;
                 Kind::Skip
             },
-            handle_eof: |_start| {
+            handle_eof: || {
                 self.trivia_builder.add_single_line_comment(self.token.start, self.offset());
                 Kind::Skip
             },
@@ -139,11 +139,11 @@ impl<'a> Lexer<'a> {
                     return self.skip_multi_line_comment_after_line_break(after_line_break);
                 }
             },
-            handle_match: |_next_byte, _start| {
+            handle_match: |_next_byte| {
                 self.trivia_builder.add_multi_line_comment(self.token.start, self.offset());
                 Kind::Skip
             },
-            handle_eof: |_start| {
+            handle_eof: || {
                 self.error(diagnostics::UnterminatedMultiLineComment(self.unterminated_range()));
                 Kind::Eof
             },

--- a/crates/oxc_parser/src/lexer/search.rs
+++ b/crates/oxc_parser/src/lexer/search.rs
@@ -265,18 +265,16 @@ pub(crate) use safe_byte_match_table;
 ///     byte_search! {
 ///       lexer: self,
 ///       table: NOT_STUFF_TABLE,
-///       handle_match: |matched_byte, start| {
+///       handle_match: |matched_byte| {
 ///         // Matching byte has been found.
 ///         // `matched_byte` is `u8` value of first byte which matched the table.
-///         // `start` is `SourcePosition` where search began.
 ///         // `lexer.source` is now positioned on first matching byte.
 ///         // Handle the next matching byte (deal with any special cases).
 ///         // Value this block evaluates to will be returned from enclosing function.
 ///         matched_byte == b'X'
 ///       },
-///       handle_eof: |start| {
+///       handle_eof: || {
 ///         // No bytes from start position to end of source matched the table.
-///         // `start` is `SourcePosition` where search began.
 ///         // `lexer.source` is now positioned at EOF.
 ///         // Handle EOF in some way.
 ///         // Value this block evaluates to will be returned from enclosing function.
@@ -387,17 +385,17 @@ macro_rules! byte_search {
     (
         lexer: $lexer:ident,
         table: $table:ident,
-        handle_match: |$match_byte:ident, $match_start:ident| $match_handler:expr,
-        handle_eof: |$eof_start:ident| $eof_handler:expr,
+        handle_match: |$match_byte:ident| $match_handler:expr,
+        handle_eof: || $eof_handler:expr,
     ) => {{
         let start = $lexer.source.position();
         byte_search! {
             lexer: $lexer,
             table: $table,
             start: start,
-            continue_if: |__byte, pos| false,
-            handle_match: |$match_byte, $match_start| $match_handler,
-            handle_eof: |$eof_start| $eof_handler,
+            continue_if: |byte, pos| false,
+            handle_match: |$match_byte| $match_handler,
+            handle_eof: || $eof_handler,
         }
     }};
 
@@ -407,8 +405,8 @@ macro_rules! byte_search {
         lexer: $lexer:ident,
         table: $table:ident,
         continue_if: |$continue_byte:ident, $pos:ident| $should_continue:expr,
-        handle_match: |$match_byte:ident, $match_start:ident| $match_handler:expr,
-        handle_eof: |$eof_start:ident| $eof_handler:expr,
+        handle_match: |$match_byte:ident| $match_handler:expr,
+        handle_eof: || $eof_handler:expr,
     ) => {{
         let start = $lexer.source.position();
         byte_search! {
@@ -416,8 +414,8 @@ macro_rules! byte_search {
             table: $table,
             start: start,
             continue_if: |$continue_byte, $pos| $should_continue,
-            handle_match: |$match_byte, $match_start| $match_handler,
-            handle_eof: |$eof_start| $eof_handler,
+            handle_match: |$match_byte| $match_handler,
+            handle_eof: || $eof_handler,
         }
     }};
 
@@ -433,30 +431,11 @@ macro_rules! byte_search {
             lexer: $lexer,
             table: $table,
             start: $start,
-            continue_if: |__byte, pos| false,
-            handle_match: |$match_byte, __start| $match_handler,
-            handle_eof: |__start| $eof_handler,
+            continue_if: |byte, pos| false,
+            handle_match: |$match_byte| $match_handler,
+            handle_eof: || $eof_handler,
         }
     };
-
-    // Provide your own `start` position, and `continue_if`
-    (
-        lexer: $lexer:ident,
-        table: $table:ident,
-        start: $start:ident,
-        continue_if: |$continue_byte:ident, $pos:ident| $should_continue:expr,
-        handle_match: |$match_byte:ident| $match_handler:expr,
-        handle_eof: || $eof_handler:expr,
-    ) => {{
-        byte_search! {
-            lexer: $lexer,
-            table: $table,
-            start: $start,
-            continue_if: |$continue_byte, $pos| $should_continue,
-            handle_match: |$match_byte, __start| $match_handler,
-            handle_eof: |__start| $eof_handler,
-        }
-    }};
 
     // Actual implementation
     (
@@ -464,8 +443,8 @@ macro_rules! byte_search {
         table: $table:ident,
         start: $start:ident,
         continue_if: |$continue_byte:ident, $pos:ident| $should_continue:expr,
-        handle_match: |$match_byte:ident, $match_start:ident| $match_handler:expr,
-        handle_eof: |$eof_start:ident| $eof_handler:expr,
+        handle_match: |$match_byte:ident| $match_handler:expr,
+        handle_eof: || $eof_handler:expr,
     ) => {{
         // SAFETY:
         // If `$table` is a `SafeByteMatchTable`, it's guaranteed that `lexer.source`
@@ -531,7 +510,6 @@ macro_rules! byte_search {
                     // Advance `lexer.source`'s position to end of file.
                     $lexer.source.set_position($pos);
 
-                    let $eof_start = $start;
                     return $eof_handler;
                 }
             };
@@ -553,7 +531,6 @@ macro_rules! byte_search {
         // SAFETY: See above about UTF-8 character boundaries invariant.
         $lexer.source.set_position($pos);
 
-        let $match_start = $start;
         return $match_handler;
     }};
 }

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -73,10 +73,10 @@ impl<'a> Lexer<'a> {
                     }
                 }
             },
-            handle_match: |_next_byte, _start| {
+            handle_match: |_next_byte| {
                 ret
             },
-            handle_eof: |_start| {
+            handle_eof: || {
                 self.error(diagnostics::UnterminatedString(self.unterminated_range()));
                 Kind::Undetermined
             },
@@ -295,14 +295,14 @@ impl<'a> Lexer<'a> {
                     }
                 }
             },
-            handle_match: |_next_byte, _start| {
+            handle_match: |_next_byte| {
                 self.save_template_string(
                     is_valid_escape_sequence,
                     str.into_bump_str(),
                 );
                 ret
             },
-            handle_eof: |_start| {
+            handle_eof: || {
                 self.error(diagnostics::UnterminatedString(self.unterminated_range()));
                 Kind::Undetermined
             },

--- a/crates/oxc_parser/src/lexer/whitespace.rs
+++ b/crates/oxc_parser/src/lexer/whitespace.rs
@@ -17,10 +17,10 @@ impl<'a> Lexer<'a> {
         byte_search! {
             lexer: self,
             table: NOT_REGULAR_WHITESPACE_OR_LINE_BREAK_TABLE,
-            handle_match: |_next_byte, _start| {
+            handle_match: |_next_byte| {
                 Kind::Skip
             },
-            handle_eof: |_start| {
+            handle_eof: || {
                 Kind::Skip
             },
         };


### PR DESCRIPTION
Simplify `byte_search` macro a bit more.