### PR TITLE
refactor(codegen): make codegen sourcemap builder clearer

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -23,7 +23,6 @@ pub struct LineOffsetTable {
 
 #[allow(clippy::struct_field_names)]
 pub struct SourcemapBuilder {
-    enable_sourcemap: bool,
     source_id: u32,
     original_source: Arc<str>,
     last_generated_update: usize,
@@ -38,7 +37,6 @@ pub struct SourcemapBuilder {
 impl Default for SourcemapBuilder {
     fn default() -> Self {
         Self {
-            enable_sourcemap: false,
             source_id: 0,
             original_source: "".into(),
             last_generated_update: 0,
@@ -54,14 +52,13 @@ impl Default for SourcemapBuilder {
 
 impl SourcemapBuilder {
     pub fn with_name_and_source(&mut self, name: &str, source: &str) {
-        self.enable_sourcemap = true;
         self.line_offset_tables = Self::generate_line_offset_tables(source);
         self.source_id = self.sourcemap_builder.set_source_and_content(name, source);
         self.original_source = source.into();
     }
 
-    pub fn into_sourcemap(self) -> Option<oxc_sourcemap::SourceMap> {
-        self.enable_sourcemap.then(|| self.sourcemap_builder.into_sourcemap())
+    pub fn into_sourcemap(self) -> oxc_sourcemap::SourceMap {
+        self.sourcemap_builder.into_sourcemap()
     }
 
     pub fn add_source_mapping_for_name(&mut self, output: &[u8], span: Span, name: &str) {
@@ -75,23 +72,21 @@ impl SourcemapBuilder {
     }
 
     pub fn add_source_mapping(&mut self, output: &[u8], position: u32, name: Option<Arc<str>>) {
-        if self.enable_sourcemap {
-            if matches!(self.last_position, Some(last_position) if last_position >= position) {
-                return;
-            }
-            let (original_line, original_column) = self.search_original_line_and_column(position);
-            self.update_generated_line_and_column(output);
-            let name_id = name.map(|s| self.sourcemap_builder.add_name(&s));
-            self.sourcemap_builder.add_token(
-                self.generated_line,
-                self.generated_column,
-                original_line,
-                original_column,
-                Some(self.source_id),
-                name_id,
-            );
-            self.last_position = Some(position);
+        if matches!(self.last_position, Some(last_position) if last_position >= position) {
+            return;
         }
+        let (original_line, original_column) = self.search_original_line_and_column(position);
+        self.update_generated_line_and_column(output);
+        let name_id = name.map(|s| self.sourcemap_builder.add_name(&s));
+        self.sourcemap_builder.add_token(
+            self.generated_line,
+            self.generated_column,
+            original_line,
+            original_column,
+            Some(self.source_id),
+            name_id,
+        );
+        self.last_position = Some(position);
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -388,7 +383,7 @@ mod test {
         builder.with_name_and_source("x.js", "ab");
         builder.add_source_mapping_for_name(output, Span::new(0, 1), "a");
         builder.add_source_mapping_for_name(output, Span::new(1, 2), "c");
-        let sm = builder.into_sourcemap().unwrap();
+        let sm = builder.into_sourcemap();
         // The name `a` not change.
         assert_eq!(
             sm.get_source_view_token(0_u32).as_ref().and_then(|token| token.get_name()),


### PR DESCRIPTION
Avoid `enable_sourcemap` appear multiply times.