### PR TITLE
feat(transformer/typescript): correct elide imports/exports statements

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -143,8 +143,6 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
     }
 
     fn visit_import_declaration(&mut self, decl: &mut ImportDeclaration<'a>) {
-        self.x0_typescript.transform_import_declaration(decl);
-
         walk_mut::walk_import_declaration_mut(self, decl);
     }
 
@@ -197,5 +195,15 @@ impl<'a> VisitMut<'a> for Transformer<'a> {
         self.x1_react.transform_variable_declarator(declarator);
 
         walk_mut::walk_variable_declarator_mut(self, declarator);
+    }
+
+    fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'a>) {
+        self.x0_typescript.transform_identifier_reference(ident);
+        walk_mut::walk_identifier_reference_mut(self, ident);
+    }
+
+    fn visit_statement(&mut self, stmt: &mut Statement<'a>) {
+        self.x0_typescript.transform_statement(stmt);
+        walk_mut::walk_statement_mut(self, stmt);
     }
 }

--- a/crates/oxc_transformer/src/typescript/collector.rs
+++ b/crates/oxc_transformer/src/typescript/collector.rs
@@ -1,0 +1,36 @@
+use oxc_ast::ast::{ExportNamedDeclaration, IdentifierReference};
+use oxc_span::Atom;
+use rustc_hash::FxHashSet;
+
+/// Collects identifier references
+/// Indicates whether the BindingIdentifier is referenced or used in the ExportNamedDeclaration
+#[derive(Debug)]
+pub struct TypeScriptReferenceCollector<'a> {
+    names: FxHashSet<Atom<'a>>,
+}
+
+impl<'a> TypeScriptReferenceCollector<'a> {
+    pub fn new() -> Self {
+        Self { names: FxHashSet::default() }
+    }
+
+    pub fn has_reference(&self, name: &Atom) -> bool {
+        self.names.contains(name)
+    }
+
+    pub fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        self.names.insert(ident.name.clone());
+    }
+
+    pub fn visit_transform_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        if decl.export_kind.is_type() {
+            return;
+        }
+
+        for specifier in &decl.specifiers {
+            if specifier.export_kind.is_value() {
+                self.names.insert(specifier.local.name().clone());
+            }
+        }
+    }
+}

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,4 +1,4 @@
-Passed: 93/227
+Passed: 123/227
 
 # All Passed:
 * babel-plugin-transform-react-jsx-source
@@ -24,7 +24,7 @@ Passed: 93/227
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (49/147)
+# babel-plugin-transform-typescript (79/147)
 * class/abstract-allowDeclareFields-false/input.ts
 * class/abstract-allowDeclareFields-true/input.ts
 * class/abstract-class-decorated/input.ts
@@ -40,48 +40,18 @@ Passed: 93/227
 * class/private-method-override-transform-private/input.ts
 * class/transform-properties-declare-wrong-order/input.ts
 * declarations/erased/input.ts
-* declarations/export-declare-enum/input.ts
 * declarations/nested-namespace/input.mjs
-* exports/declare-namespace/input.ts
 * exports/declare-shadowed/input.ts
 * exports/declared-types/input.ts
 * exports/export-const-enums/input.ts
-* exports/export-type/input.ts
-* exports/export-type-from/input.ts
 * exports/export-type-star-from/input.ts
 * exports/export=/input.ts
-* exports/imported-types/input.ts
-* exports/imported-types-only-remove-type-imports/input.ts
-* exports/issue-9916-3/input.ts
-* exports/simple/input.ts
-* exports/type-only-export-specifier-1/input.ts
-* exports/type-only-export-specifier-2/input.ts
 * function/overloads-exports/input.mjs
-* imports/elide-preact/input.ts
-* imports/elide-react/input.ts
 * imports/elide-type-referenced-in-imports-equal-no/input.ts
-* imports/elide-typeof/input.ts
-* imports/elision/input.ts
-* imports/elision-export-type/input.ts
-* imports/elision-locations/input.ts
-* imports/elision-qualifiedname/input.ts
-* imports/elision-rename/input.ts
 * imports/enum-id/input.ts
 * imports/enum-value/input.ts
-* imports/import-named-type/input.ts
-* imports/import-named-type-default-and-named/input.ts
-* imports/import-removed-exceptions/input.ts
-* imports/import-type/input.ts
-* imports/import-type-func-with-duplicate-name/input.ts
-* imports/import-type-not-removed/input.ts
 * imports/import=-module/input.ts
-* imports/only-remove-type-imports/input.ts
-* imports/property-signature/input.ts
-* imports/type-only-export-specifier-1/input.ts
 * imports/type-only-export-specifier-2/input.ts
-* imports/type-only-import-specifier-2/input.ts
-* imports/type-only-import-specifier-3/input.ts
-* imports/type-only-import-specifier-4/input.ts
 * namespace/alias/input.ts
 * namespace/ambient-module-nested/input.ts
 * namespace/ambient-module-nested-exported/input.ts


### PR DESCRIPTION
remove ts annotations one benefit: `IdentifierReference` only used on js code

The `TypescriptReferenceCollector` implementation is inspired by https://github.com/swc-project/swc/blob/5f75019683a2f1dc03dda68d6832632ee5d8699c/crates/swc_ecma_transforms_typescript/src/strip_import_export.rs#L9-L99

This seems simpler to implement than using scope