### PR TITLE
feat(format): table imports

### DIFF
--- a/crates/oxc_cli/src/command/format.rs
+++ b/crates/oxc_cli/src/command/format.rs
@@ -4,7 +4,7 @@ use bpaf::Bpaf;
 
 use super::{
     ignore::{ignore_options, IgnoreOptions},
-    misc_options, CliCommand, MiscOptions, VERSION,
+    misc_options, CliCommand, MiscOptions, PrettierOptions, prettier_options, VERSION,
 };
 
 /// Formatter for the JavaScript Oxidation Compiler
@@ -28,6 +28,9 @@ pub struct FormatOptions {
 
     #[bpaf(external)]
     pub ignore_options: IgnoreOptions,
+
+    #[bpaf(external)]
+    pub prettier_options: PrettierOptions,
 
     /// Single file, single path or list of paths
     #[bpaf(positional("PATH"), many)]

--- a/crates/oxc_cli/src/command/mod.rs
+++ b/crates/oxc_cli/src/command/mod.rs
@@ -78,3 +78,18 @@ mod misc_options {
         assert_eq!(options.threads, Some(4));
     }
 }
+
+/// Prettier Options
+#[derive(Debug, Clone, Bpaf)]
+pub struct PrettierOptions {
+    pub table_imports: bool
+}
+
+impl PrettierOptions {
+    pub fn into_options(self) -> oxc_prettier::PrettierOptions {
+        oxc_prettier::PrettierOptions {
+            table_imports: self.table_imports,
+            ..oxc_prettier::PrettierOptions::default()
+        }
+    }
+}

--- a/crates/oxc_prettier/src/analyzer/mod.rs
+++ b/crates/oxc_prettier/src/analyzer/mod.rs
@@ -1,0 +1,20 @@
+use oxc_ast::ast::Program;
+pub use table_imports::TableImports;
+
+pub mod table_imports;
+
+/// Analyzer stores context values for entire program
+/// to make formatting better
+#[derive(Debug, Default)]
+pub struct Analysis {
+	/// [TableImports]
+	pub ti: TableImports,
+}
+
+impl Analysis {
+	pub fn for_program(program: &Program) -> Self {
+		Self {
+			ti: TableImports::analyze(program)
+		}
+	}
+}

--- a/crates/oxc_prettier/src/analyzer/table_imports.rs
+++ b/crates/oxc_prettier/src/analyzer/table_imports.rs
@@ -1,0 +1,96 @@
+use oxc_allocator::Vec;
+use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind, ModuleDeclaration, ModuleExportName, Program, Statement};
+use oxc_span::GetSpan;
+
+/// Table imports context
+///
+/// Example:
+/// ```js
+/// // typ = true
+/// // gap = 9   (.:.:.:.:.)
+/// import      { useEffect } from 'react'
+/// import type { FC }        from 'react'
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct TableImports {
+	/// At least one import is type import
+	pub typ: bool,
+	/// Alignment gap length
+	///
+	/// Gap is the length of the longest symbol.
+	/// The number of spaces for alignment also
+	/// depends on the type of specifier and
+	/// the preference for spaces around curly braces.
+	pub gap: usize,
+}
+
+impl TableImports {
+	pub fn analyze(program: &Program) -> Self {
+		let mut ti = TableImports::default();
+
+		for import in imports_iter(program) {
+			if let ImportOrExportKind::Type = &import.import_kind {
+				ti.typ = true;
+			}
+
+			if let Some(specifiers) = &import.specifiers {
+				for specifier in specifiers {
+					if let ImportDeclarationSpecifier::ImportSpecifier(import) = specifier {
+						if let ImportOrExportKind::Type = &import.import_kind {
+							ti.typ = true;
+						}
+					}
+					let sl = specifier_length(specifier);
+					if sl > ti.gap {
+						ti.gap = sl;
+					}
+				}
+			}
+		}
+
+		ti
+	}
+}
+
+fn imports_iter<'a, 'ast>(program: &'a Program<'ast>) -> impl Iterator<Item = &'a ImportDeclaration<'ast>> {
+	program.body.iter().filter_map(|it| {
+		if let Statement::ModuleDeclaration(module) = it {
+			if let ModuleDeclaration::ImportDeclaration(import) = &**module {
+				Some(&**import)
+			} else {
+				None
+			}
+		} else {
+			None
+		}
+	})
+}
+
+pub fn specifiers_length(specifiers: &Vec<ImportDeclarationSpecifier>) -> usize {
+	specifiers.iter().fold(0, |acc, b| acc + specifier_length(b))
+}
+
+pub fn specifier_length(specifier: &ImportDeclarationSpecifier) -> usize {
+	match specifier {
+		ImportDeclarationSpecifier::ImportSpecifier(it) => {
+			if it.imported.span() == it.local.span {
+				it.imported.name().len() + 2
+			} else {
+				match &it.imported {
+					ModuleExportName::Identifier(id) => {
+						id.name.len() + it.local.name.len() + 2 + 2 + 2  /* `as` keyword length + 2 spaces between + 2 braces */
+					}
+					ModuleExportName::StringLiteral(lit) => {
+						lit.value.len() + it.local.name.len() + 2 /* quotes around */
+					}
+				}
+			}
+		}
+		ImportDeclarationSpecifier::ImportDefaultSpecifier(it) => {
+			it.local.name.len()
+		}
+		ImportDeclarationSpecifier::ImportNamespaceSpecifier(it) => {
+			it.local.name.len() + 2 + 2 + 1 /* `as` keyword length + spaces around + asterisk */
+		}
+	}
+}

--- a/crates/oxc_prettier/src/lib.rs
+++ b/crates/oxc_prettier/src/lib.rs
@@ -13,6 +13,7 @@ mod needs_parens;
 mod options;
 mod printer;
 mod utils;
+mod analyzer;
 
 use std::{iter::Peekable, vec};
 
@@ -21,7 +22,7 @@ use oxc_ast::{ast::Program, AstKind, CommentKind, Trivias};
 use oxc_span::Span;
 use oxc_syntax::identifier::is_line_terminator;
 
-use crate::{doc::Doc, doc::DocBuilder, format::Format, printer::Printer};
+use crate::{doc::Doc, doc::DocBuilder, format::Format, printer::Printer, analyzer::Analysis};
 
 pub use crate::options::{ArrowParens, EndOfLine, PrettierOptions, QuoteProps, TrailingComma};
 
@@ -60,6 +61,8 @@ pub struct Prettier<'a> {
 
     group_id_builder: GroupIdBuilder,
     args: PrettierArgs,
+
+    ctx: Analysis,
 }
 
 impl<'a> DocBuilder<'a> for Prettier<'a> {
@@ -84,10 +87,12 @@ impl<'a> Prettier<'a> {
             stack: vec![],
             group_id_builder: GroupIdBuilder::default(),
             args: PrettierArgs::default(),
+            ctx: Analysis::default(),
         }
     }
 
     pub fn build(mut self, program: &Program<'a>) -> String {
+        self.ctx = Analysis::for_program(program);;
         let doc = program.format(&mut self);
         Printer::new(doc, self.source_text, self.options, self.allocator).build()
     }

--- a/crates/oxc_prettier/src/lib.rs
+++ b/crates/oxc_prettier/src/lib.rs
@@ -92,7 +92,7 @@ impl<'a> Prettier<'a> {
     }
 
     pub fn build(mut self, program: &Program<'a>) -> String {
-        self.ctx = Analysis::for_program(program);;
+        self.ctx = Analysis::for_program(program);
         let doc = program.format(&mut self);
         Printer::new(doc, self.source_text, self.options, self.allocator).build()
     }

--- a/crates/oxc_prettier/src/options.rs
+++ b/crates/oxc_prettier/src/options.rs
@@ -60,6 +60,10 @@ pub struct PrettierOptions {
     /// Include parentheses around a sole arrow function parameter.
     /// Default: [ArrowParens::Always]
     pub arrow_parens: ArrowParens,
+
+    /// Split imports by specifiers and prints imports with table-like layout
+    /// Default: false
+    pub table_imports: bool,
 }
 
 impl Default for PrettierOptions {
@@ -77,6 +81,7 @@ impl Default for PrettierOptions {
             bracket_spacing: true,
             bracket_same_line: false,
             arrow_parens: ArrowParens::default(),
+            table_imports: false,
         }
     }
 }


### PR DESCRIPTION
## Details
POC for table imports. 
This feature allows to align imports and make them more readable.

It'd be cool if someone left feedback. How significant a feature is this? But honestly, I can't imagine the project without it.

### Before
```ts
import { 
  useEffect,
  useMemo,
  useRef
} from "react";
import { addScrollingClass } from "@/utils/add-scrolling-class";
import DropdownMenu from "@/components/ui/dropdown-menu";
import { useModal } from "@/components/modals/context";
import Searchbox, { drawerSearchStateAtom } from "@/components/ui/search-box";
import Logo from "@/components/ui/logo";
import { useIsMounted } from "@/hooks/use-is-mounted";
import Image from "next/image";
import { useAtom } from "jotai";
import SearchHero from "../home/search-form/search-hero";
import SearchInputForm from "../search/search-input-form";
import Link from "next/link";
import { wishlistStateAtom } from "@/app/favourites/_context";
import useLocation from "@/hooks/use-location";
import useCurrency from "@/hooks/use-currency";
import { getLocationRequest } from "@/api/location";
import { usePathname, useSearchParams } from "next/navigation";
import { tripStateAtom } from "../plan-trip/plan-trip-sidebar";
import useFetchCityLocation from "@/hooks/use-fetch-city-location";
import { useLoadScript } from "@react-google-maps/api";
import clsx from "clsx";
import { SavedTrip } from "@/types";
import { makeQueryString } from "@/utils/makeQueryString";
import { type FC } from 'react'
```

### After
###### Imports will also be split by specifier, so that each import will have only one specifier to respect the maximum length
```ts
import      { useEffect }             from "react";
import      { useMemo }               from "react";
import      { useRef }                from "react";
import      { addScrollingClass }     from "@/utils/add-scrolling-class";
import      DropdownMenu              from "@/components/ui/dropdown-menu";
import      { useModal }              from "@/components/modals/context";
import      Searchbox                 from "@/components/ui/search-box";
import      { drawerSearchStateAtom } from "@/components/ui/search-box";
import      Logo                      from "@/components/ui/logo";
import      { useIsMounted }          from "@/hooks/use-is-mounted";
import      Image                     from "next/image";
import      { useAtom }               from "jotai";
import      SearchHero                from "../home/search-form/search-hero";
import      SearchInputForm           from "../search/search-input-form";
import      Link                      from "next/link";
import      { wishlistStateAtom }     from "@/app/favourites/_context";
import      useLocation               from "@/hooks/use-location";
import      useCurrency               from "@/hooks/use-currency";
import      { getLocationRequest }    from "@/api/location";
import      { usePathname }           from "next/navigation";
import      { useSearchParams }       from "next/navigation";
import      { tripStateAtom }         from "../plan-trip/plan-trip-sidebar";
import      useFetchCityLocation      from "@/hooks/use-fetch-city-location";
import      { useLoadScript }         from "@react-google-maps/api";
import      clsx                      from "clsx";
import      { SavedTrip }             from "@/types";
import      { makeQueryString }       from "@/utils/makeQueryString";
import type { FC }                    from "react";
```

## Other
This feature adds an analyzer structure to collect data about the whole program before formatting. Is it possible to do without it?

What about sorting imports?