### PR TITLE
refactor(ast): remove `Serialize` impls for Identifier types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -314,9 +314,10 @@ impl<'a> Expression<'a> {
 }
 
 /// Identifier Name
-// See serializer in serialize.rs
 #[derive(Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 pub struct IdentifierName<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
 }
@@ -328,12 +329,15 @@ impl<'a> IdentifierName<'a> {
 }
 
 /// Identifier Reference
-// See serializer in serialize.rs
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 pub struct IdentifierReference<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_id: Cell<Option<ReferenceId>>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub reference_flag: ReferenceFlag,
 }
 
@@ -351,11 +355,13 @@ impl<'a> IdentifierReference<'a> {
 }
 
 /// Binding Identifier
-// See serializer in serialize.rs
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 pub struct BindingIdentifier<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub symbol_id: Cell<Option<SymbolId>>,
 }
 
@@ -373,9 +379,10 @@ impl<'a> BindingIdentifier<'a> {
 }
 
 /// Label Identifier
-// See serializer in serialize.rs
 #[derive(Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type", rename = "Identifier"))]
 pub struct LabelIdentifier<'a> {
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub name: Atom<'a>,
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -1,17 +1,16 @@
 use serde::{
-    ser::{SerializeSeq, SerializeStruct, Serializer},
+    ser::{SerializeSeq, Serializer},
     Serialize,
 };
 
 use crate::ast::{
     ArrayAssignmentTarget, ArrayPattern, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
-    AssignmentTargetRest, BindingIdentifier, BindingPattern, BindingPatternKind, BindingProperty,
-    BindingRestElement, FormalParameter, FormalParameterKind, FormalParameters, IdentifierName,
-    IdentifierReference, LabelIdentifier, ObjectAssignmentTarget, ObjectPattern, Program,
-    RegExpFlags, TSTypeAnnotation,
+    AssignmentTargetRest, BindingPattern, BindingPatternKind, BindingProperty, BindingRestElement,
+    FormalParameter, FormalParameterKind, FormalParameters, ObjectAssignmentTarget, ObjectPattern,
+    Program, RegExpFlags, TSTypeAnnotation,
 };
 use oxc_allocator::{Box, Vec};
-use oxc_span::{Atom, Span};
+use oxc_span::Span;
 
 pub struct EcmaFormatter;
 
@@ -43,58 +42,6 @@ impl Serialize for RegExpFlags {
         S: Serializer,
     {
         serializer.serialize_str(&self.to_string())
-    }
-}
-
-/// Serialize `BindingIdentifier`, `IdentifierReference`, `IdentifierName` and `LabelIdentifier`
-/// to be estree compatible with the `type` set to "Identifier".
-fn serialize_identifier<S: Serializer>(
-    serializer: S,
-    struct_name: &'static str,
-    span: Span,
-    name: &Atom,
-) -> Result<S::Ok, S::Error> {
-    let mut state = serializer.serialize_struct(struct_name, 4)?;
-    state.serialize_field("type", "Identifier")?;
-    state.serialize_field("start", &span.start)?;
-    state.serialize_field("end", &span.end)?;
-    state.serialize_field("name", name)?;
-    state.end()
-}
-
-impl<'a> Serialize for BindingIdentifier<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize_identifier(serializer, "BindingIdentifier", self.span, &self.name)
-    }
-}
-
-impl<'a> Serialize for IdentifierReference<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize_identifier(serializer, "IdentifierReference", self.span, &self.name)
-    }
-}
-
-impl<'a> Serialize for IdentifierName<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize_identifier(serializer, "IdentifierName", self.span, &self.name)
-    }
-}
-
-impl<'a> Serialize for LabelIdentifier<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize_identifier(serializer, "LabelIdentifier", self.span, &self.name)
     }
 }
 


### PR DESCRIPTION
`Serialize` can be derived for `IdentifierName` etc without explicit `impl Serialize`, as they just need serde to skip some fields. No changes to the JSON output, just a bit simpler.