### PR TITLE
fix(parser): fix span end for TSEmptyBodyFunctionExpression

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -123,7 +123,9 @@ impl<'a> ParserImpl<'a> {
             FunctionKind::TSDeclaration { .. } => FunctionType::TSDeclareFunction,
         };
 
-        if FunctionType::TSDeclareFunction == function_type {
+        if FunctionType::TSDeclareFunction == function_type
+            || FunctionType::TSEmptyBodyFunctionExpression == function_type
+        {
             self.asi()?;
         }
 

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1326,6 +1326,7 @@ Expect Syntax Error: "compiler/objectLiteralFreshnessWithSpread.ts"
 Expect Syntax Error: "compiler/objectLiteralFunctionArgContextualTyping.ts"
 Expect Syntax Error: "compiler/objectLiteralFunctionArgContextualTyping2.ts"
 Expect Syntax Error: "compiler/objectLiteralIndexerErrors.ts"
+Expect Syntax Error: "compiler/objectLiteralMemberWithoutBlock1.ts"
 Expect Syntax Error: "compiler/objectLiteralParameterResolution.ts"
 Expect Syntax Error: "compiler/objectLiteralPropertyImplicitlyAny.ts"
 Expect Syntax Error: "compiler/objectLiteralReferencingInternalProperties.ts"
@@ -3551,7 +3552,6 @@ Expect Syntax Error: "conformance/types/nonPrimitive/nonPrimitiveUnionIntersecti
 Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/callSignatureWithOptionalParameterAndInitializer.ts"
 Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType2.ts"
 Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithParameterInitializers.ts"
-Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithParameterInitializers2.ts"
 Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts"
 Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts"
 Expect Syntax Error: "conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts"
@@ -7932,13 +7932,6 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  1 │ var v = { foo?() { } }
    ·              ┬
    ·              ╰── `,` expected
-   ╰────
-
-  × Expected `,` but found `;`
-   ╭─[compiler/objectLiteralMemberWithoutBlock1.ts:1:16]
- 1 │ var v = { foo(); }
-   ·                ┬
-   ·                ╰── `,` expected
    ╰────
 
   × Expected `,` but found `;`
@@ -19560,6 +19553,15 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ·            ╰── `x` has already been declared here
  38 │ }
     ╰────
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+    ╭─[conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithParameterInitializers2.ts:20:15]
+ 19 │ var b = {
+ 20 │     foo(x = 1), // error
+    ·               ▲
+ 21 │     foo(x = 1) { }, // error
+    ╰────
+  help: Try insert a semicolon here
 
   × A parameter property is only allowed in a constructor implementation.
     ╭─[conformance/types/objectTypeLiteral/callSignatures/constructSignatureWithAccessibilityModifiersOnParameters.ts:16:10]


### PR DESCRIPTION
https://oxc-project.github.io/oxc/playground/?code=3YCAAICXgICAgICAgICxG4jI43W9aqTWr3WzyAs1pNu4fnf%2FXXEB3Yt%2FfiBIgA%3D%3D

The conformance test are going back to initial state. I think the `.asi` should be smarter, i can rethink that later