### PR TITLE
fix(tasks/transform-conformance) when the output file does not exist, the output content should be empty

### DIFF
--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,7 +1,6 @@
-Passed: 352/1369
+Passed: 351/1369
 
 # All Passed:
-* babel-plugin-transform-numeric-separator
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-json-strings
 * babel-plugin-transform-shorthand-properties
@@ -514,6 +513,9 @@ Passed: 352/1369
 
 # babel-plugin-transform-logical-assignment-operators (5/6)
 * logical-assignment/null-coalescing/input.js
+
+# babel-plugin-transform-numeric-separator (1/2)
+* used-with-transform-es2015-literals/input.js
 
 # babel-plugin-transform-export-namespace-from (0/4)
 * export-namespace/namespace-default/input.mjs

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -268,11 +268,7 @@ impl TestCase for ConformanceTestCase {
                 if let Some(throws) = &babel_options.throws {
                     return throws.to_string();
                 }
-                // The transformation should be equal to input.js If output.js does not exist.
-                let program = Parser::new(&allocator, &input, source_type).parse().program;
-                Codegen::<false>::new("", &input, codegen_options.clone())
-                    .build(&program)
-                    .source_text
+                String::default()
             },
             |output| {
                 // Get expected code by parsing the source text, so we can get the same code generated result.
@@ -283,7 +279,8 @@ impl TestCase for ConformanceTestCase {
             },
         );
 
-        let passed = transformed_code == output || actual_errors.contains(&output);
+        let passed =
+            transformed_code == output || (!output.is_empty() && actual_errors.contains(&output));
         if filtered {
             println!("Input:\n");
             println!("{input}\n");


### PR DESCRIPTION
https://github.com/oxc-project/oxc/pull/2795#issuecomment-2018018675