### PR TITLE
ci: ci should run when clone-submodules/action.yml changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.md'
       - '**/*.yml'
       - '!.github/workflows/ci.yml'
+      - '!.github/actions/clone-submodules/action.yml'
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - '**/*.md'
       - '**/*.yml'
       - '!.github/workflows/ci.yml'
+      - '!.github/actions/clone-submodules/action.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
When we change `clone-submodules/action.yml`, the snapshot will probably be updated as well, so I'd run ci to make sure the snapshot is correct.