### PR TITLE
fix(tasks): fix codspeed upload for PRs from forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,7 +94,8 @@ jobs:
           FIXTURE: ${{ matrix.fixture }}
         with:
           run: cargo codspeed run
-          token: ${{ secrets.CODSPEED_TOKEN }}
+          # Dummy token for tokenless runs, to suppress logging hash of metadata JSON (see `upload.mjs`)
+          token: ${{ secrets.CODSPEED_TOKEN || 'dummy' }}
           upload-url: http://localhost:${{ env.INTERCEPT_PORT }}/upload
 
       - name: Upload bench data artefact


### PR DESCRIPTION
#2751 contained a mistake, which was pointed out by Adrian @ CodSpeed on Discord.

For PRs from forks, `CODSPEED_TOKEN` is not provided, and the submission to CodSpeed is "tokenless". #2751 wrongly assumed all runs are submitted with a token. This PR fixes that.