### PR TITLE
fix(linter): svelte partial loader handle generics (#2875)

### DIFF
--- a/crates/oxc_linter/src/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/partial_loader/mod.rs
@@ -40,3 +40,24 @@ impl PartialLoader {
         }
     }
 }
+
+/// Find closing angle for situations where there is another `>` in between.
+/// e.g. `<script generic="T extends Record<string, string>">`
+fn find_script_closing_angle(source_text: &str, pointer: usize) -> Option<usize> {
+    let mut numbers_of_open_angle = 0;
+    for (offset, c) in source_text[pointer..].char_indices() {
+        match c {
+            '>' => {
+                if numbers_of_open_angle == 0 {
+                    return Some(offset);
+                }
+                numbers_of_open_angle -= 1;
+            }
+            '<' => {
+                numbers_of_open_angle += 1;
+            }
+            _ => {}
+        }
+    }
+    None
+}

--- a/crates/oxc_linter/src/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/partial_loader/vue.rs
@@ -2,7 +2,7 @@ use memchr::memmem::Finder;
 
 use oxc_span::SourceType;
 
-use super::{JavaScriptSource, SCRIPT_END, SCRIPT_START};
+use super::{find_script_closing_angle, JavaScriptSource, SCRIPT_END, SCRIPT_START};
 
 pub struct VuePartialLoader<'a> {
     source_text: &'a str,
@@ -37,7 +37,7 @@ impl<'a> VuePartialLoader<'a> {
         *pointer += offset + SCRIPT_START.len();
 
         // find closing ">"
-        let offset = self.find_script_closing_angle(*pointer)?;
+        let offset = find_script_closing_angle(self.source_text, *pointer)?;
 
         // get ts and jsx attribute
         let content = &self.source_text[*pointer..*pointer + offset];
@@ -56,27 +56,6 @@ impl<'a> VuePartialLoader<'a> {
         let source_type =
             SourceType::default().with_module(true).with_typescript(is_ts).with_jsx(is_jsx);
         Some(JavaScriptSource::new(source_text, source_type, js_start))
-    }
-
-    /// Find closing angle for situations where there is another `>` in between.
-    /// e.g. `<script generic="T extends Record<string, string>">`
-    fn find_script_closing_angle(&self, pointer: usize) -> Option<usize> {
-        let mut numbers_of_open_angle = 0;
-        for (offset, c) in self.source_text[pointer..].char_indices() {
-            match c {
-                '>' => {
-                    if numbers_of_open_angle == 0 {
-                        return Some(offset);
-                    }
-                    numbers_of_open_angle -= 1;
-                }
-                '<' => {
-                    numbers_of_open_angle += 1;
-                }
-                _ => {}
-            }
-        }
-        None
     }
 }
 


### PR DESCRIPTION
While looking into this, I knew vue would have similar problems. Which then led me to realize the generic case was handled already so I tried abstract out the function so both the vue and svelte partial loaders could reuse the code. Finally added some svelte test cases to prove this resolved the issue.

I am a bit new to rust so if there was a better way to reuse the find_script_closing_angle function open to suggestions.