### PR TITLE
refactor(transformer_conformance): skip plugins we don't support yet

### DIFF
--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,4 +1,4 @@
-Passed: 94/228
+Passed: 94/219
 
 # All Passed:
 * babel-plugin-transform-react-jsx-source
@@ -24,21 +24,14 @@ Passed: 94/228
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (49/147)
+# babel-plugin-transform-typescript (49/138)
 * class/abstract-allowDeclareFields-false/input.ts
 * class/abstract-allowDeclareFields-true/input.ts
-* class/abstract-class-decorated/input.ts
-* class/abstract-class-decorated-method/input.ts
-* class/abstract-class-decorated-parameter/input.ts
 * class/accessor-allowDeclareFields-false/input.ts
 * class/accessor-allowDeclareFields-true/input.ts
-* class/decorated-declare-properties/input.ts
 * class/parameter-properties/input.ts
 * class/parameter-properties-late-super/input.ts
-* class/parameter-properties-with-parameters/input.ts
 * class/parameter-properties-with-super/input.ts
-* class/private-method-override-transform-private/input.ts
-* class/transform-properties-declare-wrong-order/input.ts
 * declarations/erased/input.ts
 * declarations/export-declare-enum/input.ts
 * declarations/nested-namespace/input.mjs
@@ -120,9 +113,7 @@ Passed: 94/228
 * optimize-const-enums/local-shadowed/input.ts
 * optimize-const-enums/merged/input.ts
 * optimize-const-enums/merged-exported/input.ts
-* regression/10338/input.ts
 * regression/15768/input.ts
-* variable-declaration/non-null-in-optional-chain/input.ts
 
 # babel-preset-react (2/13)
 * preset-options/development/input.js

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -45,6 +45,8 @@ fn fixture_root() -> PathBuf {
 }
 
 const PLUGINS: &[&str] = &[
+    // syntax
+    "babel-plugin-syntax-jsx",
     // // ES2024
     // "babel-plugin-transform-unicode-sets-regex",
     // // ES2022
@@ -101,15 +103,6 @@ const PLUGINS: &[&str] = &[
     "babel-plugin-transform-react-jsx-development",
     // // Proposal
     // "babel-plugin-proposal-decorators",
-];
-
-pub(crate) const PLUGINS_NOT_SUPPORTED_YET: &[&str] = &[
-    "transform-classes",
-    "transform-modules-commonjs",
-    "transform-object-rest-spread",
-    "transform-react-constant-elements",
-    "transform-property-literals",
-    "transform-arrow-functions",
 ];
 
 const EXCLUDE_TESTS: &[&str] = &["babel-plugin-transform-typescript/test/fixtures/enum"];

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -17,7 +17,7 @@ use oxc_transformer::{
     DecoratorsOptions, ReactOptions, TransformOptions, Transformer, TypeScriptOptions,
 };
 
-use crate::{fixture_root, root, TestRunnerEnv, PLUGINS_NOT_SUPPORTED_YET};
+use crate::{fixture_root, root, TestRunnerEnv, PLUGINS};
 
 #[derive(Debug)]
 pub enum TestCaseKind {
@@ -127,7 +127,17 @@ pub trait TestCase {
         let options = self.options();
 
         // Skip plugins we don't support yet
-        if PLUGINS_NOT_SUPPORTED_YET.iter().any(|plugin| options.get_plugin(plugin).is_some()) {
+        if options.plugins.iter().any(|value| {
+            if let Some(plugin_name) = match value {
+                Value::String(name) => Some(name.to_string()),
+                Value::Array(a) => a.first().and_then(Value::as_str).map(ToString::to_string),
+                _ => None,
+            } {
+                !PLUGINS.contains(&format!("babel-plugin-{plugin_name}").as_str())
+            } else {
+                false
+            }
+        }) {
             return true;
         }
 


### PR DESCRIPTION
We don't need `PLUGINS_NOT_SUPPORTED_YET`. The `PLUGINS` are the plugins we supported.