### PR TITLE
refactor(parser): `byte_search` macro evaluate to matched byte

### DIFF
--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -27,7 +27,7 @@ impl<'a> Lexer<'a> {
         byte_search! {
             lexer: self,
             table: LINE_BREAK_TABLE,
-            continue_if: |next_byte, pos| {
+            continue_if: (next_byte, pos) {
                 // Match found. Decide whether to continue searching.
                 // If this is end of comment, create trivia, and advance `pos` to after line break.
                 // Do that here rather than in `handle_match`, to avoid branching twice on value of
@@ -69,15 +69,14 @@ impl<'a> Lexer<'a> {
                     })
                 }
             },
-            handle_match: |_next_byte| {
-                self.token.is_on_new_line = true;
-                Kind::Skip
-            },
-            handle_eof: || {
+            handle_eof: {
                 self.trivia_builder.add_single_line_comment(self.token.start, self.offset());
-                Kind::Skip
+                return Kind::Skip;
             },
         };
+
+        self.token.is_on_new_line = true;
+        Kind::Skip
     }
 
     /// Section 12.4 Multi Line Comment
@@ -90,7 +89,7 @@ impl<'a> Lexer<'a> {
         byte_search! {
             lexer: self,
             table: MULTILINE_COMMENT_START_TABLE,
-            continue_if: |next_byte, pos| {
+            continue_if: (next_byte, pos) {
                 // Match found. Decide whether to continue searching.
                 if next_byte == b'*' {
                     // SAFETY: Next byte is `*` (ASCII) so after it is UTF-8 char boundary
@@ -145,15 +144,14 @@ impl<'a> Lexer<'a> {
                     return self.skip_multi_line_comment_after_line_break(after_line_break);
                 }
             },
-            handle_match: |_next_byte| {
-                self.trivia_builder.add_multi_line_comment(self.token.start, self.offset());
-                Kind::Skip
-            },
-            handle_eof: || {
+            handle_eof: {
                 self.error(diagnostics::UnterminatedMultiLineComment(self.unterminated_range()));
-                Kind::Eof
+                return Kind::Eof;
             },
         };
+
+        self.trivia_builder.add_multi_line_comment(self.token.start, self.offset());
+        Kind::Skip
     }
 
     fn skip_multi_line_comment_after_line_break(&mut self, pos: SourcePosition) -> Kind {

--- a/crates/oxc_parser/src/lexer/search.rs
+++ b/crates/oxc_parser/src/lexer/search.rs
@@ -250,10 +250,9 @@ pub(crate) use safe_byte_match_table;
 /// Search processes source in batches of `SEARCH_BATCH_SIZE` bytes for speed.
 /// When not enough bytes remaining in source for a batch, search source byte by byte.
 ///
-/// This is a macro rather than a function for 2 reasons:
-/// 1. Searching is a bit faster when all the code is in a single function.
-/// 2. The `handle_match` section has to be repeated twice.
-///    This macro does that, so code using the macro can be DRY-er.
+/// This is a macro rather than a function because searching is a bit faster when all the code
+/// is in a single function, and some parts (e.g. `continue_if`) can be statically removed by
+/// the compiler if they're not used.
 ///
 /// Used as follows:
 ///
@@ -262,28 +261,24 @@ pub(crate) use safe_byte_match_table;
 ///
 /// impl<'a> Lexer<'a> {
 ///   fn eat_stuff(&mut self) -> bool {
-///     byte_search! {
+///     let matched_byte = byte_search! {
 ///       lexer: self,
 ///       table: NOT_STUFF_TABLE,
-///       handle_match: |matched_byte| {
-///         // Matching byte has been found.
-///         // `matched_byte` is `u8` value of first byte which matched the table.
-///         // `lexer.source` is now positioned on first matching byte.
-///         // Handle the next matching byte (deal with any special cases).
-///         // Value this block evaluates to will be returned from enclosing function.
-///         matched_byte == b'X'
-///       },
-///       handle_eof: || {
+///       handle_eof: {
 ///         // No bytes from start position to end of source matched the table.
 ///         // `lexer.source` is now positioned at EOF.
-///         // Handle EOF in some way.
-///         // Value this block evaluates to will be returned from enclosing function.
-///         false
+///         // Evaluate to a `u8` which macro call will evaluate to.
+///         0xFF
+///         // Or can `return` from enclosing function e.g. `return false;`
 ///       },
 ///     };
 ///
-///     // This is unreachable.
-///     // Macro always exits current function with a `return` statement.
+///     // Matching byte has been found.
+///     // `matched_byte` is `u8` value of first byte which matched the table
+///     // (or `0xFF` if EOF, because `handle_eof` evaluates to `0xFF`).
+///     // `lexer.source` is now positioned on first matching byte.
+///     // Handle the next matching byte (deal with any special cases).
+///     matched_byte == b'X'
 ///   }
 /// }
 /// ```
@@ -294,78 +289,64 @@ pub(crate) use safe_byte_match_table;
 /// impl<'a> Lexer<'a> {
 ///   fn eat_stuff(&mut self) -> bool {
 ///     let start = unsafe { self.source.position().add(1) };
-///     byte_search! {
+///     let matched_byte = byte_search! {
 ///       lexer: self,
 ///       table: NOT_STUFF_TABLE,
 ///       start: start,
-///       handle_match: |matched_byte| {
-///         // Matching byte has been found.
-///         // `matched_byte` is `u8` value of first byte which matched the table.
-///         // `lexer.source` is now positioned on first matching byte.
-///         // Handle the next matching byte (deal with any special cases).
-///         // Value this block evaluates to will be returned from enclosing function.
-///         true
-///       },
-///       handle_eof: || {
+///       handle_eof: {
 ///         // No bytes from start position to end of source matched the table.
 ///         // `lexer.source` is now positioned at EOF.
-///         // Handle EOF in some way.
-///         // Value this block evaluates to will be returned from enclosing function.
-///         false
+///         return false;
 ///       },
 ///     };
 ///
-///     // This is unreachable.
-///     // Macro always exits current function with a `return` statement.
+///     // Matching byte has been found.
+///     // `matched_byte` is `u8` value of first byte which matched the table.
+///     // `lexer.source` is now positioned on first matching byte.
+///     // Handle the next matching byte (deal with any special cases).
+///     matched_byte == b'X'
 ///   }
 /// }
 /// ```
 ///
 /// Can also add a block to decide whether to continue searching for some matches:
 ///
-/// ```text
+/// ```
 /// impl<'a> Lexer<'a> {
 ///   fn eat_stuff(&mut self) -> bool {
-///     byte_search! {
+///     let matched_byte = byte_search! {
 ///       lexer: self,
 ///       table: NOT_STUFF_TABLE,
-///       continue_if: |matched_byte, pos| {
+///       continue_if: (matched_byte, pos) {
 ///         // Matching byte found. Decide whether it's really a match.
+///         // Return `true` to continue searching, or `false` to end search.
 ///         // NB: `lexer.source` has NOT been updated at this point.
 ///         if matched_byte == 0xE2 {
 ///           // Only match a specific Unicode char (in this case 0xE2, 0x80, 0xA8)
-///           unsafe { pos.add(1).read() != 0x80 || pos.add(2).read() != 0xA8) }
+///           // NB: We don't need to check if `pos` is at EOF here, as 0xE2 is always 1st byte
+///           // of a 3-byte Unicode char, but if matching an ASCII char, would need to make sure
+///           // don't read out of bounds.
+///           unsafe { pos.add(1).read() != 0x80 || pos.add(2).read() != 0xA8 }
 ///         } else {
-///           // All others do match. `handle_match` is executed.
+///           // End search for all other possibilities
 ///           false
 ///         }
 ///       },
-///       handle_match: |matched_byte| {
-///         // Matching byte has been found and `continue_if` returned `false` for it.
-///         // `matched_byte` is `u8` value of first byte which matched the table.
-///         // `lexer.source` is now positioned on first matching byte.
-///         // Handle the next matching byte (deal with any special cases).
-///         // Value this block evaluates to will be returned from enclosing function.
-///         true
-///       },
-///       handle_eof: || {
+///       handle_eof: {
 ///         // No bytes from start position to end of source matched the table.
 ///         // `lexer.source` is now positioned at EOF.
-///         // Handle EOF in some way.
-///         // Value this block evaluates to will be returned from enclosing function.
-///         false
+///         return false;
 ///       },
 ///     };
 ///
-///     // This is unreachable.
-///     // Macro always exits current function with a `return` statement.
+///     // Matching byte has been found.
+///     // `matched_byte` is `u8` value of first byte which matched the table.
+///     // `lexer.source` is now positioned on first matching byte.
+///     // Handle the next matching byte (deal with any special cases).
+///     matched_byte == b'X'
 ///   }
 /// }
 /// ```
-///
-/// NB: The macro always causes enclosing function to return.
-/// It creates `return` statements with the value that `handle_match` / `handle_eof` blocks evaluate to.
-/// After the `byte_search!` macro is unreachable.
 ///
 /// # SAFETY
 ///
@@ -380,71 +361,64 @@ pub(crate) use safe_byte_match_table;
 /// It is caller's responsibility to ensure that `lexer.source` is moved onto a UTF-8 character boundary.
 /// This is similar to the contract's of `Source`'s unsafe methods.
 macro_rules! byte_search {
-    // Standard version.
+    // Simple version.
     // `start` is calculated from current position of `lexer.source`.
     (
         lexer: $lexer:ident,
         table: $table:ident,
-        handle_match: |$match_byte:ident| $match_handler:expr,
-        handle_eof: || $eof_handler:expr,
+        handle_eof: $eof_handler:expr,
     ) => {{
         let start = $lexer.source.position();
         byte_search! {
             lexer: $lexer,
             table: $table,
             start: start,
-            continue_if: |byte, pos| false,
-            handle_match: |$match_byte| $match_handler,
-            handle_eof: || $eof_handler,
+            continue_if: (byte, pos) false,
+            handle_eof: $eof_handler,
         }
     }};
 
-    // Standard version with `continue_if`.
+    // With `continue_if`.
     // `start` is calculated from current position of `lexer.source`.
     (
         lexer: $lexer:ident,
         table: $table:ident,
-        continue_if: |$continue_byte:ident, $pos:ident| $should_continue:expr,
-        handle_match: |$match_byte:ident| $match_handler:expr,
-        handle_eof: || $eof_handler:expr,
+        continue_if: ($byte:ident, $pos:ident) $should_continue:expr,
+        handle_eof: $eof_handler:expr,
     ) => {{
         let start = $lexer.source.position();
         byte_search! {
             lexer: $lexer,
             table: $table,
             start: start,
-            continue_if: |$continue_byte, $pos| $should_continue,
-            handle_match: |$match_byte| $match_handler,
-            handle_eof: || $eof_handler,
+            continue_if: ($byte, $pos) $should_continue,
+            handle_eof: $eof_handler,
         }
     }};
 
-    // Provide your own `start` position
+    // With provided `start` position
     (
         lexer: $lexer:ident,
         table: $table:ident,
         start: $start:ident,
-        handle_match: |$match_byte:ident| $match_handler:expr,
-        handle_eof: || $eof_handler:expr,
+        handle_eof: $eof_handler:expr,
     ) => {
         byte_search! {
             lexer: $lexer,
             table: $table,
             start: $start,
-            continue_if: |byte, pos| false,
-            handle_match: |$match_byte| $match_handler,
-            handle_eof: || $eof_handler,
+            continue_if: (byte, pos) false,
+            handle_eof: $eof_handler,
         }
     };
 
-    // Actual implementation
+    // Actual implementation - with both `start` and `continue_if`
     (
         lexer: $lexer:ident,
         table: $table:ident,
         start: $start:ident,
-        continue_if: |$continue_byte:ident, $pos:ident| $should_continue:expr,
-        handle_match: |$match_byte:ident| $match_handler:expr,
-        handle_eof: || $eof_handler:expr,
+        continue_if: ($byte:ident, $pos:ident) $should_continue:expr,
+        handle_eof: $eof_handler:expr,
     ) => {{
         // SAFETY:
         // If `$table` is a `SafeByteMatchTable`, it's guaranteed that `lexer.source`
@@ -458,8 +432,8 @@ macro_rules! byte_search {
 
         let mut $pos = $start;
         #[allow(unused_unsafe)] // Silence warnings if macro called in unsafe code
-        let $match_byte = 'outer: loop {
-            let $continue_byte = if $pos.addr() <= $lexer.source.end_for_batch_search_addr() {
+        'outer: loop {
+            let $byte = if $pos.addr() <= $lexer.source.end_for_batch_search_addr() {
                 // Search a batch of `SEARCH_BATCH_SIZE` bytes.
                 //
                 // `'inner: loop {}` is not a real loop - it always exits on first turn.
@@ -510,7 +484,12 @@ macro_rules! byte_search {
                     // Advance `lexer.source`'s position to end of file.
                     $lexer.source.set_position($pos);
 
-                    return $eof_handler;
+                    // Avoid lint errors if `$eof_handler` contains `return` statement
+                    #[allow(unused_variables, unreachable_code, clippy::diverging_sub_expression)]
+                    {
+                        let eof_ret = $eof_handler;
+                        break 'outer eof_ret;
+                    }
                 }
             };
 
@@ -523,15 +502,13 @@ macro_rules! byte_search {
                 continue;
             }
 
-            // Match confirmed
-            break $continue_byte;
-        };
+            // Match confirmed.
+            // Advance `lexer.source`'s position up to `$pos`, consuming unmatched bytes.
+            // SAFETY: See above about UTF-8 character boundaries invariant.
+            $lexer.source.set_position($pos);
 
-        // Advance `lexer.source`'s position up to `$pos`, consuming unmatched bytes.
-        // SAFETY: See above about UTF-8 character boundaries invariant.
-        $lexer.source.set_position($pos);
-
-        return $match_handler;
+            break $byte;
+        }
     }};
 }
 pub(crate) use byte_search;

--- a/crates/oxc_parser/src/lexer/whitespace.rs
+++ b/crates/oxc_parser/src/lexer/whitespace.rs
@@ -17,12 +17,9 @@ impl<'a> Lexer<'a> {
         byte_search! {
             lexer: self,
             table: NOT_REGULAR_WHITESPACE_OR_LINE_BREAK_TABLE,
-            handle_match: |_next_byte| {
-                Kind::Skip
-            },
-            handle_eof: || {
-                Kind::Skip
-            },
+            handle_eof: 0, // Fall through to below
         };
+
+        Kind::Skip
     }
 }


### PR DESCRIPTION
Change behavior of `byte_search!` macro, to make it easier to understand and use:

1. `handle_match` removed. Macro instead evaluates to the first matching byte.
2. `handle_eof` does not return from enclosing function.
3. Alter syntax to make clear that `continue_if` and `handle_eof` are not closures, so can use `return` statements in them.

These changes enabled by #2552.