### PR TITLE
fix(ast): expose NumericLiteral.raw

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -61,7 +61,6 @@ pub struct NumericLiteral<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub value: f64,
-    #[cfg_attr(feature = "serde", serde(skip))]
     pub raw: &'a str,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub base: NumberBase,


### PR DESCRIPTION
This is needed for Prettier to preserve the base when printing numbers. This is not in the spec but available in both Babel and TSESLint.