### PR TITLE
perf(ast): box `ImportDeclarationSpecifier` enum variants

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2373,11 +2373,11 @@ pub struct ImportDeclaration<'a> {
 pub enum ImportDeclarationSpecifier<'a> {
     /// import {imported} from "source"
     /// import {imported as local} from "source"
-    ImportSpecifier(ImportSpecifier<'a>),
+    ImportSpecifier(Box<'a, ImportSpecifier<'a>>),
     /// import local from "source"
-    ImportDefaultSpecifier(ImportDefaultSpecifier<'a>),
+    ImportDefaultSpecifier(Box<'a, ImportDefaultSpecifier<'a>>),
     /// import * as local from "source"
-    ImportNamespaceSpecifier(ImportNamespaceSpecifier<'a>),
+    ImportNamespaceSpecifier(Box<'a, ImportNamespaceSpecifier<'a>>),
 }
 
 // import {imported} from "source"

--- a/crates/oxc_transformer/src/helpers/module_imports.rs
+++ b/crates/oxc_transformer/src/helpers/module_imports.rs
@@ -85,7 +85,7 @@ impl<'a> ModuleImports<'a> {
         names: std::vec::Vec<NamedImport>,
     ) -> Statement<'a> {
         let specifiers = self.ast.new_vec_from_iter(names.into_iter().map(|name| {
-            ImportDeclarationSpecifier::ImportSpecifier(ImportSpecifier {
+            ImportDeclarationSpecifier::ImportSpecifier(self.ast.alloc(ImportSpecifier {
                 span: SPAN,
                 imported: ModuleExportName::Identifier(IdentifierName::new(
                     SPAN,
@@ -96,7 +96,7 @@ impl<'a> ModuleImports<'a> {
                     self.ast.new_atom(name.local.unwrap_or(name.imported).as_str()),
                 ),
                 import_kind: ImportOrExportKind::Value,
-            })
+            }))
         }));
         let import_stmt = self.ast.import_declaration(
             SPAN,


### PR DESCRIPTION
Part of #3047.

As with #3058, it's hard to interpret the benchmark results here. But in this case I think it's easier to see from "first principles" that this should be an improvement - `ImportSpecifier` is pretty massive (80 bytes) vs `ImportDefaultSpecifier` (40 bytes), and the latter (e.g. `import React from 'react'`) is common in JS code.