### PR TITLE
fix(ast): support TSIndexSignature.readonly

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -582,6 +582,7 @@ pub struct TSIndexSignature<'a> {
     pub span: Span,
     pub parameters: Vec<'a, Box<'a, TSIndexSignatureName<'a>>>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
+    pub readonly: bool,
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1364,11 +1364,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         parameters: Vec<'a, Box<'a, TSIndexSignatureName<'a>>>,
         type_annotation: Box<'a, TSTypeAnnotation<'a>>,
+        readonly: bool,
     ) -> TSSignature<'a> {
         TSSignature::TSIndexSignature(self.alloc(TSIndexSignature {
             span,
             parameters,
             type_annotation,
+            readonly,
         }))
     }
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1071,8 +1071,11 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_index_signature_member(&mut self) -> Result<TSSignature<'a>> {
         let span = self.start_span();
+        let mut readonly = false;
         while self.is_nth_at_modifier(0, false) {
-            if !self.eat(Kind::Readonly) {
+            if self.eat(Kind::Readonly) {
+                readonly = true;
+            } else {
                 return Err(self.unexpected());
             }
         }
@@ -1087,7 +1090,12 @@ impl<'a> ParserImpl<'a> {
         if let Some(type_annotation) = type_annotation {
             self.bump(Kind::Comma);
             self.bump(Kind::Semicolon);
-            Ok(self.ast.ts_index_signature(self.end_span(span), parameters, type_annotation))
+            Ok(self.ast.ts_index_signature(
+                self.end_span(span),
+                parameters,
+                type_annotation,
+                readonly,
+            ))
         } else {
             Err(self.unexpected())
         }


### PR DESCRIPTION
[playground](https://oxc-project.github.io/oxc/playground/?code=3YCAAIDKgICAgICAgIC0GwpuZs97oWDqPM4xvCuoRB73mPOSrYb%2BTQEZf3b8RF0G%2B60jF5tYXUE9Me2%2FmMqVEwVy%2FiBIlyIMX6PqBpqsSmIXTJcsRqi4f3%2Bj6ICA)