### PR TITLE
fix(parser): don't parse null as a literal type

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -397,7 +397,8 @@ impl<'a> ParserImpl<'a> {
             Kind::Import => self.parse_ts_import_type(),
             Kind::Minus if self.peek_kind().is_number() => self.parse_ts_literal_type(),
             Kind::Question => self.parse_js_doc_unknown_or_nullable_type(),
-            kind if kind.is_literal() => self.parse_ts_literal_type(),
+            // null should not be parsed as a literal type
+            kind if kind.is_literal() && kind != Kind::Null => self.parse_ts_literal_type(),
             _ => {
                 if !self.peek_at(Kind::Dot) {
                     let keyword = self.parse_ts_keyword_type();


### PR DESCRIPTION
See playgrounds:

- [oxc](https://oxc-project.github.io/oxc/playground/?code=3YCAAIDbgICAgICAgIC6nsrEgteLFrCnQnPuEizmC%2BDQ8C8bP9fXPj%2B7%2FjjmRZPvpAH3N7PfIPDu7RDOlrl79cHiork8WA08r39%2FqpCAgA%3D%3D)
- [Babel](https://astexplorer.net/#/gist/9f43cf0fe91760e11f1572934681c92f/3a263be55bc89804aac7cf89a756d60111313136)