### PR TITLE
chore(task): add specific pnpm version for codespeed task

### DIFF
--- a/tasks/benchmark/codspeed/package.json
+++ b/tasks/benchmark/codspeed/package.json
@@ -5,5 +5,6 @@
     "axios": "^1.6.8",
     "express": "^4.18.3",
     "tar": "^6.2.0"
-  }
+  },
+  "packageManager": "pnpm@8.15.7"
 }


### PR DESCRIPTION
> Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz.  
> Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm
https://github.com/oxc-project/oxc/actions/runs/8703527853/job/23877194263?pr=2874