### PR TITLE
fix(parser): set span end for TSEnumDeclaration

### DIFF
--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -34,6 +34,7 @@ impl<'a> ParserImpl<'a> {
 
         let id = self.parse_binding_identifier()?;
         let members = TSEnumMemberList::parse(self)?.members;
+        let span = self.end_span(span);
         Ok(self.ast.ts_enum_declaration(span, id, members, modifiers))
     }
 


### PR DESCRIPTION
[playground](https://oxc-project.github.io/oxc/playground/?code=3YCAAIDHgICAgICAgICyHorESipoTXPdvBaE9wxyPnC9nb7Q6xEpIf3AzkuhOU2arZOLF1u08q1G2hs5klxiUYA6%2BBkL693d0iAZC%2BUFyne3yIKPv32k8IA%3D)

(Tell me if you prefer that I group this kind of small fixes together)