### PR TITLE
feat(semantic): distinguish type imports in ModuleRecord

### DIFF
--- a/crates/oxc_semantic/src/module_record/builder.rs
+++ b/crates/oxc_semantic/src/module_record/builder.rs
@@ -170,33 +170,35 @@ impl ModuleRecordBuilder {
     }
 
     fn visit_import_declaration(&mut self, decl: &ImportDeclaration) {
-        if decl.import_kind.is_type() {
-            return;
-        }
         let module_request = NameSpan::new(decl.source.value.to_compact_str(), decl.source.span);
+
         if let Some(specifiers) = &decl.specifiers {
             for specifier in specifiers {
-                let (import_name, local_name) = match specifier {
+                let (import_name, local_name, is_type) = match specifier {
                     ImportDeclarationSpecifier::ImportSpecifier(specifier) => (
                         ImportImportName::Name(NameSpan::new(
                             specifier.imported.name().to_compact_str(),
                             specifier.imported.span(),
                         )),
                         NameSpan::new(specifier.local.name.to_compact_str(), specifier.local.span),
+                        decl.import_kind.is_type() || specifier.import_kind.is_type(),
                     ),
                     ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => (
                         ImportImportName::NamespaceObject,
                         NameSpan::new(specifier.local.name.to_compact_str(), specifier.local.span),
+                        decl.import_kind.is_type(),
                     ),
                     ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => (
                         ImportImportName::Default(specifier.span),
                         NameSpan::new(specifier.local.name.to_compact_str(), specifier.local.span),
+                        decl.import_kind.is_type(),
                     ),
                 };
                 self.add_import_entry(ImportEntry {
                     module_request: module_request.clone(),
                     import_name,
                     local_name,
+                    is_type,
                 });
             }
         }

--- a/crates/oxc_semantic/src/module_record/mod.rs
+++ b/crates/oxc_semantic/src/module_record/mod.rs
@@ -35,6 +35,7 @@ mod module_record_tests {
             module_request: NameSpan::new("mod".into(), Span::new(14, 19)),
             import_name: ImportImportName::Default(Span::new(7, 8)),
             local_name: NameSpan::new("v".into(), Span::new(7, 8)),
+            is_type: false,
         };
         assert_eq!(module_record.import_entries.len(), 1);
         assert_eq!(module_record.import_entries[0], import_entry);
@@ -47,6 +48,7 @@ mod module_record_tests {
             module_request: NameSpan::new("mod".into(), Span::new(20, 25)),
             import_name: ImportImportName::NamespaceObject,
             local_name: NameSpan::new("ns".into(), Span::new(12, 14)),
+            is_type: false,
         };
         assert_eq!(module_record.import_entries.len(), 1);
         assert_eq!(module_record.import_entries[0], import_entry);
@@ -59,6 +61,7 @@ mod module_record_tests {
             module_request: NameSpan::new("mod".into(), Span::new(18, 23)),
             import_name: ImportImportName::Name(NameSpan::new("x".into(), Span::new(9, 10))),
             local_name: NameSpan::new("x".into(), Span::new(9, 10)),
+            is_type: false,
         };
         assert_eq!(module_record.import_entries.len(), 1);
         assert_eq!(module_record.import_entries[0], import_entry);
@@ -71,6 +74,7 @@ mod module_record_tests {
             module_request: NameSpan::new("mod".into(), Span::new(23, 28)),
             import_name: ImportImportName::Name(NameSpan::new("x".into(), Span::new(9, 10))),
             local_name: NameSpan::new("v".into(), Span::new(14, 15)),
+            is_type: false,
         };
         assert_eq!(module_record.import_entries.len(), 1);
         assert_eq!(module_record.import_entries[0], import_entry);

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -148,6 +148,8 @@ pub struct ImportEntry {
 
     /// The name that is used to locally access the imported value from within the importing module.
     pub local_name: NameSpan,
+
+    pub is_type: bool,
 }
 
 /// `ImportName` For `ImportEntry`


### PR DESCRIPTION
I am not sure moving `ImportOrExportKind` to `oxc-syntax` is a good solution. 