### PR TITLE
feat(playground): support TS codegen

### DIFF
--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -118,7 +118,7 @@ impl Oxc {
         run_options: &OxcRunOptions,
         parser_options: &OxcParserOptions,
         _linter_options: &OxcLinterOptions,
-        _codegen_options: &OxcCodegenOptions,
+        codegen_options: &OxcCodegenOptions,
         minifier_options: &OxcMinifierOptions,
     ) -> Result<(), serde_wasm_bindgen::Error> {
         self.diagnostics = RefCell::default();
@@ -229,9 +229,17 @@ impl Oxc {
         }
 
         self.codegen_text = if minifier_options.whitespace() {
-            Codegen::<true>::new(source_text.len(), CodegenOptions::default()).build(program)
+            Codegen::<true>::new(
+                source_text.len(),
+                CodegenOptions { enable_typescript: codegen_options.enable_typescript },
+            )
+            .build(program)
         } else {
-            Codegen::<false>::new(source_text.len(), CodegenOptions::default()).build(program)
+            Codegen::<false>::new(
+                source_text.len(),
+                CodegenOptions { enable_typescript: codegen_options.enable_typescript },
+            )
+            .build(program)
         };
 
         Ok(())

--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -146,6 +146,8 @@ impl OxcLinterOptions {
 #[derive(Default, Clone, Copy)]
 pub struct OxcCodegenOptions {
     pub indentation: u8,
+    #[wasm_bindgen(js_name = enableTypescript)]
+    pub enable_typescript: bool,
 }
 
 #[wasm_bindgen]

--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -11,6 +11,16 @@
 export interface ParserOptions {
   sourceType?: 'script' | 'module' | 'unambiguous' | undefined
   sourceFilename?: string
+  /**
+   * Emit `ParenthesizedExpression` in AST.
+   *
+   * If this option is true, parenthesized expressions are represented by
+   * (non-standard) `ParenthesizedExpression` nodes that have a single `expression` property
+   * containing the expression inside parentheses.
+   *
+   * Default: true
+   */
+  preserveParens?: boolean
 }
 export interface ParseResult {
   program: string

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -7,26 +7,26 @@
     <title>Oxc - The JavaScript Oxidation Compiler Playground</title>
     <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/Boshen/oxc-assets/main/oxc.ico">
     <style>
-      body { font-family: monospace; font-size: 16px; margin: 0 }
+      body { font-family: monospace; font-size: 16px; background-color: #24292e; color: white; margin: 0 }
       button { cursor: pointer }
       label { display: inline-flex; align-items: center; cursor: pointer; user-select: none; }
       .cm-editor { height: 100%; }
       #logo { display: flex; justify-content: center; cursor: pointer; color: white; text-decoration: inherit; }
       #logo > img { margin-right: .5em; }
-      #loading { background: white; position: fixed; top: 0; left: 0; right: 0; bottom: 0; z-index: 1; display: flex; justify-content: center; align-items: center; }
+      #loading { position: fixed; top: 0; left: 0; right: 0; bottom: 0; z-index: 1; display: flex; justify-content: center; align-items: center; }
       #container { display: flex; height: 100vh; }
       #left { display: flex; flex: 1; flex-direction: column; border-right: 1px solid #444 }
       #editor { flex: 1; overflow-y: auto; }
-      #panel { height: 20%; overflow-y: auto; padding: 1em; color: #d1d5da; background-color: #24292e; border-top: 1px solid #444!important; }
+      #panel { height: 20%; overflow-y: auto; padding: 1em; color: #d1d5da; border-top: 1px solid #444!important; }
       #right { flex: 1; display:flex; flex-direction: column; min-width: 0; }
-      .header { color: white; background: #24292e; border-bottom: 1px solid #444; }
+      .header { border-bottom: 1px solid #444; }
       .left-container { padding: .8em 1em; display: flex; align-items: center; justify-content: space-between; }
       .controls { padding: .6em; }
-      .controls > div { padding: .2em 1em; display: flex; align-items: center; }
-      .controls > div > button { margin-right: 4px; padding: 8px 16px; background-color: #2c3136; color: white; border: 1px solid #444; transition: background-color 0.3s;}
+      .controls > div { padding: .2em .5em; display: flex; flex-wrap: wrap; gap: 4px; }
+      .controls > div > button { padding: 8px 16px; background-color: #2c3136; color: white; border: 1px solid #444; transition: background-color 0.3s; white-space: nowrap; }
       .controls > div > button:hover { background-color: #444; }
       .controls > div > button.active { background-color: #555; }
-      .controls > div > label { margin-right: 8px; }
+      .controls > div > label { margin-right: 4px; }
       .controls label { font-size: 14px; }
       #duration { margin-left: auto; }
       #viewer { flex: 1; overflow-y: auto; }
@@ -76,8 +76,9 @@
             <button type="button" id="symbol">Symbol</button>
             <button type="button" id="ir-copy">Copy IR to clipboard</button>
           </div>
-          <div>
+          <div id="codegen-controls">
             <label id="transform">Transform<input id="transform-checkbox" type="checkbox"></label>
+            <label id="codegen-ts">TS<input id="codegen-ts-checkbox" type="checkbox"></label>
             <label>| Minify: </label>
             <label id="whitespace">whitespace<input id="whitespace-checkbox" type="checkbox"></label>
             <label id="mangle">mangle<input id="mangle-checkbox" type="checkbox"></label>

--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -363,6 +363,7 @@ class Playground {
     this.currentView = view;
 
     document.getElementById("ir-copy").style.display = "none";
+    document.getElementById("codegen-controls").style.display = "none";
     document.getElementById("duration").style.display = "inline";
     document.getElementById("panel").style.display = "inline";
     this.runOptions.format = false;
@@ -387,6 +388,7 @@ class Playground {
         text = renderSymbols(this.oxc.symbols)
         break;
       case "codegen":
+        document.getElementById("codegen-controls").style.display = "block";
         this.run();
         text = this.oxc.codegenText;
         break;
@@ -606,6 +608,12 @@ async function main() {
   document.getElementById("transform").onchange = function () {
     const checked = document.getElementById("transform-checkbox").checked;
     playground.runOptions.transform = checked;
+    playground.updateView("codegen");
+  };
+
+  document.getElementById("codegen-ts").onchange = function () {
+    const checked = document.getElementById("codegen-ts-checkbox").checked;
+    playground.codegenOptions.enableTypescript = checked;
     playground.updateView("codegen");
   };
 


### PR DESCRIPTION
Help me for debugging of #2578:

<img width="1356" alt="Screenshot 2024-03-03 at 19 38 54" src="https://github.com/oxc-project/oxc/assets/14235743/934e9044-9166-4a11-98a5-a428f500a403">

Other things I wanted to add:
- Only show codegen options for the codegen view
- Dark background on loading
- Wrap items on smaller screen

<img width="1166" alt="Screenshot 2024-03-03 at 19 39 04" src="https://github.com/oxc-project/oxc/assets/14235743/1fbc55cf-dd93-4a53-9acd-1bd6c3709860">

