### PR TITLE
fix(semantic/jsdoc): Skip parsing `@` inside of backticks

### DIFF
--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -306,7 +306,7 @@ line2
     }
 
     #[test]
-    fn parses_with_codeblock() {
+    fn parses_with_backticks() {
         let allocator = Allocator::default();
         let semantic = build_semantic(
             &allocator,
@@ -316,7 +316,7 @@ line2
              *
              * @example ```ts
              /** @comment */ 
-            @decorator
+            @decoratorInComment
             class Foo { }
             ```
              */

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -304,4 +304,30 @@ line2
         let (type_part, comment_part) = tag.type_comment();
         assert_eq!((type_part, comment_part.parsed()), (None, "flattened data".to_string()));
     }
+
+    #[test]
+    fn parses_with_codeblock() {
+        let allocator = Allocator::default();
+        let semantic = build_semantic(
+            &allocator,
+            "
+            /**
+             * This is normal comment, `@xxx` should not parsed as tag.
+             *
+             * @example ```ts
+             /** @comment */ 
+            @decorator
+            class Foo { }
+            ```
+             */
+            ",
+        );
+        let jsdoc = semantic.jsdoc().iter_all().next().unwrap();
+
+        let mut tags = jsdoc.tags().iter();
+        assert_eq!(tags.len(), 1);
+
+        let tag = tags.next().unwrap();
+        assert_eq!(tag.kind.parsed(), "example");
+    }
 }

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -315,10 +315,10 @@ line2
              * This is normal comment, `@xxx` should not parsed as tag.
              *
              * @example ```ts
-             /** @comment */ 
-            @decoratorInComment
-            class Foo { }
-            ```
+                // @comment
+                @decoratorInComment
+                class Foo { }
+               ```
              */
             ",
         );

--- a/crates/oxc_semantic/src/jsdoc/parser/parse.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/parse.rs
@@ -24,6 +24,7 @@ pub fn parse_jsdoc(source_text: &str, jsdoc_span_start: u32) -> (JSDocCommentPar
     let mut comment_found = false;
     // Parser local offsets, not for global span
     let (mut start, mut end) = (0, 0);
+
     let mut chars = source_text.chars().peekable();
     while let Some(ch) = chars.next() {
         let can_parse = !(in_braces || in_backticks);
@@ -35,7 +36,7 @@ pub fn parse_jsdoc(source_text: &str, jsdoc_span_start: u32) -> (JSDocCommentPar
             // (for nested code blocks)
             // But for now, 4, 6, ... backticks are not handled here to keep things simple...
             '`' => {
-                if chars.peek().map_or(false, |&c| c != '`') {
+                if chars.peek().is_some_and(|&c| c != '`') {
                     in_backticks = !in_backticks;
                 }
             }

--- a/crates/oxc_semantic/src/jsdoc/parser/parse.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/parse.rs
@@ -20,13 +20,13 @@ pub fn parse_jsdoc(source_text: &str, jsdoc_span_start: u32) -> (JSDocCommentPar
     // But `@` can be found inside of `{}` (e.g. `{@see link}`), it should be distinguished.
     let mut in_braces = false;
     // Also, `@` is often found inside of backtick(` or ```), like markdown.
-    let mut in_backtick = false;
+    let mut in_backticks = false;
     let mut comment_found = false;
     // Parser local offsets, not for global span
     let (mut start, mut end) = (0, 0);
     let mut chars = source_text.chars().peekable();
     while let Some(ch) = chars.next() {
-        let can_parse = !(in_braces || in_backtick);
+        let can_parse = !(in_braces || in_backticks);
         match ch {
             // NOTE: For now, only odd backtick(s) are handled.
             // - 1 backtick: inline code
@@ -36,7 +36,7 @@ pub fn parse_jsdoc(source_text: &str, jsdoc_span_start: u32) -> (JSDocCommentPar
             // But for now, 4, 6, ... backticks are not handled here to keep things simple...
             '`' => {
                 if chars.peek().map_or(false, |&c| c != '`') {
-                    in_backtick = !in_backtick;
+                    in_backticks = !in_backticks;
                 }
             }
             '{' => in_braces = true,


### PR DESCRIPTION
This PR aims to support these cases.

````js
/**
 * This is normal comment, `@xxx` should not parsed as tag.
 *
 * @example ```ts
    // @comment
    @decoratorInComment
    class Foo { }
   ```
 */
````

Only `@example` should be parsed as tag.

