### PR TITLE
feat(transformer/typescript): remove `verbatim_module_syntax` option

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -104,8 +104,7 @@ impl<'a> Transformer<'a> {
         Self {
             ctx: ctx.clone(),
             decorators: Decorators::new(Rc::clone(&ast), ctx.clone(), &options),
-            // TODO: pass verbatim_module_syntax from user config
-            typescript: source_type.is_typescript().then(|| TypeScript::new(Rc::clone(&ast), ctx.clone(), false, &options)),
+            typescript: source_type.is_typescript().then(|| TypeScript::new(Rc::clone(&ast), ctx.clone(), &options)),
             regexp_flags: RegexpFlags::new(Rc::clone(&ast), &options),
             // es2022
             es2022_class_static_block: es2022::ClassStaticBlock::new(Rc::clone(&ast), &options),


### PR DESCRIPTION
Remove `verbatim_module_syntax` option, Because Babel's [onlyRemoveTypeImports](https://babeljs.io/docs/babel-plugin-transform-typescript#onlyremovetypeimports) option same behavior with `verbatim_module_syntax` , You can see https://github.com/babel/babel/issues/15493#issuecomment-1466453493