### PR TITLE
fix(parser): fix failed to parse `JSXChild` after `JSXEmptyExpression`

### DIFF
--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -34,7 +34,7 @@ seq-macro        = { workspace = true }
 memchr = "2.7.1"
 
 [dev-dependencies]
-oxc_ast    = { workspace = true }
+oxc_ast    = { workspace = true, features = ["serialize"] }
 miette     = { workspace = true }
 serde_json = { workspace = true }
 ouroboros  = "0.18.3"             # for `multi-thread` example

--- a/tasks/coverage/codegen_misc.snap
+++ b/tasks/coverage/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 14/14 (100.00%)
-Positive Passed: 14/14 (100.00%)
+AST Parsed     : 15/15 (100.00%)
+Positive Passed: 15/15 (100.00%)

--- a/tasks/coverage/misc/pass/oxc-2723.jsx
+++ b/tasks/coverage/misc/pass/oxc-2723.jsx
@@ -1,0 +1,13 @@
+const A = (
+  <div>
+    {/* comment */}
+    AAAA
+  </div>
+);
+
+const B = (
+  <div>
+    BBBB
+    {/* comment */}
+  </div>
+);

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 14/14 (100.00%)
-Positive Passed: 14/14 (100.00%)
+AST Parsed     : 15/15 (100.00%)
+Positive Passed: 15/15 (100.00%)
 Negative Passed: 8/8 (100.00%)
 
   × Unexpected token

--- a/tasks/coverage/prettier_misc.snap
+++ b/tasks/coverage/prettier_misc.snap
@@ -1,9 +1,10 @@
 prettier_misc Summary:
-AST Parsed     : 14/14 (100.00%)
-Positive Passed: 8/14 (57.14%)
+AST Parsed     : 15/15 (100.00%)
+Positive Passed: 8/15 (53.33%)
 Expect to Parse: "pass/oxc-1740.tsx"
 Expect to Parse: "pass/oxc-2087.ts"
 Expect to Parse: "pass/oxc-2394.ts"
 Expect to Parse: "pass/oxc-2674.tsx"
+Expect to Parse: "pass/oxc-2723.jsx"
 Expect to Parse: "pass/swc-1627.js"
 Expect to Parse: "pass/swc-8243.tsx"


### PR DESCRIPTION
fixes #2723