### PR TITLE
fix(parser): add support for empty module declaration

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -697,7 +697,7 @@ pub struct TSModuleDeclaration<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
     pub id: TSModuleDeclarationName<'a>,
-    pub body: TSModuleDeclarationBody<'a>,
+    pub body: Option<TSModuleDeclarationBody<'a>>,
     /// The keyword used to define this module declaration
     /// ```text
     /// namespace Foo {}
@@ -742,7 +742,6 @@ impl<'a> TSModuleDeclarationName<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TSModuleDeclarationBody<'a> {
-    EmptyDeclaration,
     TSModuleDeclaration(Box<'a, TSModuleDeclaration<'a>>),
     TSModuleBlock(Box<'a, TSModuleBlock<'a>>),
 }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -742,6 +742,7 @@ impl<'a> TSModuleDeclarationName<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TSModuleDeclarationBody<'a> {
+    EmptyDeclaration,
     TSModuleDeclaration(Box<'a, TSModuleDeclaration<'a>>),
     TSModuleBlock(Box<'a, TSModuleBlock<'a>>),
 }

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1273,7 +1273,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
-        body: TSModuleDeclarationBody<'a>,
+        body: Option<TSModuleDeclarationBody<'a>>,
         kind: TSModuleDeclarationKind,
         modifiers: Modifiers<'a>,
     ) -> Box<'a, TSModuleDeclaration<'a>> {

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -2493,11 +2493,13 @@ pub mod walk {
             TSModuleDeclarationName::StringLiteral(lit) => visitor.visit_string_literal(lit),
         }
         match &decl.body {
-            TSModuleDeclarationBody::TSModuleDeclaration(decl) => {
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(decl)) => {
                 visitor.visit_ts_module_declaration(decl);
             }
-            TSModuleDeclarationBody::TSModuleBlock(block) => visitor.visit_ts_module_block(block),
-            TSModuleDeclarationBody::EmptyDeclaration => {}
+            Some(TSModuleDeclarationBody::TSModuleBlock(block)) => {
+                visitor.visit_ts_module_block(block)
+            }
+            None => {}
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -2497,6 +2497,7 @@ pub mod walk {
                 visitor.visit_ts_module_declaration(decl);
             }
             TSModuleDeclarationBody::TSModuleBlock(block) => visitor.visit_ts_module_block(block),
+            TSModuleDeclarationBody::EmptyDeclaration => {}
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -2497,7 +2497,7 @@ pub mod walk {
                 visitor.visit_ts_module_declaration(decl);
             }
             Some(TSModuleDeclarationBody::TSModuleBlock(block)) => {
-                visitor.visit_ts_module_block(block)
+                visitor.visit_ts_module_block(block);
             }
             None => {}
         }

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -2698,7 +2698,7 @@ pub mod walk_mut {
                 visitor.visit_ts_module_declaration(decl);
             }
             Some(TSModuleDeclarationBody::TSModuleBlock(block)) => {
-                visitor.visit_ts_module_block(block)
+                visitor.visit_ts_module_block(block);
             }
             None => {}
         }

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -2694,11 +2694,13 @@ pub mod walk_mut {
             TSModuleDeclarationName::StringLiteral(lit) => visitor.visit_string_literal(lit),
         }
         match &mut decl.body {
-            TSModuleDeclarationBody::TSModuleDeclaration(decl) => {
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(decl)) => {
                 visitor.visit_ts_module_declaration(decl);
             }
-            TSModuleDeclarationBody::TSModuleBlock(block) => visitor.visit_ts_module_block(block),
-            TSModuleDeclarationBody::EmptyDeclaration => {}
+            Some(TSModuleDeclarationBody::TSModuleBlock(block)) => {
+                visitor.visit_ts_module_block(block)
+            }
+            None => {}
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -2698,6 +2698,7 @@ pub mod walk_mut {
                 visitor.visit_ts_module_declaration(decl);
             }
             TSModuleDeclarationBody::TSModuleBlock(block) => visitor.visit_ts_module_block(block),
+            TSModuleDeclarationBody::EmptyDeclaration => {}
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_codegen/src/gen_ts.rs
+++ b/crates/oxc_codegen/src/gen_ts.rs
@@ -553,6 +553,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSModuleDeclaration<'a> {
                 p.print_semicolon_if_needed();
                 p.print_block_end(body.span.end);
             }
+            TSModuleDeclarationBody::EmptyDeclaration => {}
         }
         if MINIFY {
             p.print_semicolon();

--- a/crates/oxc_codegen/src/gen_ts.rs
+++ b/crates/oxc_codegen/src/gen_ts.rs
@@ -539,12 +539,12 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSModuleDeclaration<'a> {
         p.wrap_quote(name, |p, _| p.print_str(name.as_bytes()));
         p.print_hard_space();
         match &self.body {
-            TSModuleDeclarationBody::TSModuleDeclaration(body) => {
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(body)) => {
                 p.print_block_start(body.span.start);
                 body.gen(p, ctx);
                 p.print_block_end(body.span.end);
             }
-            TSModuleDeclarationBody::TSModuleBlock(body) => {
+            Some(TSModuleDeclarationBody::TSModuleBlock(body)) => {
                 p.print_block_start(body.span.start);
                 for item in &body.body {
                     p.print_semicolon_if_needed();
@@ -553,7 +553,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSModuleDeclaration<'a> {
                 p.print_semicolon_if_needed();
                 p.print_block_end(body.span.end);
             }
-            TSModuleDeclarationBody::EmptyDeclaration => {}
+            None => {}
         }
         if MINIFY {
             p.print_semicolon();

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -406,7 +406,7 @@ impl<'a> ParserImpl<'a> {
 
 #[cfg(test)]
 mod test {
-
+    use std::path::Path;
     use oxc_ast::CommentKind;
 
     use super::*;
@@ -435,6 +435,16 @@ mod test {
         assert!(ret.program.is_empty());
         assert_eq!(ret.errors.first().unwrap().to_string(), "Flow is not supported");
     }
+
+    #[test]
+    fn ts_module_declaration() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path(Path::new("module.ts")).unwrap();
+        let source = "declare module 'test'\n";
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        assert_eq!(ret.errors.len(), 0)
+    }
+
 
     #[test]
     fn directives() {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -406,8 +406,8 @@ impl<'a> ParserImpl<'a> {
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
     use oxc_ast::CommentKind;
+    use std::path::Path;
 
     use super::*;
 
@@ -442,9 +442,8 @@ mod test {
         let source_type = SourceType::from_path(Path::new("module.ts")).unwrap();
         let source = "declare module 'test'\n";
         let ret = Parser::new(&allocator, source, source_type).parse();
-        assert_eq!(ret.errors.len(), 0)
+        assert_eq!(ret.errors.len(), 0);
     }
-
 
     #[test]
     fn directives() {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -212,13 +212,11 @@ impl<'a> ParserImpl<'a> {
 
         let mut statements = self.ast.new_vec();
 
-        if self.at(Kind::LCurly) {
-            self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly)?;
 
-            while !self.eat(Kind::RCurly) && !self.at(Kind::Eof) {
-                let stmt = self.parse_ts_module_item()?;
-                statements.push(stmt);
-            }
+        while !self.eat(Kind::RCurly) && !self.at(Kind::Eof) {
+            let stmt = self.parse_ts_module_item()?;
+            statements.push(stmt);
         }
 
         Ok(self.ast.ts_module_block(self.end_span(span), statements))
@@ -244,10 +242,13 @@ impl<'a> ParserImpl<'a> {
             let decl =
                 self.parse_ts_namespace_or_module_declaration_body(span, kind, Modifiers::empty())?;
             TSModuleDeclarationBody::TSModuleDeclaration(decl)
-        } else {
+        } else if self.at(Kind::LCurly) {
             let block = self.parse_ts_module_block()?;
             self.asi()?;
             TSModuleDeclarationBody::TSModuleBlock(block)
+        } else {
+            self.asi()?;
+            TSModuleDeclarationBody::EmptyDeclaration
         };
 
         Ok(self.ast.ts_module_declaration(self.end_span(span), id, body, kind, modifiers))

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -241,14 +241,14 @@ impl<'a> ParserImpl<'a> {
             let span = self.start_span();
             let decl =
                 self.parse_ts_namespace_or_module_declaration_body(span, kind, Modifiers::empty())?;
-            TSModuleDeclarationBody::TSModuleDeclaration(decl)
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(decl))
         } else if self.at(Kind::LCurly) {
             let block = self.parse_ts_module_block()?;
             self.asi()?;
-            TSModuleDeclarationBody::TSModuleBlock(block)
+            Some(TSModuleDeclarationBody::TSModuleBlock(block))
         } else {
             self.asi()?;
-            TSModuleDeclarationBody::EmptyDeclaration
+            None
         };
 
         Ok(self.ast.ts_module_declaration(self.end_span(span), id, body, kind, modifiers))

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -668,6 +668,7 @@ impl<'a> TypeScript<'a> {
             TSModuleDeclarationBody::TSModuleBlock(ts_module_block) => {
                 self.ctx.ast.move_statement_vec(&mut ts_module_block.body)
             }
+            TSModuleDeclarationBody::EmptyDeclaration => self.ctx.ast.new_vec(),
         };
 
         let name = block.id.name();

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -661,14 +661,14 @@ impl<'a> TypeScript<'a> {
         block: &mut Box<'a, TSModuleDeclaration<'a>>,
     ) -> Statement<'a> {
         let body_statements = match &mut block.body {
-            TSModuleDeclarationBody::TSModuleDeclaration(decl) => {
+            Some(TSModuleDeclarationBody::TSModuleDeclaration(decl)) => {
                 let transformed_module_block = self.transform_ts_module_block(decl);
                 self.ctx.ast.new_vec_single(transformed_module_block)
             }
-            TSModuleDeclarationBody::TSModuleBlock(ts_module_block) => {
+            Some(TSModuleDeclarationBody::TSModuleBlock(ts_module_block)) => {
                 self.ctx.ast.move_statement_vec(&mut ts_module_block.body)
             }
-            TSModuleDeclarationBody::EmptyDeclaration => self.ctx.ast.new_vec(),
+            None => self.ctx.ast.new_vec(),
         };
 
         let name = block.id.name();


### PR DESCRIPTION
Should be merged after #2829, Tried a few times to get it done with graphite stacking but found no success. I guess it either doesn't work with forks or It is just a skill issue since I'm not familiar with it.

closes: #2829
closes: #2830