### PR TITLE
refactor(bench): prettier benchmark don't include parse time + reuse allocator

### DIFF
--- a/tasks/benchmark/benches/prettier.rs
+++ b/tasks/benchmark/benches/prettier.rs
@@ -13,10 +13,10 @@ fn bench_prettier(criterion: &mut Criterion) {
             BenchmarkId::from_parameter(&file.file_name),
             &file.source_text,
             |b, source_text| {
+                let allocator1 = Allocator::default();
+                let mut allocator2 = Allocator::default();
+                let ret = Parser::new(&allocator1, source_text, source_type).parse();
                 b.iter(|| {
-                    let allocator1 = Allocator::default();
-                    let allocator2 = Allocator::default();
-                    let ret = Parser::new(&allocator1, source_text, source_type).parse();
                     let _ = Prettier::new(
                         &allocator2,
                         source_text,
@@ -24,6 +24,7 @@ fn bench_prettier(criterion: &mut Criterion) {
                         PrettierOptions::default(),
                     )
                     .build(&ret.program);
+                    allocator2.reset();
                 });
             },
         );


### PR DESCRIPTION
Was trying to get benchmark to measure prettify time only, without parse. But cannot figure out the lifetimes to make it work.