### PR TITLE
fix(semantic): allow `root_node` to be empty for empty trees.

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -52,11 +52,11 @@ impl Rule for NoBarrelFile {
     fn run_once(&self, ctx: &LintContext<'_>) {
         let semantic = ctx.semantic();
         let module_record = semantic.module_record();
-        let Some(root) = semantic.nodes().root_node() else {
-            // Return early if the semantic's root node isn't set.
-            // It usually means we are running on an empty or invalid file.
+        let root_id = semantic.nodes().root();
+        if root_id == usize::MAX {
             return;
-        };
+        }
+        let root = semantic.nodes().get_node(root_id);
 
         let AstKind::Program(program) = root.kind() else { unreachable!() };
 

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -52,7 +52,11 @@ impl Rule for NoBarrelFile {
     fn run_once(&self, ctx: &LintContext<'_>) {
         let semantic = ctx.semantic();
         let module_record = semantic.module_record();
-        let Some(root) = ctx.nodes().iter().next() else { return };
+        let Some(root) = semantic.nodes().root_node() else {
+            // Return early if the semantic's root node isn't set.
+            // It usually means we are running on an empty or invalid file.
+            return;
+        };
 
         let AstKind::Program(program) = root.kind() else { unreachable!() };
 

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -54,17 +54,11 @@ impl<'a> AstNode<'a> {
 }
 
 /// Untyped AST nodes flattened into an vec
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AstNodes<'a> {
     root: Option<AstNodeId>,
     nodes: IndexVec<AstNodeId, AstNode<'a>>,
     parent_ids: IndexVec<AstNodeId, Option<AstNodeId>>,
-}
-
-impl<'a> Default for AstNodes<'a> {
-    fn default() -> Self {
-        Self { root: None, nodes: IndexVec::default(), parent_ids: IndexVec::default() }
-    }
 }
 
 impl<'a> AstNodes<'a> {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -56,18 +56,14 @@ impl<'a> AstNode<'a> {
 /// Untyped AST nodes flattened into an vec
 #[derive(Debug)]
 pub struct AstNodes<'a> {
-    root: AstNodeId,
+    root: Option<AstNodeId>,
     nodes: IndexVec<AstNodeId, AstNode<'a>>,
     parent_ids: IndexVec<AstNodeId, Option<AstNodeId>>,
 }
 
 impl<'a> Default for AstNodes<'a> {
     fn default() -> Self {
-        Self {
-            root: AstNodeId::new(0),
-            nodes: IndexVec::default(),
-            parent_ids: IndexVec::default(),
-        }
+        Self { root: None, nodes: IndexVec::default(), parent_ids: IndexVec::default() }
     }
 }
 
@@ -110,7 +106,8 @@ impl<'a> AstNodes<'a> {
     }
 
     /// Get the root `AstNodeId`, It is always pointing to a `Program`.
-    pub fn root(&self) -> AstNodeId {
+    /// Returns `None` if root node isn't set.
+    pub fn root(&self) -> Option<AstNodeId> {
         self.root
     }
 
@@ -123,20 +120,22 @@ impl<'a> AstNodes<'a> {
     pub(super) unsafe fn set_root(&mut self, root: &AstNode<'a>) {
         match root.kind() {
             AstKind::Program(_) => {
-                self.root = root.id();
+                self.root = Some(root.id());
             }
             _ => unreachable!("Expected a `Program` node as the root of the tree."),
         }
     }
 
     /// Get the root node as immutable reference, It is always guaranteed to be a `Program`.
-    pub fn root_node(&self) -> &AstNode<'a> {
-        self.get_node(self.root())
+    /// Returns `None` if root node isn't set.
+    pub fn root_node(&self) -> Option<&AstNode<'a>> {
+        self.root().map(|id| self.get_node(id))
     }
 
     /// Get the root node as mutable reference, It is always guaranteed to be a `Program`.
-    pub fn root_node_mut(&mut self) -> &mut AstNode<'a> {
-        self.get_node_mut(self.root())
+    /// Returns `None` if root node isn't set.
+    pub fn root_node_mut(&mut self) -> Option<&mut AstNode<'a>> {
+        self.root().map(|id| self.get_node_mut(id))
     }
 
     /// Walk up the AST, iterating over each parent node.

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -151,7 +151,6 @@ impl<'a> AstNodes<'a> {
         std::iter::successors(Some(ast_node_id), |node_id| parent_ids[*node_id])
     }
 
-    /// Adds an `AstNode` to the `AstNodes` tree and returns its `AstNodeId`.
     pub fn add_node(&mut self, node: AstNode<'a>, parent_id: Option<AstNodeId>) -> AstNodeId {
         let mut node = node;
         let ast_node_id = self.parent_ids.push(parent_id);

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -54,11 +54,21 @@ impl<'a> AstNode<'a> {
 }
 
 /// Untyped AST nodes flattened into an vec
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AstNodes<'a> {
-    root: Option<AstNodeId>,
+    root: AstNodeId,
     nodes: IndexVec<AstNodeId, AstNode<'a>>,
     parent_ids: IndexVec<AstNodeId, Option<AstNodeId>>,
+}
+
+impl<'a> Default for AstNodes<'a> {
+    fn default() -> Self {
+        Self {
+            root: AstNodeId::new(usize::MAX),
+            nodes: IndexVec::default(),
+            parent_ids: IndexVec::default(),
+        }
+    }
 }
 
 impl<'a> AstNodes<'a> {
@@ -101,7 +111,7 @@ impl<'a> AstNodes<'a> {
 
     /// Get the root `AstNodeId`, It is always pointing to a `Program`.
     /// Returns `None` if root node isn't set.
-    pub fn root(&self) -> Option<AstNodeId> {
+    pub fn root(&self) -> AstNodeId {
         self.root
     }
 
@@ -114,7 +124,7 @@ impl<'a> AstNodes<'a> {
     pub(super) unsafe fn set_root(&mut self, root: &AstNode<'a>) {
         match root.kind() {
             AstKind::Program(_) => {
-                self.root = Some(root.id());
+                self.root = root.id();
             }
             _ => unreachable!("Expected a `Program` node as the root of the tree."),
         }
@@ -122,14 +132,14 @@ impl<'a> AstNodes<'a> {
 
     /// Get the root node as immutable reference, It is always guaranteed to be a `Program`.
     /// Returns `None` if root node isn't set.
-    pub fn root_node(&self) -> Option<&AstNode<'a>> {
-        self.root().map(|id| self.get_node(id))
+    pub fn root_node(&self) -> &AstNode<'a> {
+        self.get_node(self.root())
     }
 
     /// Get the root node as mutable reference, It is always guaranteed to be a `Program`.
     /// Returns `None` if root node isn't set.
-    pub fn root_node_mut(&mut self) -> Option<&mut AstNode<'a>> {
-        self.root().map(|id| self.get_node_mut(id))
+    pub fn root_node_mut(&mut self) -> &mut AstNode<'a> {
+        self.get_node_mut(self.root())
     }
 
     /// Walk up the AST, iterating over each parent node.

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -141,6 +141,7 @@ impl<'a> AstNodes<'a> {
         std::iter::successors(Some(ast_node_id), |node_id| parent_ids[*node_id])
     }
 
+    /// Adds an `AstNode` to the `AstNodes` tree and returns its `AstNodeId`.
     pub fn add_node(&mut self, node: AstNode<'a>, parent_id: Option<AstNodeId>) -> AstNodeId {
         let mut node = node;
         let ast_node_id = self.parent_ids.push(parent_id);


### PR DESCRIPTION
related to #3082, #3030 and #3069