### PR TITLE
ci(coverage): update babel version.

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ ready:
 # Clone or update submodules
 submodules:
   just clone-submodule tasks/coverage/test262 git@github.com:tc39/test262.git 17ba9aea47e496f5b2bc6ce7405b3f32e3cfbf7a
-  just clone-submodule tasks/coverage/babel git@github.com:babel/babel.git eccbd203383487f6957dcf086aa83d773691560b
+  just clone-submodule tasks/coverage/babel git@github.com:babel/babel.git acf3d17fdfe150a270c822581b709dddac4548ce
   just clone-submodule tasks/coverage/typescript git@github.com:microsoft/TypeScript.git 64d2eeea7b9c7f1a79edf42cb99f302535136a2e
   just clone-submodule tasks/prettier_conformance/prettier git@github.com:prettier/prettier.git 7142cf354cce2558f41574f44b967baf11d5b603
 


### PR DESCRIPTION
This PR updates the babel submodule in the justfile to take advantage of [this PR](https://github.com/babel/babel/pull/16381). Related to #2795 and #2797.

