### PR TITLE
perf(parser): skip whitespace after comment

### DIFF
--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -75,8 +75,8 @@ impl<'a> Lexer<'a> {
             },
         };
 
-        self.token.is_on_new_line = true;
-        Kind::Skip
+        // Skip indentation after line break
+        self.line_break_handler()
     }
 
     /// Section 12.4 Multi Line Comment

--- a/crates/oxc_parser/src/lexer/whitespace.rs
+++ b/crates/oxc_parser/src/lexer/whitespace.rs
@@ -7,6 +7,7 @@ static NOT_REGULAR_WHITESPACE_OR_LINE_BREAK_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'));
 
 impl<'a> Lexer<'a> {
+    #[inline]
     pub(super) fn line_break_handler(&mut self) -> Kind {
         self.token.is_on_new_line = true;
 


### PR DESCRIPTION
Small optimization to skip whitespace after single-line comments. Single line comments end with a line break, and typically indentation follows, so bypass the byte table for this common case.