### PR TITLE
chore: using numeric value for `profile.dev.debug`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ serde-wasm-bindgen = { version = "0.6.5" }
 handlebars         = { version = "5.1.2" }
 
 [profile.dev]
-debug = "limited" # speed up compilation; debug info without type or variable-level information.
+debug = 1 # "limited" debug, speed up compilation; debug info without type or variable-level information.
 
 [profile.release.package.oxc_wasm]
 opt-level = 'z'


### PR DESCRIPTION
Change the `profile.dev.debug` value from `limited` to `1` which is the same thing according to [this](https://doc.rust-lang.org/cargo/reference/profiles.html#debug).

For some reason, the numeric value was failing when running the codspeed benchmark.

------

#### Edit:

it was resulting in the following error:

```
   failed to parse manifest at `/home/runner/work/oxc/oxc/Cargo.toml`
```

Related to #2812 