### PR TITLE
chore(tasks): remove dummy comment

### DIFF
--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::trailing_empty_array)]
 
-// Dummy comment
-
 mod module_lexer;
 
 use std::sync::Arc;


### PR DESCRIPTION
Had to add this dummy comment to get CI to run on #2783. So now removing it again.