### PR TITLE
fix(ast): support FormalParameter.override

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1799,6 +1799,7 @@ pub struct FormalParameter<'a> {
     pub pattern: BindingPattern<'a>,
     pub accessibility: Option<TSAccessibility>,
     pub readonly: bool,
+    pub r#override: bool,
     pub decorators: Vec<'a, Decorator<'a>>,
 }
 

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -796,9 +796,10 @@ impl<'a> AstBuilder<'a> {
         pattern: BindingPattern<'a>,
         accessibility: Option<TSAccessibility>,
         readonly: bool,
+        r#override: bool,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> FormalParameter<'a> {
-        FormalParameter { span, pattern, accessibility, readonly, decorators }
+        FormalParameter { span, pattern, accessibility, readonly, r#override, decorators }
     }
 
     pub fn ts_this_parameter(

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -227,6 +227,7 @@ impl<'a> ParserImpl<'a> {
             pattern,
             None,
             false,
+            false,
             AstBuilder::new_vec(&self.ast),
         );
         let params = self.ast.formal_parameters(

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -258,6 +258,7 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
         let modifiers = p.parse_class_element_modifiers(true);
         let accessibility = modifiers.accessibility();
         let readonly = modifiers.readonly();
+        let r#override = modifiers.r#override();
 
         match p.cur_kind() {
             Kind::This if p.ts_enabled() => {
@@ -278,6 +279,7 @@ impl<'a> SeparatedList<'a> for FormalParameterList<'a> {
                     pattern,
                     accessibility,
                     readonly,
+                    r#override,
                     decorators,
                 );
                 self.elements.push(formal_parameter);

--- a/crates/oxc_transformer/src/proposals/decorators.rs
+++ b/crates/oxc_transformer/src/proposals/decorators.rs
@@ -96,6 +96,7 @@ enum Version {
     #[default]
     Year202305,
 }
+
 impl Version {
     fn is_legacy(self) -> bool {
         matches!(self, Self::Legacy)
@@ -479,6 +480,7 @@ impl<'a> Decorators<'a> {
                                                     ),
                                                     None,
                                                     false,
+                                                    false,
                                                     self.ast.new_vec(),
                                                 )),
                                                 None,
@@ -554,6 +556,7 @@ impl<'a> Decorators<'a> {
                                                 false,
                                             ),
                                             None,
+                                            false,
                                             false,
                                             self.ast.new_vec(),
                                         ))
@@ -909,6 +912,7 @@ impl<'a> Decorators<'a> {
                         ),
                         None,
                         false,
+                        false,
                         self.ast.new_vec(),
                     ));
                     let private_field = self.ast.private_field(
@@ -958,6 +962,7 @@ impl<'a> Decorators<'a> {
                                 false,
                             ),
                             None,
+                            false,
                             false,
                             self.ast.new_vec(),
                         ));

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -487,7 +487,7 @@ impl<'a> TypeScript<'a> {
         let mut params = self.ast.new_vec();
 
         // ((Foo) => {
-        params.push(self.ast.formal_parameter(SPAN, id, None, false, self.ast.new_vec()));
+        params.push(self.ast.formal_parameter(SPAN, id, None, false, false, self.ast.new_vec()));
 
         let params = self.ast.formal_parameters(
             SPAN,
@@ -679,6 +679,7 @@ impl<'a> TypeScript<'a> {
                         false,
                     ),
                     None,
+                    false,
                     false,
                     self.ast.new_vec(),
                 )),


### PR DESCRIPTION
This [code](https://oxc-project.github.io/oxc/playground/?code=3YCAAIC1gICAgICAgICxG4jI43W9aqTWr3WzyA0TqSOjtB34F78iblvTQruFcqR6BUbbiLtWhj5rEL0NnFkDs4pF3dHiw39X7YCA) can't be represented in the current OXC AST:

```ts
class Foo {
  constructor(override bar: string) {}
}
```