### PR TITLE
fix(transformer): optional-catch-binding unused variable side effect

### DIFF
--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -223,7 +223,7 @@ impl<'a> ExponentiationOperator<'a> {
         expr: Expression<'a>,
         nodes: &mut Vec<'a, Expression<'a>>,
     ) -> Expression<'a> {
-        let ident = self.create_new_var(&expr);
+        let ident = self.create_new_var_with_expression(&expr);
         // Add new reference `_name = name` to nodes
         let target = self.ast.simple_assignment_target_identifier(ident.clone());
         let op = AssignmentOperator::Assign;

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -1,9 +1,12 @@
-use std::rc::Rc;
-
-use oxc_ast::{ast::*, AstBuilder};
+use oxc_allocator::Vec;
+use oxc_ast::ast::*;
 use oxc_span::SPAN;
 
-use crate::options::{TransformOptions, TransformTarget};
+use crate::{
+    context::TransformerCtx,
+    options::{TransformOptions, TransformTarget},
+    utils::CreateVars,
+};
 
 /// ES2019: Optional Catch Binding
 ///
@@ -11,22 +14,34 @@ use crate::options::{TransformOptions, TransformTarget};
 /// * <https://babel.dev/docs/babel-plugin-transform-optional-catch-binding>
 /// * <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-optional-catch-binding>
 pub struct OptionalCatchBinding<'a> {
-    ast: Rc<AstBuilder<'a>>,
+    ctx: TransformerCtx<'a>,
+    vars: Vec<'a, VariableDeclarator<'a>>,
+}
+
+impl<'a> CreateVars<'a> for OptionalCatchBinding<'a> {
+    fn ctx(&self) -> &TransformerCtx<'a> {
+        &self.ctx
+    }
+
+    fn vars_mut(&mut self) -> &mut Vec<'a, VariableDeclarator<'a>> {
+        &mut self.vars
+    }
 }
 
 impl<'a> OptionalCatchBinding<'a> {
-    pub fn new(ast: Rc<AstBuilder<'a>>, options: &TransformOptions) -> Option<Self> {
+    pub fn new(ctx: TransformerCtx<'a>, options: &TransformOptions) -> Option<Self> {
         (options.target < TransformTarget::ES2019 || options.optional_catch_binding)
-            .then_some(Self { ast })
+            .then_some(Self { vars: ctx.ast.new_vec(), ctx })
     }
 
     pub fn transform_catch_clause<'b>(&mut self, clause: &'b mut CatchClause<'a>) {
         if clause.param.is_some() {
             return;
         }
-        let binding_identifier = BindingIdentifier::new(SPAN, "_unused".into());
-        let binding_pattern_kind = self.ast.binding_pattern_identifier(binding_identifier);
-        let binding_pattern = self.ast.binding_pattern(binding_pattern_kind, None, false);
+        let unused = self.create_new_named_var("unused");
+        let binding_identifier = BindingIdentifier::new(SPAN, unused.name);
+        let binding_pattern_kind = self.ctx.ast.binding_pattern_identifier(binding_identifier);
+        let binding_pattern = self.ctx.ast.binding_pattern(binding_pattern_kind, None, false);
         clause.param = Some(binding_pattern);
     }
 }

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -74,7 +74,7 @@ impl<'a> NullishCoalescingOperator<'a> {
             reference = self.ast.copy(&logical_expr.left);
             assignment = self.ast.copy(&logical_expr.left);
         } else {
-            let ident = self.create_new_var(&logical_expr.left);
+            let ident = self.create_new_var_with_expression(&logical_expr.left);
             reference = self.ast.identifier_reference_expression(ident.clone());
             let left = self.ast.simple_assignment_target_identifier(ident);
             let right = self.ast.copy(&logical_expr.left);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -126,7 +126,7 @@ impl<'a> Transformer<'a> {
             es2020_nullish_coalescing_operators: NullishCoalescingOperator::new(Rc::clone(&ast), ctx.clone(), &options),
             // es2019
             es2019_json_strings: JsonStrings::new(Rc::clone(&ast), &options),
-            es2019_optional_catch_binding: OptionalCatchBinding::new(Rc::clone(&ast), &options),
+            es2019_optional_catch_binding: OptionalCatchBinding::new(ctx.clone(), &options),
             // es2016
             es2016_exponentiation_operator: ExponentiationOperator::new(Rc::clone(&ast), ctx.clone(), &options),
             // es2015

--- a/crates/oxc_transformer/src/utils.rs
+++ b/crates/oxc_transformer/src/utils.rs
@@ -42,6 +42,23 @@ pub trait CreateVars<'a> {
         IdentifierReference::new(Span::default(), name)
     }
 
+    fn create_new_named_var(&mut self, name: &'a str) -> IdentifierReference<'a> {
+        let name = self.ctx().scopes().generate_uid(name);
+        self.ctx().add_binding(name.clone());
+
+        // Add `var name` to scope
+        // TODO: hookup symbol id
+        let name = self.ctx().ast.new_atom(name.as_str());
+        let binding_identifier = BindingIdentifier::new(Span::default(), name.clone());
+        let binding_pattern_kind = self.ctx().ast.binding_pattern_identifier(binding_identifier);
+        let binding = self.ctx().ast.binding_pattern(binding_pattern_kind, None, false);
+        let kind = VariableDeclarationKind::Var;
+        let decl = self.ctx().ast.variable_declarator(Span::default(), kind, binding, None, false);
+        self.vars_mut().push(decl);
+        // TODO: add reference id and flag
+        IdentifierReference::new(Span::default(), name)
+    }
+
     /// Possibly generate a memoised identifier if it is not static and has consequences.
     /// <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L578>
     fn maybe_generate_memoised(

--- a/crates/oxc_transformer/src/utils.rs
+++ b/crates/oxc_transformer/src/utils.rs
@@ -150,18 +150,17 @@ fn create_new_var<'a, V: CreateVars<'a> + ?Sized>(
     create_vars: &mut V,
     name: CompactStr,
 ) -> IdentifierReference<'a> {
-    create_vars.ctx().add_binding(name.clone());
-
     // Add `var name` to scope
     // TODO: hookup symbol id
-    let name = create_vars.ctx().ast.new_atom(name.as_str());
-    let binding_identifier = BindingIdentifier::new(Span::default(), name.clone());
+    let atom = create_vars.ctx().ast.new_atom(name.as_str());
+    let binding_identifier = BindingIdentifier::new(Span::default(), atom.clone());
     let binding_pattern_kind = create_vars.ctx().ast.binding_pattern_identifier(binding_identifier);
     let binding = create_vars.ctx().ast.binding_pattern(binding_pattern_kind, None, false);
     let kind = VariableDeclarationKind::Var;
     let decl =
         create_vars.ctx().ast.variable_declarator(Span::default(), kind, binding, None, false);
+    create_vars.ctx().add_binding(name);
     create_vars.vars_mut().push(decl);
     // TODO: add reference id and flag
-    IdentifierReference::new(Span::default(), name)
+    IdentifierReference::new(Span::default(), atom)
 }

--- a/crates/oxc_transformer/src/utils.rs
+++ b/crates/oxc_transformer/src/utils.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
-use oxc_span::Span;
+use oxc_span::{CompactStr, Span};
 use oxc_syntax::identifier::is_identifier_name;
 
 use crate::context::TransformerCtx;
@@ -25,38 +25,14 @@ pub trait CreateVars<'a> {
         stmts.insert(0, stmt);
     }
 
-    fn create_new_var(&mut self, expr: &Expression<'a>) -> IdentifierReference<'a> {
+    fn create_new_var_with_expression(&mut self, expr: &Expression<'a>) -> IdentifierReference<'a> {
         let name = self.ctx().scopes().generate_uid_based_on_node(expr);
-        self.ctx().add_binding(name.clone());
-
-        // Add `var name` to scope
-        // TODO: hookup symbol id
-        let name = self.ctx().ast.new_atom(name.as_str());
-        let binding_identifier = BindingIdentifier::new(Span::default(), name.clone());
-        let binding_pattern_kind = self.ctx().ast.binding_pattern_identifier(binding_identifier);
-        let binding = self.ctx().ast.binding_pattern(binding_pattern_kind, None, false);
-        let kind = VariableDeclarationKind::Var;
-        let decl = self.ctx().ast.variable_declarator(Span::default(), kind, binding, None, false);
-        self.vars_mut().push(decl);
-        // TODO: add reference id and flag
-        IdentifierReference::new(Span::default(), name)
+        create_new_var(self, name)
     }
 
     fn create_new_named_var(&mut self, name: &'a str) -> IdentifierReference<'a> {
         let name = self.ctx().scopes().generate_uid(name);
-        self.ctx().add_binding(name.clone());
-
-        // Add `var name` to scope
-        // TODO: hookup symbol id
-        let name = self.ctx().ast.new_atom(name.as_str());
-        let binding_identifier = BindingIdentifier::new(Span::default(), name.clone());
-        let binding_pattern_kind = self.ctx().ast.binding_pattern_identifier(binding_identifier);
-        let binding = self.ctx().ast.binding_pattern(binding_pattern_kind, None, false);
-        let kind = VariableDeclarationKind::Var;
-        let decl = self.ctx().ast.variable_declarator(Span::default(), kind, binding, None, false);
-        self.vars_mut().push(decl);
-        // TODO: add reference id and flag
-        IdentifierReference::new(Span::default(), name)
+        create_new_var(self, name)
     }
 
     /// Possibly generate a memoised identifier if it is not static and has consequences.
@@ -68,7 +44,7 @@ pub trait CreateVars<'a> {
         if self.ctx().symbols().is_static(expr) {
             None
         } else {
-            Some(self.create_new_var(expr))
+            Some(self.create_new_var_with_expression(expr))
         }
     }
 }
@@ -168,4 +144,24 @@ pub fn is_reserved_word(name: &str, in_module: bool) -> bool {
 /// https://github.com/babel/babel/blob/main/packages/babel-types/src/validators/isValidES3Identifier.ts#L35
 pub fn is_valid_es3_identifier(name: &str) -> bool {
     is_valid_identifier(name, true) && !RESERVED_WORDS_ES3_ONLY.contains(name)
+}
+
+fn create_new_var<'a, V: CreateVars<'a> + ?Sized>(
+    create_vars: &mut V,
+    name: CompactStr,
+) -> IdentifierReference<'a> {
+    create_vars.ctx().add_binding(name.clone());
+
+    // Add `var name` to scope
+    // TODO: hookup symbol id
+    let name = create_vars.ctx().ast.new_atom(name.as_str());
+    let binding_identifier = BindingIdentifier::new(Span::default(), name.clone());
+    let binding_pattern_kind = create_vars.ctx().ast.binding_pattern_identifier(binding_identifier);
+    let binding = create_vars.ctx().ast.binding_pattern(binding_pattern_kind, None, false);
+    let kind = VariableDeclarationKind::Var;
+    let decl =
+        create_vars.ctx().ast.variable_declarator(Span::default(), kind, binding, None, false);
+    create_vars.vars_mut().push(decl);
+    // TODO: add reference id and flag
+    IdentifierReference::new(Span::default(), name)
 }


### PR DESCRIPTION
Before this PR for this given case:

```javascript
const _unused = "It's a lie, They gonna use me:(";
try {
    throw 0;
} catch {
  console.log(_unused);
}
```

We would've generated this:

```javascript
const _unused = "It's a lie, They gonna use me:(";
try {
    throw 0;
} catch (_unused) {
  console.log(_unused);
}
```

This is incorrect, This PR aims to use the `CreateVars` trait in order to ensure the variable uniqueness.

Now it would output this:

```javascript
const _unused = "It's a lie, They gonna use me:(";
try {
    throw 0;
} catch (_unused2) {
  console.log(_unused);
}
```