### PR TITLE
feat(cli): wildcard expansion in paths for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +710,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -977,6 +999,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -1365,6 +1393,7 @@ name = "oxc_cli"
 version = "0.0.0"
 dependencies = [
  "bpaf",
+ "glob",
  "ignore",
  "jemallocator",
  "miette",
@@ -1376,6 +1405,7 @@ dependencies = [
  "oxc_prettier",
  "oxc_span",
  "rayon",
+ "tempfile",
  "tracing-subscriber",
 ]
 
@@ -2150,6 +2180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2516,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ convert_case              = { version = "0.6.0" }
 dashmap                   = { version = "5.5.3" }
 flate2                    = { version = "1.0.28" }
 futures                   = { version = "0.3.30" }
+glob                      = { version = "0.3.1" }
 ignore                    = { version = "0.4.22" }
 itertools                 = { version = "0.12.1" }
 jemallocator              = { version = "0.5.4" }
@@ -118,6 +119,7 @@ seq-macro                 = { version = "0.3.5" }
 serde                     = { version = "1.0.197" }
 serde_json                = { version = "1.0.114" }
 syn                       = { version = "=1.0.109" }
+tempfile                  = { version = "3.10.1" }
 thiserror                 = { version = "1.0.58" }
 tokio                     = { version = "1" }
 tower-lsp                 = { version = "0.20.0", features = ["proposed"] }

--- a/crates/oxc_cli/Cargo.toml
+++ b/crates/oxc_cli/Cargo.toml
@@ -43,6 +43,7 @@ oxc_span        = { workspace = true }
 
 ignore             = { workspace = true, features = ["simd-accel"] }
 miette             = { workspace = true }
+tempfile           = {workspace=true}
 rayon              = { workspace = true }
 bpaf               = { workspace = true, features = ["derive", "autocomplete", "bright-color"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
@@ -52,3 +53,4 @@ jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = { workspace = true }
+glob     = { workspace = true }

--- a/crates/oxc_cli/src/command/format.rs
+++ b/crates/oxc_cli/src/command/format.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use bpaf::Bpaf;
 
 use super::{
+    expand_glob,
     ignore::{ignore_options, IgnoreOptions},
-    misc_options, CliCommand, MiscOptions, VERSION,
+    misc_options, validate_paths, CliCommand, MiscOptions, PATHS_ERROR_MESSAGE, VERSION,
 };
 
 /// Formatter for the JavaScript Oxidation Compiler
@@ -30,6 +31,6 @@ pub struct FormatOptions {
     pub ignore_options: IgnoreOptions,
 
     /// Single file, single path or list of paths
-    #[bpaf(positional("PATH"), many)]
+    #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE), map(expand_glob))]
     pub paths: Vec<PathBuf>,
 }

--- a/crates/oxc_cli/src/command/mod.rs
+++ b/crates/oxc_cli/src/command/mod.rs
@@ -3,6 +3,7 @@ mod ignore;
 mod lint;
 
 use bpaf::Bpaf;
+use std::path::PathBuf;
 
 pub use self::{
     format::{format_command, FormatOptions},
@@ -54,6 +55,42 @@ pub struct MiscOptions {
     /// Number of threads to use. Set to 1 for using only 1 CPU core
     #[bpaf(argument("INT"), hide_usage)]
     pub threads: Option<usize>,
+}
+
+#[allow(clippy::ptr_arg)]
+fn validate_paths(paths: &Vec<PathBuf>) -> bool {
+    if paths.is_empty() {
+        true
+    } else {
+        paths.iter().all(|p| p.components().all(|c| c != std::path::Component::ParentDir))
+    }
+}
+
+const PATHS_ERROR_MESSAGE: &str = "PATH must not contain \"..\"";
+
+#[cfg(target_os = "windows")]
+#[allow(clippy::needless_pass_by_value)]
+fn expand_glob(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let match_options = glob::MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: false,
+        require_literal_leading_dot: false,
+    };
+
+    paths
+        .iter()
+        .filter_map(|path| path.to_str())
+        .filter_map(|path| glob::glob_with(path, match_options).ok())
+        .flatten()
+        .filter_map(Result::ok)
+        .collect()
+}
+
+#[cfg(not(target_os = "windows"))]
+#[allow(clippy::needless_pass_by_value)]
+fn expand_glob(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    // no-op on any os other than windows, since they expand globs
+    paths
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Unlike on other OS, on Windows there is no wildcard expansion/globbing by the shell. Instead the application has to handle this. Therefore I used the `glob` package to handle wildcards on Windows.

I also had to make the parent directory check more strict due to the glob package resolving `..` in the middle of the path as well.

This closes #2695.