### PR TITLE
ci: actions/checkout@v4 -> taiki-e/checkout-action@v1

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -10,5 +10,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
       - uses: actions/labeler@v5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,10 +49,7 @@ jobs:
             fixture: 4
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
-        with:
-          show-progress: false
-          persist-credentials: false
+        uses: taiki-e/checkout-action@v1
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -115,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
         with:
           show-progress: false
           persist-credentials: false
@@ -195,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
         with:
           show-progress: false
           persist-credentials: false

--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cargo-llvm-lines.yml
+++ b/.github/workflows/cargo-llvm-lines.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -51,7 +51,7 @@ jobs:
     name: Check Wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -82,7 +82,7 @@ jobs:
     name: Spell Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - uses: crate-ci/typos@master
         with:
@@ -92,7 +92,7 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -116,7 +116,7 @@ jobs:
     name: Check Unused Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -146,7 +146,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust
         uses: ./.github/actions/rustup
@@ -160,7 +160,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust
         uses: ./.github/actions/rustup
@@ -174,7 +174,7 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust
         uses: ./.github/actions/rustup
@@ -195,7 +195,7 @@ jobs:
           - os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         uses: ./.github/actions/rustup
       - run: cargo test --quiet
@@ -204,7 +204,7 @@ jobs:
     name: Conformance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Clone submodules
         uses: ./.github/actions/clone-submodules
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Checkout
         if: env.CODECOV_TOKEN
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Download coverage file
         if: env.CODECOV_TOKEN

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust
         uses: ./.github/actions/rustup
@@ -59,7 +59,7 @@ jobs:
             ref: master
     steps:
       - name: Clone ${{ matrix.repository }}
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
         with:
           show-progress: false
           repository: ${{ matrix.repository }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Check Links
         uses: lycheeverse/lychee-action@master

--- a/.github/workflows/lint-rules.yml
+++ b/.github/workflows/lint-rules.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Install Rust
         uses: ./.github/actions/rustup

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ env.version }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Check version changes
         uses: EndBug/version-check@v2
@@ -74,7 +74,7 @@ jobs:
     name: Package ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Rust toolchain
         run: rustup target add ${{ matrix.target }}
@@ -131,7 +131,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release_napi_parser.yml
+++ b/.github/workflows/release_napi_parser.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ env.version }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Check version changes
         uses: EndBug/version-check@v2
@@ -81,7 +81,7 @@ jobs:
     name: Package ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       ### install musl dependencies ###
       #
@@ -163,7 +163,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release_oxlint.yml
+++ b/.github/workflows/release_oxlint.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Check version changes
         uses: EndBug/version-check@v2
@@ -78,7 +78,7 @@ jobs:
     name: Package ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install cross
         uses: taiki-e/install-action@cross
@@ -128,7 +128,7 @@ jobs:
       contents: write # for softprops/action-gh-release@v1
       id-token: write # for `npm publish --provenance`
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ env.version }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Check vscode version changes
         uses: EndBug/version-check@v2
@@ -67,7 +67,7 @@ jobs:
     name: Package ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install pnpm
         working-directory: editors/vscode
@@ -137,7 +137,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Download extension artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release_wasm.yml
+++ b/.github/workflows/release_wasm.yml
@@ -20,7 +20,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Check version changes
         uses: EndBug/version-check@v2
@@ -43,7 +43,7 @@ jobs:
     permissions:
       id-token: write # for `npm publish --provenance`
     steps:
-      - uses: actions/checkout@v4
+      - uses: taiki-e/checkout-action@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: taiki-e/checkout-action@v1
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup


### PR DESCRIPTION
This does not depend on node.js, and sets persist-credentials to false