### PR TITLE
perf(sourcemap): remove unnecessary binary search

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,3 +1,4 @@
+
 use oxc_syntax::identifier::{LS, PS};
 
 // Irregular line breaks - '\u{2028}' (LS) and '\u{2029}' (PS)
@@ -24,6 +25,7 @@ pub struct SourcemapBuilder {
     source_id: u32,
     last_generated_update: usize,
     last_position: Option<u32>,
+    last_search_line: usize,
     line_offset_tables: Vec<LineOffsetTable>,
     sourcemap_builder: sourcemap::SourceMapBuilder,
     generated_line: u32,
@@ -37,6 +39,7 @@ impl Default for SourcemapBuilder {
             source_id: 0,
             last_generated_update: 0,
             last_position: None,
+            last_search_line: 0,
             line_offset_tables: vec![],
             sourcemap_builder: sourcemap::SourceMapBuilder::new(None),
             generated_line: 0,
@@ -78,11 +81,18 @@ impl SourcemapBuilder {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    fn search_original_line_and_column(&self, position: u32) -> (u32, u32) {
-        let result = self
-            .line_offset_tables
-            .partition_point(|table| table.byte_offset_to_start_of_line <= position as usize);
-        let original_line = if result > 0 { result - 1 } else { 0 };
+    fn search_original_line_and_column(&mut self, position: u32) -> (u32, u32) {
+        let mut original_line = 0;
+        for i in self.last_search_line..self.line_offset_tables.len() {
+            if self.line_offset_tables[i].byte_offset_to_start_of_line > position as usize {
+                original_line = i - 1;
+                break;
+            }
+            if i == self.line_offset_tables.len() - 1 {
+                original_line = i;
+            }
+        }
+        self.last_search_line = original_line;
         let line = &self.line_offset_tables[original_line];
         let mut original_column = (position as usize) - line.byte_offset_to_start_of_line;
         if original_column >= line.byte_offset_to_first {

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,4 +1,3 @@
-
 use oxc_syntax::identifier::{LS, PS};
 
 // Irregular line breaks - '\u{2028}' (LS) and '\u{2029}' (PS)


### PR DESCRIPTION
Becuase `position` argument is ordering, using  binary search is unnecessary.