### PR TITLE
refactor(bench): reuse allocator in parser + lexer benchmarks

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{convert::From, ops::Deref};
+use std::{
+    convert::From,
+    ops::{Deref, DerefMut},
+};
 
 mod arena;
 
@@ -21,6 +24,12 @@ impl Deref for Allocator {
 
     fn deref(&self) -> &Self::Target {
         &self.bump
+    }
+}
+
+impl DerefMut for Allocator {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.bump
     }
 }
 

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -27,14 +27,14 @@ fn bench_lexer(criterion: &mut Criterion) {
             BenchmarkId::from_parameter(&file.file_name),
             &file.source_text,
             |b, source_text| {
-                b.iter_with_large_drop(|| {
-                    // Include the allocator drop time to make time measurement consistent.
-                    // Otherwise the allocator will allocate huge memory chunks (by power of two) from the
-                    // system allocator, which makes time measurement unequal during long runs.
-                    let allocator = Allocator::default();
+                // Do not include initializing allocator in benchmark.
+                // User code would likely reuse the same allocator over and over to parse multiple files,
+                // so we do the same here.
+                let mut allocator = Allocator::default();
+                b.iter(|| {
                     let mut lexer = Lexer::new_for_benchmarks(&allocator, source_text, source_type);
                     while lexer.next_token().kind != Kind::Eof {}
-                    allocator
+                    allocator.reset();
                 });
             },
         );

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -12,13 +12,13 @@ fn bench_parser(criterion: &mut Criterion) {
             BenchmarkId::from_parameter(&file.file_name),
             &file.source_text,
             |b, source_text| {
-                b.iter_with_large_drop(|| {
-                    // Include the allocator drop time to make time measurement consistent.
-                    // Otherwise the allocator will allocate huge memory chunks (by power of two) from the
-                    // system allocator, which makes time measurement unequal during long runs.
-                    let allocator = Allocator::default();
-                    _ = Parser::new(&allocator, source_text, source_type).parse();
-                    allocator
+                // Do not include initializing allocator in benchmark.
+                // User code would likely reuse the same allocator over and over to parse multiple files,
+                // so we do the same here.
+                let mut allocator = Allocator::default();
+                b.iter(|| {
+                    Parser::new(&allocator, source_text, source_type).parse();
+                    allocator.reset();
                 });
             },
         );


### PR DESCRIPTION
Re-use allocator in parser + lexer benchmarks.

I believe this is the recommended usage when parsing a bunch of files - to re-use one allocator rather than create a fresh one for each run, so it makes sense to me that this is what the benchmark should measure.

Doesn't show much difference on CodSpeed because it only runs the benchmark once, and it treats allocations as free anyway. But I imagine the difference may show up a bit more in a standard criterion benchmark.