### PR TITLE
fix(ast): fix serializing rest elements

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -227,13 +227,15 @@ impl<'a, 'b, E, R> ElementsAndRest<'a, 'b, E, R> {
 
 impl<'a, 'b, E: Serialize, R: Serialize> Serialize for ElementsAndRest<'a, 'b, E, R> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut seq = serializer.serialize_seq(Some(self.elements.len() + 1))?;
-        for element in self.elements {
-            seq.serialize_element(element)?;
-        }
         if let Some(rest) = self.rest {
+            let mut seq = serializer.serialize_seq(Some(self.elements.len() + 1))?;
+            for element in self.elements {
+                seq.serialize_element(element)?;
+            }
             seq.serialize_element(rest)?;
+            seq.end()
+        } else {
+            self.elements.serialize(serializer)
         }
-        seq.end()
     }
 }


### PR DESCRIPTION
Fix a mistake I made in #2567. Length that `serialize_seq` is called with should only be `+1` if there is a rest element being added on the end.

Makes no difference for serializing to JSON, as JSON serializer doesn't use the `len` value, but still better to get it right.