### PR TITLE
fix(ast)!: align TSImportType with ESTree

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -761,8 +761,16 @@ pub struct TSInferType<'a> {
 pub struct TSTypeQuery<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub expr_name: TSTypeName<'a>,
+    pub expr_name: TSTypeQueryExprName<'a>,
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+}
+
+#[derive(Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(untagged))]
+#[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
+pub enum TSTypeQueryExprName<'a> {
+    TSTypeName(TSTypeName<'a>),
+    TSImportType(TSImportType<'a>),
 }
 
 #[derive(Debug, Hash)]
@@ -771,7 +779,6 @@ pub struct TSTypeQuery<'a> {
 pub struct TSImportType<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
-    pub is_type_of: bool,
     pub argument: TSType<'a>,
     pub qualifier: Option<TSTypeName<'a>>,
     pub attributes: Option<TSImportAttributes<'a>>,

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1642,7 +1642,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_query_type(
         &self,
         span: Span,
-        expr_name: TSTypeName<'a>,
+        expr_name: TSTypeQueryExprName<'a>,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> TSType<'a> {
         TSType::TSTypeQuery(self.alloc(TSTypeQuery { span, expr_name, type_parameters }))
@@ -1687,7 +1687,6 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_import_type(
         &self,
         span: Span,
-        is_type_of: bool,
         argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
         attributes: Option<TSImportAttributes<'a>>,
@@ -1695,7 +1694,6 @@ impl<'a> AstBuilder<'a> {
     ) -> TSType<'a> {
         TSType::TSImportType(self.alloc(TSImportType {
             span,
-            is_type_of,
             argument,
             qualifier,
             attributes,

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -1870,7 +1870,10 @@ pub trait Visit<'a>: Sized {
     fn visit_ts_type_query(&mut self, ty: &TSTypeQuery<'a>) {
         let kind = AstKind::TSTypeQuery(self.alloc(ty));
         self.enter_node(kind);
-        self.visit_ts_type_name(&ty.expr_name);
+        match &ty.expr_name {
+            TSTypeQueryExprName::TSTypeName(name) => self.visit_ts_type_name(name),
+            TSTypeQueryExprName::TSImportType(_import) => {} // TODO
+        }
         if let Some(type_parameters) = &ty.type_parameters {
             self.visit_ts_type_parameter_instantiation(type_parameters);
         }

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -1872,7 +1872,10 @@ pub trait VisitMut<'a>: Sized {
     fn visit_ts_type_query(&mut self, ty: &mut TSTypeQuery<'a>) {
         let kind = AstKind::TSTypeQuery(self.alloc(ty));
         self.enter_node(kind);
-        self.visit_ts_type_name(&mut ty.expr_name);
+        match &mut ty.expr_name {
+            TSTypeQueryExprName::TSTypeName(name) => self.visit_ts_type_name(name),
+            TSTypeQueryExprName::TSImportType(_import) => {} // TODO
+        }
         if let Some(type_parameters) = &mut ty.type_parameters {
             self.visit_ts_type_parameter_instantiation(type_parameters);
         }

--- a/crates/oxc_codegen/src/gen_ts.rs
+++ b/crates/oxc_codegen/src/gen_ts.rs
@@ -143,12 +143,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSType<'a> {
                 decl.literal.gen(p, ctx);
             }
             Self::TSImportType(decl) => {
-                if decl.is_type_of {
-                    p.print_str(b"typeof ");
-                }
-                p.print_str(b"import(");
-                decl.argument.gen(p, ctx);
-                p.print_str(b")");
+                decl.gen(p, ctx);
             }
             Self::TSQualifiedName(decl) => {
                 decl.left.gen(p, ctx);
@@ -447,6 +442,23 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSTypeQuery<'a> {
         if let Some(type_params) = &self.type_parameters {
             type_params.gen(p, ctx);
         }
+    }
+}
+
+impl<'a, const MINIFY: bool> Gen<MINIFY> for TSTypeQueryExprName<'a> {
+    fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
+        match self {
+            Self::TSTypeName(decl) => decl.gen(p, ctx),
+            Self::TSImportType(decl) => decl.gen(p, ctx),
+        }
+    }
+}
+
+impl<'a, const MINIFY: bool> Gen<MINIFY> for TSImportType<'a> {
+    fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
+        p.print_str(b"import(");
+        self.argument.gen(p, ctx);
+        p.print_str(b")");
     }
 }
 


### PR DESCRIPTION
Implements https://github.com/typescript-eslint/typescript-eslint/issues/2998

The copy of props feels wrong, but could not get it working otherwise with the box and borrow things 😅

Also I found that TSImportType was missing some entries for visitors and codegen.

In the case of codegen I'm not really understand the need as all the types seems to be dismissed?
