### PR TITLE
feat(linter): add new property for `parse_jest_fn`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -94,7 +94,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
         if let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) {
-            let ParsedGeneralJestFnCall { kind, members, name } = jest_fn_call;
+            let ParsedGeneralJestFnCall { kind, members, name, .. } = jest_fn_call;
             // `test('foo')`
             let kind = match kind {
                 JestFnKind::Expect | JestFnKind::Unknown => return,

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -70,7 +70,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
     let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) else {
         return;
     };
-    let ParsedGeneralJestFnCall { kind, members, name } = jest_fn_call;
+    let ParsedGeneralJestFnCall { kind, members, name, .. } = jest_fn_call;
     if !matches!(kind, JestFnKind::General(JestGeneralFnKind::Describe | JestGeneralFnKind::Test)) {
         return;
     }


### PR DESCRIPTION
This pr is to add a new return value: `local`, which current property `name` always return `expect` and the `local` property will return its alias name for the following example:

```js
import { expect as JEST_EXPECT } from '@jest/globals';
```

and the `jest_expect_fn_call.name` will return `expect` and the `jest_expect_fn_call.local` wil return `JEST_EXPECT`.