### PR TITLE
fix(semantic): flag function expressions with `SymbolFlags::Function`

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -146,7 +146,7 @@ impl<'a> Binder for Function<'a> {
                 let symbol_id = builder.declare_symbol(
                     ident.span,
                     &ident.name,
-                    SymbolFlags::empty(),
+                    SymbolFlags::Function,
                     SymbolFlags::empty(),
                 );
                 ident.symbol_id.set(Some(symbol_id));

--- a/crates/oxc_semantic/tests/symbols.rs
+++ b/crates/oxc_semantic/tests/symbols.rs
@@ -35,7 +35,7 @@ fn test_function_expressions() {
     SemanticTester::js("const x = () => {}")
         .has_some_symbol("x")
         .contains_flags(SymbolFlags::BlockScopedVariable | SymbolFlags::ConstVariable)
-        .test()
+        .test();
 }
 
 #[test]

--- a/crates/oxc_semantic/tests/symbols.rs
+++ b/crates/oxc_semantic/tests/symbols.rs
@@ -27,6 +27,18 @@ fn test_function_simple() {
 }
 
 #[test]
+fn test_function_expressions() {
+    SemanticTester::js("const x = function y() {}")
+        .has_some_symbol("y")
+        .contains_flags(SymbolFlags::Function)
+        .test();
+    SemanticTester::js("const x = () => {}")
+        .has_some_symbol("x")
+        .contains_flags(SymbolFlags::BlockScopedVariable | SymbolFlags::ConstVariable)
+        .test()
+}
+
+#[test]
 fn test_var_simple() {
     SemanticTester::js("let x; { let y; }")
         .has_some_symbol("x")


### PR DESCRIPTION
# What This PR Does

Consider the following code snippet

```js
const x = function y() {}
```

`y` will now be flagged with `SymbolFlags::Function`. This follow's tsc's behavior.

- [Example in OXC Playground](https://oxc-project.github.io/oxc/playground/?code=3YCAAICagICAgICAgICxG0qZRraXZOpcCHVsSRwDq2kRR0HprsTfRRT5WMw%2Ff2epoIA%3D)
- [Example in TypeScript AST Viewer](https://ts-ast-viewer.com/#code/MYewdgzgLgBAHjAvDAZgVzMKBLcMCeAFAJQwDeAvgFBA)