### PR TITLE
chore: remove cargo-machete package metadata

### DIFF
--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -52,6 +52,3 @@ json-strip-comments = "1.0.2"
 
 [dev-dependencies]
 insta = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["once_cell"]

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -38,6 +38,3 @@ oxc_codegen = { workspace = true }
 insta     = { workspace = true }
 walkdir   = { workspace = true }
 pico-args = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["insta", "walkdir"]

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -38,6 +38,3 @@ napi-derive = { workspace = true }
 
 [build-dependencies]
 napi-build = "2"
-
-[package.metadata.cargo-machete]
-ignored = ["napi_build"]


### PR DESCRIPTION
`cargo-machete` has been replaced with `cargo-shear`, so the package metadata for `cargo-machete` is no longer required.