### PR TITLE
feat(linter/jsdoc): Update settings.jsdoc method

### DIFF
--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -30,7 +30,6 @@ pub struct JSDocPluginSettings {
 
     #[serde(default, rename = "tagNamePreference")]
     tag_name_preference: FxHashMap<String, TagNamePreference>,
-    
     // Not planning to support for now
     // min_lines: number
     // max_lines: number


### PR DESCRIPTION
Add `list_preferred_tag_names()` to enumerate user defined tag names in `tagNamePreferences`.