### PR TITLE
chore(napi): only enable Codspeed plugin on CI

### DIFF
--- a/napi/parser/vitest.config.mjs
+++ b/napi/parser/vitest.config.mjs
@@ -2,5 +2,5 @@ import {defineConfig} from 'vitest/config';
 import codspeedPlugin from '@codspeed/vitest-plugin';
 
 export default defineConfig({
-    plugins: [codspeedPlugin()]
+    plugins: process.env.CI ? [codspeedPlugin()] : []
 });


### PR DESCRIPTION
When running NAPI benchmarks locally, Codspeed plugin hides the benchmark results.