### PR TITLE
experiment: NonZeroIndexVec?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,8 +761,7 @@ dependencies = [
 [[package]]
 name = "index_vec"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74086667896a940438f2118212f313abba4aff3831fef6f4b17d02add5c8bb60"
+source = "git+https://github.com/rzvxa/index_vec.git?branch=non-zero-idx#8156107419c1d5a9ab4bf22a409ab2080b71e0d7"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ ureq                = { version = "2.9.6", default-features = false }
 url                 = "2.5.0"
 walkdir             = "2.5.0"
 indexmap            = "2.2.6"
-index_vec           = "0.1.3"
+index_vec           = { git = "https://github.com/rzvxa/index_vec.git", branch= "non-zero-idx" }
 static_assertions   = "1.1.0"
 tracing-subscriber  = "0.3"
 insta               = "1.38.0"

--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -13,6 +13,7 @@ macro_rules! ast_kinds {
         /// Untyped AST Node Kind
         #[derive(Debug, Clone, Copy)]
         pub enum AstKind<'a> {
+            Dummy,
             $($ident($type),)*
         }
     )
@@ -356,6 +357,7 @@ impl<'a> GetSpan for AstKind<'a> {
     #[allow(clippy::match_same_arms)]
     fn span(&self) -> Span {
         match self {
+            Self::Dummy => Span::new(0, 0),
             Self::Program(x) => x.span,
             Self::Directive(x) => x.span,
             Self::Hashbang(x) => x.span,
@@ -546,6 +548,7 @@ impl<'a> AstKind<'a> {
     /// usage of this method within your code.
     pub fn debug_name(&self) -> std::borrow::Cow<str> {
         match self {
+            Self::Dummy => "Dummy".into(),
             Self::Program(_) => "Program".into(),
             Self::Directive(d) => d.directive.as_ref().into(),
             Self::Hashbang(_) => "Hashbang".into(),

--- a/crates/oxc_index/src/lib.rs
+++ b/crates/oxc_index/src/lib.rs
@@ -2,5 +2,7 @@
 //!
 //! <https://doc.rust-lang.org/beta/nightly-rustc/rustc_index>
 
-pub use index_vec::{define_index_type, index_vec, IndexSlice, IndexVec};
+pub use index_vec::{
+    define_index_type, define_non_zero_index_type, index_vec, IndexSlice, IndexVec,
+};
 pub use static_assertions::*;

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -58,6 +58,7 @@ impl Rule for NoBarrelFile {
             return;
         };
 
+        dbg!(root);
         let AstKind::Program(program) = root.kind() else { unreachable!() };
 
         let declarations = program.body.iter().fold(0, |acc, node| match node {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -58,7 +58,6 @@ impl Rule for NoBarrelFile {
             return;
         };
 
-        dbg!(root);
         let AstKind::Program(program) = root.kind() else { unreachable!() };
 
         let declarations = program.body.iter().fold(0, |acc, node| match node {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -90,7 +90,7 @@ impl<'a> SemanticBuilder<'a> {
             source_type,
             trivias: Rc::clone(&trivias),
             errors: RefCell::new(vec![]),
-            current_node_id: AstNodeId::new(0),
+            current_node_id: AstNodeId::new(1),
             current_node_flags: NodeFlags::empty(),
             current_symbol_flags: SymbolFlags::empty(),
             in_type_definition: false,

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,7 +1,7 @@
 use petgraph::stable_graph::NodeIndex;
 
 use oxc_ast::AstKind;
-use oxc_index::IndexVec;
+use oxc_index::{index_vec, IndexVec};
 
 use crate::scope::ScopeId;
 
@@ -25,7 +25,7 @@ pub struct AstNode<'a> {
 
 impl<'a> AstNode<'a> {
     pub fn new(kind: AstKind<'a>, scope_id: ScopeId, cfg_ix: NodeIndex, flags: NodeFlags) -> Self {
-        Self { id: AstNodeId::new(0), kind, cfg_ix, scope_id, flags }
+        Self { id: AstNodeId::new(1), kind, cfg_ix, scope_id, flags }
     }
 
     pub fn id(&self) -> AstNodeId {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -54,11 +54,24 @@ impl<'a> AstNode<'a> {
 }
 
 /// Untyped AST nodes flattened into an vec
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AstNodes<'a> {
     root: Option<AstNodeId>,
     nodes: IndexVec<AstNodeId, AstNode<'a>>,
     parent_ids: IndexVec<AstNodeId, Option<AstNodeId>>,
+}
+
+impl<'a> Default for AstNodes<'a> {
+    fn default() -> Self {
+        let nodes = index_vec![AstNode::new(
+            AstKind::Dummy,
+            ScopeId::new(0),
+            NodeIndex::new(0),
+            NodeFlags::JSDoc
+        )];
+        let parent_ids = index_vec![None];
+        Self { root: None, nodes, parent_ids }
+    }
 }
 
 impl<'a> AstNodes<'a> {

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -1,8 +1,10 @@
-use bitflags::bitflags;
-use oxc_index::define_index_type;
+use std::num::NonZeroUsize;
 
-define_index_type! {
-    pub struct AstNodeId = usize;
+use bitflags::bitflags;
+use oxc_index::define_non_zero_index_type;
+
+define_non_zero_index_type! {
+    pub struct AstNodeId = NonZeroUsize;
 }
 
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
We have a lot of `Option<IndexType>` scattered throughout the code, Being able to use a non-zero usize as our index would reduce the size of many structures, Mainly the `AstNodes`.

Extending it to the graph structure might also prove beneficial.