### PR TITLE
feat(span): conversion from arena `String` to `Atom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ version = "0.9.0"
 dependencies = [
  "compact_str",
  "miette",
+ "oxc_allocator",
  "serde",
  "tsify",
  "wasm-bindgen",

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -19,6 +19,8 @@ workspace = true
 doctest = false
 
 [dependencies]
+oxc_allocator = { workspace = true }
+
 miette      = { workspace = true }
 compact_str = { version = "0.7.1" }
 

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -63,6 +63,12 @@ impl<'a> From<&'a str> for Atom<'a> {
     }
 }
 
+impl<'a> From<oxc_allocator::String<'a>> for Atom<'a> {
+    fn from(s: oxc_allocator::String<'a>) -> Self {
+        Self(s.into_bump_str())
+    }
+}
+
 impl<'a> Deref for Atom<'a> {
     type Target = str;
 


### PR DESCRIPTION
Sugar for converting an `oxc_allocator::String<'a>` to `Atom<'a>`.