### PR TITLE
fix(tasks/lint_rules): Fix `plugin-jest` rules collector

### DIFF
--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -39,7 +39,10 @@ const {
   configs: pluginJSXA11yConfigs,
 } = require("eslint-plugin-jsx-a11y");
 // https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts
-const { rules: pluginJestAllRules } = require("eslint-plugin-jest");
+const {
+  rules: pluginJestAllRules,
+  configs: pluginJestConfigs,
+} = require("eslint-plugin-jest");
 // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/index.js
 const { rules: pluginReactAllRules } = require("eslint-plugin-react");
 // https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/index.js
@@ -156,11 +159,16 @@ const loadPluginJSXA11yRules = (linter) => {
 
 /** @param {import("eslint").Linter} linter */
 const loadPluginJestRules = (linter) => {
+  const pluginJestRecommendedRules = new Map(
+    // @ts-expect-error: Property 'recommended' does not exist on type '{}'.
+    Object.entries(pluginJestConfigs.recommended.rules),
+  );
   for (const [name, rule] of Object.entries(pluginJestAllRules)) {
     const prefixedName = `jest/${name}`;
 
-    // Presented but type is `string | false`
-    rule.meta.docs.recommended = typeof rule.meta.docs.recommended === "string";
+    const recommendedValue = pluginJestRecommendedRules.get(prefixedName);
+    // Presented but type is `string | undefined`
+    rule.meta.docs.recommended = typeof recommendedValue === "string";
 
     linter.defineRule(prefixedName, rule);
   }

--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -232,7 +232,12 @@ exports.ALL_TARGET_PLUGINS = new Map([
 ]);
 
 // All rules(including deprecated, recommended) are loaded initially.
-exports.createESLintLinter = () => new Linter();
+exports.createESLintLinter = () =>
+  new Linter({
+    // XXX: We need to adapt to flat ESLint in near future!
+    // @ts-expect-error: Type '"eslintrc"' is not assignable to type '"flat"'.
+    configType: "eslintrc",
+  });
 
 /** @param {import("eslint").Linter} linter */
 exports.loadTargetPluginRules = (linter) => {


### PR DESCRIPTION
Fixes umbrella issue for [`plugin-jest`](https://github.com/oxc-project/oxc/issues/492) to render recommended rules section properly.

- - -

Along with sticking legacy ESLint.
Since `eslint@latest` is now v9 and it removed `Linter#defineRule()` and `Linter#getRules()` which we use heavily...