### PR TITLE
feat(linter/import): move some rules out of nursery

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -14,7 +14,7 @@ mod import {
     pub mod no_amd;
     pub mod no_cycle;
     pub mod no_default_export;
-    pub mod no_deprecated;
+    // pub mod no_deprecated;
     pub mod no_duplicates;
     pub mod no_named_as_default;
     pub mod no_named_as_default_member;
@@ -643,7 +643,7 @@ oxc_macros::declare_all_lint_rules! {
     import::namespace,
     import::no_amd,
     import::no_cycle,
-    import::no_deprecated,
+    // import::no_deprecated,
     import::no_named_as_default,
     import::no_named_as_default_member,
     import::no_self_import,

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
     /// import bar from './bar' // no default export found in ./bar
     /// ```
     Default,
-    nursery
+    correctness
 );
 
 impl Rule for Default {

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     Named,
-    nursery
+    correctness
 );
 
 impl Rule for Named {

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
     /// Also, will report for computed references (i.e. foo["bar"]()).
     /// Reports on assignment to a member of an imported namespace.
     Namespace,
-    nursery
+    correctness
 );
 
 impl Rule for Namespace {

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -16,7 +16,7 @@ declare_oxc_lint!(
     ///
     /// Reports if a resolved path is imported more than once.
     NoDuplicates,
-    nursery
+    suspicious
 );
 
 impl Rule for NoDuplicates {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     /// import bar from './foo.js';
     /// ```
     NoNamedAsDefault,
-    nursery
+    suspicious
 );
 
 impl Rule for NoNamedAsDefault {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     /// const bar = foo.bar // trying to access named export via default
     /// ```
     NoNamedAsDefaultMember,
-    nursery
+    suspicious
 );
 fn get_symbol_id_from_ident(
     ctx: &LintContext<'_>,


### PR DESCRIPTION
### Correctness
- named
- export
- default
- namespace

The above rules will prevent bugs or broken, so I changed these to correctness

### Suspicious
- no-duplicates
- no-named-as-default-member
- no-named-as-default