### PR TITLE
fix(ast): add `RestElement`s in serialized AST to elements array

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -1,11 +1,16 @@
 use serde::{
-    ser::{SerializeStruct, Serializer},
+    ser::{SerializeSeq, SerializeStruct, Serializer},
     Serialize,
 };
 
 use crate::ast::{
-    BindingIdentifier, IdentifierName, IdentifierReference, LabelIdentifier, Program, RegExpFlags,
+    ArrayAssignmentTarget, ArrayPattern, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
+    AssignmentTargetRest, BindingIdentifier, BindingPattern, BindingPatternKind, BindingProperty,
+    BindingRestElement, FormalParameter, FormalParameterKind, FormalParameters, IdentifierName,
+    IdentifierReference, LabelIdentifier, ObjectAssignmentTarget, ObjectPattern, Program,
+    RegExpFlags, TSTypeAnnotation,
 };
+use oxc_allocator::{Box, Vec};
 use oxc_span::{Atom, Span};
 
 pub struct EcmaFormatter;
@@ -90,5 +95,145 @@ impl<'a> Serialize for LabelIdentifier<'a> {
         S: Serializer,
     {
         serialize_identifier(serializer, "LabelIdentifier", self.span, &self.name)
+    }
+}
+
+/// Serialize `ArrayAssignmentTarget`, `ObjectAssignmentTarget`, `ObjectPattern`, `ArrayPattern`
+/// to be estree compatible, with `elements`/`properties` and `rest` fields combined.
+
+impl<'a> Serialize for ArrayAssignmentTarget<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let converted = SerArrayAssignmentTarget {
+            span: self.span,
+            elements: ElementsAndRest::new(&self.elements, &self.rest),
+            trailing_comma: self.trailing_comma,
+        };
+        converted.serialize(serializer)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename = "ArrayAssignmentTarget", rename_all = "camelCase")]
+struct SerArrayAssignmentTarget<'a, 'b> {
+    #[serde(flatten)]
+    span: Span,
+    elements:
+        ElementsAndRest<'a, 'b, Option<AssignmentTargetMaybeDefault<'a>>, AssignmentTargetRest<'a>>,
+    trailing_comma: Option<Span>,
+}
+
+impl<'a> Serialize for ObjectAssignmentTarget<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let converted = SerObjectAssignmentTarget {
+            span: self.span,
+            properties: ElementsAndRest::new(&self.properties, &self.rest),
+        };
+        converted.serialize(serializer)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename = "ObjectAssignmentTarget")]
+struct SerObjectAssignmentTarget<'a, 'b> {
+    #[serde(flatten)]
+    span: Span,
+    properties: ElementsAndRest<'a, 'b, AssignmentTargetProperty<'a>, AssignmentTargetRest<'a>>,
+}
+
+impl<'a> Serialize for ObjectPattern<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let converted = SerObjectPattern {
+            span: self.span,
+            properties: ElementsAndRest::new(&self.properties, &self.rest),
+        };
+        converted.serialize(serializer)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename = "ObjectPattern")]
+struct SerObjectPattern<'a, 'b> {
+    #[serde(flatten)]
+    span: Span,
+    properties: ElementsAndRest<'a, 'b, BindingProperty<'a>, Box<'a, BindingRestElement<'a>>>,
+}
+
+impl<'a> Serialize for ArrayPattern<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let converted = SerArrayPattern {
+            span: self.span,
+            elements: ElementsAndRest::new(&self.elements, &self.rest),
+        };
+        converted.serialize(serializer)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename = "ArrayPattern")]
+struct SerArrayPattern<'a, 'b> {
+    #[serde(flatten)]
+    span: Span,
+    elements: ElementsAndRest<'a, 'b, Option<BindingPattern<'a>>, Box<'a, BindingRestElement<'a>>>,
+}
+
+/// Serialize `FormalParameters`, to be estree compatible, with `items` and `rest` fields combined
+/// and `argument` field flattened.
+impl<'a> Serialize for FormalParameters<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let converted_rest = self.rest.as_ref().map(|rest| SerFormalParameterRest {
+            span: rest.span,
+            argument: &rest.argument.kind,
+            type_annotation: &rest.argument.type_annotation,
+            optional: rest.argument.optional,
+        });
+        let converted = SerFormalParameters {
+            span: self.span,
+            kind: self.kind,
+            items: ElementsAndRest::new(&self.items, &converted_rest),
+        };
+        converted.serialize(serializer)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename = "FormalParameters")]
+struct SerFormalParameters<'a, 'b> {
+    #[serde(flatten)]
+    span: Span,
+    kind: FormalParameterKind,
+    items: ElementsAndRest<'a, 'b, FormalParameter<'a>, SerFormalParameterRest<'a, 'b>>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename = "RestElement", rename_all = "camelCase")]
+struct SerFormalParameterRest<'a, 'b> {
+    #[serde(flatten)]
+    span: Span,
+    argument: &'b BindingPatternKind<'a>,
+    type_annotation: &'b Option<Box<'a, TSTypeAnnotation<'a>>>,
+    optional: bool,
+}
+
+pub struct ElementsAndRest<'a, 'b, E, R> {
+    elements: &'b Vec<'a, E>,
+    rest: &'b Option<R>,
+}
+
+impl<'a, 'b, E, R> ElementsAndRest<'a, 'b, E, R> {
+    pub fn new(elements: &'b Vec<'a, E>, rest: &'b Option<R>) -> Self {
+        Self { elements, rest }
+    }
+}
+
+impl<'a, 'b, E: Serialize, R: Serialize> Serialize for ElementsAndRest<'a, 'b, E, R> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.elements.len() + 1))?;
+        for element in self.elements {
+            seq.serialize_element(element)?;
+        }
+        if let Some(rest) = self.rest {
+            seq.serialize_element(rest)?;
+        }
+        seq.end()
     }
 }


### PR DESCRIPTION
A step towards #2463.

This PR adds `rest` onto end of `elements` / `properties` array in JSON AST for `ObjectPattern`, `ArrayPattern`, `ObjectAssignmentTarget`, `ArrayAssignmentTarget` and `FormalParameters`.