### PR TITLE
refactor(ast): add array element `Elision` type

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -441,18 +441,20 @@ pub enum ArrayExpressionElement<'a> {
     Expression(Expression<'a>),
     /// Array hole for sparse arrays
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
-    // Serialize as `null`. `serialize_elision` in serialize.rs.
-    #[cfg_attr(
-        feature = "serialize",
-        serde(serialize_with = "ArrayExpressionElement::serialize_elision")
-    )]
-    Elision(Span),
+    Elision(Elision),
 }
 
 impl<'a> ArrayExpressionElement<'a> {
     pub fn is_elision(&self) -> bool {
         matches!(self, Self::Elision(_))
     }
+}
+
+/// Array Expression Elision Element
+/// Serialized as `null` in JSON AST. See `serialize.rs`.
+#[derive(Debug, Clone, Hash)]
+pub struct Elision {
+    pub span: Span,
 }
 
 /// Object Expression

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -98,7 +98,7 @@ ast_kinds! {
     SimpleAssignmentTarget(&'a SimpleAssignmentTarget<'a>),
     AssignmentTargetWithDefault(&'a AssignmentTargetWithDefault<'a>),
     ArrayExpressionElement(&'a ArrayExpressionElement<'a>),
-    Elision(Span),
+    Elision(&'a Elision),
     ExpressionArrayElement(&'a Expression<'a>),
     SpreadElement(&'a SpreadElement<'a>),
     BindingRestElement(&'a BindingRestElement<'a>),
@@ -436,7 +436,7 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::SimpleAssignmentTarget(x) => x.span(),
             Self::AssignmentTargetWithDefault(x) => x.span,
             Self::SpreadElement(x) => x.span,
-            Self::Elision(span) => *span,
+            Self::Elision(x) => x.span,
             Self::ExpressionArrayElement(x) => x.span(),
             Self::BindingRestElement(x) => x.span,
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -4,10 +4,10 @@ use serde::{
 };
 
 use crate::ast::{
-    ArrayAssignmentTarget, ArrayExpressionElement, ArrayPattern, AssignmentTargetMaybeDefault,
-    AssignmentTargetProperty, AssignmentTargetRest, BindingPattern, BindingPatternKind,
-    BindingProperty, BindingRestElement, FormalParameter, FormalParameterKind, FormalParameters,
-    ObjectAssignmentTarget, ObjectPattern, Program, RegExpFlags, TSTypeAnnotation,
+    ArrayAssignmentTarget, ArrayPattern, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
+    AssignmentTargetRest, BindingPattern, BindingPatternKind, BindingProperty, BindingRestElement,
+    Elision, FormalParameter, FormalParameterKind, FormalParameters, ObjectAssignmentTarget,
+    ObjectPattern, Program, RegExpFlags, TSTypeAnnotation,
 };
 use oxc_allocator::{Box, Vec};
 use oxc_span::Span;
@@ -46,12 +46,11 @@ impl Serialize for RegExpFlags {
 }
 
 /// Serialize `ArrayExpressionElement::Elision` variant as `null` in JSON
-impl<'a> ArrayExpressionElement<'a> {
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub(crate) fn serialize_elision<S: Serializer>(
-        _span: &Span,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
+impl Serialize for Elision {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         serializer.serialize_none()
     }
 }

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -239,7 +239,7 @@ impl<'a> GetSpan for ArrayExpressionElement<'a> {
         match self {
             Self::SpreadElement(e) => e.span,
             Self::Expression(expr) => expr.span(),
-            Self::Elision(span) => *span,
+            Self::Elision(elision) => elision.span,
         }
     }
 }

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -5,7 +5,6 @@
 //! * [rustc visitor](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/visit.rs)
 
 use oxc_allocator::Vec;
-use oxc_span::Span;
 use oxc_syntax::scope::ScopeFlags;
 
 use crate::{ast::*, ast_kind::AstKind};
@@ -240,8 +239,8 @@ pub trait Visit<'a>: Sized {
         walk_expression_array_element(self, expr);
     }
 
-    fn visit_elision(&mut self, span: Span) {
-        walk_elision(self, span);
+    fn visit_elision(&mut self, elision: &Elision) {
+        walk_elision(self, elision);
     }
 
     fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'a>) {
@@ -1502,7 +1501,7 @@ pub mod walk {
             ArrayExpressionElement::Expression(expr) => {
                 visitor.visit_expression_array_element(expr);
             }
-            ArrayExpressionElement::Elision(span) => visitor.visit_elision(*span),
+            ArrayExpressionElement::Elision(elision) => visitor.visit_elision(elision),
         }
         visitor.leave_node(kind);
     }
@@ -1531,8 +1530,8 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
-    pub fn walk_elision<'a, V: Visit<'a>>(visitor: &mut V, span: Span) {
-        let kind = AstKind::Elision(span);
+    pub fn walk_elision<'a, V: Visit<'a>>(visitor: &mut V, elision: &Elision) {
+        let kind = AstKind::Elision(visitor.alloc(elision));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -1,7 +1,6 @@
 //! Visit Mut Pattern
 
 use oxc_allocator::Vec;
-use oxc_span::Span;
 use oxc_syntax::scope::ScopeFlags;
 
 use crate::{ast::*, AstType};
@@ -227,8 +226,8 @@ pub trait VisitMut<'a>: Sized {
         walk_expression_array_element_mut(self, expr);
     }
 
-    fn visit_elision(&mut self, span: Span) {
-        walk_elision_mut(self, span);
+    fn visit_elision(&mut self, elision: &mut Elision) {
+        walk_elision_mut(self, elision);
     }
 
     fn visit_assignment_expression(&mut self, expr: &mut AssignmentExpression<'a>) {
@@ -1536,7 +1535,7 @@ pub mod walk_mut {
             ArrayExpressionElement::Expression(expr) => {
                 visitor.visit_expression_array_element(expr);
             }
-            ArrayExpressionElement::Elision(span) => visitor.visit_elision(*span),
+            ArrayExpressionElement::Elision(elision) => visitor.visit_elision(elision),
         }
         visitor.leave_node(kind);
     }
@@ -1571,7 +1570,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
-    pub fn walk_elision_mut<'a, V: VisitMut<'a>>(visitor: &mut V, _span: Span) {
+    pub fn walk_elision_mut<'a, V: VisitMut<'a>>(visitor: &mut V, _elision: &mut Elision) {
         let kind = AstType::Elision;
         visitor.enter_node(kind);
         visitor.leave_node(kind);

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -42,12 +42,12 @@ impl Rule for NoSparseArrays {
                 .elements
                 .iter()
                 .filter_map(|el| match el {
-                    ArrayExpressionElement::Elision(span) => Some(span),
+                    ArrayExpressionElement::Elision(elision) => Some(elision),
                     _ => None,
                 })
-                .map(|span| {
+                .map(|elision| {
                     LabeledSpan::at(
-                        (span.start as usize)..(span.start as usize),
+                        (elision.span.start as usize)..(elision.span.start as usize),
                         "unexpected comma",
                     )
                 })

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -368,7 +368,7 @@ impl<'a> ParserImpl<'a> {
     ///     ,
     ///    Elision ,
     pub(crate) fn parse_elision(&mut self) -> ArrayExpressionElement<'a> {
-        ArrayExpressionElement::Elision(self.cur_token().span())
+        ArrayExpressionElement::Elision(Elision { span: self.cur_token().span() })
     }
 
     /// Section [Template Literal](https://tc39.es/ecma262/#prod-TemplateLiteral)


### PR DESCRIPTION
Pure refactor. This change does nothing except makes it more consistent with other types which are also just a wrapper around `Span` e.g. `NullLiteral` and `TSThisType`.