### PR TITLE
perf(tasks): speed up NAPI parser benchmark build

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -167,7 +167,7 @@ jobs:
           RUSTFLAGS: "-C debuginfo=2 -C strip=none -g --cfg codspeed"
         shell: bash
         run: |
-          cargo build --release -p oxc_benchmark --bench parser_napi --features codspeed_napi
+          cargo build --release -p oxc_benchmark --bench parser_napi --no-default-features --features codspeed_napi
           mkdir -p target/codspeed/oxc_benchmark/
           mv target/release/deps/parser_napi-* target/codspeed/oxc_benchmark
           rm -rf target/codspeed/oxc_benchmark/*.d

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -58,21 +58,36 @@ harness = false
 bench   = false
 
 [dependencies]
-oxc_allocator    = { workspace = true }
-oxc_linter       = { workspace = true }
-oxc_minifier     = { workspace = true }
-oxc_parser       = { workspace = true, features = ["benchmarking"] }
-oxc_prettier     = { workspace = true }
-oxc_semantic     = { workspace = true }
-oxc_span         = { workspace = true }
-oxc_tasks_common = { workspace = true }
-oxc_transformer  = { workspace = true }
-oxc_codegen      = { workspace = true }
+# All optional as `parser_napi` pseudo-benchmark doesn't need any of them,
+# and including them in compilation adds 1 minute to building that benchmark on CI.
+# See `tasks/benchmark/benches/parser_napi.rs`.
+oxc_allocator    = { workspace = true, optional = true }
+oxc_linter       = { workspace = true, optional = true }
+oxc_minifier     = { workspace = true, optional = true }
+oxc_parser       = { workspace = true, features = ["benchmarking"], optional = true }
+oxc_prettier     = { workspace = true, optional = true }
+oxc_semantic     = { workspace = true, optional = true }
+oxc_span         = { workspace = true, optional = true }
+oxc_tasks_common = { workspace = true, optional = true }
+oxc_transformer  = { workspace = true, optional = true }
+oxc_codegen      = { workspace = true, optional = true }
 
 criterion  = { package = "criterion2", version = "0.6.0", default-features = false }
 serde      = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 [features]
-codspeed      = ["criterion/codspeed"]
+default = [
+    "dep:oxc_allocator",
+    "dep:oxc_linter",
+    "dep:oxc_minifier",
+    "dep:oxc_parser",
+    "dep:oxc_prettier",
+    "dep:oxc_semantic",
+    "dep:oxc_span",
+    "dep:oxc_tasks_common",
+    "dep:oxc_transformer",
+    "dep:oxc_codegen",
+]
+codspeed = ["criterion/codspeed"]
 codspeed_napi = ["criterion/codspeed", "dep:serde", "dep:serde_json"]


### PR DESCRIPTION
The `parser_napi` pseudo-benchmark does not depend on any Oxc crates, so remove all dependencies for this benchmark. This reduces build time of this benchmark on CI by ~1 minute.

After #2780, NAPI parser benchmark sometimes took the longest of all the benchmarks, so making it faster reduces time to complete the benchmarks overall.