### PR TITLE
fix(semantic): incorrect ExportEntry span for ExportAllDeclaration in ModuleRecord

### DIFF
--- a/crates/oxc_semantic/src/module_record/builder.rs
+++ b/crates/oxc_semantic/src/module_record/builder.rs
@@ -219,6 +219,7 @@ impl ModuleRecordBuilder {
                     exported_name.span(),
                 ))
             }),
+            span: decl.span,
             ..ExportEntry::default()
         };
         self.add_export_entry(export_entry);

--- a/crates/oxc_semantic/src/module_record/mod.rs
+++ b/crates/oxc_semantic/src/module_record/mod.rs
@@ -97,6 +97,7 @@ mod module_record_tests {
         let export_entry = ExportEntry {
             module_request: Some(NameSpan::new("mod".into(), Span::new(14, 19))),
             import_name: ExportImportName::AllButDefault,
+            span: Span::new(0, 19),
             ..ExportEntry::default()
         };
         assert_eq!(module_record.star_export_entries.len(), 1);
@@ -112,6 +113,7 @@ mod module_record_tests {
             module_request: Some(NameSpan::new("mod".into(), Span::new(20, 25))),
             import_name: ExportImportName::All,
             export_name: ExportExportName::Name(NameSpan::new("ns".into(), Span::new(12, 14))),
+            span: Span::new(0, 25),
             ..ExportEntry::default()
         };
         assert_eq!(module_record.indirect_export_entries.len(), 1);
@@ -268,7 +270,7 @@ mod module_record_tests {
             module_record.indirect_export_entries[1],
             ExportEntry {
                 module_request: Some(NameSpan::new("mod".into(), Span::new(57, 62))),
-                span: Span::new(0, 0),
+                span: Span::new(37, 63),
                 import_name: ExportImportName::All,
                 export_name: ExportExportName::Name(NameSpan::new("ns".into(), Span::new(49, 51))),
                 local_name: ExportLocalName::Null,


### PR DESCRIPTION
Now the span is ExportAllDeclaration's span