### PR TITLE
feat(linter): no barrel file.

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -333,6 +333,7 @@ mod oxc {
     pub mod erasing_op;
     pub mod misrefactored_assign_op;
     pub mod no_accumulating_spread;
+    pub mod no_barrel_file;
     pub mod only_used_in_recursion;
 }
 
@@ -671,6 +672,7 @@ oxc_macros::declare_all_lint_rules! {
     oxc::erasing_op,
     oxc::misrefactored_assign_op,
     oxc::no_accumulating_spread,
+    oxc::no_barrel_file,
     oxc::only_used_in_recursion,
     nextjs::google_font_display,
     nextjs::google_font_preconnect,

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -76,18 +76,29 @@ fn test() {
         r#"export type * from "foo";"#,
         r#"export type { foo } from "foo";"#,
         r#"export type * from "foo";
-           export type { bar } from bar;"#,
+           export type { bar } from "bar";"#,
+        r#"import { foo, bar, baz } from "../feature";
+           export { foo };
+           export { bar };"#,
     ];
 
     let fail = vec![
         r#"export * from "foo";
-           export * from "bar";"#,
+           export * from "bar";
+           export * from "baz";
+           export * from "qux";"#,
         r#"export { foo } from "foo";
-           export { bar } from "bar";"#,
-        r#"export { default as module1 } from "./module1";"#,
-        r#"export { foo, type Bar } from "foo";"#,
-        r#"import { foo, bar, baz } from "../feature";
-           export { foo, bar, baz };"#,
+           export { bar } from "bar";
+           export { baz } from "baz";
+           export { qux } from "qux";"#,
+        r#"export { default as module1 } from "./module1";
+           export { default as module2 } from "./module2";
+           export { default as module3 } from "./module3";
+           export { default as module4 } from "./module4";"#,
+        r#"export { foo, type Foo } from "foo";
+           export { bar, type Bar } from "bar";
+           export { baz, type Baz } from "baz";
+           export { qux, type Qux } from "qux";"#,
     ];
 
     Tester::new(NoBarrelFile::NAME, pass, fail)

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -1,0 +1,97 @@
+use oxc_ast::{ast::Statement, AstKind};
+use oxc_diagnostics::{
+    miette::{self, Diagnostic},
+    thiserror::Error,
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "eslint-plugin-import(no-barrel-file): \
+            Avoid barrel files, they slow down performance, \
+            and cause large module graphs with modules that go unused."
+)]
+#[diagnostic(severity(warning), help("For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>"))]
+struct NoBarrelFileDiagnostic(#[label] pub Span);
+
+/// Minimum amount of exports to consider module as barrelfile
+const AMOUNT_OF_EXPORTS_TO_CONSIDER_MODULE_AS_BARREL: u8 = 3;
+
+/// <https://github.com/thepassle/eslint-plugin-barrel-files/blob/main/docs/rules/avoid-barrel-files.md>
+#[derive(Debug, Default, Clone)]
+pub struct NoBarrelFile;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow the use of barrel files.
+    ///
+    /// ### Example
+    ///
+    /// Invalid:
+    /// ```javascript
+    /// export { foo } from 'foo';
+    /// export { bar } from 'bar';
+    /// export { baz } from 'baz';
+    /// export { qux } from 'qux';
+    /// ```
+    /// Valid:
+    /// ```javascript
+    /// export type { foo } from './foo.js';
+    /// ```
+    NoBarrelFile,
+    nursery
+);
+
+impl Rule for NoBarrelFile {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let semantic = ctx.semantic();
+        let mod_rec = semantic.module_record();
+        let root = semantic.nodes().root_node();
+
+        let AstKind::Program(program) = root.kind() else { unreachable!() };
+
+        let declarations = program.body.iter().fold(0, |acc, node| match node {
+            Statement::Declaration(_) => acc + 1,
+            _ => acc,
+        });
+        let exports = mod_rec.star_export_entries.len() + mod_rec.indirect_export_entries.len();
+
+        if exports > declarations
+            && exports > AMOUNT_OF_EXPORTS_TO_CONSIDER_MODULE_AS_BARREL as usize
+        {
+            ctx.diagnostic(NoBarrelFileDiagnostic(program.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"export type * from "foo";"#,
+        r#"export type { foo } from "foo";"#,
+        r#"export type * from "foo";
+           export type { bar } from bar;"#,
+    ];
+
+    let fail = vec![
+        r#"export * from "foo";
+           export * from "bar";"#,
+        r#"export { foo } from "foo";
+           export { bar } from "bar";"#,
+        r#"export { default as module1 } from "./module1";"#,
+        r#"export { foo, type Bar } from "foo";"#,
+        r#"import { foo, bar, baz } from "../feature";
+           export { foo, bar, baz };"#,
+    ];
+
+    Tester::new(NoBarrelFile::NAME, pass, fail)
+        .change_rule_path("index.ts")
+        .with_import_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -10,7 +10,7 @@ use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Error, Diagnostic)]
 #[error(
-    "eslint-plugin-import(no-barrel-file): \
+    "oxc(no-barrel-file): \
             Avoid barrel files, they slow down performance, \
             and cause large module graphs with modules that go unused."
 )]

--- a/crates/oxc_linter/src/snapshots/no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/no_barrel_file.snap
@@ -3,29 +3,37 @@ source: crates/oxc_linter/src/tester.rs
 expression: no_barrel_file
 ---
   ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
-   ╭─[index.js:1:1]
+   ╭─[index.ts:1:1]
  1 │ ╭─▶ export * from "foo";
- 2 │ ╰─▶            export * from "bar";
+ 2 │ │              export * from "bar";
+ 3 │ │              export * from "baz";
+ 4 │ ╰─▶            export * from "qux";
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
   ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
-   ╭─[index.js:1:1]
+   ╭─[index.ts:1:1]
  1 │ ╭─▶ export { foo } from "foo";
- 2 │ ╰─▶            export { bar } from "bar";
+ 2 │ │              export { bar } from "bar";
+ 3 │ │              export { baz } from "baz";
+ 4 │ ╰─▶            export { qux } from "qux";
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
   ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
-   ╭─[index.js:1:1]
- 1 │ export { default as module1 } from "./module1";
-   · ───────────────────────────────────────────────
+   ╭─[index.ts:1:1]
+ 1 │ ╭─▶ export { default as module1 } from "./module1";
+ 2 │ │              export { default as module2 } from "./module2";
+ 3 │ │              export { default as module3 } from "./module3";
+ 4 │ ╰─▶            export { default as module4 } from "./module4";
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
   ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
-   ╭─[index.js:1:1]
- 1 │ ╭─▶ import { foo, bar, baz } from "../feature";
- 2 │ ╰─▶            export { foo, bar, baz };
+   ╭─[index.ts:1:1]
+ 1 │ ╭─▶ export { foo, type Foo } from "foo";
+ 2 │ │              export { bar, type Bar } from "bar";
+ 3 │ │              export { baz, type Baz } from "baz";
+ 4 │ ╰─▶            export { qux, type Qux } from "qux";
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>

--- a/crates/oxc_linter/src/snapshots/no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/no_barrel_file.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_barrel_file
+---
+  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[index.js:1:1]
+ 1 │ ╭─▶ export * from "foo";
+ 2 │ ╰─▶            export * from "bar";
+   ╰────
+  help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
+
+  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[index.js:1:1]
+ 1 │ ╭─▶ export { foo } from "foo";
+ 2 │ ╰─▶            export { bar } from "bar";
+   ╰────
+  help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
+
+  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[index.js:1:1]
+ 1 │ export { default as module1 } from "./module1";
+   · ───────────────────────────────────────────────
+   ╰────
+  help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
+
+  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[index.js:1:1]
+ 1 │ ╭─▶ import { foo, bar, baz } from "../feature";
+ 2 │ ╰─▶            export { foo, bar, baz };
+   ╰────
+  help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>

--- a/crates/oxc_linter/src/snapshots/no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/no_barrel_file.snap
@@ -3,15 +3,17 @@ source: crates/oxc_linter/src/tester.rs
 expression: no_barrel_file
 ---
   ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  │ Loading this barrel file results in importing 4 modules.
    ╭─[index.ts:1:1]
- 1 │ ╭─▶ export * from "foo";
- 2 │ │              export * from "bar";
- 3 │ │              export * from "baz";
- 4 │ ╰─▶            export * from "qux";
+ 1 │ ╭─▶ export * from "./deep/a.js";
+ 2 │ │              export * from "./deep/b.js";
+ 3 │ │              export * from "./deep/c.js";
+ 4 │ ╰─▶            export * from "./deep/d.js";
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
   ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  │ Loading this barrel file results in importing 0 modules.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export { foo } from "foo";
  2 │ │              export { bar } from "bar";
@@ -21,6 +23,7 @@ expression: no_barrel_file
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
   ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  │ Loading this barrel file results in importing 0 modules.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export { default as module1 } from "./module1";
  2 │ │              export { default as module2 } from "./module2";
@@ -30,6 +33,7 @@ expression: no_barrel_file
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
   ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  │ Loading this barrel file results in importing 0 modules.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export { foo, type Foo } from "foo";
  2 │ │              export { bar, type Bar } from "bar";

--- a/crates/oxc_linter/src/snapshots/no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/no_barrel_file.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 expression: no_barrel_file
 ---
-  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export * from "foo";
  2 │ │              export * from "bar";
@@ -11,7 +11,7 @@ expression: no_barrel_file
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
-  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export { foo } from "foo";
  2 │ │              export { bar } from "bar";
@@ -20,7 +20,7 @@ expression: no_barrel_file
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
-  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export { default as module1 } from "./module1";
  2 │ │              export { default as module2 } from "./module2";
@@ -29,7 +29,7 @@ expression: no_barrel_file
    ╰────
   help: For more information visit this link: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/>
 
-  ⚠ eslint-plugin-import(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+  ⚠ oxc(no-barrel-file): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
    ╭─[index.ts:1:1]
  1 │ ╭─▶ export { foo, type Foo } from "foo";
  2 │ │              export { bar, type Bar } from "bar";


### PR DESCRIPTION
closes #3004 

I've based it on [this plugin](https://github.com/thepassle/eslint-plugin-barrel-files/blob/main/lib/rules/avoid-barrel-files.js) instead of [biome](https://github.com/biomejs/biome/blob/4130ff0e4c56c4944236b11f2b4f34ca6e8ca03a/crates/biome_js_analyze/src/lint/performance/no_barrel_file.rs#L70) Since the original plugin is less likely to detect a false positive.

I didn't understand your statement [here](https://github.com/oxc-project/oxc/issues/3004#issue-2245574895), Where you've mentioned:

> In oxlint, we can do better when --import-plugin is enabled, by displaying the total number of dependencies pulled into a given file by walking

I would appreciate it if you expand upon it.

------

#### Edit:

I've added it under `eslint-plugin-import` even though it is not; I wasn't sure If I should create a whole new category for this single rule, It is a different story if we would like to adopt the other rules in [here](https://github.com/thepassle/eslint-plugin-barrel-files/tree/main/lib/rules).

Also, check my diagnosis messages; It is my first contribution to the linters so I'm just not familiar enough with the conventions of messages, rules, etc.