### PR TITLE
refactor: remove redundant imports to fix some of clippy warnings.

### DIFF
--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -1,5 +1,5 @@
 use ignore::gitignore::Gitignore;
-use std::{env, io::BufWriter, time::Instant, vec::Vec};
+use std::{env, io::BufWriter, time::Instant};
 
 use oxc_diagnostics::{DiagnosticService, GraphicalReportHandler};
 use oxc_linter::{

--- a/tasks/coverage/src/suite.rs
+++ b/tasks/coverage/src/suite.rs
@@ -5,7 +5,6 @@ use std::{
     panic::UnwindSafe,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    result::Result,
 };
 
 use console::Style;


### PR DESCRIPTION
These are raising warnings in nightly, And are in fact redundant.