### PR TITLE
refactor: rename `CompactString` to `CompactStr`

### DIFF
--- a/crates/oxc_js_regex/src/ast.rs
+++ b/crates/oxc_js_regex/src/ast.rs
@@ -1,7 +1,7 @@
 //! [`@eslint-community/regexpp`](https://github.com/eslint-community/regexpp/blob/2e8f1af992fb12eae46a446253e8fa3f6cede92a/src/ast.ts)
 
 use oxc_allocator::{Box, Vec};
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 /// The type which includes all nodes.
 #[derive(Debug)]
@@ -120,7 +120,7 @@ pub struct Group<'a> {
 #[derive(Debug)]
 pub struct CapturingGroup<'a> {
     pub span: Span,
-    pub name: Option<CompactString>,
+    pub name: Option<CompactStr>,
     pub alternatives: Vec<'a, Alternative<'a>>,
     pub references: Vec<'a, Backreference<'a>>,
 }
@@ -267,8 +267,8 @@ pub enum UnicodePropertyCharacterSet<'a> {
 #[derive(Debug)]
 pub struct CharacterUnicodePropertyCharacterSet {
     pub span: Span,
-    pub key: CompactString,
-    pub value: Option<CompactString>,
+    pub key: CompactStr,
+    pub value: Option<CompactStr>,
     pub negate: bool,
 }
 
@@ -276,7 +276,7 @@ pub struct CharacterUnicodePropertyCharacterSet {
 #[derive(Debug)]
 pub struct StringsUnicodePropertyCharacterSet {
     pub span: Span,
-    pub key: CompactString,
+    pub key: CompactStr,
 }
 
 /// The expression character class.
@@ -360,7 +360,7 @@ pub struct Character {
 #[derive(Debug)]
 pub enum BackreferenceRef {
     Number(i32),
-    CompactString(CompactString),
+    CompactStr(CompactStr),
 }
 
 /// The backreference.

--- a/crates/oxc_linter/src/rules/deepscan/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/deepscan/bad_array_method_on_arguments.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -19,7 +19,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
         "The 'arguments' object does not have '{0}()' method. If an array method was intended, consider converting the 'arguments' object to an array or using ES6 rest parameter instead."
     )
 )]
-struct BadArrayMethodOnArgumentsDiagnostic(CompactString, #[label] pub Span);
+struct BadArrayMethodOnArgumentsDiagnostic(CompactStr, #[label] pub Span);
 
 /// `https://deepscan.io/docs/rules/bad-array-method-on-arguments`
 #[derive(Debug, Default, Clone)]
@@ -61,7 +61,7 @@ impl Rule for BadArrayMethodOnArguments {
             MemberExpression::StaticMemberExpression(expr) => {
                 if ARRAY_METHODS.binary_search(&expr.property.name.as_str()).is_ok() {
                     ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
-                        expr.property.name.to_compact_string(),
+                        expr.property.name.to_compact_str(),
                         expr.span,
                     ));
                 }
@@ -71,7 +71,7 @@ impl Rule for BadArrayMethodOnArguments {
                     Expression::StringLiteral(name) => {
                         if ARRAY_METHODS.binary_search(&name.value.as_str()).is_ok() {
                             ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
-                                name.value.to_compact_string(),
+                                name.value.to_compact_str(),
                                 expr.span,
                             ));
                         }
@@ -86,7 +86,7 @@ impl Rule for BadArrayMethodOnArguments {
                             {
                                 if ARRAY_METHODS.binary_search(&name).is_ok() {
                                     ctx.diagnostic(BadArrayMethodOnArgumentsDiagnostic(
-                                        CompactString::from(name),
+                                        CompactStr::from(name),
                                         expr.span,
                                     ));
                                 }

--- a/crates/oxc_linter/src/rules/deepscan/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/deepscan/number_arg_out_of_range.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -17,7 +17,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("The first argument of 'Number.prototype.{0}' should be a number between {1} and {2}")
 )]
-struct NumberArgOutOfRangeDiagnostic(CompactString, usize, usize, #[label] pub Span);
+struct NumberArgOutOfRangeDiagnostic(CompactStr, usize, usize, #[label] pub Span);
 
 /// `https://deepscan.io/docs/rules/number-arg-out-of-range`
 #[derive(Debug, Default, Clone)]
@@ -52,19 +52,19 @@ impl Rule for NumberArgOutOfRange {
                 match member.static_property_name() {
                     Some(name @ "toString") => {
                         if !(2.0_f64..=36.0_f64).contains(&value) {
-                            let name = CompactString::from(name);
+                            let name = CompactStr::from(name);
                             ctx.diagnostic(NumberArgOutOfRangeDiagnostic(name, 2, 36, expr.span));
                         }
                     }
                     Some(name @ ("toFixed" | "toExponential")) => {
                         if !(0.0_f64..=20.0_f64).contains(&value) {
-                            let name = CompactString::from(name);
+                            let name = CompactStr::from(name);
                             ctx.diagnostic(NumberArgOutOfRangeDiagnostic(name, 0, 20, expr.span));
                         }
                     }
                     Some(name @ "toPrecision") => {
                         if !(1.0_f64..=21.0_f64).contains(&value) {
-                            let name = CompactString::from(name);
+                            let name = CompactStr::from(name);
                             ctx.diagnostic(NumberArgOutOfRangeDiagnostic(name, 1, 21, expr.span));
                         }
                     }

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 use phf::phf_set;
 use serde_json::Value;
 
@@ -28,14 +28,14 @@ enum ArrayCallbackReturnDiagnostic {
         severity(warning),
         help("Array method {0:?} needs to have valid return on all code paths")
     )]
-    ExpectReturn(CompactString, #[label] Span),
+    ExpectReturn(CompactStr, #[label] Span),
 
     #[error("eslint(array-callback-return): Unexpected return for array method {0}")]
     #[diagnostic(
         severity(warning),
         help("Array method {0} expects no useless return from the function")
     )]
-    ExpectNoReturn(CompactString, #[label] Span),
+    ExpectNoReturn(CompactStr, #[label] Span),
 }
 
 #[derive(Debug, Default, Clone)]
@@ -243,10 +243,10 @@ const TARGET_METHODS: phf::Set<&'static str> = phf_set! {
     "toSorted",
 };
 
-fn full_array_method_name(array_method: &'static str) -> CompactString {
+fn full_array_method_name(array_method: &'static str) -> CompactStr {
     match array_method {
-        "from" => CompactString::from("Array.from"),
-        s => CompactString::from(format!("Array.prototype.{s}")),
+        "from" => CompactStr::from("Array.from"),
+        s => CompactStr::from(format!("Array.prototype.{s}")),
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-class-assign): Unexpected re-assignment of class {0}")]
 #[diagnostic(severity(warning))]
 struct NoClassAssignDiagnostic(
-    CompactString,
+    CompactStr,
     #[label("{0} is declared as class here")] pub Span,
     #[label("{0} is re-assigned here")] pub Span,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-const-assign): Unexpected re-assignment of const variable {0}")]
 #[diagnostic(severity(warning))]
 struct NoConstAssignDiagnostic(
-    CompactString,
+    CompactStr,
     #[label("{0} is declared here as const")] pub Span,
     #[label("{0} is re-assigned here")] pub Span,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, CompactString, GetSpan, Span};
+use oxc_span::{Atom, CompactStr, GetSpan, Span};
 use regex::{Matches, Regex};
 
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
@@ -19,7 +19,7 @@ use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, Ast
     severity(warning),
     help("Unexpected control character(s) in regular expression: \"{0}\"")
 )]
-struct NoControlRegexDiagnostic(CompactString, #[label] pub Span);
+struct NoControlRegexDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoControlRegex;

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule};
@@ -17,7 +17,7 @@ use crate::{context::LintContext, rule::Rule};
     )
 )]
 struct NoDupeClassMembersDiagnostic(
-    CompactString, /*Class member name */
+    CompactStr, /*Class member name */
     #[label("{0:?} is previously declared here")] pub Span,
     #[label("{0:?} is re-declared here")] pub Span,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -5,14 +5,14 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-func-assign): '{0}' is a function.")]
 #[diagnostic(severity(warning))]
-struct NoFuncAssignDiagnostic(CompactString, #[label("{0} is re-assigned here")] pub Span);
+struct NoFuncAssignDiagnostic(CompactStr, #[label("{0} is re-assigned here")] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoFuncAssign;

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-global-assign): Read-only global '{0}' should not be modified.")]
 #[diagnostic(severity(warning))]
 struct NoGlobalAssignDiagnostic(
-    CompactString,
+    CompactStr,
     #[label("Read-only global '{0}' should not be modified.")] pub Span,
 );
 
@@ -20,7 +20,7 @@ pub struct NoGlobalAssign(Box<NoGlobalAssignConfig>);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoGlobalAssignConfig {
-    excludes: Vec<CompactString>,
+    excludes: Vec<CompactStr>,
 }
 
 impl std::ops::Deref for NoGlobalAssign {
@@ -58,8 +58,8 @@ impl Rule for NoGlobalAssign {
                 .iter()
                 .map(serde_json::Value::as_str)
                 .filter(std::option::Option::is_some)
-                .map(|x| CompactString::from(x.unwrap()))
-                .collect::<Vec<CompactString>>(),
+                .map(|x| CompactStr::from(x.unwrap()))
+                .collect::<Vec<CompactStr>>(),
         }))
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -16,7 +16,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("do not use {0} as a constructor, consider removing the new operator.")
 )]
-struct NoNewWrappersDiagnostic(CompactString, #[label] pub Span);
+struct NoNewWrappersDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNewWrappers;
@@ -47,7 +47,7 @@ impl Rule for NoNewWrappers {
         if (ident.name == "String" || ident.name == "Number" || ident.name == "Boolean")
             && ctx.semantic().is_reference_to_global_variable(ident)
         {
-            ctx.diagnostic(NoNewWrappersDiagnostic(ident.name.to_compact_string(), expr.span));
+            ctx.diagnostic(NoNewWrappersDiagnostic(ident.name.to_compact_str(), expr.span));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, ScopeId};
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -18,7 +18,7 @@ const NON_CALLABLE_GLOBALS: [&str; 5] = ["Atomics", "Intl", "JSON", "Math", "Ref
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-obj-calls): Disallow calling some global objects as functions")]
 #[diagnostic(severity(warning), help("{0} is not a function."))]
-struct NoObjCallsDiagnostic(CompactString, #[label] pub Span);
+struct NoObjCallsDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NoObjCalls;
@@ -141,7 +141,7 @@ impl Rule for NoObjCalls {
                     resolve_global_binding(ident, node.scope_id(), ctx)
                 {
                     if is_global_obj(top_level_reference) {
-                        ctx.diagnostic(NoObjCallsDiagnostic(ident.name.to_compact_string(), span));
+                        ctx.diagnostic(NoObjCallsDiagnostic(ident.name.to_compact_str(), span));
                     }
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::VariableInfo;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -16,7 +16,7 @@ use crate::{context::LintContext, rule::Rule};
 #[error("eslint(no-redeclare): '{0}' is already defined.")]
 #[diagnostic(severity(warning))]
 struct NoRedeclareDiagnostic(
-    CompactString,
+    CompactStr,
     #[label("'{0}' is already defined.")] pub Span,
     #[label("It can not be redeclare here.")] pub Span,
 );
@@ -25,7 +25,7 @@ struct NoRedeclareDiagnostic(
 #[error("eslint(no-redeclare): '{0}' is already defined as a built-in global variable.")]
 #[diagnostic(severity(warning))]
 struct NoRedeclareAsBuiltiInDiagnostic(
-    CompactString,
+    CompactStr,
     #[label("'{0}' is already defined as a built-in global variable.")] pub Span,
 );
 
@@ -33,7 +33,7 @@ struct NoRedeclareAsBuiltiInDiagnostic(
 #[error("eslint(no-redeclare): '{0}' is already defined by a variable declaration.")]
 #[diagnostic(severity(warning))]
 struct NoRedeclareBySyntaxDiagnostic(
-    CompactString,
+    CompactStr,
     #[label("'{0}' is already defined by a variable declaration.")] pub Span,
     #[label("It cannot be redeclared here.")] pub Span,
 );
@@ -108,12 +108,12 @@ impl NoRedeclare {
     ) {
         if self.built_in_globals && ctx.env_contains_var(&ident.name) {
             ctx.diagnostic(NoRedeclareAsBuiltiInDiagnostic(
-                ident.name.to_compact_string(),
+                ident.name.to_compact_str(),
                 ident.span,
             ));
         } else if variable.span != ident.span {
             ctx.diagnostic(NoRedeclareDiagnostic(
-                ident.name.to_compact_string(),
+                ident.name.to_compact_str(),
                 ident.span,
                 variable.span,
             ));

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -7,14 +7,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, CompactString, Span};
+use oxc_span::{Atom, CompactStr, Span};
 
 use crate::{context::LintContext, globals::PRE_DEFINE_VAR, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.")]
 #[diagnostic(severity(warning), help("Shadowing of global properties '{0}'."))]
-struct NoShadowRestrictedNamesDiagnostic(CompactString, #[label] pub Span);
+struct NoShadowRestrictedNamesDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoShadowRestrictedNames;
@@ -95,7 +95,7 @@ impl Rule for NoShadowRestrictedNames {
                     if let Some((atom, span)) = binding_pattern_is_global_obj(&decl.id) {
                         if atom.as_str() != "undefined" || decl.init.is_some() {
                             ctx.diagnostic(NoShadowRestrictedNamesDiagnostic(
-                                atom.to_compact_string(),
+                                atom.to_compact_str(),
                                 span,
                             ));
                         } else {
@@ -112,7 +112,7 @@ impl Rule for NoShadowRestrictedNames {
                             ) if ati.name == "undefined" => {
                                 if let Some(span) = nearest_span {
                                     ctx.diagnostic(NoShadowRestrictedNamesDiagnostic(
-                                        ati.name.to_compact_string(),
+                                        ati.name.to_compact_str(),
                                         span,
                                     ));
                                 }
@@ -129,7 +129,7 @@ impl Rule for NoShadowRestrictedNames {
                 AstKind::FormalParameter(param) => {
                     if let Some(value) = binding_pattern_is_global_obj(&param.pattern) {
                         ctx.diagnostic(NoShadowRestrictedNamesDiagnostic(
-                            value.0.to_compact_string(),
+                            value.0.to_compact_str(),
                             value.1,
                         ));
                     }
@@ -143,7 +143,7 @@ impl Rule for NoShadowRestrictedNames {
                     if let Some(param) = catch_clause.param.as_ref() {
                         if let Some(value) = binding_pattern_is_global_obj(param) {
                             ctx.diagnostic(NoShadowRestrictedNamesDiagnostic(
-                                value.0.to_compact_string(),
+                                value.0.to_compact_str(),
                                 value.1,
                             ));
                         }

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use oxc_syntax::operator::UnaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-undef): Disallow the use of undeclared variables")]
 #[diagnostic(severity(warning), help("'{0}' is not defined."))]
-struct NoUndefDiagnostic(CompactString, #[label] pub Span);
+struct NoUndefDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUndef {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -4,14 +4,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, fixer::Fix, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-unused-labels): Disallow unused labels")]
 #[diagnostic(severity(warning), help("'{0}:' is defined but never used."))]
-struct NoUnusedLabelsDiagnostic(CompactString, #[label] pub Span);
+struct NoUnusedLabelsDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUnusedLabels;
@@ -51,7 +51,7 @@ impl Rule for NoUnusedLabels {
                 // TODO: Ignore fix where comments exist between label and statement
                 // e.g. A: /* Comment */ function foo(){}
                 ctx.diagnostic_with_fix(
-                    NoUnusedLabelsDiagnostic(stmt.label.name.to_compact_string(), stmt.label.span),
+                    NoUnusedLabelsDiagnostic(stmt.label.name.to_compact_str(), stmt.label.span),
                     || Fix::delete(stmt.label.span),
                 );
             }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, AstNodeId, AstNodes};
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use oxc_syntax::class::ElementKind;
 
 use crate::{context::LintContext, rule::Rule};
@@ -14,7 +14,7 @@ use crate::{context::LintContext, rule::Rule};
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint(no-unused-private-class-members): '{0}' is defined but never used.")]
 #[diagnostic(severity(warning))]
-struct NoUnusedPrivateClassMembersDiagnostic(CompactString, #[label] pub Span);
+struct NoUnusedPrivateClassMembersDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUnusedPrivateClassMembers;

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -6,7 +6,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ModuleRecord;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{context::LintContext, rule::Rule};
@@ -15,10 +15,10 @@ use crate::{context::LintContext, rule::Rule};
 enum ExportDiagnostic {
     #[error("eslint-plugin-import(export): Multiple exports of name '{1}'.")]
     #[diagnostic(severity(warning))]
-    MultipleNamedExport(#[label] Span, CompactString),
+    MultipleNamedExport(#[label] Span, CompactStr),
     #[error("eslint-plugin-import(export): No named exports found in module '{1}'")]
     #[diagnostic(severity(warning))]
-    NoNamedExport(#[label] Span, CompactString),
+    NoNamedExport(#[label] Span, CompactStr),
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md>
@@ -84,7 +84,7 @@ impl Rule for Export {
 
 fn walk_exported_recursive(
     module_record: &ModuleRecord,
-    result: &mut FxHashSet<CompactString>,
+    result: &mut FxHashSet<CompactStr>,
     visited: &mut FxHashSet<PathBuf>,
 ) {
     let path = &module_record.resolved_absolute_path;

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 use oxc_syntax::module_record::ImportImportName;
 
 use crate::{context::LintContext, rule::Rule};
@@ -13,14 +13,14 @@ use crate::{context::LintContext, rule::Rule};
 enum NamespaceDiagnostic {
     #[error("eslint-plugin-import(namespace): {1:?} not found in imported namespace {2:?}.")]
     #[diagnostic(severity(warning))]
-    NoExport(#[label] Span, CompactString, CompactString),
+    NoExport(#[label] Span, CompactStr, CompactStr),
     #[error("eslint-plugin-import(namespace): Unable to validate computed reference to imported namespace {1:?}
     .")]
     #[diagnostic(severity(warning))]
-    ComputedReference(#[label] Span, CompactString),
+    ComputedReference(#[label] Span, CompactStr),
     #[error("eslint-plugin-import(namespace): Assignment to member of namespace {1:?}.'")]
     #[diagnostic(severity(warning))]
-    Assignment(#[label] Span, CompactString),
+    Assignment(#[label] Span, CompactStr),
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -5,14 +5,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(no-amd): Do not use AMD `require` and `define` calls.")]
 #[diagnostic(severity(warning), help("Expected imports instead of AMD {1}()"))]
-struct NoAmdDiagnostic(#[label] pub Span, CompactString);
+struct NoAmdDiagnostic(#[label] pub Span, CompactStr);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoAmd;
@@ -56,7 +56,7 @@ impl Rule for NoAmd {
                 {
                     ctx.diagnostic(NoAmdDiagnostic(
                         identifier.span,
-                        identifier.name.to_compact_string(),
+                        identifier.name.to_compact_str(),
                     ));
                 }
             }

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -11,7 +11,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use oxc_syntax::module_record::ModuleRecord;
 
 use crate::{context::LintContext, rule::Rule};
@@ -120,7 +120,7 @@ impl Rule for NoCycle {
 #[derive(Debug, Default)]
 struct State {
     traversed: HashSet<PathBuf>,
-    stack: Vec<(CompactString, PathBuf)>,
+    stack: Vec<(CompactStr, PathBuf)>,
 }
 
 impl NoCycle {

--- a/crates/oxc_linter/src/rules/import/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/import/no_deprecated.rs
@@ -3,14 +3,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(namespace): ")]
 #[diagnostic(severity(warning), help(""))]
-struct NoDeprecatedDiagnostic(CompactString, #[label] pub Span);
+struct NoDeprecatedDiagnostic(CompactStr, #[label] pub Span);
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-deprecated.md>
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -12,7 +12,7 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use oxc_syntax::module_record::ImportImportName;
 
 use crate::{context::LintContext, rule::Rule};
@@ -58,7 +58,7 @@ impl Rule for NoNamedAsDefaultMember {
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.semantic().module_record();
 
-        let mut has_members_map: HashMap<SymbolId, (Ref<'_, CompactString, _, _>, CompactString)> =
+        let mut has_members_map: HashMap<SymbolId, (Ref<'_, CompactStr, _, _>, CompactStr)> =
             HashMap::default();
         for import_entry in &module_record.import_entries {
             let ImportImportName::Default(_) = import_entry.import_name else {

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -3,14 +3,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-import(namespace): ")]
 #[diagnostic(severity(warning), help(""))]
-struct NoUnusedModulesDiagnostic(CompactString, #[label] pub Span);
+struct NoUnusedModulesDiagnostic(CompactStr, #[label] pub Span);
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{
     context::LintContext,
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jest(no-test-prefixes): Use {0:?} instead.")]
 #[diagnostic(severity(warning))]
-struct NoTestPrefixesDiagnostic(CompactString, #[label] pub Span);
+struct NoTestPrefixesDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoTestPrefixes;
@@ -91,7 +91,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
     });
 }
 
-fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> CompactString {
+fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> CompactStr {
     let ParsedGeneralJestFnCall { members, name, .. } = jest_fn_call;
 
     let preferred_modifier = if name.starts_with('f') { "only" } else { "skip" };
@@ -103,9 +103,9 @@ fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> CompactSt
     let name_slice = &name[1..];
 
     if member_names.is_empty() {
-        CompactString::from(format!("{name_slice}.{preferred_modifier}"))
+        CompactStr::from(format!("{name_slice}.{preferred_modifier}"))
     } else {
-        CompactString::from(format!("{name_slice}.{preferred_modifier}.{member_names}"))
+        CompactStr::from(format!("{name_slice}.{preferred_modifier}.{member_names}"))
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{
     context::LintContext,
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jest(valid-expect): {0:?}")]
 #[diagnostic(severity(warning), help("{1:?}"))]
-struct ValidExpectDiagnostic(CompactString, &'static str, #[label] Span);
+struct ValidExpectDiagnostic(CompactStr, &'static str, #[label] Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct ValidExpect(Box<ValidExpectConfig>);
@@ -142,7 +142,7 @@ impl ValidExpect {
         let Some(Expression::CallExpression(call_expr)) = jest_fn_call.head.parent else { return };
 
         if call_expr.arguments.len() < self.min_args {
-            let error = CompactString::from(format!(
+            let error = CompactStr::from(format!(
                 "Expect takes at most {} argument{} ",
                 self.min_args,
                 if self.min_args > 1 { "s" } else { "" }
@@ -152,7 +152,7 @@ impl ValidExpect {
             return;
         }
         if call_expr.arguments.len() > self.max_args {
-            let error = CompactString::from(format!(
+            let error = CompactStr::from(format!(
                 "Expect requires at least {} argument{} ",
                 self.max_args,
                 if self.max_args > 1 { "s" } else { "" }
@@ -360,26 +360,25 @@ enum Message {
 }
 
 impl Message {
-    fn details(self) -> (CompactString, &'static str) {
+    fn details(self) -> (CompactStr, &'static str) {
         match self {
             Self::MatcherNotFound => (
-                CompactString::from("Expect must have a corresponding matcher call."),
+                CompactStr::from("Expect must have a corresponding matcher call."),
                 "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)",
             ),
             Self::MatcherNotCalled => (
-                CompactString::from("Matchers must be called to assert."),
+                CompactStr::from("Matchers must be called to assert."),
                 "You need call your matcher, e.g. `expect(true).toBe(true)`.",
             ),
-            Self::ModifierUnknown => (
-                CompactString::from("Expect has an unknown modifier."),
-                "Is it a spelling mistake?",
-            ),
+            Self::ModifierUnknown => {
+                (CompactStr::from("Expect has an unknown modifier."), "Is it a spelling mistake?")
+            }
             Self::AsyncMustBeAwaited => (
-                CompactString::from("Async assertions must be awaited."),
+                CompactStr::from("Async assertions must be awaited."),
                 "Add `await` to your assertion.",
             ),
             Self::PromisesWithAsyncAssertionsMustBeAwaited => (
-                CompactString::from("Promises which return async assertions must be awaited."),
+                CompactStr::from("Promises which return async assertions must be awaited."),
                 "Add `await` to your assertion.",
             ),
         }

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 use regex::Regex;
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-jest(valid-title): {0:?}")]
 #[diagnostic(severity(warning), help("{1:?}"))]
-struct ValidTitleDiagnostic(CompactString, &'static str, #[label] pub Span);
+struct ValidTitleDiagnostic(CompactStr, &'static str, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct ValidTitle(Box<ValidTitleConfig>);
@@ -293,7 +293,7 @@ fn validate_title(
         if let Some(matched) = disallowed_words_reg.find(title) {
             let error = format!("{} is not allowed in test title", matched.as_str());
             ctx.diagnostic(ValidTitleDiagnostic(
-                CompactString::from(error),
+                CompactStr::from(error),
                 "It is included in the `disallowedWords` of your config file, try to remove it from your title",
                 span,
             ));
@@ -325,8 +325,8 @@ fn validate_title(
         if !regex.is_match(title) {
             let raw_pattern = regex.as_str();
             let message = message.as_ref().map_or_else(
-                || CompactString::from(format!("{un_prefixed_name} should match {raw_pattern}")),
-                |message| CompactString::from(message.as_str()),
+                || CompactStr::from(format!("{un_prefixed_name} should match {raw_pattern}")),
+                |message| CompactStr::from(message.as_str()),
             );
             ctx.diagnostic(ValidTitleDiagnostic(
                 message,
@@ -340,12 +340,8 @@ fn validate_title(
         if regex.is_match(title) {
             let raw_pattern = regex.as_str();
             let message = message.as_ref().map_or_else(
-                || {
-                    CompactString::from(format!(
-                        "{un_prefixed_name} should not match {raw_pattern}"
-                    ))
-                },
-                |message| CompactString::from(message.as_str()),
+                || CompactStr::from(format!("{un_prefixed_name} should not match {raw_pattern}")),
+                |message| CompactStr::from(message.as_str()),
             );
 
             ctx.diagnostic(ValidTitleDiagnostic(
@@ -386,7 +382,7 @@ impl Message {
     }
     fn diagnostic(&self, ctx: &LintContext, span: Span) {
         let (error, help) = self.detail();
-        ctx.diagnostic(ValidTitleDiagnostic(CompactString::from(error), help, span));
+        ctx.diagnostic(ValidTitleDiagnostic(CompactStr::from(error), help, span));
     }
 }
 

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -19,7 +19,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
         "Remove the argument and its usage. Alternatively, use the argument in the function body."
     )
 )]
-struct OnlyUsedInRecursionDiagnostic(#[label] pub Span, pub CompactString);
+struct OnlyUsedInRecursionDiagnostic(#[label] pub Span, pub CompactStr);
 
 #[derive(Debug, Default, Clone)]
 pub struct OnlyUsedInRecursion;
@@ -79,10 +79,7 @@ impl Rule for OnlyUsedInRecursion {
             let BindingPatternKind::BindingIdentifier(arg) = &arg.pattern.kind else { continue };
 
             if is_argument_only_used_in_recursion(function_id, arg, arg_index, ctx) {
-                ctx.diagnostic(OnlyUsedInRecursionDiagnostic(
-                    arg.span,
-                    arg.name.to_compact_string(),
-                ));
+                ctx.diagnostic(OnlyUsedInRecursionDiagnostic(arg.span, arg.name.to_compact_str()));
             }
         }
     }

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, CompactString, Span};
+use oxc_span::{Atom, CompactStr, Span};
 use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -20,7 +20,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("Remove one of the props, or rename them so each prop is distinct.")
 )]
-struct JsxNoDuplicatePropsDiagnostic(CompactString, #[label] pub Span, #[label] pub Span);
+struct JsxNoDuplicatePropsDiagnostic(CompactStr, #[label] pub Span, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct JsxNoDuplicateProps;
@@ -63,7 +63,7 @@ impl Rule for JsxNoDuplicateProps {
 
             if let Some(old_span) = props.insert(ident.name.clone(), ident.span) {
                 ctx.diagnostic(JsxNoDuplicatePropsDiagnostic(
-                    ident.name.to_compact_string(),
+                    ident.name.to_compact_str(),
                     old_span,
                     ident.span,
                 ));

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -10,14 +10,14 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX")]
 #[diagnostic(severity(warning), help("'{0}' is not defined."))]
-struct JsxNoUndefDiagnostic(CompactString, #[label] pub Span);
+struct JsxNoUndefDiagnostic(CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct JsxNoUndef;
@@ -69,7 +69,7 @@ impl Rule for JsxNoUndef {
                         return;
                     }
                 }
-                ctx.diagnostic(JsxNoUndefDiagnostic(ident.name.to_compact_string(), ident.span));
+                ctx.diagnostic(JsxNoUndefDiagnostic(ident.name.to_compact_str(), ident.span));
             }
         }
     }

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -10,7 +10,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -20,7 +20,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 )]
 #[diagnostic(severity(warning))]
 struct AdjacentOverloadSignaturesDiagnostic(
-    CompactString,
+    CompactStr,
     #[label] pub Option<Span>,
     #[label] pub Span,
 );
@@ -104,7 +104,7 @@ fn get_kind_from_key(key: &PropertyKey) -> MethodKind {
 
 #[derive(Debug)]
 struct Method {
-    name: CompactString,
+    name: CompactStr,
     r#static: bool,
     call_signature: bool,
     kind: MethodKind,
@@ -130,7 +130,7 @@ impl GetMethod for ClassElement<'_> {
     fn get_method(&self) -> Option<Method> {
         match self {
             ClassElement::MethodDefinition(def) => def.key.static_name().map(|name| Method {
-                name: name.to_compact_string(),
+                name: name.to_compact_str(),
                 r#static: def.r#static,
                 call_signature: false,
                 kind: get_kind_from_key(&def.key),
@@ -145,21 +145,21 @@ impl GetMethod for TSSignature<'_> {
     fn get_method(&self) -> Option<Method> {
         match self {
             TSSignature::TSMethodSignature(sig) => sig.key.static_name().map(|name| Method {
-                name: name.to_compact_string(),
+                name: name.to_compact_str(),
                 r#static: false,
                 call_signature: false,
                 kind: get_kind_from_key(&sig.key),
                 span: sig.key.span(),
             }),
             TSSignature::TSCallSignatureDeclaration(sig) => Some(Method {
-                name: CompactString::from("call"),
+                name: CompactStr::from("call"),
                 r#static: false,
                 call_signature: true,
                 kind: MethodKind::Normal,
                 span: sig.span,
             }),
             TSSignature::TSConstructSignatureDeclaration(decl) => Some(Method {
-                name: CompactString::from("new"),
+                name: CompactStr::from("new"),
                 r#static: false,
                 call_signature: false,
                 kind: MethodKind::Normal,
@@ -183,7 +183,7 @@ impl GetMethod for ModuleDeclaration<'_> {
                             FunctionType::FunctionDeclaration | FunctionType::TSDeclareFunction
                         ) {
                             func_decl.id.as_ref().map(|id| Method {
-                                name: id.name.to_compact_string(),
+                                name: id.name.to_compact_str(),
                                 r#static: false,
                                 call_signature: false,
                                 kind: MethodKind::Normal,
@@ -199,7 +199,7 @@ impl GetMethod for ModuleDeclaration<'_> {
             ModuleDeclaration::ExportNamedDeclaration(named_decl) => {
                 if let Some(Declaration::FunctionDeclaration(func_decl)) = &named_decl.declaration {
                     return func_decl.id.as_ref().map(|id| Method {
-                        name: id.name.to_compact_string(),
+                        name: id.name.to_compact_str(),
                         r#static: false,
                         call_signature: false,
                         kind: MethodKind::Normal,
@@ -222,7 +222,7 @@ impl GetMethod for Declaration<'_> {
                     FunctionType::FunctionDeclaration | FunctionType::TSDeclareFunction
                 ) {
                     func_decl.id.as_ref().map(|id| Method {
-                        name: id.name.to_compact_string(),
+                        name: id.name.to_compact_str(),
                         r#static: false,
                         call_signature: false,
                         kind: MethodKind::Normal,
@@ -257,7 +257,7 @@ fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext<'_>) {
 
             if index.is_some() && !method.is_same_method(last_method) {
                 let name = if method.r#static {
-                    CompactString::from(format!("static {0}", method.name))
+                    CompactStr::from(format!("static {0}", method.name))
                 } else {
                     method.name.clone()
                 };

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub enum BanTypesDiagnostic {
     #[error("typescript-eslint(ban-types): Do not use {0:?} as a type. Use \"{1}\" instead")]
     #[diagnostic(severity(warning))]
-    Type(CompactString, String, #[label] Span),
+    Type(CompactStr, String, #[label] Span),
 
     #[error("typescript-eslint(ban-types): Prefer explicitly define the object shape")]
     #[diagnostic(severity(warning), help("This type means \"any non-nullish value\", which is slightly better than 'unknown', but it's still a broad type"))]
@@ -63,7 +63,7 @@ impl Rule for BanTypes {
                 match name.as_str() {
                     "String" | "Boolean" | "Number" | "Symbol" | "BigInt" => {
                         ctx.diagnostic(BanTypesDiagnostic::Type(
-                            name.to_compact_string(),
+                            name.to_compact_str(),
                             name.to_lowercase(),
                             typ.span,
                         ));

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -37,7 +37,7 @@ pub struct NoThisAlias(Box<NoThisAliasConfig>);
 #[derive(Debug, Clone)]
 pub struct NoThisAliasConfig {
     allow_destructuring: bool,
-    allow_names: Vec<CompactString>,
+    allow_names: Vec<CompactStr>,
 }
 
 impl std::ops::Deref for NoThisAlias {
@@ -83,8 +83,8 @@ impl Rule for NoThisAlias {
             .iter()
             .map(serde_json::Value::as_str)
             .filter(std::option::Option::is_some)
-            .map(|x| CompactString::from(x.unwrap()))
-            .collect::<Vec<CompactString>>();
+            .map(|x| CompactStr::from(x.unwrap()))
+            .collect::<Vec<CompactStr>>();
 
         Self(Box::new(NoThisAliasConfig {
             allow_destructuring: obj

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -14,7 +14,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 )]
 #[diagnostic(severity(warning), help("Remove the unnecessary {1:?} constraint"))]
 struct NoUnnecessaryTypeConstraintDiagnostic(
-    CompactString,
+    CompactStr,
     &'static str,
     #[label] pub Span,
     #[label] pub Span,
@@ -60,7 +60,7 @@ impl Rule for NoUnnecessaryTypeConstraint {
                         _ => continue,
                     };
                     ctx.diagnostic(NoUnnecessaryTypeConstraintDiagnostic(
-                        param.name.name.to_compact_string(),
+                        param.name.name.to_compact_str(),
                         value,
                         param.name.span,
                         ty_span,

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -8,22 +8,22 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
-use oxc_span::{Atom, CompactString, Span};
+use oxc_span::{Atom, CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(catch-error-name): The catch parameter {0:?} should be named {1:?}")]
 #[diagnostic(severity(warning))]
-struct CatchErrorNameDiagnostic(CompactString, CompactString, #[label] pub Span);
+struct CatchErrorNameDiagnostic(CompactStr, CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct CatchErrorName(Box<CatchErrorNameConfig>);
 
 #[derive(Debug, Clone)]
 pub struct CatchErrorNameConfig {
-    ignore: Vec<CompactString>,
-    name: CompactString,
+    ignore: Vec<CompactStr>,
+    name: CompactStr,
 }
 
 impl std::ops::Deref for CatchErrorName {
@@ -36,7 +36,7 @@ impl std::ops::Deref for CatchErrorName {
 
 impl Default for CatchErrorNameConfig {
     fn default() -> Self {
-        Self { ignore: vec![], name: CompactString::new_inline("error") }
+        Self { ignore: vec![], name: CompactStr::new_inline("error") }
     }
 }
 
@@ -69,10 +69,10 @@ impl Rule for CatchErrorName {
             .iter()
             .map(serde_json::Value::as_str)
             .filter(std::option::Option::is_some)
-            .map(|x| CompactString::from(x.unwrap()))
-            .collect::<Vec<CompactString>>();
+            .map(|x| CompactStr::from(x.unwrap()))
+            .collect::<Vec<CompactStr>>();
 
-        let allowed_name = CompactString::from(
+        let allowed_name = CompactStr::from(
             value
                 .get(0)
                 .and_then(|v| v.get("name"))
@@ -96,7 +96,7 @@ impl Rule for CatchErrorName {
                     if binding_ident.name.starts_with('_') {
                         if symbol_has_references(binding_ident.symbol_id.get(), ctx) {
                             ctx.diagnostic(CatchErrorNameDiagnostic(
-                                binding_ident.name.to_compact_string(),
+                                binding_ident.name.to_compact_str(),
                                 self.name.clone(),
                                 binding_ident.span,
                             ));
@@ -105,7 +105,7 @@ impl Rule for CatchErrorName {
                     }
 
                     ctx.diagnostic(CatchErrorNameDiagnostic(
-                        binding_ident.name.to_compact_string(),
+                        binding_ident.name.to_compact_str(),
                         self.name.clone(),
                         binding_ident.span,
                     ));
@@ -158,7 +158,7 @@ impl CatchErrorName {
                     if v.name.starts_with('_') {
                         if symbol_has_references(v.symbol_id.get(), ctx) {
                             ctx.diagnostic(CatchErrorNameDiagnostic(
-                                v.name.to_compact_string(),
+                                v.name.to_compact_str(),
                                 self.name.clone(),
                                 v.span,
                             ));
@@ -168,7 +168,7 @@ impl CatchErrorName {
                     }
 
                     return Some(CatchErrorNameDiagnostic(
-                        v.name.to_compact_string(),
+                        v.name.to_compact_str(),
                         self.name.clone(),
                         v.span,
                     ));
@@ -186,7 +186,7 @@ impl CatchErrorName {
                     if binding_ident.name.starts_with('_') {
                         if symbol_has_references(binding_ident.symbol_id.get(), ctx) {
                             ctx.diagnostic(CatchErrorNameDiagnostic(
-                                binding_ident.name.to_compact_string(),
+                                binding_ident.name.to_compact_str(),
                                 self.name.clone(),
                                 binding_ident.span,
                             ));
@@ -196,7 +196,7 @@ impl CatchErrorName {
                     }
 
                     return Some(CatchErrorNameDiagnostic(
-                        binding_ident.name.to_compact_string(),
+                        binding_ident.name.to_compact_str(),
                         self.name.clone(),
                         binding_ident.span,
                     ));

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::Error,
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -15,7 +15,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[diagnostic(severity(warning))]
 pub enum ErrorMessageDiagnostic {
     #[error("eslint-plugin-unicorn(error-message): Pass a message to the {0:1} constructor.")]
-    MissingMessage(CompactString, #[label] Span),
+    MissingMessage(CompactStr, #[label] Span),
     #[error("eslint-plugin-unicorn(error-message): Error message should not be an empty string.")]
     EmptyMessage(#[label] Span),
     #[error("eslint-plugin-unicorn(error-message): Error message should be a string.")]
@@ -86,7 +86,7 @@ impl Rule for ErrorMessage {
 
         let Some(arg) = message_argument else {
             return ctx.diagnostic(ErrorMessageDiagnostic::MissingMessage(
-                constructor_name.to_compact_string(),
+                constructor_name.to_compact_str(),
                 span,
             ));
         };

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -10,7 +10,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::{
@@ -24,12 +24,12 @@ use crate::{
 enum ExplicitLengthCheckDiagnostic {
     #[error("eslint-plugin-unicorn(explicit-length-check): Use `.{1} {2}` when checking {1} is not zero.")]
     #[diagnostic(severity(warning))]
-    NoneZero(#[label] Span, CompactString, CompactString, #[help] Option<String>),
+    NoneZero(#[label] Span, CompactStr, CompactStr, #[help] Option<String>),
     #[error(
         "eslint-plugin-unicorn(explicit-length-check): Use `.{1} {2}` when checking {1} is zero."
     )]
     #[diagnostic(severity(warning))]
-    Zero(#[label] Span, CompactString, CompactString, #[help] Option<String>),
+    Zero(#[label] Span, CompactStr, CompactStr, #[help] Option<String>),
 }
 #[derive(Debug, Default, Clone)]
 enum NonZero {
@@ -218,7 +218,7 @@ impl ExplicitLengthCheck {
         let diagnostic = if is_zero_length_check {
             ExplicitLengthCheckDiagnostic::Zero(
                 span,
-                property.to_compact_string(),
+                property.to_compact_str(),
                 check_code.into(),
                 if auto_fix {
                     None
@@ -229,7 +229,7 @@ impl ExplicitLengthCheck {
         } else {
             ExplicitLengthCheckDiagnostic::NoneZero(
                 span,
-                property.to_compact_string(),
+                property.to_compact_str(),
                 check_code.into(),
                 if auto_fix {
                     None

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -17,7 +17,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
     severity(warning),
     help("Reference `this` directly instead of assigning it to a variable.")
 )]
-struct NoThisAssignmentDiagnostic(#[label] pub Span, CompactString);
+struct NoThisAssignmentDiagnostic(#[label] pub Span, CompactStr);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoThisAssignment;
@@ -78,7 +78,7 @@ impl Rule for NoThisAssignment {
 
                 ctx.diagnostic(NoThisAssignmentDiagnostic(
                     variable_decl.span,
-                    binding_ident.name.to_compact_string(),
+                    binding_ident.name.to_compact_str(),
                 ));
             }
             AstKind::AssignmentExpression(assignment_expr) => {
@@ -103,7 +103,7 @@ impl Rule for NoThisAssignment {
 
                 ctx.diagnostic(NoThisAssignmentDiagnostic(
                     assignment_expr.span,
-                    ident.name.to_compact_string(),
+                    ident.name.to_compact_str(),
                 ));
             }
             _ => {}

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
@@ -21,7 +21,7 @@ enum PreferDateNowDiagnostic {
 
     #[error("eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `new Date().{1}()`")]
     #[diagnostic(severity(warning), help("Change to `Date.now()`."))]
-    PreferDateNowOverMethods(#[label] Span, CompactString),
+    PreferDateNowOverMethods(#[label] Span, CompactStr),
 
     #[error(
         "eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `Number(new Date())`"

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 use phf::phf_map;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
@@ -15,7 +15,7 @@ use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode}
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(prefer-modern-dom-apis): Prefer using `{0}` over `{1}`.")]
 #[diagnostic(severity(warning))]
-struct PreferModernDomApisDiagnostic(pub &'static str, CompactString, #[label] pub Span);
+struct PreferModernDomApisDiagnostic(pub &'static str, CompactStr, #[label] pub Span);
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferModernDomApis;
@@ -91,7 +91,7 @@ impl Rule for PreferModernDomApis {
             if let Some(preferred_method) = DISALLOWED_METHODS.get(method) {
                 ctx.diagnostic(PreferModernDomApisDiagnostic(
                     preferred_method,
-                    CompactString::from(method),
+                    CompactStr::from(method),
                     member_expr.property.span,
                 ));
 
@@ -111,7 +111,7 @@ impl Rule for PreferModernDomApis {
                     if lit.value == position {
                         ctx.diagnostic(PreferModernDomApisDiagnostic(
                             replacer,
-                            CompactString::from(method),
+                            CompactStr::from(method),
                             member_expr.property.span,
                         ));
                     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
@@ -15,7 +15,7 @@ use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, Ast
 enum PreferStringReplaceAllDiagnostic {
     #[error("eslint-plugin-unicorn(prefer-string-replace-all): This pattern can be replaced with `{1}`.")]
     #[diagnostic(severity(warning))]
-    StringLiteral(#[label] Span, CompactString),
+    StringLiteral(#[label] Span, CompactStr),
     #[error("eslint-plugin-unicorn(prefer-string-replace-all): Prefer `String#replaceAll()` over `String#replace()` when using a regex with the global flag.")]
     #[diagnostic(severity(warning))]
     UseReplaceAll(#[label] Span),
@@ -99,7 +99,7 @@ fn is_reg_exp_with_global_flag<'a>(expr: &'a Expression<'a>) -> bool {
     false
 }
 
-fn get_pattern_replacement<'a>(expr: &'a Expression<'a>) -> Option<CompactString> {
+fn get_pattern_replacement<'a>(expr: &'a Expression<'a>) -> Option<CompactStr> {
     let Expression::RegExpLiteral(reg_exp_literal) = expr else { return None };
 
     if !reg_exp_literal.regex.flags.contains(RegExpFlags::G) {
@@ -110,7 +110,7 @@ fn get_pattern_replacement<'a>(expr: &'a Expression<'a>) -> Option<CompactString
         return None;
     }
 
-    Some(reg_exp_literal.regex.pattern.to_compact_string())
+    Some(reg_exp_literal.regex.pattern.to_compact_str())
 }
 
 fn is_simple_string(str: &str) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -4,14 +4,14 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(prefer-string-slice): Prefer String#slice() over String#{1}()")]
 #[diagnostic(severity(warning))]
-struct PreferStringSliceDiagnostic(#[label] pub Span, CompactString);
+struct PreferStringSliceDiagnostic(#[label] pub Span, CompactStr);
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferStringSlice;
@@ -50,7 +50,7 @@ impl Rule for PreferStringSlice {
             _ => return,
         };
 
-        ctx.diagnostic(PreferStringSliceDiagnostic(span, name.to_compact_string()));
+        ctx.diagnostic(PreferStringSliceDiagnostic(span, name.to_compact_str()));
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -4,14 +4,14 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
 };
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(prefer-string-trim-start-end): Prefer `{1}` over `{2}`")]
 #[diagnostic(severity(warning), help("Replace with `{1}`"))]
-struct PreferStringTrimStartEndDiagnostic(#[label] pub Span, CompactString, &'static str);
+struct PreferStringTrimStartEndDiagnostic(#[label] pub Span, CompactStr, &'static str);
 
 #[derive(Debug, Default, Clone)]
 pub struct PreferStringTrimStartEnd;
@@ -67,7 +67,7 @@ impl Rule for PreferStringTrimStartEnd {
 
         ctx.diagnostic(PreferStringTrimStartEndDiagnostic(
             span,
-            name.to_compact_string(),
+            name.to_compact_str(),
             get_replacement(name.as_str()),
         ));
     }

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -8,14 +8,14 @@ use oxc_diagnostics::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNodeId;
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("eslint-plugin-unicorn(text-encoding-identifier-case): Prefer `{1}` over `{2}`.")]
 #[diagnostic(severity(warning))]
-struct TextEncodingIdentifierCaseDiagnostic(#[label] pub Span, pub &'static str, pub CompactString);
+struct TextEncodingIdentifierCaseDiagnostic(#[label] pub Span, pub &'static str, pub CompactStr);
 
 #[derive(Debug, Default, Clone)]
 pub struct TextEncodingIdentifierCase;

--- a/crates/oxc_linter/src/utils/nextjs.rs
+++ b/crates/oxc_linter/src/utils/nextjs.rs
@@ -1,4 +1,4 @@
-use oxc_span::CompactString;
+use oxc_span::CompactStr;
 
 use crate::LintContext;
 
@@ -11,7 +11,7 @@ pub fn is_document_page(file_path: &str) -> bool {
     page.starts_with("/_document") || page.starts_with("\\_document")
 }
 
-pub fn get_next_script_import_local_name<'a>(ctx: &'a LintContext) -> Option<&'a CompactString> {
+pub fn get_next_script_import_local_name<'a>(ctx: &'a LintContext) -> Option<&'a CompactStr> {
     ctx.semantic().module_record().import_entries.iter().find_map(|entry| {
         if entry.module_request.name().as_str() == "next/script" {
             Some(entry.local_name.name())

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use oxc_ast::ast::Program;
 use oxc_index::{index_vec, IndexVec};
 use oxc_semantic::{ReferenceId, SemanticBuilder, SymbolId, SymbolTable};
-use oxc_span::CompactString;
+use oxc_span::CompactStr;
 
 type Slot = usize;
 
@@ -147,8 +147,7 @@ impl ManglerBuilder {
 
         let mut freq_iter = frequencies.iter();
         // 2. "N number of vars are going to be assigned names of the same length"
-        for (_, slice_of_same_len_strings_group) in &names.into_iter().group_by(CompactString::len)
-        {
+        for (_, slice_of_same_len_strings_group) in &names.into_iter().group_by(CompactStr::len) {
             // 1. "The most frequent vars get the shorter names"
             // (freq_iter is sorted by frequency from highest to lowest,
             //  so taking means take the N most frequent symbols remaining)
@@ -219,7 +218,7 @@ const BASE54_CHARS: &[u8; 64] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 
 /// Get the shortest mangled name for a given n.
 /// Code adapted from [terser](https://github.com/terser/terser/blob/8b966d687395ab493d2c6286cc9dd38650324c11/lib/scope.js#L1041-L1051)
-fn base54(n: usize) -> CompactString {
+fn base54(n: usize) -> CompactStr {
     let mut num = n;
     // Base 54 at first because these are the usable first characters in JavaScript identifiers
     // <https://tc39.es/ecma262/#prod-IdentifierStart>
@@ -235,5 +234,5 @@ fn base54(n: usize) -> CompactString {
         ret.push(BASE54_CHARS[num % base] as char);
         num /= base;
     }
-    CompactString::new(ret)
+    CompactStr::new(ret)
 }

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -5,7 +5,7 @@ use oxc_diagnostics::{
     thiserror::{self, Error},
     Result,
 };
-use oxc_span::{Atom, CompactString, GetSpan, Span};
+use oxc_span::{Atom, CompactStr, GetSpan, Span};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
 #[error("Identifier `{0}` has already been declared")]
 #[diagnostic()]
 struct Redeclaration(
-    pub CompactString,
+    pub CompactStr,
     #[label("`{0}` has already been declared here")] pub Span,
     #[label("It can not be redeclared here")] pub Span,
 );
@@ -317,7 +317,7 @@ impl<'a> SeparatedList<'a> for AssertEntries<'a> {
         };
 
         if let Some(old_span) = self.keys.get(&key.as_atom()) {
-            p.error(Redeclaration(key.as_atom().into_compact_string(), *old_span, key.span()));
+            p.error(Redeclaration(key.as_atom().into_compact_str(), *old_span, key.span()));
         } else {
             self.keys.insert(key.as_atom(), key.span());
         }

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -68,7 +68,7 @@ impl<'a> Binder for VariableDeclarator<'a> {
                 builder.declare_symbol_on_scope(span, name, current_scope_id, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
             for scope_id in &var_scope_ids {
-                builder.scope.add_binding(*scope_id, name.to_compact_string(), symbol_id);
+                builder.scope.add_binding(*scope_id, name.to_compact_str(), symbol_id);
             }
         });
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc};
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, AstKind, Trivias, TriviasMap, Visit};
 use oxc_diagnostics::Error;
-use oxc_span::{Atom, CompactString, SourceType, Span};
+use oxc_span::{Atom, CompactStr, SourceType, Span};
 use oxc_syntax::{
     module_record::{ExportLocalName, ModuleRecord},
     operator::AssignmentOperator,
@@ -263,7 +263,7 @@ impl<'a> SemanticBuilder<'a> {
         let includes = includes | self.current_symbol_flags;
         let symbol_id = self.symbols.create_symbol(span, name.clone(), includes, scope_id);
         self.symbols.add_declaration(self.current_node_id);
-        self.scope.add_binding(scope_id, name.to_compact_string(), symbol_id);
+        self.scope.add_binding(scope_id, name.to_compact_str(), symbol_id);
         symbol_id
     }
 
@@ -288,7 +288,7 @@ impl<'a> SemanticBuilder<'a> {
         let symbol_id = self.scope.get_binding(scope_id, name)?;
         if report_error && self.symbols.get_flag(symbol_id).intersects(excludes) {
             let symbol_span = self.symbols.get_span(symbol_id);
-            self.error(Redeclaration(name.to_compact_string(), symbol_span, span));
+            self.error(Redeclaration(name.to_compact_str(), symbol_span, span));
         }
         Some(symbol_id)
     }
@@ -298,7 +298,7 @@ impl<'a> SemanticBuilder<'a> {
         let reference_id = self.symbols.create_reference(reference);
         self.scope.add_unresolved_reference(
             self.current_scope_id,
-            CompactString::new(reference_name),
+            CompactStr::new(reference_name),
             reference_id,
         );
         reference_id
@@ -316,7 +316,7 @@ impl<'a> SemanticBuilder<'a> {
         let symbol_id =
             self.symbols.create_symbol(span, name.clone(), includes, self.current_scope_id);
         self.symbols.add_declaration(self.current_node_id);
-        self.scope.get_bindings_mut(scope_id).insert(name.to_compact_string(), symbol_id);
+        self.scope.get_bindings_mut(scope_id).insert(name.to_compact_str(), symbol_id);
         symbol_id
     }
 
@@ -1045,7 +1045,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.visit_label_identifier(&stmt.label);
 
         /* cfg */
-        self.cfg.next_label = Some(stmt.label.name.to_compact_string());
+        self.cfg.next_label = Some(stmt.label.name.to_compact_str());
         /* cfg */
 
         self.visit_statement(&stmt.body);
@@ -1856,7 +1856,7 @@ impl<'a> SemanticBuilder<'a> {
     fn reference_identifier(&mut self, ident: &IdentifierReference) {
         let flag = self.resolve_reference_usages();
         let reference =
-            Reference::new(ident.span, ident.name.to_compact_string(), self.current_node_id, flag);
+            Reference::new(ident.span, ident.name.to_compact_str(), self.current_node_id, flag);
         let reference_id = self.declare_reference(reference);
         ident.reference_id.set(Some(reference_id));
     }
@@ -1884,7 +1884,7 @@ impl<'a> SemanticBuilder<'a> {
         }
         let reference = Reference::new(
             ident.span,
-            ident.name.to_compact_string(),
+            ident.name.to_compact_str(),
             self.current_node_id,
             ReferenceFlag::read(),
         );

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::{self, Error},
 };
-use oxc_span::{Atom, CompactString, GetSpan, ModuleKind, Span};
+use oxc_span::{Atom, CompactStr, GetSpan, ModuleKind, Span};
 use oxc_syntax::{
     module_record::ExportLocalName,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -145,13 +145,13 @@ fn check_module_record(ctx: &SemanticBuilder<'_>) {
     #[derive(Debug, Error, Diagnostic)]
     #[error("Export '{0}' is not defined")]
     #[diagnostic()]
-    struct UndefinedExport(CompactString, #[label] Span);
+    struct UndefinedExport(CompactStr, #[label] Span);
 
     #[derive(Debug, Error, Diagnostic)]
     #[error("Duplicated export '{0}'")]
     #[diagnostic()]
     struct DuplicateExport(
-        CompactString,
+        CompactStr,
         #[label("Export has already been declared here")] Span,
         #[label("It cannot be redeclared here")] Span,
     );
@@ -207,7 +207,7 @@ struct ClassStaticBlockAwait(#[label] Span);
 #[derive(Debug, Error, Diagnostic)]
 #[error("The keyword '{0}' is reserved")]
 #[diagnostic()]
-struct ReservedKeyword(CompactString, #[label] Span);
+struct ReservedKeyword(CompactStr, #[label] Span);
 
 pub const STRICT_MODE_NAMES: Set<&'static str> = phf_set! {
     "implements",
@@ -229,7 +229,7 @@ fn check_identifier<'a>(name: &Atom, span: Span, node: &AstNode<'a>, ctx: &Seman
     if *name == "await" {
         // It is a Syntax Error if the goal symbol of the syntactic grammar is Module and the StringValue of IdentifierName is "await".
         if ctx.source_type.is_module() {
-            return ctx.error(ReservedKeyword(name.to_compact_string(), span));
+            return ctx.error(ReservedKeyword(name.to_compact_str(), span));
         }
         // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
         if ctx.scope.get_flags(node.scope_id()).is_class_static_block() {
@@ -239,14 +239,14 @@ fn check_identifier<'a>(name: &Atom, span: Span, node: &AstNode<'a>, ctx: &Seman
 
     // It is a Syntax Error if this phrase is contained in strict mode code and the StringValue of IdentifierName is: "implements", "interface", "let", "package", "private", "protected", "public", "static", or "yield".
     if ctx.strict_mode() && STRICT_MODE_NAMES.contains(name.as_str()) {
-        ctx.error(ReservedKeyword(name.to_compact_string(), span));
+        ctx.error(ReservedKeyword(name.to_compact_str(), span));
     }
 }
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Cannot assign to '{0}' in strict mode")]
 #[diagnostic()]
-struct UnexpectedIdentifierAssign(CompactString, #[label] Span);
+struct UnexpectedIdentifierAssign(CompactStr, #[label] Span);
 
 fn check_binding_identifier<'a>(
     ident: &BindingIdentifier,
@@ -256,7 +256,7 @@ fn check_binding_identifier<'a>(
     let strict_mode = ctx.strict_mode();
     // It is a Diagnostic if the StringValue of a BindingIdentifier is "eval" or "arguments" within strict mode code.
     if strict_mode && matches!(ident.name.as_str(), "eval" | "arguments") {
-        return ctx.error(UnexpectedIdentifierAssign(ident.name.to_compact_string(), ident.span));
+        return ctx.error(UnexpectedIdentifierAssign(ident.name.to_compact_str(), ident.span));
     }
 
     // LexicalDeclaration : LetOrConst BindingList ;
@@ -299,7 +299,7 @@ fn check_identifier_reference<'a>(
             match ctx.nodes.kind(node_id) {
                 AstKind::AssignmentTarget(_) | AstKind::SimpleAssignmentTarget(_) => {
                     return ctx.error(UnexpectedIdentifierAssign(
-                        ident.name.to_compact_string(),
+                        ident.name.to_compact_str(),
                         ident.span,
                     ));
                 }
@@ -336,8 +336,8 @@ fn check_private_identifier_outside_class(ident: &PrivateIdentifier, ctx: &Seman
         #[derive(Debug, Error, Diagnostic)]
         #[error("Private identifier '#{0}' is not allowed outside class bodies")]
         #[diagnostic()]
-        struct PrivateNotInClass(CompactString, #[label] Span);
-        ctx.error(PrivateNotInClass(ident.name.to_compact_string(), ident.span));
+        struct PrivateNotInClass(CompactStr, #[label] Span);
+        ctx.error(PrivateNotInClass(ident.name.to_compact_str(), ident.span));
     }
 }
 
@@ -354,7 +354,7 @@ fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
                 #[derive(Debug, Error, Diagnostic)]
                 #[error("Private field '{0}' must be declared in an enclosing class")]
                 #[diagnostic()]
-                struct PrivateFieldUndeclared(CompactString, #[label] Span);
+                struct PrivateFieldUndeclared(CompactStr, #[label] Span);
                 ctx.error(PrivateFieldUndeclared(reference.name.clone(), reference.span));
             }
         });

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -93,7 +93,7 @@ fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &Sem
     let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
     bound_names.bound_names(&mut |ident| {
         if let Some(old_span) = idents.insert(ident.name.clone(), ident.span) {
-            ctx.error(Redeclaration(ident.name.to_compact_string(), old_span, ident.span));
+            ctx.error(Redeclaration(ident.name.to_compact_str(), old_span, ident.span));
         }
     });
 }

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -65,7 +65,7 @@ impl ClassTableBuilder {
                 self.classes.add_element(
                     class_id,
                     Element::new(
-                        name.to_compact_string(),
+                        name.to_compact_str(),
                         property.key.span(),
                         property.r#static,
                         is_private,
@@ -86,7 +86,7 @@ impl ClassTableBuilder {
                 self.classes.add_element(
                     class_id,
                     Element::new(
-                        name.to_compact_string(),
+                        name.to_compact_str(),
                         property.key.span(),
                         property.r#static,
                         is_private,
@@ -112,7 +112,7 @@ impl ClassTableBuilder {
 
                     let reference = PrivateIdentifierReference::new(
                         current_node_id,
-                        ident.name.to_compact_string(),
+                        ident.name.to_compact_str(),
                         ident.span,
                         element_ids,
                     );
@@ -134,7 +134,7 @@ impl ClassTableBuilder {
                 self.classes.add_element(
                     class_id,
                     Element::new(
-                        name.to_compact_string(),
+                        name.to_compact_str(),
                         method.key.span(),
                         method.r#static,
                         is_private,

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -1,5 +1,5 @@
 use oxc_index::IndexVec;
-use oxc_span::{Atom, CompactString, Span};
+use oxc_span::{Atom, CompactStr, Span};
 use oxc_syntax::class::{ClassId, ElementId, ElementKind};
 use rustc_hash::FxHashMap;
 
@@ -7,7 +7,7 @@ use crate::node::AstNodeId;
 
 #[derive(Debug)]
 pub struct Element {
-    pub name: CompactString,
+    pub name: CompactStr,
     pub span: Span,
     pub is_private: bool,
     pub r#static: bool,
@@ -16,7 +16,7 @@ pub struct Element {
 
 impl Element {
     pub fn new(
-        name: CompactString,
+        name: CompactStr,
         span: Span,
         r#static: bool,
         is_private: bool,
@@ -29,18 +29,13 @@ impl Element {
 #[derive(Debug)]
 pub struct PrivateIdentifierReference {
     pub id: AstNodeId,
-    pub name: CompactString,
+    pub name: CompactStr,
     pub span: Span,
     pub element_ids: Vec<ElementId>,
 }
 
 impl PrivateIdentifierReference {
-    pub fn new(
-        id: AstNodeId,
-        name: CompactString,
-        span: Span,
-        element_ids: Vec<ElementId>,
-    ) -> Self {
+    pub fn new(id: AstNodeId, name: CompactStr, span: Span, element_ids: Vec<ElementId>) -> Self {
         Self { id, name, span, element_ids }
     }
 }

--- a/crates/oxc_semantic/src/control_flow.rs
+++ b/crates/oxc_semantic/src/control_flow.rs
@@ -1,4 +1,4 @@
-use oxc_span::CompactString;
+use oxc_span::CompactStr;
 use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
 };
@@ -14,8 +14,8 @@ pub enum Register {
 
 #[derive(Debug, Clone)]
 pub enum ObjectPropertyAccessBy {
-    PrivateProperty(CompactString),
-    Property(CompactString),
+    PrivateProperty(CompactStr),
+    Property(CompactStr),
     Expression(Register),
 }
 
@@ -139,8 +139,8 @@ pub struct ControlFlowGraph {
     pub basic_blocks_with_continues: Vec<Vec<NodeIndex>>,
     // node indexes of the basic blocks of switch case conditions
     pub switch_case_conditions: Vec<Vec<NodeIndex>>,
-    pub next_label: Option<CompactString>,
-    pub label_to_ast_node_ix: Vec<(CompactString, AstNodeId)>,
+    pub next_label: Option<CompactStr>,
+    pub label_to_ast_node_ix: Vec<(CompactStr, AstNodeId)>,
     pub ast_node_to_break_continue: Vec<(AstNodeId, usize, Option<usize>)>,
     pub after_throw_block: Option<NodeIndex>,
 }

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -2,13 +2,13 @@ use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::{self, Error},
 };
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Identifier `{0}` has already been declared")]
 #[diagnostic()]
 pub struct Redeclaration(
-    pub CompactString,
+    pub CompactStr,
     #[label("`{0}` has already been declared here")] pub Span,
     #[label("It can not be redeclared here")] pub Span,
 );

--- a/crates/oxc_semantic/src/module_record/builder.rs
+++ b/crates/oxc_semantic/src/module_record/builder.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, syntax_directed_operations::BoundNames};
-use oxc_span::{CompactString, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 #[allow(clippy::wildcard_imports)]
 use oxc_syntax::module_record::*;
 
@@ -65,7 +65,7 @@ impl ModuleRecordBuilder {
         self.module_record.star_export_entries.push(entry);
     }
 
-    fn add_export_binding(&mut self, name: CompactString, span: Span) {
+    fn add_export_binding(&mut self, name: CompactStr, span: Span) {
         if let Some(old_node) = self.module_record.exported_bindings.insert(name.clone(), span) {
             self.module_record.exported_bindings_duplicated.push(NameSpan::new(name, old_node));
         }
@@ -173,33 +173,24 @@ impl ModuleRecordBuilder {
         if decl.import_kind.is_type() {
             return;
         }
-        let module_request = NameSpan::new(decl.source.value.to_compact_string(), decl.source.span);
+        let module_request = NameSpan::new(decl.source.value.to_compact_str(), decl.source.span);
         if let Some(specifiers) = &decl.specifiers {
             for specifier in specifiers {
                 let (import_name, local_name) = match specifier {
                     ImportDeclarationSpecifier::ImportSpecifier(specifier) => (
                         ImportImportName::Name(NameSpan::new(
-                            specifier.imported.name().to_compact_string(),
+                            specifier.imported.name().to_compact_str(),
                             specifier.imported.span(),
                         )),
-                        NameSpan::new(
-                            specifier.local.name.to_compact_string(),
-                            specifier.local.span,
-                        ),
+                        NameSpan::new(specifier.local.name.to_compact_str(), specifier.local.span),
                     ),
                     ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => (
                         ImportImportName::NamespaceObject,
-                        NameSpan::new(
-                            specifier.local.name.to_compact_string(),
-                            specifier.local.span,
-                        ),
+                        NameSpan::new(specifier.local.name.to_compact_str(), specifier.local.span),
                     ),
                     ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => (
                         ImportImportName::Default(specifier.span),
-                        NameSpan::new(
-                            specifier.local.name.to_compact_string(),
-                            specifier.local.span,
-                        ),
+                        NameSpan::new(specifier.local.name.to_compact_str(), specifier.local.span),
                     ),
                 };
                 self.add_import_entry(ImportEntry {
@@ -213,7 +204,7 @@ impl ModuleRecordBuilder {
     }
 
     fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration) {
-        let module_request = NameSpan::new(decl.source.value.to_compact_string(), decl.source.span);
+        let module_request = NameSpan::new(decl.source.value.to_compact_str(), decl.source.span);
         let export_entry = ExportEntry {
             module_request: Some(module_request.clone()),
             import_name: decl
@@ -222,7 +213,7 @@ impl ModuleRecordBuilder {
                 .map_or(ExportImportName::AllButDefault, |_| ExportImportName::All),
             export_name: decl.exported.as_ref().map_or(ExportExportName::Null, |exported_name| {
                 ExportExportName::Name(NameSpan::new(
-                    exported_name.name().to_compact_string(),
+                    exported_name.name().to_compact_str(),
                     exported_name.span(),
                 ))
             }),
@@ -230,7 +221,7 @@ impl ModuleRecordBuilder {
         };
         self.add_export_entry(export_entry);
         if let Some(exported_name) = &decl.exported {
-            self.add_export_binding(exported_name.name().to_compact_string(), exported_name.span());
+            self.add_export_binding(exported_name.name().to_compact_str(), exported_name.span());
         }
         self.add_module_request(&module_request);
     }
@@ -255,7 +246,7 @@ impl ModuleRecordBuilder {
             local_name: id.as_ref().map_or_else(
                 || ExportLocalName::Default(exported_name.span()),
                 |ident| {
-                    ExportLocalName::Name(NameSpan::new(ident.name.to_compact_string(), ident.span))
+                    ExportLocalName::Name(NameSpan::new(ident.name.to_compact_str(), ident.span))
                 },
             ),
             span: decl.declaration.span(),
@@ -276,7 +267,7 @@ impl ModuleRecordBuilder {
         let module_request = decl
             .source
             .as_ref()
-            .map(|source| NameSpan::new(source.value.to_compact_string(), source.span));
+            .map(|source| NameSpan::new(source.value.to_compact_str(), source.span));
 
         if let Some(module_request) = &module_request {
             self.add_module_request(module_request);
@@ -284,14 +275,10 @@ impl ModuleRecordBuilder {
 
         if let Some(decl) = &decl.declaration {
             decl.bound_names(&mut |ident| {
-                let export_name = ExportExportName::Name(NameSpan::new(
-                    ident.name.to_compact_string(),
-                    ident.span,
-                ));
-                let local_name = ExportLocalName::Name(NameSpan::new(
-                    ident.name.to_compact_string(),
-                    ident.span,
-                ));
+                let export_name =
+                    ExportExportName::Name(NameSpan::new(ident.name.to_compact_str(), ident.span));
+                let local_name =
+                    ExportLocalName::Name(NameSpan::new(ident.name.to_compact_str(), ident.span));
                 let export_entry = ExportEntry {
                     span: decl.span(),
                     module_request: module_request.clone(),
@@ -300,18 +287,18 @@ impl ModuleRecordBuilder {
                     local_name,
                 };
                 self.add_export_entry(export_entry);
-                self.add_export_binding(ident.name.to_compact_string(), ident.span);
+                self.add_export_binding(ident.name.to_compact_str(), ident.span);
             });
         }
 
         for specifier in &decl.specifiers {
             let export_name = ExportExportName::Name(NameSpan::new(
-                specifier.exported.name().to_compact_string(),
+                specifier.exported.name().to_compact_str(),
                 specifier.exported.span(),
             ));
             let import_name = if module_request.is_some() {
                 ExportImportName::Name(NameSpan::new(
-                    specifier.local.name().to_compact_string(),
+                    specifier.local.name().to_compact_str(),
                     specifier.local.span(),
                 ))
             } else {
@@ -321,7 +308,7 @@ impl ModuleRecordBuilder {
                 ExportLocalName::Null
             } else {
                 ExportLocalName::Name(NameSpan::new(
-                    specifier.local.name().to_compact_string(),
+                    specifier.local.name().to_compact_str(),
                     specifier.local.span(),
                 ))
             };
@@ -334,7 +321,7 @@ impl ModuleRecordBuilder {
             };
             self.add_export_entry(export_entry);
             self.add_export_binding(
-                specifier.exported.name().to_compact_string(),
+                specifier.exported.name().to_compact_str(),
                 specifier.exported.span(),
             );
         }

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,4 +1,4 @@
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub use oxc_syntax::reference::{ReferenceFlag, ReferenceId};
 pub struct Reference {
     span: Span,
     /// The name of the identifier that was referred to
-    name: CompactString,
+    name: CompactStr,
     node_id: AstNodeId,
     symbol_id: Option<SymbolId>,
     /// Describes how this referenced is used by other AST nodes. References can
@@ -21,7 +21,7 @@ pub struct Reference {
 }
 
 impl Reference {
-    pub fn new(span: Span, name: CompactString, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
+    pub fn new(span: Span, name: CompactStr, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
         Self { span, name, node_id, symbol_id: None, flag }
     }
 
@@ -29,7 +29,7 @@ impl Reference {
         self.span
     }
 
-    pub fn name(&self) -> &CompactString {
+    pub fn name(&self) -> &CompactStr {
         &self.name
     }
 

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -3,7 +3,7 @@ use std::hash::BuildHasherDefault;
 use indexmap::IndexMap;
 use oxc_ast::{ast::Expression, syntax_directed_operations::GatherNodeParts};
 use oxc_index::IndexVec;
-use oxc_span::CompactString;
+use oxc_span::CompactStr;
 pub use oxc_syntax::scope::{ScopeFlags, ScopeId};
 use rustc_hash::{FxHashMap, FxHasher};
 
@@ -11,8 +11,8 @@ use crate::{reference::ReferenceId, symbol::SymbolId, AstNodeId};
 
 type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
-type Bindings = FxIndexMap<CompactString, SymbolId>;
-type UnresolvedReferences = FxHashMap<CompactString, Vec<ReferenceId>>;
+type Bindings = FxIndexMap<CompactStr, SymbolId>;
+type UnresolvedReferences = FxHashMap<CompactStr, Vec<ReferenceId>>;
 
 /// Scope Tree
 ///
@@ -120,9 +120,7 @@ impl ScopeTree {
         self.node_ids[&scope_id]
     }
 
-    pub fn iter_bindings(
-        &self,
-    ) -> impl Iterator<Item = (ScopeId, SymbolId, &'_ CompactString)> + '_ {
+    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, SymbolId, &'_ CompactStr)> + '_ {
         self.bindings.iter_enumerated().flat_map(|(scope_id, bindings)| {
             bindings.iter().map(move |(name, symbol_id)| (scope_id, *symbol_id, name))
         })
@@ -149,14 +147,14 @@ impl ScopeTree {
         self.node_ids.insert(scope_id, node_id);
     }
 
-    pub fn add_binding(&mut self, scope_id: ScopeId, name: CompactString, symbol_id: SymbolId) {
+    pub fn add_binding(&mut self, scope_id: ScopeId, name: CompactStr, symbol_id: SymbolId) {
         self.bindings[scope_id].insert(name, symbol_id);
     }
 
     pub(crate) fn add_unresolved_reference(
         &mut self,
         scope_id: ScopeId,
-        name: CompactString,
+        name: CompactStr,
         reference_id: ReferenceId,
     ) {
         self.unresolved_references[scope_id].entry(name).or_default().push(reference_id);
@@ -165,7 +163,7 @@ impl ScopeTree {
     pub(crate) fn extend_unresolved_reference(
         &mut self,
         scope_id: ScopeId,
-        name: CompactString,
+        name: CompactStr,
         reference_ids: Vec<ReferenceId>,
     ) {
         self.unresolved_references[scope_id].entry(name).or_default().extend(reference_ids);
@@ -180,7 +178,7 @@ impl ScopeTree {
 
     // TODO:
     // <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L543>
-    pub fn generate_uid_based_on_node(&self, expr: &Expression) -> CompactString {
+    pub fn generate_uid_based_on_node(&self, expr: &Expression) -> CompactStr {
         let mut parts = std::vec::Vec::with_capacity(1);
         expr.gather(&mut |part| parts.push(part));
         let name = parts.join("$");
@@ -189,7 +187,7 @@ impl ScopeTree {
     }
 
     // <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L495>
-    pub fn generate_uid(&self, name: &str) -> CompactString {
+    pub fn generate_uid(&self, name: &str) -> CompactStr {
         for i in 0.. {
             let name = Self::internal_generate_uid(name, i);
             if !self.has_binding(ScopeId::new(0), &name) {
@@ -200,7 +198,7 @@ impl ScopeTree {
     }
 
     // <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L523>
-    fn internal_generate_uid(name: &str, i: i32) -> CompactString {
-        CompactString::from(if i > 1 { format!("_{name}{i}") } else { format!("_{name}") })
+    fn internal_generate_uid(name: &str, i: i32) -> CompactStr {
+        CompactStr::from(if i > 1 { format!("_{name}{i}") } else { format!("_{name}") })
     }
 }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::Expression;
 use oxc_index::IndexVec;
-use oxc_span::{Atom, CompactString, Span};
+use oxc_span::{Atom, CompactStr, Span};
 pub use oxc_syntax::{
     scope::ScopeId,
     symbol::{SymbolFlags, SymbolId},
@@ -31,7 +31,7 @@ export type IndexVec<I, T> = Array<T>;
 #[cfg_attr(all(feature = "serde", feature = "wasm"), derive(tsify::Tsify))]
 pub struct SymbolTable {
     pub spans: IndexVec<SymbolId, Span>,
-    pub names: IndexVec<SymbolId, CompactString>,
+    pub names: IndexVec<SymbolId, CompactStr>,
     pub flags: IndexVec<SymbolId, SymbolFlags>,
     pub scope_ids: IndexVec<SymbolId, ScopeId>,
     /// Pointer to the AST Node where this symbol is declared
@@ -81,7 +81,7 @@ impl SymbolTable {
         &self.names[symbol_id]
     }
 
-    pub fn set_name(&mut self, symbol_id: SymbolId, name: CompactString) {
+    pub fn set_name(&mut self, symbol_id: SymbolId, name: CompactStr) {
         self.names[symbol_id] = name;
     }
 
@@ -117,7 +117,7 @@ impl SymbolTable {
         scope_id: ScopeId,
     ) -> SymbolId {
         _ = self.spans.push(span);
-        _ = self.names.push(name.into_compact_string());
+        _ = self.names.push(name.into_compact_str());
         _ = self.flags.push(flag);
         _ = self.scope_ids.push(scope_id);
         self.resolved_references.push(vec![])

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -16,12 +16,15 @@ use compact_str::CompactString;
 #[allow(dead_code)]
 const TS_APPEND_CONTENT: &'static str = r#"
 export type Atom = string;
-export type CompactString = string;
+export type CompactStr = string;
 "#;
 
 /// An inlinable string for oxc_allocator.
 ///
-/// Use [CompactString] with [Atom::to_compact_string()] for the lifetimeless form.
+/// Use [CompactStr] with [Atom::to_compact_str] or [Atom::into_compact_str] for the
+/// lifetimeless form.
+///
+/// [CompactStr]: crate::CompactStr
 #[derive(Clone, Eq)]
 pub enum Atom<'a> {
     Arena(&'a str),
@@ -56,7 +59,7 @@ impl<'a> Atom<'a> {
     }
 
     #[inline]
-    pub fn into_compact_string(self) -> CompactString {
+    pub fn into_compact_str(self) -> CompactString {
         match self {
             Self::Arena(s) => CompactString::new(s),
             Self::Compact(s) => s,
@@ -64,7 +67,7 @@ impl<'a> Atom<'a> {
     }
 
     #[inline]
-    pub fn to_compact_string(&self) -> CompactString {
+    pub fn to_compact_str(&self) -> CompactString {
         match &self {
             Self::Arena(s) => CompactString::new(s),
             Self::Compact(s) => s.clone(),

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -11,4 +11,4 @@ pub use crate::{
     source_type::{Language, LanguageVariant, ModuleKind, SourceType, VALID_EXTENSIONS},
     span::{GetSpan, Span, SPAN},
 };
-pub use compact_str::CompactString;
+pub use compact_str::CompactString as CompactStr;

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -6,7 +6,7 @@ use dashmap::DashMap;
 use indexmap::IndexMap;
 use rustc_hash::{FxHashMap, FxHasher};
 
-use oxc_span::{CompactString, Span};
+use oxc_span::{CompactStr, Span};
 
 /// ESM Module Record
 ///
@@ -32,13 +32,13 @@ pub struct ModuleRecord {
     ///   import ModuleSpecifier
     ///   export ExportFromClause FromClause
     /// Keyed by ModuleSpecifier, valued by all node occurrences
-    pub requested_modules: IndexMap<CompactString, Vec<Span>, BuildHasherDefault<FxHasher>>,
+    pub requested_modules: IndexMap<CompactStr, Vec<Span>, BuildHasherDefault<FxHasher>>,
 
     /// `[[LoadedModules]]`
     ///
     /// A map from the specifier strings used by the module represented by this record to request the importation of a module to the resolved Module Record.
     /// The list does not contain two different Records with the same `[[Specifier]]`.
-    pub loaded_modules: DashMap<CompactString, Arc<ModuleRecord>, BuildHasherDefault<FxHasher>>,
+    pub loaded_modules: DashMap<CompactStr, Arc<ModuleRecord>, BuildHasherDefault<FxHasher>>,
 
     /// `[[ImportEntries]]`
     ///
@@ -65,7 +65,7 @@ pub struct ModuleRecord {
     /// not including export * as namespace declarations.
     pub star_export_entries: Vec<ExportEntry>,
 
-    pub exported_bindings: FxHashMap<CompactString, Span>,
+    pub exported_bindings: FxHashMap<CompactStr, Span>,
     pub exported_bindings_duplicated: Vec<NameSpan>,
 
     pub export_default: Option<Span>,
@@ -107,16 +107,16 @@ impl fmt::Debug for ModuleRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NameSpan {
-    name: CompactString,
+    name: CompactStr,
     span: Span,
 }
 
 impl NameSpan {
-    pub fn new(name: CompactString, span: Span) -> Self {
+    pub fn new(name: CompactStr, span: Span) -> Self {
         Self { name, span }
     }
 
-    pub fn name(&self) -> &CompactString {
+    pub fn name(&self) -> &CompactStr {
         &self.name
     }
 

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -7,7 +7,7 @@ use std::{
 use oxc_ast::AstBuilder;
 use oxc_diagnostics::Error;
 use oxc_semantic::{ScopeId, ScopeTree, Semantic, SymbolId, SymbolTable};
-use oxc_span::{CompactString, SourceType};
+use oxc_span::{CompactStr, SourceType};
 
 #[derive(Clone)]
 pub struct TransformerCtx<'a> {
@@ -37,7 +37,7 @@ impl<'a> TransformerCtx<'a> {
         RefMut::map(self.semantic.borrow_mut(), |semantic| semantic.scopes_mut())
     }
 
-    pub fn add_binding(&self, name: CompactString) {
+    pub fn add_binding(&self, name: CompactStr) {
         // TODO: use the correct scope and symbol id
         self.scopes_mut().add_binding(ScopeId::new(0), name, SymbolId::new(0));
     }

--- a/crates/oxc_transformer/src/proposals/decorators.rs
+++ b/crates/oxc_transformer/src/proposals/decorators.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap, rc::Rc};
 use bitflags::bitflags;
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{ast::*, AstBuilder};
-use oxc_span::{Atom, CompactString, SPAN};
+use oxc_span::{Atom, CompactStr, SPAN};
 use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
 use serde::Deserialize;
 
@@ -23,7 +23,7 @@ pub struct Decorators<'a> {
     top_statements: Vec<'a, Statement<'a>>,
     // Insert to the bottom of the program
     bottom_statements: Vec<'a, Statement<'a>>,
-    uid_map: HashMap<CompactString, u32>,
+    uid_map: HashMap<CompactStr, u32>,
 }
 
 bitflags! {
@@ -146,10 +146,10 @@ impl<'a> Decorators<'a> {
     }
 
     // TODO: use generate_uid of scope to generate unique name
-    pub fn get_unique_name(&mut self, name: &str) -> CompactString {
-        let uid = self.uid_map.entry(CompactString::new(name)).or_insert(0);
+    pub fn get_unique_name(&mut self, name: &str) -> CompactStr {
+        let uid = self.uid_map.entry(CompactStr::new(name)).or_insert(0);
         *uid += 1;
-        CompactString::from(format!(
+        CompactStr::from(format!(
             "_{name}{}",
             if *uid == 1 { String::new() } else { uid.to_string() }
         ))
@@ -324,7 +324,7 @@ impl<'a> Decorators<'a> {
     pub fn transform_class(
         &mut self,
         class: &mut Box<'a, Class<'a>>,
-        class_name: Option<CompactString>,
+        class_name: Option<CompactStr>,
     ) -> Declaration<'a> {
         if self.options.version.is_legacy() {
             return self.transform_class_legacy(class, class_name);
@@ -755,7 +755,7 @@ impl<'a> Decorators<'a> {
     pub fn transform_class_legacy(
         &mut self,
         class: &mut Box<'a, Class<'a>>,
-        class_name: Option<CompactString>,
+        class_name: Option<CompactStr>,
     ) -> Declaration<'a> {
         let class_binding_identifier = &class.id.clone().unwrap_or_else(|| {
             let class_name = class_name.unwrap_or_else(|| self.get_unique_name("class"));

--- a/crates/oxc_transformer/src/react_jsx/mod.rs
+++ b/crates/oxc_transformer/src/react_jsx/mod.rs
@@ -8,7 +8,7 @@ use oxc_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::Error,
 };
-use oxc_span::{Atom, CompactString, GetSpan, Span, SPAN};
+use oxc_span::{Atom, CompactStr, GetSpan, Span, SPAN};
 use oxc_syntax::{
     identifier::{is_irregular_whitespace, is_line_terminator},
     xml_entities::XML_ENTITIES,
@@ -58,7 +58,7 @@ pub struct ReactJsx<'a> {
     import_fragment: bool,
     import_create_element: bool,
     require_jsx_runtime: bool,
-    jsx_runtime_importer: CompactString,
+    jsx_runtime_importer: CompactStr,
     pub babel_8_breaking: Option<bool>,
     default_runtime: ReactJsxRuntime,
 }
@@ -129,9 +129,9 @@ impl<'a> ReactJsx<'a> {
 
         let jsx_runtime_importer =
             if jsx_options.import_source == "react" || default_runtime.is_classic() {
-                CompactString::from("react/jsx-runtime")
+                CompactStr::from("react/jsx-runtime")
             } else {
-                CompactString::from(format!("{}/jsx-runtime", jsx_options.import_source))
+                CompactStr::from(format!("{}/jsx-runtime", jsx_options.import_source))
             };
         Some(Self {
             ast,


### PR DESCRIPTION
Preparatory step for #2620.

This PR purely changes names of types and methods:

* `CompactString` -> `CompactStr`
* `Atom::to_compact_string` -> `to_compact_str`
* `Atom::into_compact_string` -> `into_compact_str`

Have split this into a separate PR as the diff is large, but it does absolutely nothing but renaming (I've checked the whole diff twice, so feel free not to check it again!). This should make it easier to see the content of the substantive change in #2620.