### PR TITLE
refactor(ast): remove duplicate `TSNamedTupleMember` representation

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -299,7 +299,6 @@ pub enum TSTupleElement<'a> {
     TSType(TSType<'a>),
     TSOptionalType(Box<'a, TSOptionalType<'a>>),
     TSRestType(Box<'a, TSRestType<'a>>),
-    TSNamedTupleMember(Box<'a, TSNamedTupleMember<'a>>),
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -2748,7 +2748,6 @@ pub mod walk {
             TSTupleElement::TSType(ty) => visitor.visit_ts_type(ty),
             TSTupleElement::TSOptionalType(ty) => visitor.visit_ts_type(&ty.type_annotation),
             TSTupleElement::TSRestType(ty) => visitor.visit_ts_type(&ty.type_annotation),
-            TSTupleElement::TSNamedTupleMember(ty) => visitor.visit_ts_type(&ty.element_type),
         };
     }
 

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -2900,7 +2900,6 @@ pub mod walk_mut {
             TSTupleElement::TSType(ty) => visitor.visit_ts_type(ty),
             TSTupleElement::TSOptionalType(ty) => visitor.visit_ts_type(&mut ty.type_annotation),
             TSTupleElement::TSRestType(ty) => visitor.visit_ts_type(&mut ty.type_annotation),
-            TSTupleElement::TSNamedTupleMember(ty) => visitor.visit_ts_type(&mut ty.element_type),
         };
     }
 

--- a/crates/oxc_codegen/src/gen_ts.rs
+++ b/crates/oxc_codegen/src/gen_ts.rs
@@ -509,9 +509,6 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSTupleElement<'a> {
                 p.print_str(b"...");
                 ts_type.type_annotation.gen(p, ctx);
             }
-            TSTupleElement::TSNamedTupleMember(ts_type) => {
-                ts_type.gen(p, ctx);
-            }
         }
     }
 }

--- a/crates/oxc_parser/src/ts/list.rs
+++ b/crates/oxc_parser/src/ts/list.rs
@@ -74,9 +74,9 @@ impl<'a> SeparatedList<'a> for TSTupleElementList<'a> {
             p.expect(Kind::Colon)?;
 
             let element_type = p.parse_ts_type()?;
-            self.elements.push(TSTupleElement::TSNamedTupleMember(p.ast.alloc(
+            self.elements.push(TSTupleElement::TSType(TSType::TSNamedTupleMember(p.ast.alloc(
                 TSNamedTupleMember { span: p.end_span(span), element_type, label, optional },
-            )));
+            ))));
 
             return Ok(());
         }


### PR DESCRIPTION
Removes duplicate representation of a `TSTupleElement` which is a `TSNamedTupleMember`.

Closes #3100.
