### PR TITLE
feat(linter): fallback to the default tsconfig path

### DIFF
--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -135,7 +135,9 @@ pub struct Runtime {
 
 impl Runtime {
     fn new(linter: Linter, options: LintServiceOptions) -> Self {
-        let resolver = linter.options().import_plugin.then(|| Self::get_resolver(options.tsconfig));
+        let resolver = linter.options().import_plugin.then(|| {
+            Self::get_resolver(options.tsconfig.or_else(|| Some(options.cwd.join("tsconfig.json"))))
+        });
         Self {
             cwd: options.cwd,
             paths: options.paths.iter().cloned().collect(),


### PR DESCRIPTION
Users usually do not need to manually set the tsconfig path, as it is usually located in cwd/tsconfig.json.
