### PR TITLE
ci: skip benchmark-napi because it is flaky

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -110,6 +110,7 @@ jobs:
   benchmark-napi:
     name: Benchmark NAPI parser
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Checkout Branch
         uses: taiki-e/checkout-action@v1
@@ -188,7 +189,8 @@ jobs:
 
   upload:
     name: Upload benchmarks
-    needs: [benchmark, benchmark-napi]
+    # needs: [benchmark, benchmark-napi]
+    needs: [benchmark]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch


### PR DESCRIPTION
The flakiness and all the noise produced by it is starting to hurt maintenance because I can no longer tell if main or PR is failing properly :-(

codspeed doesn't have the feature "let it run but don't report as error" or "different thresholds on different benchmarks"