### PR TITLE
fix(parser): parse named rest element in type tuple

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -118,6 +118,7 @@ pub enum TSType<'a> {
     TSIntersectionType(Box<'a, TSIntersectionType<'a>>),
     TSLiteralType(Box<'a, TSLiteralType<'a>>),
     TSMappedType(Box<'a, TSMappedType<'a>>),
+    TSNamedTupleMember(Box<'a, TSNamedTupleMember<'a>>),
     TSQualifiedName(Box<'a, TSQualifiedName<'a>>),
     TSTemplateLiteralType(Box<'a, TSTemplateLiteralType<'a>>),
     TSTupleType(Box<'a, TSTupleType<'a>>),

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -323,6 +323,7 @@ impl<'a> GetSpan for TSType<'a> {
             Self::TSArrayType(t) => t.span,
             Self::TSIntersectionType(t) => t.span,
             Self::TSMappedType(t) => t.span,
+            Self::TSNamedTupleMember(t) => t.span,
             Self::TSInferType(t) => t.span,
             Self::TSConstructorType(t) => t.span,
             Self::TSIndexedAccessType(t) => t.span,

--- a/crates/oxc_codegen/src/gen_ts.rs
+++ b/crates/oxc_codegen/src/gen_ts.rs
@@ -139,6 +139,9 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSType<'a> {
                 p.print_semicolon_if_needed();
                 p.print_str(b"}");
             }
+            Self::TSNamedTupleMember(decl) => {
+                decl.gen(p, ctx);
+            }
             Self::TSLiteralType(decl) => {
                 decl.literal.gen(p, ctx);
             }
@@ -507,12 +510,18 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSTupleElement<'a> {
                 ts_type.type_annotation.gen(p, ctx);
             }
             TSTupleElement::TSNamedTupleMember(ts_type) => {
-                ts_type.label.gen(p, ctx);
-                p.print_str(b":");
-                p.print_soft_space();
-                ts_type.element_type.gen(p, ctx);
+                ts_type.gen(p, ctx);
             }
         }
+    }
+}
+
+impl<'a, const MINIFY: bool> Gen<MINIFY> for TSNamedTupleMember<'a> {
+    fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
+        self.label.gen(p, ctx);
+        p.print_str(b":");
+        p.print_soft_space();
+        self.element_type.gen(p, ctx);
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -408,6 +408,7 @@ fn get_ts_element_type_span(ts_type: &TSType) -> Option<Span> {
         TSType::TSIntersectionType(t) => Some(t.span),
         TSType::TSLiteralType(t) => Some(t.span),
         TSType::TSMappedType(t) => Some(t.span),
+        TSType::TSNamedTupleMember(t) => Some(t.span),
         TSType::TSQualifiedName(t) => Some(t.span),
         TSType::TSTemplateLiteralType(t) => Some(t.span),
         TSType::TSTupleType(t) => Some(t.span),

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -676,6 +676,7 @@ impl<'a> Format<'a> for TSType<'a> {
             TSType::TSIntersectionType(v) => v.format(p),
             TSType::TSLiteralType(v) => v.format(p),
             TSType::TSMappedType(v) => v.format(p),
+            TSType::TSNamedTupleMember(v) => v.format(p),
             TSType::TSQualifiedName(v) => v.format(p),
             TSType::TSTemplateLiteralType(v) => v.format(p),
             TSType::TSTupleType(v) => v.format(p),
@@ -838,6 +839,12 @@ impl<'a> Format<'a> for TSLiteralType<'a> {
 }
 
 impl<'a> Format<'a> for TSMappedType<'a> {
+    fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
+        line!()
+    }
+}
+
+impl<'a> Format<'a> for TSNamedTupleMember<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         line!()
     }


### PR DESCRIPTION
This is fixing the parser for `type X = [...args: string[]];`

In TSESLint TSNamedTupleMember in part of the TSType union, so I did the same.