### PR TITLE
perf(ast): reduce indirection in AST types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2025,7 +2025,7 @@ pub struct Class<'a> {
     pub body: Box<'a, ClassBody<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub super_type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-    pub implements: Option<Vec<'a, Box<'a, TSClassImplements<'a>>>>,
+    pub implements: Option<Vec<'a, TSClassImplements<'a>>>,
     pub decorators: Vec<'a, Decorator<'a>>,
     /// Valid Modifiers: `export`, `abstract`
     pub modifiers: Modifiers<'a>,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -504,7 +504,7 @@ pub struct TSTypeParameter<'a> {
 pub struct TSTypeParameterDeclaration<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub params: Vec<'a, Box<'a, TSTypeParameter<'a>>>,
+    pub params: Vec<'a, TSTypeParameter<'a>>,
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -551,7 +551,7 @@ pub struct TSInterfaceDeclaration<'a> {
     pub id: BindingIdentifier<'a>,
     pub body: Box<'a, TSInterfaceBody<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-    pub extends: Option<Vec<'a, Box<'a, TSInterfaceHeritage<'a>>>>,
+    pub extends: Option<Vec<'a, TSInterfaceHeritage<'a>>>,
     /// Valid Modifiers: `export`, `default`, `declare`
     pub modifiers: Modifiers<'a>,
 }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -595,7 +595,7 @@ pub enum TSSignature<'a> {
 pub struct TSIndexSignature<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub parameters: Vec<'a, Box<'a, TSIndexSignatureName<'a>>>,
+    pub parameters: Vec<'a, TSIndexSignatureName<'a>>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
     pub readonly: bool,
 }

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1451,10 +1451,12 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_interface_heritages(
         &self,
         extends: Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>,
-    ) -> Vec<'a, Box<'a, TSInterfaceHeritage<'a>>> {
+    ) -> Vec<'a, TSInterfaceHeritage<'a>> {
         Vec::from_iter_in(
-            extends.into_iter().map(|(expression, type_parameters, span)| {
-                self.alloc(TSInterfaceHeritage { span, expression, type_parameters })
+            extends.into_iter().map(|(expression, type_parameters, span)| TSInterfaceHeritage {
+                span,
+                expression,
+                type_parameters,
             }),
             self.allocator,
         )
@@ -1635,7 +1637,7 @@ impl<'a> AstBuilder<'a> {
         id: BindingIdentifier<'a>,
         body: Box<'a, TSInterfaceBody<'a>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-        extends: Option<Vec<'a, Box<'a, TSInterfaceHeritage<'a>>>>,
+        extends: Option<Vec<'a, TSInterfaceHeritage<'a>>>,
         modifiers: Modifiers<'a>,
     ) -> Declaration<'a> {
         Declaration::TSInterfaceDeclaration(self.alloc(TSInterfaceDeclaration {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1473,7 +1473,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_index_signature(
         &self,
         span: Span,
-        parameters: Vec<'a, Box<'a, TSIndexSignatureName<'a>>>,
+        parameters: Vec<'a, TSIndexSignatureName<'a>>,
         type_annotation: Box<'a, TSTypeAnnotation<'a>>,
         readonly: bool,
     ) -> TSSignature<'a> {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1436,14 +1436,14 @@ impl<'a> AstBuilder<'a> {
         r#in: bool,
         out: bool,
         r#const: bool,
-    ) -> Box<'a, TSTypeParameter<'a>> {
-        self.alloc(TSTypeParameter { span, name, constraint, default, r#in, out, r#const })
+    ) -> TSTypeParameter<'a> {
+        TSTypeParameter { span, name, constraint, default, r#in, out, r#const }
     }
 
     pub fn ts_type_parameters(
         &self,
         span: Span,
-        params: Vec<'a, Box<'a, TSTypeParameter<'a>>>,
+        params: Vec<'a, TSTypeParameter<'a>>,
     ) -> Box<'a, TSTypeParameterDeclaration<'a>> {
         self.alloc(TSTypeParameterDeclaration { span, params })
     }

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -944,7 +944,7 @@ impl<'a> AstBuilder<'a> {
         body: Box<'a, ClassBody<'a>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
         super_type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-        implements: Option<Vec<'a, Box<'a, TSClassImplements<'a>>>>,
+        implements: Option<Vec<'a, TSClassImplements<'a>>>,
         decorators: Vec<'a, Decorator<'a>>,
         modifiers: Modifiers<'a>,
     ) -> Box<'a, Class<'a>> {
@@ -1423,8 +1423,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: TSTypeName<'a>,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-    ) -> Box<'a, TSClassImplements<'a>> {
-        self.alloc(TSClassImplements { span, expression, type_parameters })
+    ) -> TSClassImplements<'a> {
+        TSClassImplements { span, expression, type_parameters }
     }
 
     pub fn ts_type_parameter(

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -9,7 +9,7 @@ use crate::{diagnostics, lexer::Kind, list::NormalList, ParserImpl, StatementCon
 type Extends<'a> =
     Vec<'a, (Expression<'a>, Option<Box<'a, TSTypeParameterInstantiation<'a>>>, Span)>;
 
-type Implements<'a> = Vec<'a, Box<'a, TSClassImplements<'a>>>;
+type Implements<'a> = Vec<'a, TSClassImplements<'a>>;
 
 /// Section 15.7 Class Definitions
 impl<'a> ParserImpl<'a> {

--- a/crates/oxc_parser/src/ts/list.rs
+++ b/crates/oxc_parser/src/ts/list.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_diagnostics::Result;
 
@@ -103,7 +103,7 @@ impl<'a> SeparatedList<'a> for TSTupleElementList<'a> {
 }
 
 pub struct TSTypeParameterList<'a> {
-    pub params: Vec<'a, Box<'a, TSTypeParameter<'a>>>,
+    pub params: Vec<'a, TSTypeParameter<'a>>,
 }
 
 impl<'a> SeparatedList<'a> for TSTypeParameterList<'a> {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -150,7 +150,7 @@ impl<'a> ParserImpl<'a> {
         Ok(implements)
     }
 
-    pub(crate) fn parse_ts_type_parameter(&mut self) -> Result<Box<'a, TSTypeParameter<'a>>> {
+    pub(crate) fn parse_ts_type_parameter(&mut self) -> Result<TSTypeParameter<'a>> {
         let span = self.start_span();
 
         let mut r#in = false;
@@ -632,7 +632,7 @@ impl<'a> ParserImpl<'a> {
         let name = self.parse_binding_identifier()?;
         self.expect(Kind::In)?;
         let constraint = self.parse_ts_type()?;
-        let type_parameter = self.ast.ts_type_parameter(
+        let type_parameter = self.ast.alloc(self.ast.ts_type_parameter(
             self.end_span(type_parameter_span),
             name,
             Some(constraint),
@@ -640,7 +640,7 @@ impl<'a> ParserImpl<'a> {
             false,
             false,
             false,
-        );
+        ));
 
         let name_type = if self.eat(Kind::As) { Some(self.parse_ts_type()?) } else { None };
         self.expect(Kind::RBrack)?;
@@ -854,7 +854,7 @@ impl<'a> ParserImpl<'a> {
 
         let constraint = self.try_parse(ParserImpl::parse_constraint_of_infer_type).unwrap_or(None);
 
-        let type_parameter = self.ast.ts_type_parameter(
+        let type_parameter = self.ast.alloc(self.ast.ts_type_parameter(
             self.end_span(parameter_span),
             name,
             constraint,
@@ -862,7 +862,7 @@ impl<'a> ParserImpl<'a> {
             false,
             false,
             false,
-        );
+        ));
 
         Ok(self.ast.ts_infer_type(self.end_span(span), type_parameter))
     }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1110,7 +1110,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_ts_index_signature_name(&mut self) -> Result<Box<'a, TSIndexSignatureName<'a>>> {
+    fn parse_ts_index_signature_name(&mut self) -> Result<TSIndexSignatureName<'a>> {
         let span = self.start_span();
         let name = self.parse_identifier_name()?.name;
         let type_annotation = self.parse_ts_type_annotation()?;
@@ -1119,11 +1119,11 @@ impl<'a> ParserImpl<'a> {
             return Err(self.unexpected());
         }
 
-        Ok(self.ast.alloc(TSIndexSignatureName {
+        Ok(TSIndexSignatureName {
             span: self.end_span(span),
             name,
             type_annotation: type_annotation.unwrap(),
-        }))
+        })
     }
 
     pub(crate) fn parse_class_element_modifiers(

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -137,9 +137,7 @@ impl<'a> ParserImpl<'a> {
         Ok(Some(self.ast.ts_type_parameters(self.end_span(span), params)))
     }
 
-    pub(crate) fn parse_ts_implements_clause(
-        &mut self,
-    ) -> Result<Vec<'a, Box<'a, TSClassImplements<'a>>>> {
+    pub(crate) fn parse_ts_implements_clause(&mut self) -> Result<Vec<'a, TSClassImplements<'a>>> {
         self.expect(Kind::Implements)?;
         let first = self.parse_ts_implement_name()?;
         let mut implements = self.ast.new_vec();
@@ -483,7 +481,7 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.ts_type_reference(self.end_span(span), type_name, type_parameters))
     }
 
-    fn parse_ts_implement_name(&mut self) -> Result<Box<'a, TSClassImplements<'a>>> {
+    fn parse_ts_implement_name(&mut self) -> Result<TSClassImplements<'a>> {
         let span = self.start_span();
         let expression = self.parse_ts_type_name()?;
         let type_parameters =


### PR DESCRIPTION
Fixes #3048.

No apparent change on benchmarks. Likely these TS features are not much used in the benchmark fixtures.