### PR TITLE
refactor(ast): rework enum of structures

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1456,14 +1456,45 @@ pub struct ForStatement<'a> {
 
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
+#[cfg_attr(feature = "serialize", serde(tag = "type"))]
+pub struct ForStatementInit<'a> {
+    pub kind: ForStatementInitKind<'a>,
+}
+
+impl<'a> ForStatementInit<'a> {
+    pub fn with_expression(expr: Expression<'a>) -> Self {
+        Self { kind: ForStatementInitKind::Expression(expr) }
+    }
+
+    pub fn with_variable_declaration(decl: Box<'a, VariableDeclaration<'a>>) -> Self {
+        Self { kind: ForStatementInitKind::VariableDeclaration(decl) }
+    }
+
+    pub fn with_using_declaration(using: Box<'a, UsingDeclaration<'a>>) -> Self {
+        Self { kind: ForStatementInitKind::UsingDeclaration(using) }
+    }
+
+    /// LexicalDeclaration[In, Yield, Await] :
+    ///   LetOrConst BindingList[?In, ?Yield, ?Await] ;
+    pub fn is_lexical_declaration(&self) -> bool {
+        self.kind.is_lexical_declaration()
+    }
+
+    pub fn expression(&self) -> Option<&Expression<'a>> {
+        self.kind.expression()
+    }
+}
+
+#[derive(Debug, Hash)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
-pub enum ForStatementInit<'a> {
+pub enum ForStatementInitKind<'a> {
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>),
     Expression(Expression<'a>),
     UsingDeclaration(Box<'a, UsingDeclaration<'a>>),
 }
 
-impl<'a> ForStatementInit<'a> {
+impl<'a> ForStatementInitKind<'a> {
     /// LexicalDeclaration[In, Yield, Await] :
     ///   LetOrConst BindingList[?In, ?Yield, ?Await] ;
     pub fn is_lexical_declaration(&self) -> bool {

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -251,6 +251,12 @@ impl<'a> GetSpan for ArrayExpressionElement<'a> {
 
 impl<'a> GetSpan for ForStatementInit<'a> {
     fn span(&self) -> Span {
+        self.kind.span()
+    }
+}
+
+impl<'a> GetSpan for ForStatementInitKind<'a> {
+    fn span(&self) -> Span {
         match self {
             Self::VariableDeclaration(x) => x.span,
             Self::Expression(x) => x.span(),

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -959,14 +959,14 @@ pub mod walk {
     pub fn walk_for_statement_init<'a, V: Visit<'a>>(visitor: &mut V, init: &ForStatementInit<'a>) {
         let kind = AstKind::ForStatementInit(visitor.alloc(init));
         visitor.enter_node(kind);
-        match init {
-            ForStatementInit::UsingDeclaration(decl) => {
+        match &init.kind {
+            ForStatementInitKind::UsingDeclaration(decl) => {
                 visitor.visit_using_declaration(decl);
             }
-            ForStatementInit::VariableDeclaration(decl) => {
+            ForStatementInitKind::VariableDeclaration(decl) => {
                 visitor.visit_variable_declaration(decl);
             }
-            ForStatementInit::Expression(expr) => visitor.visit_expression(expr),
+            ForStatementInitKind::Expression(expr) => visitor.visit_expression(expr),
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -989,12 +989,12 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ForStatementInit;
         visitor.enter_node(kind);
-        match init {
-            ForStatementInit::VariableDeclaration(decl) => {
+        match &mut init.kind {
+            ForStatementInitKind::VariableDeclaration(decl) => {
                 visitor.visit_variable_declaration(decl);
             }
-            ForStatementInit::Expression(expr) => visitor.visit_expression(expr),
-            ForStatementInit::UsingDeclaration(decl) => {
+            ForStatementInitKind::Expression(expr) => visitor.visit_expression(expr),
+            ForStatementInitKind::UsingDeclaration(decl) => {
                 visitor.visit_using_declaration(decl);
             }
         }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -224,12 +224,12 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for ForStatement<'a> {
 
         if let Some(init) = self.init.as_ref() {
             let ctx = Context::empty();
-            match init {
-                ForStatementInit::UsingDeclaration(decl) => decl.gen(p, ctx),
-                ForStatementInit::Expression(expr) => {
+            match &init.kind {
+                ForStatementInitKind::UsingDeclaration(decl) => decl.gen(p, ctx),
+                ForStatementInitKind::Expression(expr) => {
                     expr.gen_expr(p, Precedence::lowest(), ctx);
                 }
-                ForStatementInit::VariableDeclaration(var) => var.gen(p, ctx),
+                ForStatementInitKind::VariableDeclaration(var) => var.gen(p, ctx),
             }
         }
 

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -299,7 +299,7 @@ impl<'a> ParserImpl<'a> {
             return self.parse_for_in_or_of_loop(span, r#await, for_stmt_left);
         }
 
-        self.parse_for_loop(span, Some(ForStatementInit::Expression(init_expression)), r#await)
+        self.parse_for_loop(span, Some(ForStatementInit::with_expression(init_expression)), r#await)
     }
 
     fn parse_variable_declaration_for_statement(
@@ -319,7 +319,7 @@ impl<'a> ParserImpl<'a> {
             return self.parse_for_in_or_of_loop(span, r#await, init);
         }
 
-        let init = Some(ForStatementInit::VariableDeclaration(init_declaration));
+        let init = Some(ForStatementInit::with_variable_declaration(init_declaration));
         self.parse_for_loop(span, init, r#await)
     }
 
@@ -347,7 +347,7 @@ impl<'a> ParserImpl<'a> {
             return self.parse_for_in_or_of_loop(span, r#await, init);
         }
 
-        let init = Some(ForStatementInit::UsingDeclaration(self.ast.alloc(using_decl)));
+        let init = Some(ForStatementInit::with_using_declaration(self.ast.alloc(using_decl)));
         self.parse_for_loop(span, init, r#await)
     }
 

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -232,10 +232,10 @@ impl<'a> Format<'a> for ForStatement<'a> {
 
 impl<'a> Format<'a> for ForStatementInit<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
-        match self {
-            ForStatementInit::VariableDeclaration(v) => v.format(p),
-            ForStatementInit::Expression(v) => v.format(p),
-            ForStatementInit::UsingDeclaration(v) => v.format(p),
+        match &self.kind {
+            ForStatementInitKind::VariableDeclaration(v) => v.format(p),
+            ForStatementInitKind::Expression(v) => v.format(p),
+            ForStatementInitKind::UsingDeclaration(v) => v.format(p),
         }
     }
 }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -805,14 +805,14 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_for_statement_init(&mut self, init: &ForStatementInit<'a>) {
         let kind = AstKind::ForStatementInit(self.alloc(init));
         self.enter_node(kind);
-        match init {
-            ForStatementInit::UsingDeclaration(decl) => {
+        match &init.kind {
+            ForStatementInitKind::UsingDeclaration(decl) => {
                 self.visit_using_declaration(decl);
             }
-            ForStatementInit::VariableDeclaration(decl) => {
+            ForStatementInitKind::VariableDeclaration(decl) => {
                 self.visit_variable_declaration(decl);
             }
-            ForStatementInit::Expression(expr) => self.visit_expression(expr),
+            ForStatementInitKind::Expression(expr) => self.visit_expression(expr),
         }
         self.leave_node(kind);
     }


### PR DESCRIPTION
* [x] ForStatementInit
* [ ] MemberExpression
* [ ] PropertyKey
* [ ] Argument
* [ ] AssignmentTarget
* [ ] SimpleAssignmentTarget
* [ ] ArrayExpressionElement
* [ ] Expression
* [ ] ModuleDeclaration
* [ ] JSXElementName
* [ ] JSXAttributeItem
* [ ] JSXMemberExpressionObject
* [ ] TSTypeName
* [ ] Statement (not needed but we might also refactor it for the good measure)
