### PR TITLE
fix(transformer/typescript): modifiers should not be removed

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -88,15 +88,10 @@ impl<'a> TypeScriptAnnotations<'a> {
 
                     decl.export_kind.is_type()
                         || ((decl.declaration.is_none()
-                            || decl.declaration.as_ref().is_some_and(|d| {
-                                d.modifiers().is_some_and(|modifiers| {
-                                    modifiers.contains(ModifierKind::Declare)
-                                }) || matches!(
-                                    d,
-                                    Declaration::TSInterfaceDeclaration(_)
-                                        | Declaration::TSTypeAliasDeclaration(_)
-                                )
-                            }))
+                            || decl
+                                .declaration
+                                .as_ref()
+                                .is_some_and(Declaration::is_typescript_syntax))
                             && decl.specifiers.is_empty())
                 }
                 ModuleDeclaration::ImportDeclaration(decl) => {
@@ -196,7 +191,6 @@ impl<'a> TypeScriptAnnotations<'a> {
         class.type_parameters = None;
         class.super_type_parameters = None;
         class.implements = None;
-        class.modifiers.remove_type_modifiers();
     }
 
     pub fn transform_class_body(&mut self, body: &mut ClassBody<'a>) {
@@ -236,7 +230,6 @@ impl<'a> TypeScriptAnnotations<'a> {
         func.this_param = None;
         func.type_parameters = None;
         func.return_type = None;
-        func.modifiers.remove_type_modifiers();
     }
 
     pub fn transform_jsx_opening_element(&mut self, elem: &mut JSXOpeningElement<'a>) {

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,4 +1,4 @@
-Passed: 134/217
+Passed: 136/217
 
 # All Passed:
 * babel-plugin-transform-react-jsx-source
@@ -16,7 +16,7 @@ Passed: 134/217
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (80/147)
+# babel-plugin-transform-typescript (82/147)
 * class/abstract-allowDeclareFields-false/input.ts
 * class/abstract-allowDeclareFields-true/input.ts
 * class/abstract-class-decorated/input.ts
@@ -31,9 +31,7 @@ Passed: 134/217
 * class/parameter-properties-with-super/input.ts
 * class/private-method-override-transform-private/input.ts
 * class/transform-properties-declare-wrong-order/input.ts
-* declarations/erased/input.ts
 * declarations/nested-namespace/input.mjs
-* exports/declare-shadowed/input.ts
 * exports/declared-types/input.ts
 * exports/export-const-enums/input.ts
 * exports/export-type-star-from/input.ts


### PR DESCRIPTION
`codegen` relies on the modifier to decide whether to print or not. For example, if declare is present, nothing will be printed if typescript is not enabled.

We may need to solve this problem in a way that doesn't rely on modifers.
