### PR TITLE
fix(semantic): incorrect reference in parameters

### DIFF
--- a/crates/oxc_semantic/tests/scopes.rs
+++ b/crates/oxc_semantic/tests/scopes.rs
@@ -106,3 +106,34 @@ fn test_switch_case() {
     .has_number_of_references(1)
     .test();
 }
+
+#[test]
+fn test_function_parameters() {
+    SemanticTester::js(
+        "
+            const foo = 2;
+            function func(a = foo, b = a) {
+                const foo = 0;
+            }
+        ",
+    )
+    .has_root_symbol("foo")
+    .has_number_of_references(1)
+    .test();
+}
+
+#[test]
+fn test_catch_clause_parameters() {
+    SemanticTester::js(
+        "
+            const a = 0;
+            try {
+            } catch ({ [a]: b }) {
+                const a = 1;
+            }
+        ",
+    )
+    .has_root_symbol("a")
+    .has_number_of_references(1)
+    .test();
+}


### PR DESCRIPTION
close: #2499

We need to collect parameter bindings. If an IdentifierReference is used on a parameter, we need to check if the current parameter binding is already defined, if not then it can only access the parent scope's bindings.

Let's look at an example.

```ts
const foo = 0;
function a(b = foo, c = b) {
   const foo = 1;
   const c = 2;
}  
```

The parameter has a reference to `foo`, but there is no `foo` in the parameter binding, so it must access the parent scope. Let's look at `c = b`, which has a reference to `b`, and the first parameter already has a `b` binding defined, so in the current scope we can access `b`.

I apologize for adding two more properties to the SemanticBuilder, the current implementation can't avoid adding them. Please let me know if you have a better solution, I'm interested in a better solution!
