### PR TITLE
chore(napi): remove `oxc-parser` from benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,12 +38,6 @@ jobs:
           shared-key: 'benchmark'
           save-cache: ${{ github.ref_name == 'main' }}
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Install codspeed
         uses: taiki-e/install-action@v2
         with:
@@ -65,19 +59,9 @@ jobs:
           mv target/release/deps/codegen_sourcemap-* target/codspeed/oxc_benchmark
           rm -rf target/codspeed/oxc_benchmark/*.d
 
-      - name: Build NAPI benchmark
-        working-directory: ./napi/parser
-        run: |
-          corepack enable
-          pnpm install
-          pnpm run build
-
       - name: Run benchmark
         uses: CodSpeedHQ/action@v2
         timeout-minutes: 30
         with:
-          run: |
-            cargo codspeed run
-            cd napi/parser
-            pnpm run bench
+          run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
#2724 added CodSpeed benchmarks for NodeJS `oxc-parser`.

Unfortunately it turns out CodSpeed's results are wildly inaccurate. Unclear why, but have raised an issue with CodSpeed (https://github.com/CodSpeedHQ/action/issues/96). In meantime it seems best to remove the benchmarks as they're not useful at present.