### PR TITLE
fix(ast): change TSMappedType.type_annotation from TSTypeAnnotation to TSType

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -836,7 +836,7 @@ pub struct TSMappedType<'a> {
     pub span: Span,
     pub type_parameter: Box<'a, TSTypeParameter<'a>>,
     pub name_type: Option<TSType<'a>>,
-    pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    pub type_annotation: Option<TSType<'a>>,
     pub optional: TSMappedTypeModifierOperator,
     pub readonly: TSMappedTypeModifierOperator,
 }

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1667,7 +1667,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_parameter: Box<'a, TSTypeParameter<'a>>,
         name_type: Option<TSType<'a>>,
-        type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
+        type_annotation: Option<TSType<'a>>,
         optional: TSMappedTypeModifierOperator,
         readonly: TSMappedTypeModifierOperator,
     ) -> TSType<'a> {

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -1668,7 +1668,7 @@ pub trait Visit<'a>: Sized {
             self.visit_ts_type(name);
         }
         if let Some(type_annotation) = &ty.type_annotation {
-            self.visit_ts_type_annotation(type_annotation);
+            self.visit_ts_type(type_annotation);
         }
     }
 

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -1667,7 +1667,7 @@ pub trait VisitMut<'a>: Sized {
             self.visit_ts_type(name);
         }
         if let Some(type_annotation) = &mut ty.type_annotation {
-            self.visit_ts_type_annotation(type_annotation);
+            self.visit_ts_type(type_annotation);
         }
     }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -75,15 +75,6 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn parse_ts_mapped_type_annotation(&mut self) -> Result<Option<TSType<'a>>> {
-        if self.at(Kind::Colon) {
-            self.bump_any(); // bump ':'
-            Ok(Some(self.parse_ts_type()?))
-        } else {
-            Ok(None)
-        }
-    }
-
     pub(crate) fn parse_ts_variable_annotation(
         &mut self,
     ) -> Result<(Option<Box<'a, TSTypeAnnotation<'a>>>, bool)> {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -75,6 +75,15 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
+    pub(crate) fn parse_ts_mapped_type_annotation(&mut self) -> Result<Option<TSType<'a>>> {
+        if self.at(Kind::Colon) {
+            self.bump_any(); // bump ':'
+            Ok(Some(self.parse_ts_type()?))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub(crate) fn parse_ts_variable_annotation(
         &mut self,
     ) -> Result<(Option<Box<'a, TSTypeAnnotation<'a>>>, bool)> {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -656,7 +656,7 @@ impl<'a> ParserImpl<'a> {
             _ => TSMappedTypeModifierOperator::None,
         };
 
-        let type_annotation = self.parse_ts_type_annotation()?;
+        let type_annotation = self.parse_ts_mapped_type_annotation()?;
         self.bump(Kind::Semicolon);
         self.expect(Kind::RCurly)?;
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -656,7 +656,7 @@ impl<'a> ParserImpl<'a> {
             _ => TSMappedTypeModifierOperator::None,
         };
 
-        let type_annotation = self.parse_ts_mapped_type_annotation()?;
+        let type_annotation = self.eat(Kind::Colon).then(|| self.parse_ts_type()).transpose()?;
         self.bump(Kind::Semicolon);
         self.expect(Kind::RCurly)?;
 


### PR DESCRIPTION
Is ESTree, in that special case, there is no TSTypeAnnotation wrapper:

(See `type X` in each)

- [oxc playground](https://oxc-project.github.io/oxc/playground/?code=3YCAAIAWgICAgICAgICyHorESipoToAAwTlix58geR2%2Beeu9rZHQZOqK%2B%2BX85ZQ9ldchOoVw2oAm2qi9okF3bJ9o4l78ENP3f%2Bc%2B8cIK6Itp%2B3SIInU72Vk0%2FSqawy1VNV5zTgBr7gOpGtUZsvkc12Yp8MC2shel9fbpgDySpYsWdgDhf3jVlIA%3D)
- [astexplorer TSESLint parser](https://astexplorer.net/#/gist/626dd346956a02c221d4e128450652af/9fc767f3a5265865693571f25c82d65695ab31e1)
- [astexplorer Babel parser](https://astexplorer.net/#/gist/ece6c59a642c58f726e6876d54dc18b5/9a4b02fae125c08e2f5e681d40b339c5ed938ef4)