### PR TITLE
refactor(bench): minifier benchmark don't include parse time

### DIFF
--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -15,12 +15,11 @@ fn bench_minifier(criterion: &mut Criterion) {
             &file.source_text,
             |b, source_text| {
                 let options = MinifierOptions::default();
-                b.iter_with_large_drop(|| {
-                    let allocator = Allocator::default();
-                    let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                    let program = allocator.alloc(program);
+                let allocator = Allocator::default();
+                let program = Parser::new(&allocator, source_text, source_type).parse().program;
+                let program = allocator.alloc(program);
+                b.iter(|| {
                     Minifier::new(options).build(&allocator, program);
-                    allocator
                 });
             },
         );


### PR DESCRIPTION
Was trying to get benchmark to measure minify time only, without parse. But cannot figure out the lifetimes to make it work.