### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+
+## [0.10.1](https://github.com/oxc-project/oxc/compare/oxc-v0.10.0...oxc-v0.10.1) - 2024-03-30
+
+### Added
+- add oxc sourcemap crate ([#2825](https://github.com/oxc-project/oxc/pull/2825))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "oxc"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bumpalo",
  "serde",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bitflags 2.5.0",
  "num-bigint",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64 0.22.0",
  "bitflags 2.5.0",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "miette",
  "owo-colors",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "insta",
  "itertools",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.5.0",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "indexmap",
  "insta",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "compact_str",
  "miette",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bitflags 2.5.0",
  "dashmap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bitflags 2.5.0",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,18 @@ cargo_common_metadata   = "allow"                           # TODO: fix this
 
 [workspace.dependencies]
 # publish = true
-oxc             = { version = "0.10.0", path = "crates/oxc" }
-oxc_allocator   = { version = "0.10.0", path = "crates/oxc_allocator" }
-oxc_ast         = { version = "0.10.0", path = "crates/oxc_ast" }
-oxc_codegen     = { version = "0.10.0", path = "crates/oxc_codegen" }
-oxc_diagnostics = { version = "0.10.0", path = "crates/oxc_diagnostics" }
+oxc             = { version = "0.10.1", path = "crates/oxc" }
+oxc_allocator   = { version = "0.10.1", path = "crates/oxc_allocator" }
+oxc_ast         = { version = "0.10.1", path = "crates/oxc_ast" }
+oxc_codegen     = { version = "0.10.1", path = "crates/oxc_codegen" }
+oxc_diagnostics = { version = "0.10.1", path = "crates/oxc_diagnostics" }
 oxc_index       = { version = "0.10.0", path = "crates/oxc_index" }
-oxc_minifier    = { version = "0.10.0", path = "crates/oxc_minifier" }
-oxc_parser      = { version = "0.10.0", path = "crates/oxc_parser" }
-oxc_semantic    = { version = "0.10.0", path = "crates/oxc_semantic" }
-oxc_span        = { version = "0.10.0", path = "crates/oxc_span" }
-oxc_syntax      = { version = "0.10.0", path = "crates/oxc_syntax" }
-oxc_transformer = { version = "0.10.0", path = "crates/oxc_transformer" }
+oxc_minifier    = { version = "0.10.1", path = "crates/oxc_minifier" }
+oxc_parser      = { version = "0.10.1", path = "crates/oxc_parser" }
+oxc_semantic    = { version = "0.10.1", path = "crates/oxc_semantic" }
+oxc_span        = { version = "0.10.1", path = "crates/oxc_span" }
+oxc_syntax      = { version = "0.10.1", path = "crates/oxc_syntax" }
+oxc_transformer = { version = "0.10.1", path = "crates/oxc_transformer" }
 oxc_sourcemap   = { version = "0.10.0", path = "crates/oxc_sourcemap" }
 
 # publish = false

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc"
-version                = "0.10.0"
+version                = "0.10.1"
 publish                = true
 authors.workspace      = true
 description.workspace  = true

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_allocator"
-version                = "0.10.0"
+version                = "0.10.1"
 authors.workspace      = true
 description.workspace  = true
 edition.workspace      = true

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_ast"
-version                = "0.10.0"
+version                = "0.10.1"
 authors.workspace      = true
 description.workspace  = true
 edition.workspace      = true

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_codegen"
-version                = "0.10.0"
+version                = "0.10.1"
 publish                = true
 authors.workspace      = true
 description.workspace  = true

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_diagnostics"
-version                = "0.10.0"
+version                = "0.10.1"
 authors.workspace      = true
 description.workspace  = true
 edition.workspace      = true

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_minifier"
-version                = "0.10.0"
+version                = "0.10.1"
 publish                = true
 authors.workspace      = true
 description.workspace  = true

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_parser"
-version                = "0.10.0"
+version                = "0.10.1"
 authors.workspace      = true
 description.workspace  = true
 edition.workspace      = true

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_semantic"
-version                = "0.10.0"
+version                = "0.10.1"
 authors.workspace      = true
 description.workspace  = true
 edition.workspace      = true

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_span"
-version                = "0.10.0"
+version                = "0.10.1"
 publish                = true
 authors.workspace      = true
 description.workspace  = true

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_syntax"
-version                = "0.10.0"
+version                = "0.10.1"
 publish                = true
 authors.workspace      = true
 description.workspace  = true

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "oxc_transformer"
-version                = "0.10.0"
+version                = "0.10.1"
 publish                = true
 authors.workspace      = true
 description.workspace  = true


### PR DESCRIPTION
## 🤖 New release
* `oxc`: 0.10.0 -> 0.10.1
* `oxc_allocator`: 0.10.0 -> 0.10.1
* `oxc_ast`: 0.10.0 -> 0.10.1
* `oxc_span`: 0.10.0 -> 0.10.1
* `oxc_syntax`: 0.10.0 -> 0.10.1
* `oxc_codegen`: 0.10.0 -> 0.10.1
* `oxc_sourcemap`: 0.10.0
* `oxc_parser`: 0.10.0 -> 0.10.1
* `oxc_diagnostics`: 0.10.0 -> 0.10.1
* `oxc_minifier`: 0.10.0 -> 0.10.1
* `oxc_semantic`: 0.10.0 -> 0.10.1
* `oxc_transformer`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `oxc`
<blockquote>

## [0.10.1](https://github.com/oxc-project/oxc/compare/oxc-v0.10.0...oxc-v0.10.1) - 2024-03-30

### Added
- add oxc sourcemap crate ([#2825](https://github.com/oxc-project/oxc/pull/2825))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).