### PR TITLE
fix(ast): `FinallyClause` won't get visited as `BlockStatement` anymore.

### DIFF
--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -1099,9 +1099,11 @@ pub mod walk {
 
     pub fn walk_finally_clause<'a, V: Visit<'a>>(visitor: &mut V, clause: &BlockStatement<'a>) {
         let kind = AstKind::FinallyClause(visitor.alloc(clause));
+        visitor.enter_scope(ScopeFlags::empty());
         visitor.enter_node(kind);
-        visitor.visit_block_statement(clause);
+        visitor.visit_statements(&clause.body);
         visitor.leave_node(kind);
+        visitor.leave_scope();
     }
 
     pub fn walk_while_statement<'a, V: Visit<'a>>(visitor: &mut V, stmt: &WhileStatement<'a>) {

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -1159,9 +1159,11 @@ pub mod walk_mut {
         clause: &mut BlockStatement<'a>,
     ) {
         let kind = AstType::FinallyClause;
+        visitor.enter_scope(ScopeFlags::empty());
         visitor.enter_node(kind);
-        visitor.visit_block_statement(clause);
+        visitor.visit_statements(&mut clause.body);
         visitor.leave_node(kind);
+        visitor.leave_scope();
     }
 
     pub fn walk_while_statement_mut<'a, V: VisitMut<'a>>(

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -65,6 +65,16 @@ impl Rule for NoEmpty {
                 }
                 ctx.diagnostic(NoEmptyDiagnostic("block", catch_clause.body.span));
             }
+            // The visitor does not visit the `BlockStatement` inside the `FinallyClause`.
+            // See `Visit::visit_finally_clause`.
+            AstKind::FinallyClause(finally_clause)
+                if finally_clause.body.is_empty() =>
+            {
+                if ctx.semantic().trivias().has_comments_between(finally_clause.span) {
+                    return;
+                }
+                ctx.diagnostic(NoEmptyDiagnostic("block", finally_clause.span));
+            }
             AstKind::SwitchStatement(switch) if switch.cases.is_empty() => {
                 ctx.diagnostic(NoEmptyDiagnostic("switch", switch.span));
             }

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -67,9 +67,7 @@ impl Rule for NoEmpty {
             }
             // The visitor does not visit the `BlockStatement` inside the `FinallyClause`.
             // See `Visit::visit_finally_clause`.
-            AstKind::FinallyClause(finally_clause)
-                if finally_clause.body.is_empty() =>
-            {
+            AstKind::FinallyClause(finally_clause) if finally_clause.body.is_empty() => {
                 if ctx.semantic().trivias().has_comments_between(finally_clause.span) {
                     return;
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -73,7 +73,7 @@ impl Rule for NoUnsafeFinally {
         };
 
         let mut label_inside = false;
-        for node_id in ctx.nodes().ancestors(node.id()).skip(1) {
+        for node_id in ctx.nodes().ancestors(node.id()) {
             let ast_kind = ctx.nodes().kind(node_id);
 
             if sentinel_node_type.test(ast_kind) {

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -70,6 +70,13 @@ impl Rule for EmptyBraceSpaces {
                     catch_clause.body.span,
                 );
             }
+            AstKind::FinallyClause(finally_clause) => {
+                remove_empty_braces_spaces(
+                    ctx,
+                    finally_clause.body.is_empty(),
+                    finally_clause.span,
+                );
+            }
             _ => (),
         };
     }


### PR DESCRIPTION
This would fix the issue found in #2877,

As it is right now, the `FinallyClause` gets visited 2 times, once as the Finally and once as a block.

This PR addresses this issue by making the `visit_finally_clause` method visit the body statements instead of visiting the block itself. Now it works similar to the `CatchClause`.