### PR TITLE
fix(parser): fix span start for return type in function type

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -834,8 +834,8 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         let type_parameters = self.parse_ts_type_parameters()?;
         let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature)?;
-        self.expect(Kind::Arrow)?;
         let return_type_span = self.start_span();
+        self.expect(Kind::Arrow)?;
         let return_type = self.parse_ts_return_type()?;
         let return_type = self.ast.ts_type_annotation(self.end_span(return_type_span), return_type);
         Ok(self.ast.ts_function_type(


### PR DESCRIPTION
This matter for code like. This matches the behavior of both Babel and TSESLint.

```ts
export type Plugin = (
  a: string
) => // Comment
number
```

[TSESLint](https://ast.sxzz.moe/#eNo9jMEKwjAMQH8l5KQw2X0wL/6AB/HUS61hVNq0pKkoY/9u52C35L3kzRhwwJd92+LEZ8UOcwP6zbSBE5XgeeWucfrkJAqrhmuok2cY4WAYwA5QVDxPho8wnqHv4ZJiJFbDXOODpCVSS8zrtcGSqji6tZDBoe0xPWtoc7dpctHeSYpPvPlglYruXixP/0+VSoYXXH53+0Kk)
[OXC](https://oxc-project.github.io/oxc/playground/?code=3YCAAIC5gICAgICAgICyHorESipoTp3admelrvvzLVu5WllVkMM9n7p1s27YYhddDchOGSC6foF%2BGw%2B1Mfo7DYhiNueGpuc27%2F3gf2tToIA%3D)
