### PR TITLE
refactor(sourcemap): enable_source_map using Arc<str> instead of String

### DIFF
--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -30,12 +30,12 @@ fn main() -> std::io::Result<()> {
 
     let options = CodegenOptions::default();
     let printed =
-        Codegen::<false>::new(&source_text, options.clone()).build(&ret.program).source_text;
+        Codegen::<false>::new("", &source_text, options.clone()).build(&ret.program).source_text;
     println!("Printed:");
     println!("{printed}");
 
     let ret = Parser::new(&allocator, &printed, source_type).parse();
-    let minified = Codegen::<true>::new(&source_text, options).build(&ret.program).source_text;
+    let minified = Codegen::<true>::new("", &source_text, options).build(&ret.program).source_text;
     println!("Minified:");
     println!("{minified}");
 

--- a/crates/oxc_codegen/examples/sourcemap.rs
+++ b/crates/oxc_codegen/examples/sourcemap.rs
@@ -26,13 +26,11 @@ fn main() -> std::io::Result<()> {
         return Ok(());
     }
 
-    let codegen_options = CodegenOptions {
-        enable_source_map: Some(path.to_string_lossy().into()),
-        enable_typescript: true,
-    };
+    let codegen_options = CodegenOptions { enable_source_map: true, enable_typescript: true };
 
     let CodegenReturn { source_text, source_map } =
-        Codegen::<false>::new(&source_text, codegen_options).build(&ret.program);
+        Codegen::<false>::new(path.to_string_lossy().as_ref(), &source_text, codegen_options)
+            .build(&ret.program);
 
     if let Some(source_map) = source_map {
         let mut buff = vec![];

--- a/crates/oxc_codegen/examples/sourcemap.rs
+++ b/crates/oxc_codegen/examples/sourcemap.rs
@@ -27,7 +27,7 @@ fn main() -> std::io::Result<()> {
     }
 
     let codegen_options = CodegenOptions {
-        enable_source_map: Some(path.to_string_lossy().to_string()),
+        enable_source_map: Some(path.to_string_lossy().into()),
         enable_typescript: true,
     };
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -14,7 +14,7 @@ mod gen_ts;
 mod operator;
 mod sourcemap_builder;
 mod sourcemap_visualizer;
-use std::{str::from_utf8_unchecked, sync::Arc};
+use std::str::from_utf8_unchecked;
 
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
@@ -38,7 +38,7 @@ pub use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct CodegenOptions {
     /// Pass in the filename to enable source map support.
-    pub enable_source_map: Option<Arc<str>>,
+    pub enable_source_map: bool,
 
     /// Enable TypeScript code generation.
     pub enable_typescript: bool,
@@ -85,14 +85,14 @@ pub enum Separator {
 }
 
 impl<const MINIFY: bool> Codegen<MINIFY> {
-    pub fn new(source_text: &str, options: CodegenOptions) -> Self {
+    pub fn new(source_name: &str, source_text: &str, options: CodegenOptions) -> Self {
         // Initialize the output code buffer to reduce memory reallocation.
         // Minification will reduce by at least half of the original size.
         let source_len = source_text.len();
         let capacity = if MINIFY { source_len / 2 } else { source_len };
 
         let mut sourcemap_builder = SourcemapBuilder::default();
-        if let Some(source_name) = &options.enable_source_map {
+        if options.enable_source_map {
             sourcemap_builder.with_name_and_source(source_name, source_text);
         }
         Self {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -14,7 +14,7 @@ mod gen_ts;
 mod operator;
 mod sourcemap_builder;
 mod sourcemap_visualizer;
-use std::str::from_utf8_unchecked;
+use std::{str::from_utf8_unchecked, sync::Arc};
 
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
@@ -38,7 +38,7 @@ pub use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct CodegenOptions {
     /// Pass in the filename to enable source map support.
-    pub enable_source_map: Option<String>,
+    pub enable_source_map: Option<Arc<str>>,
 
     /// Enable TypeScript code generation.
     pub enable_typescript: bool,

--- a/crates/oxc_codegen/tests/mod.rs
+++ b/crates/oxc_codegen/tests/mod.rs
@@ -8,8 +8,9 @@ fn test(source_text: &str, expected: &str) {
     let source_type = SourceType::default().with_module(true);
     let program = Parser::new(&allocator, source_text, source_type).parse().program;
     let program = allocator.alloc(program);
-    let result =
-        Codegen::<false>::new(source_text, CodegenOptions::default()).build(program).source_text;
+    let result = Codegen::<false>::new("", source_text, CodegenOptions::default())
+        .build(program)
+        .source_text;
     assert_eq!(expected, result, "for source {source_text}, expect {expected}, got {result}");
 }
 
@@ -22,7 +23,7 @@ fn test_ts(source_text: &str, expected: &str, is_typescript_definition: bool) {
     let program = Parser::new(&allocator, source_text, source_type).parse().program;
     let program = allocator.alloc(program);
     let codegen_options = CodegenOptions { enable_typescript: true, ..CodegenOptions::default() };
-    let result = Codegen::<false>::new(source_text, codegen_options).build(program).source_text;
+    let result = Codegen::<false>::new("", source_text, codegen_options).build(program).source_text;
     assert_eq!(expected, result, "for source {source_text}, expect {expected}, got {result}");
 }
 

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -151,7 +151,7 @@ impl<'a> LintContext<'a> {
 
     #[allow(clippy::unused_self)]
     pub fn codegen(&self) -> Codegen<false> {
-        Codegen::<false>::new("", CodegenOptions::default())
+        Codegen::<false>::new("", "", CodegenOptions::default())
     }
 
     /* JSDoc */

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -43,9 +43,9 @@ fn minify(source_text: &str, source_type: SourceType, mangle: bool, whitespace: 
     let options = MinifierOptions { mangle, ..MinifierOptions::default() };
     Minifier::new(options).build(&allocator, program);
     if whitespace {
-        Codegen::<true>::new(source_text, CodegenOptions::default()).build(program)
+        Codegen::<true>::new("", source_text, CodegenOptions::default()).build(program)
     } else {
-        Codegen::<false>::new(source_text, CodegenOptions::default()).build(program)
+        Codegen::<false>::new("", source_text, CodegenOptions::default()).build(program)
     }
     .source_text
 }

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -19,7 +19,7 @@ pub(crate) fn minify(
     let program = Parser::new(&allocator, source_text, source_type).parse().program;
     let program = allocator.alloc(program);
     Minifier::new(options).build(&allocator, program);
-    Codegen::<true>::new(source_text, CodegenOptions::default()).build(program).source_text
+    Codegen::<true>::new("", source_text, CodegenOptions::default()).build(program).source_text
 }
 
 pub(crate) fn test(source_text: &str, expected: &str) {

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -55,8 +55,9 @@ fn main() {
     };
     Transformer::new(&allocator, source_type, semantic, transform_options).build(program).unwrap();
 
-    let printed =
-        Codegen::<false>::new(&source_text, CodegenOptions::default()).build(program).source_text;
+    let printed = Codegen::<false>::new("", &source_text, CodegenOptions::default())
+        .build(program)
+        .source_text;
     println!("Transformed:\n");
     println!("{printed}");
 }

--- a/crates/oxc_transformer/src/tester.rs
+++ b/crates/oxc_transformer/src/tester.rs
@@ -43,11 +43,15 @@ impl Tester {
         Transformer::new(&self.allocator, self.source_type, semantic, self.options.clone())
             .build(program)?;
 
-        Ok(Codegen::<false>::new(source_text, CodegenOptions::default()).build(program).source_text)
+        Ok(Codegen::<false>::new("", source_text, CodegenOptions::default())
+            .build(program)
+            .source_text)
     }
 
     fn codegen(&self, source_text: &str) -> String {
         let program = Parser::new(&self.allocator, source_text, self.source_type).parse().program;
-        Codegen::<false>::new(source_text, CodegenOptions::default()).build(&program).source_text
+        Codegen::<false>::new("", source_text, CodegenOptions::default())
+            .build(&program)
+            .source_text
     }
 }

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -272,9 +272,9 @@ impl Oxc {
             ..CodegenOptions::default()
         };
         self.codegen_text = if minifier_options.whitespace() {
-            Codegen::<true>::new(source_text, codegen_options).build(program).source_text
+            Codegen::<true>::new("", source_text, codegen_options).build(program).source_text
         } else {
-            Codegen::<false>::new(source_text, codegen_options).build(program).source_text
+            Codegen::<false>::new("", source_text, codegen_options).build(program).source_text
         };
 
         Ok(())

--- a/tasks/benchmark/benches/codegen_sourcemap.rs
+++ b/tasks/benchmark/benches/codegen_sourcemap.rs
@@ -14,12 +14,10 @@ fn bench_codegen_sourcemap(criterion: &mut Criterion) {
         group.bench_with_input(id, &file.source_text, |b, source_text| {
             let allocator = Allocator::default();
             let program = Parser::new(&allocator, source_text, source_type).parse().program;
-            let codegen_options = CodegenOptions {
-                enable_source_map: Some(file.file_name.as_str().into()),
-                ..CodegenOptions::default()
-            };
+            let codegen_options =
+                CodegenOptions { enable_source_map: true, ..CodegenOptions::default() };
             b.iter_with_large_drop(|| {
-                Codegen::<false>::new(source_text, codegen_options.clone())
+                Codegen::<false>::new(file.file_name.as_str(), source_text, codegen_options.clone())
                     .build(&program)
                     .source_map
             });

--- a/tasks/benchmark/benches/codegen_sourcemap.rs
+++ b/tasks/benchmark/benches/codegen_sourcemap.rs
@@ -15,7 +15,7 @@ fn bench_codegen_sourcemap(criterion: &mut Criterion) {
             let allocator = Allocator::default();
             let program = Parser::new(&allocator, source_text, source_type).parse().program;
             let codegen_options = CodegenOptions {
-                enable_source_map: Some(file.file_name.clone()),
+                enable_source_map: Some(file.file_name.as_str().into()),
                 ..CodegenOptions::default()
             };
             b.iter_with_large_drop(|| {

--- a/tasks/coverage/src/codegen.rs
+++ b/tasks/coverage/src/codegen.rs
@@ -72,12 +72,12 @@ fn get_normal_result(
     let options = CodegenOptions::default();
     let allocator = Allocator::default();
     let parse_result1 = Parser::new(&allocator, source_text, source_type).parse();
-    let source_text1 = Codegen::<false>::new(source_text, options.clone())
+    let source_text1 = Codegen::<false>::new("", source_text, options.clone())
         .build(&parse_result1.program)
         .source_text;
     let parse_result2 = Parser::new(&allocator, &source_text1, source_type).parse();
     let source_text2 =
-        Codegen::<false>::new(&source_text1, options).build(&parse_result2.program).source_text;
+        Codegen::<false>::new("", &source_text1, options).build(&parse_result2.program).source_text;
     let result = source_text1 == source_text2;
 
     if !result {
@@ -114,12 +114,12 @@ fn get_minify_result(
     let options = CodegenOptions::default();
     let allocator = Allocator::default();
     let parse_result1 = Parser::new(&allocator, source_text, source_type).parse();
-    let source_text1 = Codegen::<true>::new(source_text, options.clone())
+    let source_text1 = Codegen::<true>::new("", source_text, options.clone())
         .build(&parse_result1.program)
         .source_text;
     let parse_result2 = Parser::new(&allocator, source_text1.as_str(), source_type).parse();
     let source_text2 =
-        Codegen::<true>::new(&source_text1, options).build(&parse_result2.program).source_text;
+        Codegen::<true>::new("", &source_text1, options).build(&parse_result2.program).source_text;
     let result = source_text1 == source_text2;
 
     if !result {
@@ -153,15 +153,15 @@ fn get_typescript_result(
     source_text: &str,
     source_type: SourceType,
 ) -> bool {
-    let options = CodegenOptions { enable_source_map: None, enable_typescript: true };
+    let options = CodegenOptions { enable_source_map: false, enable_typescript: true };
     let allocator = Allocator::default();
     let parse_result1 = Parser::new(&allocator, source_text, source_type).parse();
-    let source_text1 = Codegen::<false>::new(source_text, options.clone())
+    let source_text1 = Codegen::<false>::new("", source_text, options.clone())
         .build(&parse_result1.program)
         .source_text;
     let parse_result2 = Parser::new(&allocator, &source_text1, source_type).parse();
     let source_text2 =
-        Codegen::<false>::new(&source_text1, options).build(&parse_result2.program).source_text;
+        Codegen::<false>::new("", &source_text1, options).build(&parse_result2.program).source_text;
     let result = source_text1 == source_text2;
 
     if !result {

--- a/tasks/coverage/src/minifier.rs
+++ b/tasks/coverage/src/minifier.rs
@@ -100,5 +100,5 @@ fn minify(source_text: &str, source_type: SourceType, options: MinifierOptions) 
     let program = Parser::new(&allocator, source_text, source_type).parse().program;
     let program = allocator.alloc(program);
     Minifier::new(options).build(&allocator, program);
-    Codegen::<true>::new(source_text, CodegenOptions::default()).build(program).source_text
+    Codegen::<true>::new("", source_text, CodegenOptions::default()).build(program).source_text
 }

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -138,7 +138,7 @@ impl Case for CodegenRuntimeTest262Case {
                 let source_type = SourceType::default().with_module(is_module);
                 let allocator = Allocator::default();
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let mut text = Codegen::<false>::new(source_text, CodegenOptions::default())
+                let mut text = Codegen::<false>::new("", source_text, CodegenOptions::default())
                     .build(&program)
                     .source_text;
                 if is_only_strict {

--- a/tasks/coverage/src/sourcemap.rs
+++ b/tasks/coverage/src/sourcemap.rs
@@ -127,7 +127,7 @@ impl Case for SourcemapCase {
         }
 
         let codegen_options = CodegenOptions {
-            enable_source_map: Some(self.path.to_string_lossy().to_string()),
+            enable_source_map: Some(self.path.to_string_lossy().into()),
             ..CodegenOptions::default()
         };
         let codegen_ret = Codegen::<false>::new(source_text, codegen_options).build(&ret.program);

--- a/tasks/coverage/src/sourcemap.rs
+++ b/tasks/coverage/src/sourcemap.rs
@@ -126,11 +126,14 @@ impl Case for SourcemapCase {
             }
         }
 
-        let codegen_options = CodegenOptions {
-            enable_source_map: Some(self.path.to_string_lossy().into()),
-            ..CodegenOptions::default()
-        };
-        let codegen_ret = Codegen::<false>::new(source_text, codegen_options).build(&ret.program);
+        let codegen_options =
+            CodegenOptions { enable_source_map: true, ..CodegenOptions::default() };
+        let codegen_ret = Codegen::<false>::new(
+            self.path.to_string_lossy().as_ref(),
+            source_text,
+            codegen_options,
+        )
+        .build(&ret.program);
 
         TestResult::Snapshot(
             SourcemapVisualizer::new(&codegen_ret.source_text, &codegen_ret.source_map.unwrap())

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -73,7 +73,7 @@ fn minify(source_text: &str, source_type: SourceType, options: MinifierOptions) 
     let program = Parser::new(&allocator, source_text, source_type).parse().program;
     let program = allocator.alloc(program);
     Minifier::new(options).build(&allocator, program);
-    Codegen::<true>::new(source_text, CodegenOptions::default()).build(program).source_text
+    Codegen::<true>::new("", source_text, CodegenOptions::default()).build(program).source_text
 }
 
 fn gzip_size(s: &str) -> usize {

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -179,7 +179,7 @@ pub trait TestCase {
             .build(transformed_program);
 
         result.map(|()| {
-            Codegen::<false>::new(&source_text, CodegenOptions::default())
+            Codegen::<false>::new("", &source_text, CodegenOptions::default())
                 .build(transformed_program)
                 .source_text
         })
@@ -253,8 +253,9 @@ impl TestCase for ConformanceTestCase {
         let mut actual_errors = String::new();
         let result = transformer.build(program);
         if result.is_ok() {
-            transformed_code =
-                Codegen::<false>::new(&input, codegen_options.clone()).build(program).source_text;
+            transformed_code = Codegen::<false>::new("", &input, codegen_options.clone())
+                .build(program)
+                .source_text;
         } else {
             actual_errors = result.err().unwrap().iter().map(ToString::to_string).collect();
         }
@@ -269,12 +270,16 @@ impl TestCase for ConformanceTestCase {
                 }
                 // The transformation should be equal to input.js If output.js does not exist.
                 let program = Parser::new(&allocator, &input, source_type).parse().program;
-                Codegen::<false>::new(&input, codegen_options.clone()).build(&program).source_text
+                Codegen::<false>::new("", &input, codegen_options.clone())
+                    .build(&program)
+                    .source_text
             },
             |output| {
                 // Get expected code by parsing the source text, so we can get the same code generated result.
                 let program = Parser::new(&allocator, &output, source_type).parse().program;
-                Codegen::<false>::new(&output, codegen_options.clone()).build(&program).source_text
+                Codegen::<false>::new("", &output, codegen_options.clone())
+                    .build(&program)
+                    .source_text
             },
         );
 
@@ -334,7 +339,7 @@ impl ExecTestCase {
         let source_type = SourceType::from_path(&target_path).unwrap();
         let transformed_program =
             Parser::new(&allocator, &source_text, source_type).parse().program;
-        let result = Codegen::<false>::new(&source_text, CodegenOptions::default())
+        let result = Codegen::<false>::new("", &source_text, CodegenOptions::default())
             .build(&transformed_program)
             .source_text;
 

--- a/tasks/transform_conformance/src/ts_fixtures.rs
+++ b/tasks/transform_conformance/src/ts_fixtures.rs
@@ -127,7 +127,7 @@ impl TypeScriptFixtures {
 
         result
             .map(|()| {
-                Codegen::<false>::new(&source_text, CodegenOptions::default())
+                Codegen::<false>::new("", &source_text, CodegenOptions::default())
                     .build(transformed_program)
                     .source_text
             })


### PR DESCRIPTION
The `source_name` using `String` caused more memory allocate at rolldown, here using `Arc<str>` to avoid this.