### PR TITLE
Make ast types covariant over the allocator lifetime.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +194,9 @@ name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -1286,6 +1295,7 @@ dependencies = [
 name = "oxc_allocator"
 version = "0.12.3"
 dependencies = [
+ "allocator-api2",
  "bumpalo",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ napi        = "2"
 napi-derive = "2"
 
 assert-unchecked    = "0.1.2"
+allocator-api2      = "0.2.16"
 bpaf                = "0.9.11"
 bitflags            = "2.5.0"
 bumpalo             = "3.15.4"

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -18,8 +18,9 @@ workspace = true
 doctest = false
 
 [dependencies]
-bumpalo = { workspace = true, features = ["collections"] }
-serde   = { workspace = true }
+bumpalo        = { workspace = true, features = ["collections", "allocator-api2"] }
+serde          = { workspace = true }
+allocator-api2 = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -46,6 +46,7 @@ impl<'alloc, T: ?Sized> ops::Deref for Box<'alloc, T> {
 
     #[allow(unsafe_code)]
     fn deref(&self) -> &T {
+        // SAFETY: self.0 is always a unique reference allocated from a Bump in Box::new_in
         unsafe { self.0.as_ref() }
     }
 }
@@ -53,6 +54,7 @@ impl<'alloc, T: ?Sized> ops::Deref for Box<'alloc, T> {
 impl<'alloc, T: ?Sized> ops::DerefMut for Box<'alloc, T> {
     #[allow(unsafe_code)]
     fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: self.0 is always a unique reference allocated from a Bump in Box::new_in
         unsafe { self.0.as_mut() }
     }
 }
@@ -108,7 +110,7 @@ impl<'alloc, T> Vec<'alloc, T> {
 
     #[inline]
     pub fn from_iter_in<I: IntoIterator<Item = T>>(iter: I, allocator: &'alloc Allocator) -> Self {
-        let mut vec = vec::Vec::new_in(allocator.deref());
+        let mut vec = vec::Vec::new_in(&**allocator);
         vec.extend(iter);
         Self(vec)
     }

--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -59,7 +59,7 @@ impl<'alloc, T: ?Sized> ops::DerefMut for Box<'alloc, T> {
 
 impl<'alloc, T: ?Sized + Debug> Debug for Box<'alloc, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.deref().fmt(f)
     }
 }
 

--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -95,12 +95,6 @@ impl<'alloc, T: Hash> Hash for Box<'alloc, T> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Vec<'alloc, T>(vec::Vec<T, &'alloc Bump>);
 
-fn _variance_asserts() {
-    fn test_fn<'a: 'b, 'b>(program: Vec<'a, ()>) -> Vec<'b, ()> {
-        program
-    }
-}
-
 impl<'alloc, T> Vec<'alloc, T> {
     #[inline]
     pub fn new_in(allocator: &'alloc Allocator) -> Self {
@@ -244,5 +238,15 @@ mod test {
         v.push("x");
         let v = serde_json::to_string(&v).unwrap();
         assert_eq!(v, "[\"x\"]");
+    }
+
+    #[test]
+    fn lifetime_variance() {
+        fn _assert_box_variant_lifetime<'a: 'b, 'b, T>(program: Box<'a, T>) -> Box<'b, T> {
+            program
+        }
+        fn _assert_vec_variant_lifetime<'a: 'b, 'b, T>(program: Vec<'a, T>) -> Vec<'b, T> {
+            program
+        }
     }
 }

--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -87,7 +87,7 @@ where
 
 impl<'alloc, T: Hash> Hash for Box<'alloc, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
+        self.deref().hash(state);
     }
 }
 
@@ -195,6 +195,8 @@ impl<'alloc, T: Hash> Hash for Vec<'alloc, T> {
 
 #[cfg(test)]
 mod test {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
     use crate::{Allocator, Box, Vec};
 
     #[test]
@@ -212,6 +214,21 @@ mod test {
         let b = Box::new_in("x", &allocator);
         let b = format!("{b:?}");
         assert_eq!(b, "\"x\"");
+    }
+
+    #[test]
+    fn box_hash() {
+        fn hash(val: &impl Hash) -> u64 {
+            let mut hasher = DefaultHasher::default();
+            val.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let allocator = Allocator::default();
+        let a = Box::new_in("x", &allocator);
+        let b = Box::new_in("x", &allocator);
+
+        assert_eq!(hash(&a), hash(&b));
     }
 
     #[test]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -208,9 +208,7 @@ impl<'a> Expression<'a> {
     /// Remove nested parentheses from this expression.
     pub fn without_parenthesized(&self) -> &Self {
         match self {
-            Expression::ParenthesizedExpression(Box(expr)) => {
-                expr.expression.without_parenthesized()
-            }
+            Expression::ParenthesizedExpression(expr) => expr.expression.without_parenthesized(),
             _ => self,
         }
     }

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -111,7 +111,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         source_type: SourceType,
-        directives: Vec<'a, Directive>,
+        directives: Vec<'a, Directive<'a>>,
         hashbang: Option<Hashbang<'a>>,
         body: Vec<'a, Statement<'a>>,
     ) -> Program<'a> {
@@ -150,7 +150,7 @@ impl<'a> AstBuilder<'a> {
     pub fn template_literal(
         &self,
         span: Span,
-        quasis: Vec<'a, TemplateElement>,
+        quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
     ) -> TemplateLiteral<'a> {
         TemplateLiteral { span, quasis, expressions }
@@ -875,7 +875,7 @@ impl<'a> AstBuilder<'a> {
     pub fn function_body(
         &self,
         span: Span,
-        directives: Vec<'a, Directive>,
+        directives: Vec<'a, Directive<'a>>,
         statements: Vec<'a, Statement<'a>>,
     ) -> Box<'a, FunctionBody<'a>> {
         self.alloc(FunctionBody { span, directives, statements })
@@ -1117,7 +1117,7 @@ impl<'a> AstBuilder<'a> {
     pub fn import_declaration(
         &self,
         span: Span,
-        specifiers: Option<Vec<'a, ImportDeclarationSpecifier>>,
+        specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         with_clause: Option<WithClause<'a>>,
         import_kind: ImportOrExportKind,
@@ -1149,7 +1149,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
-        specifiers: Vec<'a, ExportSpecifier>,
+        specifiers: Vec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
         with_clause: Option<WithClause<'a>>,

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -31,7 +31,7 @@ impl<'a> AstBuilder<'a> {
 
     #[inline]
     pub fn alloc<T>(&self, value: T) -> Box<'a, T> {
-        Box(self.allocator.alloc(value))
+        Box::new_in(value, &self.allocator)
     }
 
     #[inline]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -31,7 +31,7 @@ impl<'a> AstBuilder<'a> {
 
     #[inline]
     pub fn alloc<T>(&self, value: T) -> Box<'a, T> {
-        Box::new_in(value, &self.allocator)
+        Box::new_in(value, self.allocator)
     }
 
     #[inline]

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -71,3 +71,6 @@ fn size_asserts() {
     assert_eq_size!(ast::TSLiteral, [u8; 16]);
     assert_eq_size!(ast::TSType, [u8; 16]);
 }
+
+#[test]
+fn variance_asserts() {}

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -73,4 +73,10 @@ fn size_asserts() {
 }
 
 #[test]
-fn variance_asserts() {}
+fn lifetime_variance() {
+    use crate::ast;
+
+    fn _assert_program_variant_lifetime<'a: 'b, 'b>(program: ast::Program<'a>) -> ast::Program<'b> {
+        program
+    }
+}

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -188,19 +188,19 @@ fn wrap_to_avoid_ambiguous_else(stmt: &Statement) -> bool {
     let mut current = stmt;
     loop {
         current = match current {
-            Statement::IfStatement(Box(IfStatement { alternate, .. })) => {
-                if let Some(stmt) = &alternate {
+            Statement::IfStatement(if_stmt) => {
+                if let Some(stmt) = &if_stmt.alternate {
                     stmt
                 } else {
                     return true;
                 }
             }
-            Statement::ForStatement(Box(ForStatement { body, .. }))
-            | Statement::ForOfStatement(Box(ForOfStatement { body, .. }))
-            | Statement::ForInStatement(Box(ForInStatement { body, .. }))
-            | Statement::WhileStatement(Box(WhileStatement { body, .. }))
-            | Statement::WithStatement(Box(WithStatement { body, .. }))
-            | Statement::LabeledStatement(Box(LabeledStatement { body, .. })) => body,
+            Statement::ForStatement(for_stmt) => &for_stmt.body,
+            Statement::ForOfStatement(for_of_stmt) => &for_of_stmt.body,
+            Statement::ForInStatement(for_in_stmt) => &for_in_stmt.body,
+            Statement::WhileStatement(while_stmt) => &while_stmt.body,
+            Statement::WithStatement(with_stmt) => &with_stmt.body,
+            Statement::LabeledStatement(labeled_stmt) => &labeled_stmt.body,
             _ => return false,
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use oxc_ast::{
     ast::{
         ArrayExpressionElement, AssignmentTarget, AssignmentTargetMaybeDefault,
@@ -253,7 +251,7 @@ impl NoSelfAssign {
             {
                 if let ObjectPropertyKind::ObjectProperty(obj_prop) = right {
                     if let ObjectProperty { method: false, value: expr, span, key, .. } =
-                        obj_prop.deref()
+                        &**obj_prop
                     {
                         if key.static_name().is_some_and(|name| name == id1.binding.name) {
                             if let Expression::Identifier(id2) = expr.without_parenthesized() {
@@ -273,8 +271,7 @@ impl NoSelfAssign {
                     }
                 };
                 if let ObjectPropertyKind::ObjectProperty(obj_prop) = right {
-                    if let ObjectProperty { method: false, value: expr, key, .. } = obj_prop.deref()
-                    {
+                    if let ObjectProperty { method: false, value: expr, key, .. } = &**obj_prop {
                         let property_name = property.name.static_name();
                         let key_name = key.static_name();
                         if property_name.is_some() && property_name == key_name {

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression, MemberExpression},
@@ -217,7 +217,7 @@ impl PreferToBe {
         };
 
         let is_cmp_mem_expr =
-            matches!(mem_expr.deref(), MemberExpression::ComputedMemberExpression(_));
+            matches!(&**mem_expr, MemberExpression::ComputedMemberExpression(_));
         let modifiers = jest_expect_fn_call.modifiers();
         let maybe_not_modifier = modifiers.iter().find(|modifier| modifier.is_name_equal("not"));
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression, MemberExpression},
     AstKind,
@@ -213,7 +215,9 @@ impl PreferToBe {
         let Some(Expression::MemberExpression(mem_expr)) = matcher.parent else {
             return;
         };
-        let is_cmp_mem_expr = matches!(mem_expr.0, MemberExpression::ComputedMemberExpression(_));
+
+        let is_cmp_mem_expr =
+            matches!(mem_expr.deref(), MemberExpression::ComputedMemberExpression(_));
         let modifiers = jest_expect_fn_call.modifiers();
         let maybe_not_modifier = modifiers.iter().find(|modifier| modifier.is_name_equal("not"));
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression, MemberExpression},
     AstKind,
@@ -216,8 +214,7 @@ impl PreferToBe {
             return;
         };
 
-        let is_cmp_mem_expr =
-            matches!(&**mem_expr, MemberExpression::ComputedMemberExpression(_));
+        let is_cmp_mem_expr = matches!(&**mem_expr, MemberExpression::ComputedMemberExpression(_));
         let modifiers = jest_expect_fn_call.modifiers();
         let maybe_not_modifier = modifiers.iter().find(|modifier| modifier.is_name_equal("not"));
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression, MemberExpression},
     AstKind,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression, MemberExpression},
     AstKind,
@@ -85,7 +87,7 @@ impl PreferToHaveLength {
                 let Expression::CallExpression(expr_call_expr) = mem_expr.object() else {
                     return;
                 };
-                match &mem_expr.0 {
+                match mem_expr.deref() {
                     MemberExpression::ComputedMemberExpression(_) => Self::check_and_fix(
                         call_expr,
                         expr_call_expr,

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{
     ast::{Argument, CallExpression, Expression, MemberExpression},
@@ -87,7 +87,7 @@ impl PreferToHaveLength {
                 let Expression::CallExpression(expr_call_expr) = mem_expr.object() else {
                     return;
                 };
-                match mem_expr.deref() {
+                match &**mem_expr {
                     MemberExpression::ComputedMemberExpression(_) => Self::check_and_fix(
                         call_expr,
                         expr_call_expr,

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{
     ast::{
@@ -106,7 +106,7 @@ fn get_outer_member_expression<'a, 'b>(
     assignment: &'b SimpleAssignmentTarget<'a>,
 ) -> Option<&'b StaticMemberExpression<'a>> {
     if let SimpleAssignmentTarget::MemberAssignmentTarget(member_expr) = assignment {
-        match member_expr.deref() {
+        match &**member_expr {
             MemberExpression::StaticMemberExpression(expr) => {
                 let mut node = expr;
                 loop {
@@ -139,7 +139,7 @@ fn get_static_member_expression_obj<'a, 'b>(
     expression: &'b Expression<'a>,
 ) -> Option<&'b StaticMemberExpression<'a>> {
     match expression {
-        Expression::MemberExpression(member_expr) => match member_expr.deref() {
+        Expression::MemberExpression(member_expr) => match &**member_expr {
             MemberExpression::StaticMemberExpression(expr) => Some(expr),
             _ => None,
         },

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{
     ast::{
         AssignmentTarget, Expression, MemberExpression, MethodDefinitionKind,
@@ -104,7 +106,7 @@ fn get_outer_member_expression<'a, 'b>(
     assignment: &'b SimpleAssignmentTarget<'a>,
 ) -> Option<&'b StaticMemberExpression<'a>> {
     if let SimpleAssignmentTarget::MemberAssignmentTarget(member_expr) = assignment {
-        match &member_expr.0 {
+        match member_expr.deref() {
             MemberExpression::StaticMemberExpression(expr) => {
                 let mut node = expr;
                 loop {
@@ -137,7 +139,7 @@ fn get_static_member_expression_obj<'a, 'b>(
     expression: &'b Expression<'a>,
 ) -> Option<&'b StaticMemberExpression<'a>> {
     match expression {
-        Expression::MemberExpression(member_expr) => match &member_expr.0 {
+        Expression::MemberExpression(member_expr) => match member_expr.deref() {
             MemberExpression::StaticMemberExpression(expr) => Some(expr),
             _ => None,
         },

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{
     ast::{
         AssignmentTarget, Expression, MemberExpression, MethodDefinitionKind,

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -1,6 +1,4 @@
-use std::{
-    cell::{Cell, RefCell},
-};
+use std::cell::{Cell, RefCell};
 
 use oxc_ast::{
     ast::{

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::{Cell, RefCell},
-    ops::Deref,
 };
 
 use oxc_ast::{
@@ -84,7 +83,7 @@ impl<'a> ListenerMap for Statement<'a> {
             }
             Self::ModuleDeclaration(decl) => {
                 if matches!(
-                    decl.deref(),
+                    &**decl,
                     ModuleDeclaration::ExportAllDeclaration(_)
                         | ModuleDeclaration::ImportDeclaration(_)
                 ) {

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -1,4 +1,7 @@
-use std::cell::{Cell, RefCell};
+use std::{
+    cell::{Cell, RefCell},
+    ops::Deref,
+};
 
 use oxc_ast::{
     ast::{
@@ -81,7 +84,7 @@ impl<'a> ListenerMap for Statement<'a> {
             }
             Self::ModuleDeclaration(decl) => {
                 if matches!(
-                    decl.0,
+                    decl.deref(),
                     ModuleDeclaration::ExportAllDeclaration(_)
                         | ModuleDeclaration::ImportDeclaration(_)
                 ) {

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{
     ast::{
@@ -130,7 +130,7 @@ impl Rule for NoThenable {
                         SimpleAssignmentTarget::MemberAssignmentTarget(target),
                     ),
                 ..
-            }) => match target.deref() {
+            }) => match &**target {
                 MemberExpression::ComputedMemberExpression(expr) => {
                     if let Some(span) = check_expression(&expr.expression, ctx) {
                         ctx.diagnostic(NoThenableDiagnostic::Class(span));

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{
     ast::{
         Argument, ArrayExpressionElement, AssignmentExpression, AssignmentTarget,

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{
     ast::{
         Argument, ArrayExpressionElement, AssignmentExpression, AssignmentTarget,
@@ -128,7 +130,7 @@ impl Rule for NoThenable {
                         SimpleAssignmentTarget::MemberAssignmentTarget(target),
                     ),
                 ..
-            }) => match &target.0 {
+            }) => match target.deref() {
                 MemberExpression::ComputedMemberExpression(expr) => {
                     if let Some(span) = check_expression(&expr.expression, ctx) {
                         ctx.diagnostic(NoThenableDiagnostic::Class(span));

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::{
     miette::{self, Diagnostic},

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::{
@@ -62,7 +62,7 @@ impl Rule for PreferEventTarget {
                     return;
                 };
 
-                if ident as *const _ != callee_ident.deref() as *const _ {
+                if ident as *const _ != std::ptr::addr_of!(**callee_ident) {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::{
     miette::{self, Diagnostic},
@@ -60,7 +62,7 @@ impl Rule for PreferEventTarget {
                     return;
                 };
 
-                if ident as *const _ != callee_ident.0 as *const _ {
+                if ident as *const _ != callee_ident.deref() as *const _ {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{
     ast::{Argument, Expression, MemberExpression},
@@ -72,7 +72,7 @@ impl Rule for PreferModernDomApis {
             return;
         };
 
-        let MemberExpression::StaticMemberExpression(member_expr) = member_expr.deref() else {
+        let MemberExpression::StaticMemberExpression(member_expr) = &**member_expr else {
             return;
         };
         let method = member_expr.property.name.as_str();

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{
     ast::{Argument, Expression, MemberExpression},
     AstKind,
@@ -66,13 +68,13 @@ impl Rule for PreferModernDomApis {
             return;
         };
 
-        let Expression::MemberExpression(oxc_allocator::Box(
-            MemberExpression::StaticMemberExpression(member_expr),
-        )) = &call_expr.callee
-        else {
+        let Expression::MemberExpression(member_expr) = &call_expr.callee else {
             return;
         };
 
+        let MemberExpression::StaticMemberExpression(member_expr) = member_expr.deref() else {
+            return;
+        };
         let method = member_expr.property.name.as_str();
 
         if is_method_call(

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{
     ast::{Argument, Expression, MemberExpression},
     AstKind,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+
 
 use oxc_ast::{
     ast::{Argument, Expression, MemberExpression},
@@ -84,7 +84,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the for statement is the same node as the call expression.
-                if call_expr2.deref() as *const _ != call_expr as *const _ {
+                if std::ptr::addr_of!(**call_expr2) != call_expr as *const _ {
                     return;
                 }
             }
@@ -94,7 +94,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the conditional expression is the same node as the call expression.
-                if call_expr2.deref() as *const _ != call_expr as *const _ {
+                if std::ptr::addr_of!(**call_expr2) != call_expr as *const _ {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use oxc_ast::{
     ast::{Argument, Expression, MemberExpression},
     AstKind,
@@ -82,7 +84,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the for statement is the same node as the call expression.
-                if call_expr2.0 as *const _ != call_expr as *const _ {
+                if call_expr2.deref() as *const _ != call_expr as *const _ {
                     return;
                 }
             }
@@ -92,7 +94,7 @@ impl Rule for PreferRegexpTest {
                 };
 
                 // Check if the `test` of the conditional expression is the same node as the call expression.
-                if call_expr2.0 as *const _ != call_expr as *const _ {
+                if call_expr2.deref() as *const _ != call_expr as *const _ {
                     return;
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -1,5 +1,3 @@
-
-
 use oxc_ast::{
     ast::{Argument, Expression, MemberExpression},
     AstKind,

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -52,7 +52,7 @@ pub fn has_jsx_prop_lowercase<'a, 'b>(
 
 pub fn get_prop_value<'a, 'b>(item: &'b JSXAttributeItem<'a>) -> Option<&'b JSXAttributeValue<'a>> {
     if let JSXAttributeItem::Attribute(attr) = item {
-        attr.0.value.as_ref()
+        attr.value.as_ref()
     } else {
         None
     }

--- a/crates/oxc_minifier/src/compressor/fold.rs
+++ b/crates/oxc_minifier/src/compressor/fold.rs
@@ -889,20 +889,20 @@ impl<'a> Compressor<'a> {
     pub(crate) fn fold_condition<'b>(&mut self, stmt: &'b mut Statement<'a>) {
         match stmt {
             Statement::WhileStatement(while_stmt) => {
-                let minimized_expr = self.fold_expression_in_condition(&mut while_stmt.0.test);
+                let minimized_expr = self.fold_expression_in_condition(&mut while_stmt.test);
 
                 if let Some(min_expr) = minimized_expr {
-                    while_stmt.0.test = min_expr;
+                    while_stmt.test = min_expr;
                 }
             }
             Statement::ForStatement(for_stmt) => {
-                let test_expr = for_stmt.0.test.as_mut();
+                let test_expr = for_stmt.test.as_mut();
 
                 if let Some(test_expr) = test_expr {
                     let minimized_expr = self.fold_expression_in_condition(test_expr);
 
                     if let Some(min_expr) = minimized_expr {
-                        for_stmt.0.test = Some(min_expr);
+                        for_stmt.test = Some(min_expr);
                     }
                 }
             }
@@ -917,10 +917,10 @@ impl<'a> Compressor<'a> {
         let folded_expr = match expr {
             Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
                 UnaryOperator::LogicalNot => {
-                    let should_fold = self.try_minimize_not(&mut unary_expr.0.argument);
+                    let should_fold = self.try_minimize_not(&mut unary_expr.argument);
 
                     if should_fold {
-                        Some(self.move_out_expression(&mut unary_expr.0.argument))
+                        Some(self.move_out_expression(&mut unary_expr.argument))
                     } else {
                         None
                     }
@@ -945,12 +945,12 @@ impl<'a> Compressor<'a> {
 
         match expr {
             Expression::BinaryExpression(binary_expr) => {
-                let new_op = binary_expr.0.operator.equality_inverse_operator();
+                let new_op = binary_expr.operator.equality_inverse_operator();
 
                 match new_op {
                     Some(new_op) => {
-                        binary_expr.0.operator = new_op;
-                        binary_expr.0.span = *span;
+                        binary_expr.operator = new_op;
+                        binary_expr.span = *span;
 
                         true
                     }

--- a/crates/oxc_parser/examples/multi-thread.rs
+++ b/crates/oxc_parser/examples/multi-thread.rs
@@ -34,7 +34,7 @@ struct AST {
     allocator: Allocator,
     source_text: Arc<str>,
     #[borrows(allocator, source_text)]
-    #[not_covariant]
+    #[covariant]
     ast: &'this BumpaloProgram<'this>,
 }
 
@@ -79,9 +79,7 @@ fn main() {
         let ast = ast_rx.recv().unwrap();
         let index = ast.borrow_index();
         println!("received ast({index}) in {:?} at {}", thread::current().id(), timestamp());
-        ast.with_ast(|bumpalo_program| {
-            println!("AST span: {:?}", bumpalo_program.0.span);
-        });
+        println!("AST span: {:?}", ast.borrow_ast().0.span);
     }
 }
 

--- a/crates/oxc_prettier/src/doc.rs
+++ b/crates/oxc_prettier/src/doc.rs
@@ -190,7 +190,7 @@ pub trait DocBuilder<'a> {
 
     #[inline]
     fn boxed(&self, doc: Doc<'a>) -> Box<'a, Doc<'a>> {
-        Box(self.allocator().alloc(doc))
+        Box::new_in(doc, self.allocator())
     }
 
     #[allow(unused)]

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -42,13 +42,13 @@ impl ClassTableBuilder {
         for element in &class.body {
             match element {
                 ClassElement::PropertyDefinition(definition) => {
-                    self.declare_class_property(&definition);
+                    self.declare_class_property(definition);
                 }
                 ClassElement::MethodDefinition(definition) => {
-                    self.declare_class_method(&definition);
+                    self.declare_class_method(definition);
                 }
                 ClassElement::AccessorProperty(definition) => {
-                    self.declare_class_accessor(&definition);
+                    self.declare_class_accessor(definition);
                 }
                 _ => {}
             }

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -42,13 +42,13 @@ impl ClassTableBuilder {
         for element in &class.body {
             match element {
                 ClassElement::PropertyDefinition(definition) => {
-                    self.declare_class_property(definition.0);
+                    self.declare_class_property(&definition);
                 }
                 ClassElement::MethodDefinition(definition) => {
-                    self.declare_class_method(definition.0);
+                    self.declare_class_method(&definition);
                 }
                 ClassElement::AccessorProperty(definition) => {
-                    self.declare_class_accessor(definition.0);
+                    self.declare_class_accessor(&definition);
                 }
                 _ => {}
             }

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     fmt::{self, Display, Formatter},
+    ops::Deref,
 };
 
 use convert_case::{Case, Casing};
@@ -185,7 +186,7 @@ impl<'a> Visit<'a> for TestCase<'a> {
                                     continue;
                                 };
                                 let MemberExpression::StaticMemberExpression(member) =
-                                    &member_expr.0
+                                    member_expr.deref()
                                 else {
                                     continue;
                                 };
@@ -348,7 +349,7 @@ impl<'a> Visit<'a> for State<'a> {
             Statement::ExpressionStatement(expr_stmt) => self.visit_expression_statement(expr_stmt),
             // for eslint-plugin-jsdoc
             Statement::ModuleDeclaration(mod_decl) => {
-                if let ModuleDeclaration::ExportDefaultDeclaration(export_decl) = &mod_decl.0 {
+                if let ModuleDeclaration::ExportDefaultDeclaration(export_decl) = mod_decl.deref() {
                     if let ExportDefaultDeclarationKind::Expression(Expression::ObjectExpression(
                         obj_expr,
                     )) = &export_decl.declaration
@@ -479,7 +480,7 @@ fn find_parser_arguments<'a, 'b>(
     };
     let MemberExpression::StaticMemberExpression(StaticMemberExpression {
         object, property, ..
-    }) = &member_expr.0
+    }) = member_expr.deref()
     else {
         return None;
     };

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -2,7 +2,6 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     fmt::{self, Display, Formatter},
-    ops::Deref,
 };
 
 use convert_case::{Case, Casing};
@@ -186,7 +185,7 @@ impl<'a> Visit<'a> for TestCase<'a> {
                                     continue;
                                 };
                                 let MemberExpression::StaticMemberExpression(member) =
-                                    member_expr.deref()
+                                    &**member_expr
                                 else {
                                     continue;
                                 };
@@ -349,7 +348,7 @@ impl<'a> Visit<'a> for State<'a> {
             Statement::ExpressionStatement(expr_stmt) => self.visit_expression_statement(expr_stmt),
             // for eslint-plugin-jsdoc
             Statement::ModuleDeclaration(mod_decl) => {
-                if let ModuleDeclaration::ExportDefaultDeclaration(export_decl) = mod_decl.deref() {
+                if let ModuleDeclaration::ExportDefaultDeclaration(export_decl) = &**mod_decl {
                     if let ExportDefaultDeclarationKind::Expression(Expression::ObjectExpression(
                         obj_expr,
                     )) = &export_decl.declaration
@@ -480,7 +479,7 @@ fn find_parser_arguments<'a, 'b>(
     };
     let MemberExpression::StaticMemberExpression(StaticMemberExpression {
         object, property, ..
-    }) = member_expr.deref()
+    }) = &**member_expr
     else {
         return None;
     };


### PR DESCRIPTION
## Why

Due to the usage of `&'alloc mut T` in `oxc_allocator::Box`, and `bumpalo::collections::Vec` in `oxc_allocator::Vec`, ast types are currently invariant over their allocator lifetime `'a`. This prevents `ouroboros` from generating `borrow_*` on ast type fields, leading to the unfriendly `with_*` api: https://github.com/oxc-project/oxc/blob/c250b288ef0b9a3ca72ac01ff96e3e240b78a30d/crates/oxc_parser/examples/multi-thread.rs#L82-L84

## How

- For `oxc_allocator::Vec`, switch to `allocator_api2::vec::Vec`, which has a covariant relationship with the allocator lifetime.
- For `oxc_allocator::Box`, use `std::ptr::NonNull` which is specifically designed to be covariant. I don't use `allocator_api2::boxed::Box` because it holds the allocator for dropping, so the size is bigger.

## Downside

Now that `oxc_allocator::Box` uses the unsafe `NonNull`. It has to be a private field to be safe. This make it impossible to do `Box(....)` pattern matching.
