### PR TITLE
refactor: derive `SerAttrs` on all AST types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1898,7 +1898,7 @@ impl<'a> Function<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub enum FunctionType {
@@ -2069,7 +2069,7 @@ impl<'a> Class<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub enum ClassType {
@@ -2208,7 +2208,7 @@ pub struct MethodDefinition<'a> {
     pub decorators: Vec<'a, Decorator<'a>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub enum MethodDefinitionType {
@@ -2238,7 +2238,7 @@ pub struct PropertyDefinition<'a> {
     pub decorators: Vec<'a, Decorator<'a>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub enum PropertyDefinitionType {

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -142,7 +142,7 @@ pub struct RegExpLiteral<'a> {
     pub regex: RegExp<'a>,
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct RegExp<'a> {
@@ -234,7 +234,7 @@ impl fmt::Display for RegExpFlags {
     }
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 pub struct EmptyObject;

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 
 use miette::{SourceOffset, SourceSpan};
+use oxc_macros::SerAttrs;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 #[cfg(feature = "wasm")]
@@ -14,7 +15,7 @@ pub const SPAN: Span = Span::new(0, 0);
 /// See the [`text-size`](https://docs.rs/text-size) crate for details.
 /// Utility methods can be copied from the `text-size` crate if they are needed.
 /// NOTE: `u32` is sufficient for "all" reasonable programs. Larger than u32 is a 4GB JS file.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "wasm", derive(Tsify))]
 #[non_exhaustive] // disallow struct expression constructor `Span {}`

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -1,5 +1,7 @@
 //! Common code for JavaScript Syntax
 
+use oxc_macros::SerAttrs;
+
 pub mod assumptions;
 pub mod class;
 pub mod identifier;
@@ -13,7 +15,7 @@ pub mod scope;
 pub mod symbol;
 pub mod xml_entities;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, SerAttrs)]
 pub enum NumberBase {
     Float,
     Decimal,
@@ -28,7 +30,7 @@ impl NumberBase {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, SerAttrs)]
 pub enum BigintBase {
     Decimal,
     Binary,


### PR DESCRIPTION
Add `SerAttrs` derive to a few types that I missed out in #2669.