### PR TITLE
fix(ast)!: rename BigintLiteral to BigIntLiteral

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -63,7 +63,7 @@ pub enum Expression<'a> {
     BooleanLiteral(Box<'a, BooleanLiteral>),
     NullLiteral(Box<'a, NullLiteral>),
     NumericLiteral(Box<'a, NumericLiteral<'a>>),
-    BigintLiteral(Box<'a, BigintLiteral<'a>>),
+    BigintLiteral(Box<'a, BigIntLiteral<'a>>),
     RegExpLiteral(Box<'a, RegExpLiteral<'a>>),
     StringLiteral(Box<'a, StringLiteral<'a>>),
     TemplateLiteral(Box<'a, TemplateLiteral<'a>>),

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -108,7 +108,7 @@ impl<'a> Hash for NumericLiteral<'a> {
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(tag = "type"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-pub struct BigintLiteral<'a> {
+pub struct BigIntLiteral<'a> {
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub span: Span,
     pub raw: Atom<'a>,
@@ -116,7 +116,7 @@ pub struct BigintLiteral<'a> {
     pub base: BigintBase,
 }
 
-impl<'a> BigintLiteral<'a> {
+impl<'a> BigIntLiteral<'a> {
     pub fn is_zero(&self) -> bool {
         self.raw == "0n"
     }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -82,7 +82,7 @@ pub enum TSLiteral<'a> {
     BooleanLiteral(Box<'a, BooleanLiteral>),
     NullLiteral(Box<'a, NullLiteral>),
     NumericLiteral(Box<'a, NumericLiteral<'a>>),
-    BigintLiteral(Box<'a, BigintLiteral<'a>>),
+    BigintLiteral(Box<'a, BigIntLiteral<'a>>),
     RegExpLiteral(Box<'a, RegExpLiteral<'a>>),
     StringLiteral(Box<'a, StringLiteral<'a>>),
     TemplateLiteral(Box<'a, TemplateLiteral<'a>>),

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -140,8 +140,8 @@ impl<'a> AstBuilder<'a> {
         BooleanLiteral { span, value }
     }
 
-    pub fn bigint_literal(&self, span: Span, raw: Atom<'a>, base: BigintBase) -> BigintLiteral<'a> {
-        BigintLiteral { span, raw, base }
+    pub fn bigint_literal(&self, span: Span, raw: Atom<'a>, base: BigintBase) -> BigIntLiteral<'a> {
+        BigIntLiteral { span, raw, base }
     }
 
     pub fn template_literal(
@@ -199,7 +199,7 @@ impl<'a> AstBuilder<'a> {
         Expression::NumericLiteral(self.alloc(literal))
     }
 
-    pub fn literal_bigint_expression(&self, literal: BigintLiteral<'a>) -> Expression<'a> {
+    pub fn literal_bigint_expression(&self, literal: BigIntLiteral<'a>) -> Expression<'a> {
         Expression::BigintLiteral(self.alloc(literal))
     }
 

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -49,7 +49,7 @@ pub enum AstKind<'a> {
     StringLiteral(&'a StringLiteral<'a>),
     BooleanLiteral(&'a BooleanLiteral),
     NullLiteral(&'a NullLiteral),
-    BigintLiteral(&'a BigintLiteral<'a>),
+    BigintLiteral(&'a BigIntLiteral<'a>),
     RegExpLiteral(&'a RegExpLiteral<'a>),
     TemplateLiteral(&'a TemplateLiteral<'a>),
 

--- a/crates/oxc_ast/src/visit.rs
+++ b/crates/oxc_ast/src/visit.rs
@@ -1278,7 +1278,7 @@ pub trait Visit<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_bigint_literal(&mut self, lit: &BigintLiteral<'a>) {
+    fn visit_bigint_literal(&mut self, lit: &BigIntLiteral<'a>) {
         let kind = AstKind::BigintLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);

--- a/crates/oxc_ast/src/visit_mut.rs
+++ b/crates/oxc_ast/src/visit_mut.rs
@@ -1272,7 +1272,7 @@ pub trait VisitMut<'a>: Sized {
         self.leave_node(kind);
     }
 
-    fn visit_bigint_literal(&mut self, lit: &mut BigintLiteral<'a>) {
+    fn visit_bigint_literal(&mut self, lit: &mut BigIntLiteral<'a>) {
         let kind = AstKind::BigintLiteral(self.alloc(lit));
         self.enter_node(kind);
         self.leave_node(kind);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1164,7 +1164,7 @@ fn print_non_negative_float<const MINIFY: bool>(value: f64, _p: &Codegen<{ MINIF
     result
 }
 
-impl<'a, const MINIFY: bool> Gen<MINIFY> for BigintLiteral<'a> {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for BigIntLiteral<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, _ctx: Context) {
         p.add_source_mapping(self.span.start);
         if self.raw.contains('_') {

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 use oxc_ast::{
-    ast::{BigintLiteral, NumericLiteral},
+    ast::{BigIntLiteral, NumericLiteral},
     AstKind,
 };
 use oxc_diagnostics::{
@@ -162,7 +162,7 @@ impl NumericSeparatorsStyle {
         }
     }
 
-    fn format_bigint(&self, number: &BigintLiteral, raw: &str) -> String {
+    fn format_bigint(&self, number: &BigIntLiteral, raw: &str) -> String {
         use oxc_syntax::BigintBase;
 
         let raw_without_bigint_n_suffix = &raw[..raw.len() - 1];

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -310,7 +310,7 @@ impl<'a> ParserImpl<'a> {
         Ok(NumericLiteral::new(self.end_span(span), value, src, base))
     }
 
-    pub(crate) fn parse_literal_bigint(&mut self) -> Result<BigintLiteral<'a>> {
+    pub(crate) fn parse_literal_bigint(&mut self) -> Result<BigIntLiteral<'a>> {
         let span = self.start_span();
         let base = match self.cur_kind() {
             Kind::Decimal => BigintBase::Decimal,

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -1357,7 +1357,7 @@ impl<'a> Format<'a> for NumericLiteral<'a> {
     }
 }
 
-impl<'a> Format<'a> for BigintLiteral<'a> {
+impl<'a> Format<'a> for BigIntLiteral<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let text = self.span.source_text(p.source_text);
         // Perf: avoid a memory allocation from `to_ascii_lowercase`.


### PR DESCRIPTION
This matches the case for the name in Babel. (in ESTree everything is a `Literal`)