### PR TITLE
fix(parser)!: drop TSImportEqualsDeclaration.is_export

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -908,7 +908,6 @@ pub struct TSImportEqualsDeclaration<'a> {
     pub span: Span,
     pub id: BindingIdentifier<'a>,
     pub module_reference: Box<'a, TSModuleReference<'a>>,
-    pub is_export: bool,
     pub import_kind: ImportOrExportKind,
 }
 

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1548,14 +1548,12 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
-        is_export: bool,
         import_kind: ImportOrExportKind,
     ) -> Declaration<'a> {
         Declaration::TSImportEqualsDeclaration(self.alloc(TSImportEqualsDeclaration {
             span,
             id,
             module_reference: self.alloc(module_reference),
-            is_export,
             import_kind,
         }))
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -42,7 +42,7 @@ impl<'a> ParserImpl<'a> {
                     && self.peek_kind().is_binding_identifier()
                     && self.nth_at(2, Kind::Eq)))
         {
-            let decl = self.parse_ts_import_equals_declaration(span, false)?;
+            let decl = self.parse_ts_import_equals_declaration(span)?;
             return Ok(Statement::Declaration(decl));
         }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -301,7 +301,7 @@ impl<'a> ParserImpl<'a> {
                 .map(Declaration::ClassDeclaration),
             Kind::Import => {
                 self.bump_any();
-                self.parse_ts_import_equals_declaration(start_span, true)
+                self.parse_ts_import_equals_declaration(start_span)
             }
             kind if kind.is_variable_declaration() => self
                 .parse_variable_declaration(
@@ -357,7 +357,6 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_import_equals_declaration(
         &mut self,
         span: Span,
-        is_export: bool,
     ) -> Result<Declaration<'a>> {
         let import_kind = if !self.peek_at(Kind::Eq) && self.eat(Kind::Type) {
             ImportOrExportKind::Type
@@ -388,7 +387,6 @@ impl<'a> ParserImpl<'a> {
             self.end_span(span),
             id,
             module_reference,
-            is_export,
             import_kind,
         ))
     }

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -934,10 +934,6 @@ impl<'a> Format<'a> for TSImportEqualsDeclaration<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = p.vec();
 
-        if self.is_export {
-            parts.push(ss!("export "));
-        }
-
         parts.push(ss!("import "));
 
         if self.import_kind == ImportOrExportKind::Type {


### PR DESCRIPTION
This is one point where Babel and TSESLint diverge. For linter purposes TSESLint structure makes more sense and that the reason of https://github.com/typescript-eslint/typescript-eslint/issues/4130

The remaining `is_export` was creating redundant information and made prettier (and the WIP oxc/prettier) print the AST of `export import X = Y` as `export export import X = Y`.