### PR TITLE
refactor(transformer/typescript): remove all code that removes ts annotations

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -82,32 +82,22 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
     // ALPHASORT
 
     fn visit_arrow_expression(&mut self, expr: &mut ArrowFunctionExpression<'a>) {
-        self.x0_typescript.transform_arrow_expression(expr);
-
         walk_mut::walk_arrow_expression_mut(self, expr);
     }
 
     fn visit_binding_pattern(&mut self, pat: &mut BindingPattern<'a>) {
-        self.x0_typescript.transform_binding_pattern(pat);
-
         walk_mut::walk_binding_pattern_mut(self, pat);
     }
 
     fn visit_call_expression(&mut self, expr: &mut CallExpression<'a>) {
-        self.x0_typescript.transform_call_expression(expr);
-
         walk_mut::walk_call_expression_mut(self, expr);
     }
 
     fn visit_class(&mut self, class: &mut Class<'a>) {
-        self.x0_typescript.transform_class(class);
-
         walk_mut::walk_class_mut(self, class);
     }
 
     fn visit_class_body(&mut self, body: &mut ClassBody<'a>) {
-        self.x0_typescript.transform_class_body(body);
-
         walk_mut::walk_class_body_mut(self, body);
     }
 
@@ -131,25 +121,18 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
     }
 
     fn visit_formal_parameter(&mut self, param: &mut FormalParameter<'a>) {
-        self.x0_typescript.transform_formal_parameter(param);
-
         walk_mut::walk_formal_parameter_mut(self, param);
     }
 
     fn visit_function(&mut self, func: &mut Function<'a>, flags: Option<oxc_semantic::ScopeFlags>) {
-        self.x0_typescript.transform_function(func, flags);
-
         walk_mut::walk_function_mut(self, func, flags);
     }
 
     fn visit_import_declaration(&mut self, decl: &mut ImportDeclaration<'a>) {
-        self.x0_typescript.transform_import_declaration(decl);
-
         walk_mut::walk_import_declaration_mut(self, decl);
     }
 
     fn visit_jsx_opening_element(&mut self, elem: &mut JSXOpeningElement<'a>) {
-        self.x0_typescript.transform_jsx_opening_element(elem);
         self.x1_react.transform_jsx_opening_element(elem);
 
         walk_mut::walk_jsx_opening_element_mut(self, elem);
@@ -162,8 +145,6 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
     }
 
     fn visit_new_expression(&mut self, expr: &mut NewExpression<'a>) {
-        self.x0_typescript.transform_new_expression(expr);
-
         walk_mut::walk_new_expression_mut(self, expr);
     }
 
@@ -174,8 +155,6 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
     }
 
     fn visit_property_definition(&mut self, def: &mut PropertyDefinition<'a>) {
-        self.x0_typescript.transform_property_definition(def);
-
         walk_mut::walk_property_definition_mut(self, def);
     }
 
@@ -183,14 +162,6 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
         self.x0_typescript.transform_statements(stmts);
 
         walk_mut::walk_statements_mut(self, stmts);
-
-        self.x0_typescript.transform_statements_on_exit(stmts);
-    }
-
-    fn visit_tagged_template_expression(&mut self, expr: &mut TaggedTemplateExpression<'a>) {
-        self.x0_typescript.transform_tagged_template_expression(expr);
-
-        walk_mut::walk_tagged_template_expression_mut(self, expr);
     }
 
     fn visit_variable_declarator(&mut self, declarator: &mut VariableDeclarator<'a>) {

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -63,26 +63,6 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_program_on_exit(program);
     }
 
-    pub fn transform_arrow_expression(&mut self, expr: &mut ArrowFunctionExpression<'a>) {
-        self.annotations.transform_arrow_expression(expr);
-    }
-
-    pub fn transform_binding_pattern(&mut self, pat: &mut BindingPattern<'a>) {
-        self.annotations.transform_binding_pattern(pat);
-    }
-
-    pub fn transform_call_expression(&mut self, expr: &mut CallExpression<'a>) {
-        self.annotations.transform_call_expression(expr);
-    }
-
-    pub fn transform_class(&mut self, class: &mut Class<'a>) {
-        self.annotations.transform_class(class);
-    }
-
-    pub fn transform_class_body(&mut self, body: &mut ClassBody<'a>) {
-        self.annotations.transform_class_body(body);
-    }
-
     pub fn transform_export_named_declaration(&mut self, decl: &mut ExportNamedDeclaration<'a>) {
         self.annotations.transform_export_named_declaration(decl);
     }
@@ -91,50 +71,11 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_expression(expr);
     }
 
-    pub fn transform_formal_parameter(&mut self, param: &mut FormalParameter<'a>) {
-        self.annotations.transform_formal_parameter(param);
-    }
-
-    pub fn transform_function(
-        &mut self,
-        func: &mut Function<'a>,
-        flags: Option<oxc_semantic::ScopeFlags>,
-    ) {
-        self.annotations.transform_function(func, flags);
-    }
-
-    pub fn transform_import_declaration(&mut self, decl: &mut ImportDeclaration<'a>) {
-        self.annotations.transform_import_declaration(decl);
-    }
-
-    pub fn transform_jsx_opening_element(&mut self, elem: &mut JSXOpeningElement<'a>) {
-        self.annotations.transform_jsx_opening_element(elem);
-    }
-
     pub fn transform_method_definition(&mut self, def: &mut MethodDefinition<'a>) {
         self.annotations.transform_method_definition(def);
     }
 
-    pub fn transform_new_expression(&mut self, expr: &mut NewExpression<'a>) {
-        self.annotations.transform_new_expression(expr);
-    }
-
-    pub fn transform_property_definition(&mut self, def: &mut PropertyDefinition<'a>) {
-        self.annotations.transform_property_definition(def);
-    }
-
     pub fn transform_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>) {
         self.transform_statements_for_namespace(stmts);
-    }
-
-    pub fn transform_statements_on_exit(&mut self, stmts: &mut Vec<'a, Statement<'a>>) {
-        self.annotations.transform_statements_on_exit(stmts);
-    }
-
-    pub fn transform_tagged_template_expression(
-        &mut self,
-        expr: &mut TaggedTemplateExpression<'a>,
-    ) {
-        self.annotations.transform_tagged_template_expression(expr);
     }
 }

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -43,7 +43,6 @@ Passed: 93/227
 * declarations/export-declare-enum/input.ts
 * declarations/nested-namespace/input.mjs
 * exports/declare-namespace/input.ts
-* exports/declare-shadowed/input.ts
 * exports/declared-types/input.ts
 * exports/export-const-enums/input.ts
 * exports/export-type/input.ts
@@ -79,6 +78,7 @@ Passed: 93/227
 * imports/property-signature/input.ts
 * imports/type-only-export-specifier-1/input.ts
 * imports/type-only-export-specifier-2/input.ts
+* imports/type-only-import-specifier-1/input.ts
 * imports/type-only-import-specifier-2/input.ts
 * imports/type-only-import-specifier-3/input.ts
 * imports/type-only-import-specifier-4/input.ts


### PR DESCRIPTION
As https://github.com/oxc-project/oxc/pull/2951#issuecomment-2053608494 said. oxc_codegen will not print all typescript-only code. So removing ts annotations is redundant