### PR TITLE
fix(ast): serialize empty array elements as null

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -414,6 +414,7 @@ pub struct ThisExpression {
 pub struct ArrayExpression<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[tsify(type = "Array<SpreadElement | Expression | null>")]
     pub elements: Vec<'a, ArrayExpressionElement<'a>>,
     /// Array trailing comma
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
@@ -423,13 +424,14 @@ pub struct ArrayExpression<'a> {
 /// Array Expression Element
 #[derive(Debug, Hash, SerAttrs)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "wasm", derive(Tsify))]
 #[serde(untagged)]
 pub enum ArrayExpressionElement<'a> {
     SpreadElement(Box<'a, SpreadElement<'a>>),
     Expression(Expression<'a>),
     /// Array hole for sparse arrays
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
+    // Serialize as `null`. `serialize_elision` in serialize.rs.
+    #[serde(serialize_with = "ArrayExpressionElement::serialize_elision")]
     Elision(Span),
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -4,10 +4,10 @@ use serde::{
 };
 
 use crate::ast::{
-    ArrayAssignmentTarget, ArrayPattern, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
-    AssignmentTargetRest, BindingPattern, BindingPatternKind, BindingProperty, BindingRestElement,
-    FormalParameter, FormalParameterKind, FormalParameters, ObjectAssignmentTarget, ObjectPattern,
-    Program, RegExpFlags, TSTypeAnnotation,
+    ArrayAssignmentTarget, ArrayExpressionElement, ArrayPattern, AssignmentTargetMaybeDefault,
+    AssignmentTargetProperty, AssignmentTargetRest, BindingPattern, BindingPatternKind,
+    BindingProperty, BindingRestElement, FormalParameter, FormalParameterKind, FormalParameters,
+    ObjectAssignmentTarget, ObjectPattern, Program, RegExpFlags, TSTypeAnnotation,
 };
 use oxc_allocator::{Box, Vec};
 use oxc_span::Span;
@@ -42,6 +42,17 @@ impl Serialize for RegExpFlags {
         S: Serializer,
     {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+/// Serialize `ArrayExpressionElement::Elision` variant as `null` in JSON
+impl<'a> ArrayExpressionElement<'a> {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub(crate) fn serialize_elision<S: Serializer>(
+        _span: &Span,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_none()
     }
 }
 


### PR DESCRIPTION
Serialize `ArrayExpressionElement::Elision` variant as `null` in JSON AST, to align with ESTree.