### PR TITLE
feat(tasks/transforme_conformance): support for testing oxc's test cases

### DIFF
--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,0 +1,9 @@
+Passed: 0/1
+
+# All Passed:
+
+
+
+# babel-plugin-transform-optional-catch-binding (0/1)
+* try-catch-shadow/input.js
+

--- a/tasks/transform_conformance/oxc_exec.snap.md
+++ b/tasks/transform_conformance/oxc_exec.snap.md
@@ -1,0 +1,6 @@
+Passed: 0/0
+
+# All Passed:
+
+
+

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-catch-binding/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-catch-binding/test/fixtures/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-optional-catch-binding"]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-catch-binding/test/fixtures/try-catch-shadow/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-catch-binding/test/fixtures/try-catch-shadow/input.js
@@ -1,0 +1,6 @@
+const _unused = "It's a lie, They gonna use me:(";
+try {
+  throw 0;
+} catch {
+  console.log(_unused);
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-catch-binding/test/fixtures/try-catch-shadow/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-catch-binding/test/fixtures/try-catch-shadow/output.js
@@ -1,0 +1,6 @@
+const _unused = "It's a lie, They gonna use me:(";
+try {
+  throw 0;
+} catch (_unused2) {
+  console.log(_unused);
+}


### PR DESCRIPTION
Related to: https://github.com/oxc-project/oxc/pull/2822#issuecomment-2021802212

Although `babel` has a lot of test cases, we still need to add edge cases that `babel` doesn't have.

This PR will allow us to add our test cases to `/root/oxc/tasks/transform_conformance/tests`. The directory structure is consistent with `babel`

For example
```shell
# cd /root/oxc/tasks/transform_conformance/tests
- babel-transform-plugin–optional-catch-binding
   - test
       - fixtures
           - your tests # add test cases here
```