### PR TITLE
feat(semantic):  add root node to the `AstNodes` structure.

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -202,7 +202,7 @@ impl<'a> SemanticBuilder<'a> {
             #[allow(unsafe_code)]
             // SAFETY: `ast_node` is a `Program` and hence the root of the tree.
             unsafe {
-                self.nodes.set_root(&ast_node)
+                self.nodes.set_root(&ast_node);
             }
             id
         } else {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -117,7 +117,7 @@ impl<'a> AstNodes<'a> {
     /// Set the root node,
     /// SAFETY:
     /// The root `AstNode` should always point to a `Program` and this should be the real root of
-    /// the tree, It isn't possible to staticly check for this so user should think about it before
+    /// the tree, It isn't possible to statically check for this so user should think about it before
     /// using.
     #[allow(unsafe_code)]
     pub(super) unsafe fn set_root(&mut self, root: &AstNode<'a>) {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -54,10 +54,21 @@ impl<'a> AstNode<'a> {
 }
 
 /// Untyped AST nodes flattened into an vec
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AstNodes<'a> {
+    root: AstNodeId,
     nodes: IndexVec<AstNodeId, AstNode<'a>>,
     parent_ids: IndexVec<AstNodeId, Option<AstNodeId>>,
+}
+
+impl<'a> Default for AstNodes<'a> {
+    fn default() -> Self {
+        Self {
+            root: AstNodeId::new(0),
+            nodes: IndexVec::default(),
+            parent_ids: IndexVec::default(),
+        }
+    }
 }
 
 impl<'a> AstNodes<'a> {
@@ -96,6 +107,36 @@ impl<'a> AstNodes<'a> {
 
     pub fn get_node_mut(&mut self, ast_node_id: AstNodeId) -> &mut AstNode<'a> {
         &mut self.nodes[ast_node_id]
+    }
+
+    /// Get the root `AstNodeId`, It is always pointing to a `Program`.
+    pub fn root(&self) -> AstNodeId {
+        self.root
+    }
+
+    /// Set the root node,
+    /// SAFETY:
+    /// The root `AstNode` should always point to a `Program` and this should be the real root of
+    /// the tree, It isn't possible to staticly check for this so user should think about it before
+    /// using.
+    #[allow(unsafe_code)]
+    pub(super) unsafe fn set_root(&mut self, root: &AstNode<'a>) {
+        match root.kind() {
+            AstKind::Program(_) => {
+                self.root = root.id();
+            }
+            _ => unreachable!("Expected a `Program` node as the root of the tree."),
+        }
+    }
+
+    /// Get the root node as immutable reference, It is always guaranteed to be a `Program`.
+    pub fn root_node(&self) -> &AstNode<'a> {
+        self.get_node(self.root())
+    }
+
+    /// Get the root node as mutable reference, It is always guaranteed to be a `Program`.
+    pub fn root_node_mut(&mut self) -> &mut AstNode<'a> {
+        self.get_node_mut(self.root())
     }
 
     /// Walk up the AST, iterating over each parent node.


### PR DESCRIPTION
Adds a way to fetch the root node without iterating over all ancestors which has a nondeterministic time - best case O(1) worst case O(n!) - It is only possible to set this field in the semantic builder.