### PR TITLE
fix(oxc_language_server): use config path at init

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -88,7 +88,6 @@ impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         self.init(params.root_uri)?;
         self.init_ignore_glob().await;
-        self.init_linter_config().await;
         let options = params.initialization_options.and_then(|mut value| {
             let settings = value.get_mut("settings")?.take();
             serde_json::from_value::<Options>(settings).ok()
@@ -99,6 +98,7 @@ impl LanguageServer for Backend {
             info!("language server version: {:?}", env!("CARGO_PKG_VERSION"));
             *self.options.lock().await = value;
         }
+        self.init_linter_config().await;
         Ok(InitializeResult {
             server_info: Some(ServerInfo { name: "oxc".into(), version: None }),
             offset_encoding: None,


### PR DESCRIPTION
`config_path` was not use in initialization.
Must merge #2568 before to fix vscode.