### PR TITLE
feat(ast): add `callee_name` method to the `CallExpression`.

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -787,6 +787,14 @@ pub struct CallExpression<'a> {
 }
 
 impl<'a> CallExpression<'a> {
+    pub fn callee_name(&self) -> Option<&str> {
+        match &self.callee {
+            Expression::Identifier(ident) => Some(ident.name.as_str()),
+            Expression::MemberExpression(member) => member.static_property_name(),
+            _ => None,
+        }
+    }
+
     pub fn is_require_call(&self) -> bool {
         if self.arguments.len() != 1 {
             return false;


### PR DESCRIPTION
Adds a simple way to get the name of a given `CallExpression`.