### PR TITLE
feat(transformer): add transform callback methods

### DIFF
--- a/crates/oxc_transformer/src/decorators/mod.rs
+++ b/crates/oxc_transformer/src/decorators/mod.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use oxc_ast::ast::*;
+
 /// Only `"2023-11"` will be implemented because Babel 8 will only support "2023-11" and "legacy".
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -16,4 +18,9 @@ impl Decorators {
     pub fn new(options: DecoratorsOptions) -> Self {
         Self { options }
     }
+}
+
+// Transformers
+impl Decorators {
+    pub fn transform_statement(&mut self, _stmt: &mut Statement<'_>) {}
 }

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -4,6 +4,8 @@ mod jsx_self;
 mod jsx_source;
 mod options;
 
+use oxc_ast::ast::*;
+
 pub use self::{
     display_name::{ReactDisplayName, ReactDisplayNameOptions},
     jsx::ReactJsx,
@@ -28,6 +30,7 @@ pub struct React {
     display_name: ReactDisplayName,
 }
 
+// Constructors
 impl React {
     pub fn new(&mut self, options: ReactOptions) -> &mut Self {
         self.jsx = ReactJsx::new(options);
@@ -47,5 +50,20 @@ impl React {
     pub fn with_display_name(&mut self, options: ReactDisplayNameOptions) -> &mut Self {
         self.display_name = ReactDisplayName::new(options);
         self
+    }
+}
+
+// Transformers
+impl React {
+    pub fn transform_expression(&mut self, expr: &mut Expression<'_>) {
+        match expr {
+            Expression::JSXElement(_e) => {
+                // *expr = unimplemented!();
+            }
+            Expression::JSXFragment(_e) => {
+                // *expr = unimplemented!();
+            }
+            _ => {}
+        }
     }
 }

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use oxc_ast::ast::*;
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeScriptOptions;
@@ -35,4 +37,9 @@ impl TypeScript {
     pub fn new(options: TypeScriptOptions) -> Self {
         Self { options }
     }
+}
+
+// Transformers
+impl TypeScript {
+    pub fn transform_statement(&mut self, _stmt: &mut Statement<'_>) {}
 }


### PR DESCRIPTION
For milestone 1, I think it's safe to just layout all the transformations manually.


In TypeScript, the transformers are collected dynamically and ran on each ast node; this achieves a single AST pass. https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformer.ts#L129-L145

To maximize performance and reduce confusion, I think it's safe to layout all the transformations manually for milestone 1.

The next PR will add transformation context to all presets so we can start adding "context". 