### PR TITLE
perf(ast): box typescript enum variants.

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -67,7 +67,7 @@ pub enum TSEnumMemberName<'a> {
     Identifier(Box<'a, IdentifierName<'a>>),
     StringLiteral(Box<'a, StringLiteral<'a>>),
     // Invalid Grammar `enum E { [computed] }`
-    ComputedPropertyName(Box<'a, Expression<'a>>),
+    ComputedPropertyName(Expression<'a>),
     // Invalid Grammar `enum E { 1 }`
     NumericLiteral(Box<'a, NumericLiteral<'a>>),
 }
@@ -934,7 +934,7 @@ pub struct TSImportEqualsDeclaration<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged, rename_all = "camelCase"))]
 pub enum TSModuleReference<'a> {
-    TypeName(Box<'a, TSTypeName<'a>>),
+    TypeName(TSTypeName<'a>),
     ExternalModuleReference(Box<'a, TSExternalModuleReference<'a>>),
 }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -64,12 +64,12 @@ pub struct TSEnumMember<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TSEnumMemberName<'a> {
-    Identifier(IdentifierName<'a>),
-    StringLiteral(StringLiteral<'a>),
+    Identifier(Box<'a, IdentifierName<'a>>),
+    StringLiteral(Box<'a, StringLiteral<'a>>),
     // Invalid Grammar `enum E { [computed] }`
-    ComputedPropertyName(Expression<'a>),
+    ComputedPropertyName(Box<'a, Expression<'a>>),
     // Invalid Grammar `enum E { 1 }`
-    NumericLiteral(NumericLiteral<'a>),
+    NumericLiteral(Box<'a, NumericLiteral<'a>>),
 }
 
 #[derive(Debug, Hash)]
@@ -686,7 +686,7 @@ pub struct TSTypePredicate<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged, rename_all = "camelCase"))]
 pub enum TSTypePredicateName<'a> {
-    Identifier(IdentifierName<'a>),
+    Identifier(Box<'a, IdentifierName<'a>>),
     This(TSThisType),
 }
 
@@ -788,7 +788,7 @@ pub struct TSTypeQuery<'a> {
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum TSTypeQueryExprName<'a> {
     TSTypeName(TSTypeName<'a>),
-    TSImportType(TSImportType<'a>),
+    TSImportType(Box<'a, TSImportType<'a>>),
 }
 
 #[derive(Debug, Hash)]
@@ -926,7 +926,7 @@ pub struct TSImportEqualsDeclaration<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
     pub id: BindingIdentifier<'a>,
-    pub module_reference: Box<'a, TSModuleReference<'a>>,
+    pub module_reference: TSModuleReference<'a>,
     pub import_kind: ImportOrExportKind,
 }
 
@@ -934,8 +934,8 @@ pub struct TSImportEqualsDeclaration<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged, rename_all = "camelCase"))]
 pub enum TSModuleReference<'a> {
-    TypeName(TSTypeName<'a>),
-    ExternalModuleReference(TSExternalModuleReference<'a>),
+    TypeName(Box<'a, TSTypeName<'a>>),
+    ExternalModuleReference(Box<'a, TSExternalModuleReference<'a>>),
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1624,7 +1624,7 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSImportEqualsDeclaration(self.alloc(TSImportEqualsDeclaration {
             span,
             id,
-            module_reference: self.alloc(module_reference),
+            module_reference,
             import_kind,
         }))
     }
@@ -1862,6 +1862,70 @@ impl<'a> AstBuilder<'a> {
             asserts,
             type_annotation,
         }))
+    }
+
+    pub fn ts_enum_member_name_identifier(
+        &self,
+        ident: IdentifierName<'a>,
+    ) -> TSEnumMemberName<'a> {
+        TSEnumMemberName::Identifier(self.alloc(ident))
+    }
+
+    pub fn ts_enum_member_name_string_literal(
+        &self,
+        lit: StringLiteral<'a>,
+    ) -> TSEnumMemberName<'a> {
+        TSEnumMemberName::StringLiteral(self.alloc(lit))
+    }
+
+    pub fn ts_enum_member_name_computed_property_name(
+        &self,
+        expr: Expression<'a>,
+    ) -> TSEnumMemberName<'a> {
+        TSEnumMemberName::ComputedPropertyName(self.alloc(expr))
+    }
+
+    pub fn ts_enum_member_name_number_literal(
+        &self,
+        lit: NumericLiteral<'a>,
+    ) -> TSEnumMemberName<'a> {
+        TSEnumMemberName::NumericLiteral(self.alloc(lit))
+    }
+
+    pub fn ts_module_reference_external_module_reference(
+        &self,
+        reference: TSExternalModuleReference<'a>,
+    ) -> TSModuleReference<'a> {
+        TSModuleReference::ExternalModuleReference(self.alloc(reference))
+    }
+
+    pub fn ts_module_reference_type_name(
+        &self,
+        reference: TSTypeName<'a>,
+    ) -> TSModuleReference<'a> {
+        TSModuleReference::TypeName(self.alloc(reference))
+    }
+
+    pub fn ts_type_predicate_name_this(&self, ty: TSThisType) -> TSTypePredicateName<'a> {
+        TSTypePredicateName::This(ty)
+    }
+
+    pub fn ts_type_predicate_name_identifier(
+        &self,
+        ident: IdentifierName<'a>,
+    ) -> TSTypePredicateName<'a> {
+        TSTypePredicateName::Identifier(self.alloc(ident))
+    }
+
+    pub fn ts_type_query_expr_name_import_type(
+        &self,
+        ty: TSImportType<'a>,
+    ) -> TSTypeQueryExprName<'a> {
+        TSTypeQueryExprName::TSImportType(self.alloc(ty))
+    }
+
+    pub fn ts_type_query_expr_name_type_name(&self, ty: TSTypeName<'a>) -> TSTypeQueryExprName<'a> {
+        TSTypeQueryExprName::TSTypeName(ty)
     }
 
     /* JSDoc */

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1882,7 +1882,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         expr: Expression<'a>,
     ) -> TSEnumMemberName<'a> {
-        TSEnumMemberName::ComputedPropertyName(self.alloc(expr))
+        TSEnumMemberName::ComputedPropertyName(expr)
     }
 
     pub fn ts_enum_member_name_number_literal(
@@ -1903,7 +1903,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         reference: TSTypeName<'a>,
     ) -> TSModuleReference<'a> {
-        TSModuleReference::TypeName(self.alloc(reference))
+        TSModuleReference::TypeName(reference)
     }
 
     pub fn ts_type_predicate_name_this(&self, ty: TSThisType) -> TSTypePredicateName<'a> {

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -134,7 +134,7 @@ impl Rule for TripleSlashReference {
             for stmt in &program.body {
                 match stmt {
                     Statement::Declaration(Declaration::TSImportEqualsDeclaration(decl)) => {
-                        match *decl.module_reference {
+                        match decl.module_reference {
                             TSModuleReference::ExternalModuleReference(ref mod_ref) => {
                                 if let Some(v) =
                                     refs_for_import.get(mod_ref.expression.value.as_str())

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -51,13 +51,21 @@ impl<'a> ParserImpl<'a> {
     fn parse_ts_enum_member_name(&mut self) -> Result<TSEnumMemberName<'a>> {
         match self.cur_kind() {
             Kind::LBrack => {
-                Ok(TSEnumMemberName::ComputedPropertyName(self.parse_computed_property_name()?))
+                let node = self.parse_computed_property_name()?;
+                Ok(self.ast.ts_enum_member_name_computed_property_name(node))
             }
-            Kind::Str => Ok(TSEnumMemberName::StringLiteral(self.parse_literal_string()?)),
+            Kind::Str => {
+                let node = self.parse_literal_string()?;
+                Ok(self.ast.ts_enum_member_name_string_literal(node))
+            }
             kind if kind.is_number() => {
-                Ok(TSEnumMemberName::NumericLiteral(self.parse_literal_number()?))
+                let node = self.parse_literal_number()?;
+                Ok(self.ast.ts_enum_member_name_number_literal(node))
             }
-            _ => Ok(TSEnumMemberName::Identifier(self.parse_identifier_name()?)),
+            _ => {
+                let node = self.parse_identifier_name()?;
+                Ok(self.ast.ts_enum_member_name_identifier(node))
+            }
         }
     }
 
@@ -374,12 +382,13 @@ impl<'a> ParserImpl<'a> {
             self.expect(Kind::LParen)?;
             let expression = self.parse_literal_string()?;
             self.expect(Kind::RParen)?;
-            TSModuleReference::ExternalModuleReference(TSExternalModuleReference {
+            self.ast.ts_module_reference_external_module_reference(TSExternalModuleReference {
                 span: self.end_span(reference_span),
                 expression,
             })
         } else {
-            TSModuleReference::TypeName(self.parse_ts_type_name()?)
+            let node = self.parse_ts_type_name()?;
+            self.ast.ts_module_reference_type_name(node)
         };
 
         self.asi()?;

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -763,9 +763,11 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.expect(Kind::Typeof)?;
         let expr_name: TSTypeQueryExprName = if self.at(Kind::Import) {
-            TSTypeQueryExprName::TSImportType(self.parse_ts_import_type()?)
+            let node = self.parse_ts_import_type()?;
+            self.ast.ts_type_query_expr_name_import_type(node)
         } else {
-            TSTypeQueryExprName::TSTypeName(self.parse_ts_type_name()?)
+            let node = self.parse_ts_type_name()?;
+            self.ast.ts_type_query_expr_name_type_name(node)
         };
         let type_parameters = self.parse_ts_type_arguments()?;
         Ok(self.ast.ts_type_query_type(self.end_span(span), expr_name, type_parameters))
@@ -902,9 +904,10 @@ impl<'a> ParserImpl<'a> {
         let parameter_name = if self.at(Kind::This) {
             let span = self.start_span();
             self.bump_any();
-            TSTypePredicateName::This(TSThisType { span: self.end_span(span) })
+            self.ast.ts_type_predicate_name_this(TSThisType { span: self.end_span(span) })
         } else {
-            TSTypePredicateName::Identifier(self.parse_identifier_name()?)
+            let node = self.parse_identifier_name()?;
+            self.ast.ts_type_predicate_name_identifier(node)
         };
 
         if !asserts {

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -44,8 +44,10 @@ impl<'a> TypeScript<'a> {
             let binding = self.ctx.ast.binding_pattern(binding_pattern_kind, None, false);
             let decl_span = decl.span;
 
-            let init = match &mut *decl.module_reference {
-                TSModuleReference::TypeName(type_name) => self.transform_ts_type_name(type_name),
+            let init = match &mut decl.module_reference {
+                TSModuleReference::TypeName(type_name) => {
+                    self.transform_ts_type_name(&mut *type_name)
+                }
                 TSModuleReference::ExternalModuleReference(reference) => {
                     if self.ctx.source_type().is_module() {
                         self.ctx.error(ImportEqualsRequireUnsupported(decl_span));


### PR DESCRIPTION
Similar to #3058 and #3061 it is a continuation of #3047.

Handles these enum types:

> TSEnumMemberName
> Variant sizes: 16, 24, 24, 40
> Unboxed variants: IdentifierName (struct), StringLiteral (struct), NumericLiteral (struct)
> Dependents: TSEnumMember (struct)
> => Box all variants.
>
> TSModuleReference 
> Variant sizes: 16, 32
> Unboxed variants: TSExternalModuleReference (struct)
> Dependents: Box<TSModuleReference> in TSImportEqualsDeclaration
> => Box all variants. Replace Box<TSModuleReference> with TSModuleReference in TSImportEqualsDeclaration.
>
> TSTypePredicateName 
> Variant sizes: 8, 24
> Unboxed variants: IdentifierName (struct), TSThisType (struct)
> Dependents: TSTypePredicate (struct)
> => Box Identifier variant. Do not box This variant as only 8 bytes (just contains Span).
>
> TSTypeQueryExprName 
> Variant sizes: 16, 88
> Unboxed variants: TSImportType (struct)
> Dependents: TSTypeQuery (struct)
> => Box TSImportType variant. Do not box TSTypeName variant, as is another enum.
