### PR TITLE
fix(semantic): ModuleRecord's indirect_export_entires missing reexported imports

### DIFF
--- a/crates/oxc_semantic/src/module_record/builder.rs
+++ b/crates/oxc_semantic/src/module_record/builder.rs
@@ -85,15 +85,14 @@ impl ModuleRecordBuilder {
         for ee in export_entries {
             // a. If ee.[[ModuleRequest]] is null, then
             if ee.module_request.is_none() {
-                let local_name = match &ee.local_name {
-                    ExportLocalName::Name(name) => Some(name),
+                let found_import_entry = match &ee.local_name {
+                    ExportLocalName::Name(name) => self
+                        .module_record
+                        .import_entries
+                        .iter()
+                        .find(|entry| entry.local_name.name() == name.name()),
                     _ => None,
                 };
-                let found_import_entry = self
-                    .module_record
-                    .import_entries
-                    .iter()
-                    .find(|import_entry| Some(&import_entry.local_name) == local_name);
                 match found_import_entry {
                     // i. If ee.[[LocalName]] is not an element of importedBoundNames, then
                     None => {
@@ -130,6 +129,7 @@ impl ModuleRecordBuilder {
                                         ImportImportName::NamespaceObject => unreachable!(),
                                     },
                                     export_name: ee.export_name.clone(),
+                                    span: ee.span,
                                     ..ExportEntry::default()
                                 };
                                 self.append_indirect_export_entry(export_entry);

--- a/crates/oxc_semantic/src/module_record/mod.rs
+++ b/crates/oxc_semantic/src/module_record/mod.rs
@@ -244,4 +244,31 @@ mod module_record_tests {
         assert_eq!(module_record.local_export_entries.len(), 1);
         assert_eq!(module_record.local_export_entries[0], export_entry);
     }
+
+    #[test]
+    fn indirect_export_entries() {
+        let module_record =
+            build("import { x } from 'mod';export { x };export * as ns from 'mod';");
+        assert_eq!(module_record.indirect_export_entries.len(), 2);
+        assert_eq!(
+            module_record.indirect_export_entries[0],
+            ExportEntry {
+                module_request: Some(NameSpan::new("mod".into(), Span::new(18, 23))),
+                span: Span::new(33, 34),
+                import_name: ExportImportName::Name(NameSpan::new("x".into(), Span::new(9, 10))),
+                export_name: ExportExportName::Name(NameSpan::new("x".into(), Span::new(33, 34))),
+                local_name: ExportLocalName::Null,
+            }
+        );
+        assert_eq!(
+            module_record.indirect_export_entries[1],
+            ExportEntry {
+                module_request: Some(NameSpan::new("mod".into(), Span::new(57, 62))),
+                span: Span::new(0, 0),
+                import_name: ExportImportName::All,
+                export_name: ExportExportName::Name(NameSpan::new("ns".into(), Span::new(49, 51))),
+                local_name: ExportLocalName::Null,
+            }
+        );
+    }
 }


### PR DESCRIPTION
local_name has `name` and `span`. We can't directly compare ExportEntry's local_name and ImportEntry's local_name. because the span is never equal.