### PR TITLE
fix(ast): add `type` field to TS types for `ObjectPattern` etc

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1027,6 +1027,7 @@ pub enum AssignmentTargetPattern<'a> {
 // See serializer in serialize.rs
 #[derive(Debug, Hash, SerAttrs)]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
+#[serde(tag = "type")]
 pub struct ArrayAssignmentTarget<'a> {
     #[serde(flatten)]
     pub span: Span,
@@ -1049,6 +1050,7 @@ impl<'a> ArrayAssignmentTarget<'a> {
 // See serializer in serialize.rs
 #[derive(Debug, Hash, SerAttrs)]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
+#[serde(tag = "type")]
 pub struct ObjectAssignmentTarget<'a> {
     #[serde(flatten)]
     pub span: Span,
@@ -1765,6 +1767,7 @@ pub struct AssignmentPattern<'a> {
 // See serializer in serialize.rs
 #[derive(Debug, Hash, SerAttrs)]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
+#[serde(tag = "type")]
 pub struct ObjectPattern<'a> {
     #[serde(flatten)]
     pub span: Span,
@@ -1800,6 +1803,7 @@ pub struct BindingProperty<'a> {
 // See serializer in serialize.rs
 #[derive(Debug, Hash, SerAttrs)]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
+#[serde(tag = "type")]
 pub struct ArrayPattern<'a> {
     #[serde(flatten)]
     pub span: Span,
@@ -1909,6 +1913,7 @@ pub enum FunctionType {
 // See serializer in serialize.rs
 #[derive(Debug, Hash, SerAttrs)]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
+#[serde(tag = "type")]
 pub struct FormalParameters<'a> {
     #[serde(flatten)]
     pub span: Span,


### PR DESCRIPTION
Fixes #2658 (details given in https://github.com/oxc-project/oxc/issues/2657#issuecomment-1987289481).

Add `type` fields to TS types for `ObjectPattern`, `ArrayPattern` etc which were missing previously.