### PR TITLE
feat(oxc_ast): add missing ast visits for types

### DIFF
--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -159,6 +159,18 @@ ast_kinds! {
     TSTypeReference(&'a TSTypeReference<'a>),
     TSUnionType(&'a TSUnionType<'a>),
     TSVoidKeyword(&'a TSVoidKeyword),
+    TSBigIntKeyword(&'a TSBigIntKeyword),
+    TSBooleanKeyword(&'a TSBooleanKeyword),
+    TSNeverKeyword(&'a TSNeverKeyword),
+    TSNumberKeyword(&'a TSNumberKeyword),
+    TSObjectKeyword(&'a TSObjectKeyword),
+    TSStringKeyword(&'a TSStringKeyword),
+    TSSymbolKeyword(&'a TSSymbolKeyword),
+    TSThisType(&'a TSThisType),
+    TSUndefinedKeyword(&'a TSUndefinedKeyword),
+    TSUnknownKeyword(&'a TSUnknownKeyword),
+    TSInferType(&'a TSInferType<'a>),
+    TSTemplateLiteralType(&'a TSTemplateLiteralType<'a>),
 
     TSIndexedAccessType(&'a TSIndexedAccessType<'a>),
 
@@ -185,6 +197,7 @@ ast_kinds! {
     TSTypeParameterDeclaration(&'a TSTypeParameterDeclaration<'a>),
     TSTypeParameterInstantiation(&'a TSTypeParameterInstantiation<'a>),
     TSImportType(&'a TSImportType<'a>),
+    TSNamedTupleMember(&'a TSNamedTupleMember<'a>),
 
     TSPropertySignature(&'a TSPropertySignature<'a>),
 }
@@ -241,6 +254,22 @@ impl<'a> AstKind<'a> {
                 | Self::TSLiteralType(_)
                 | Self::TSTypeReference(_)
                 | Self::TSMethodSignature(_)
+                | Self::TSNullKeyword(_)
+                | Self::TSTypeLiteral(_)
+                | Self::TSUnionType(_)
+                | Self::TSVoidKeyword(_)
+                | Self::TSBigIntKeyword(_)
+                | Self::TSBooleanKeyword(_)
+                | Self::TSNeverKeyword(_)
+                | Self::TSNumberKeyword(_)
+                | Self::TSObjectKeyword(_)
+                | Self::TSStringKeyword(_)
+                | Self::TSSymbolKeyword(_)
+                | Self::TSThisType(_)
+                | Self::TSUndefinedKeyword(_)
+                | Self::TSUnknownKeyword(_)
+                | Self::TSInferType(_)
+                | Self::TSTemplateLiteralType(_)
         )
     }
 
@@ -477,6 +506,18 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::TSTypeReference(x) => x.span,
             Self::TSUnionType(x) => x.span,
             Self::TSVoidKeyword(x) => x.span,
+            Self::TSBigIntKeyword(x) => x.span,
+            Self::TSBooleanKeyword(x) => x.span,
+            Self::TSNeverKeyword(x) => x.span,
+            Self::TSNumberKeyword(x) => x.span,
+            Self::TSObjectKeyword(x) => x.span,
+            Self::TSStringKeyword(x) => x.span,
+            Self::TSSymbolKeyword(x) => x.span,
+            Self::TSThisType(x) => x.span,
+            Self::TSUndefinedKeyword(x) => x.span,
+            Self::TSUnknownKeyword(x) => x.span,
+            Self::TSInferType(x) => x.span,
+            Self::TSTemplateLiteralType(x) => x.span,
 
             Self::TSIndexedAccessType(x) => x.span,
 
@@ -502,6 +543,7 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::TSTypeParameterDeclaration(x) => x.span,
             Self::TSTypeParameterInstantiation(x) => x.span,
             Self::TSImportType(x) => x.span,
+            Self::TSNamedTupleMember(x) => x.span,
 
             Self::TSPropertySignature(x) => x.span,
         }
@@ -664,6 +706,18 @@ impl<'a> AstKind<'a> {
             Self::TSTypeReference(_) => "TSTypeReference".into(),
             Self::TSUnionType(_) => "TSUnionType".into(),
             Self::TSVoidKeyword(_) => "TSVoidKeyword".into(),
+            Self::TSBigIntKeyword(_) => "TSBigIntKeyword".into(),
+            Self::TSBooleanKeyword(_) => "TSBooleanKeyword".into(),
+            Self::TSNeverKeyword(_) => "TSNeverKeyword".into(),
+            Self::TSNumberKeyword(_) => "TSNumberKeyword".into(),
+            Self::TSObjectKeyword(_) => "TSObjectKeyword".into(),
+            Self::TSStringKeyword(_) => "TSStringKeyword".into(),
+            Self::TSSymbolKeyword(_) => "TSSymbolKeyword".into(),
+            Self::TSThisType(_) => "TSThisType".into(),
+            Self::TSUndefinedKeyword(_) => "TSUndefinedKeyword".into(),
+            Self::TSUnknownKeyword(_) => "TSUnknownKeyword".into(),
+            Self::TSInferType(_) => "TSInferType".into(),
+            Self::TSTemplateLiteralType(_) => "TSTemplateLiteralType".into(),
 
             Self::TSIndexedAccessType(_) => "TSIndexedAccessType".into(),
 
@@ -690,6 +744,7 @@ impl<'a> AstKind<'a> {
             Self::TSTypeParameterDeclaration(_) => "TSTypeParameterDeclaration".into(),
             Self::TSTypeParameterInstantiation(_) => "TSTypeParameterInstantiation".into(),
             Self::TSImportType(_) => "TSImportType".into(),
+            Self::TSNamedTupleMember(_) => "TSNamedTupleMember".into(),
 
             Self::TSPropertySignature(_) => "TSPropertySignature".into(),
         }

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -818,6 +818,46 @@ pub trait Visit<'a>: Sized {
     fn visit_ts_import_attribute_name(&mut self, name: &TSImportAttributeName<'a>) {
         walk_ts_import_attribute_name(self, name);
     }
+
+    fn visit_ts_big_int_keyword(&mut self, ty: &TSBigIntKeyword) {
+        walk_ts_big_int_keyword(self, ty);
+    }
+    fn visit_ts_boolean_keyword(&mut self, ty: &TSBooleanKeyword) {
+        walk_ts_boolean_keyword(self, ty);
+    }
+    fn visit_ts_never_keyword(&mut self, ty: &TSNeverKeyword) {
+        walk_ts_never_keyword(self, ty);
+    }
+    fn visit_ts_number_keyword(&mut self, ty: &TSNumberKeyword) {
+        walk_ts_number_keyword(self, ty);
+    }
+    fn visit_ts_object_keyword(&mut self, ty: &TSObjectKeyword) {
+        walk_ts_object_keyword(self, ty);
+    }
+    fn visit_ts_string_keyword(&mut self, ty: &TSStringKeyword) {
+        walk_ts_string_keyword(self, ty);
+    }
+    fn visit_ts_symbol_keyword(&mut self, ty: &TSSymbolKeyword) {
+        walk_ts_symbol_keyword(self, ty);
+    }
+    fn visit_ts_this_type(&mut self, ty: &TSThisType) {
+        walk_ts_this_type(self, ty);
+    }
+    fn visit_ts_undefined_keyword(&mut self, ty: &TSUndefinedKeyword) {
+        walk_ts_undefined_keyword(self, ty);
+    }
+    fn visit_ts_unknown_keyword(&mut self, ty: &TSUnknownKeyword) {
+        walk_ts_unknown_keyword(self, ty);
+    }
+    fn visit_ts_infer_type(&mut self, ty: &TSInferType<'a>) {
+        walk_ts_infer_type(self, ty);
+    }
+    fn visit_ts_named_tuple_member(&mut self, ty: &TSNamedTupleMember<'a>) {
+        walk_ts_named_tuple_member(self, ty);
+    }
+    fn visit_ts_template_literal_type(&mut self, ty: &TSTemplateLiteralType<'a>) {
+        walk_ts_template_literal_type(self, ty);
+    }
 }
 
 pub mod walk {
@@ -2623,7 +2663,22 @@ pub mod walk {
             TSType::TSTypeLiteral(ty) => visitor.visit_ts_type_literal(ty),
             TSType::TSIndexedAccessType(ty) => visitor.visit_ts_indexed_access_type(ty),
             TSType::TSTypeQuery(ty) => visitor.visit_ts_type_query(ty),
-            _ => {}
+            TSType::TSImportType(ty) => visitor.visit_ts_import_type(ty),
+            TSType::TSBigIntKeyword(ty) => visitor.visit_ts_big_int_keyword(ty),
+            TSType::TSBooleanKeyword(ty) => visitor.visit_ts_boolean_keyword(ty),
+            TSType::TSNeverKeyword(ty) => visitor.visit_ts_never_keyword(ty),
+            TSType::TSNumberKeyword(ty) => visitor.visit_ts_number_keyword(ty),
+            TSType::TSObjectKeyword(ty) => visitor.visit_ts_object_keyword(ty),
+            TSType::TSStringKeyword(ty) => visitor.visit_ts_string_keyword(ty),
+            TSType::TSSymbolKeyword(ty) => visitor.visit_ts_symbol_keyword(ty),
+            TSType::TSThisType(ty) => visitor.visit_ts_this_type(ty),
+            TSType::TSUndefinedKeyword(ty) => visitor.visit_ts_undefined_keyword(ty),
+            TSType::TSUnknownKeyword(ty) => visitor.visit_ts_unknown_keyword(ty),
+            TSType::TSInferType(ty) => visitor.visit_ts_infer_type(ty),
+            TSType::TSNamedTupleMember(ty) => visitor.visit_ts_named_tuple_member(ty),
+            TSType::TSQualifiedName(ty) => visitor.visit_ts_qualified_name(ty),
+            TSType::TSTemplateLiteralType(ty) => visitor.visit_ts_template_literal_type(ty),
+            TSType::JSDocNullableType(_) | TSType::JSDocUnknownType(_) => { /* TODO */ }
         }
     }
 
@@ -2955,5 +3010,86 @@ pub mod walk {
             TSImportAttributeName::Identifier(ident) => visitor.visit_identifier_name(ident),
             TSImportAttributeName::StringLiteral(ident) => visitor.visit_string_literal(ident),
         }
+    }
+
+    pub fn walk_ts_big_int_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSBigIntKeyword) {
+        let kind = AstKind::TSBigIntKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_boolean_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSBooleanKeyword) {
+        let kind = AstKind::TSBooleanKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_never_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSNeverKeyword) {
+        let kind = AstKind::TSNeverKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_number_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSNumberKeyword) {
+        let kind = AstKind::TSNumberKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_object_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSObjectKeyword) {
+        let kind = AstKind::TSObjectKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_string_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSStringKeyword) {
+        let kind = AstKind::TSStringKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_symbol_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSSymbolKeyword) {
+        let kind = AstKind::TSSymbolKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_this_type<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSThisType) {
+        let kind = AstKind::TSThisType(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_undefined_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSUndefinedKeyword) {
+        let kind = AstKind::TSUndefinedKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_unknown_keyword<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSUnknownKeyword) {
+        let kind = AstKind::TSUnknownKeyword(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_infer_type<'a, V: Visit<'a>>(visitor: &mut V, ty: &TSInferType<'a>) {
+        let kind = AstKind::TSInferType(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.visit_ts_type_parameter(&ty.type_parameter);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_named_tuple_member<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        ty: &TSNamedTupleMember<'a>,
+    ) {
+        let kind = AstKind::TSNamedTupleMember(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        visitor.visit_identifier_name(&ty.label);
+        visitor.visit_ts_type(&ty.element_type);
+        visitor.leave_node(kind);
+    }
+    pub fn walk_ts_template_literal_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        ty: &TSTemplateLiteralType<'a>,
+    ) {
+        let kind = AstKind::TSTemplateLiteralType(visitor.alloc(ty));
+        visitor.enter_node(kind);
+        for quasi in &ty.quasis {
+            visitor.visit_template_element(quasi);
+        }
+        for ty in &ty.types {
+            visitor.visit_ts_type(ty);
+        }
+        visitor.leave_node(kind);
     }
 }


### PR DESCRIPTION
Fixes #2936

*personally* I think it's best if all of the `_ => {}` match cases were removed from the codebase so that things are provably exhaustive.
This does exactly that specifically for `walk_ts_type` - filling in the missing cases and all the required code for them.
