### PR TITLE
chore: make `oxc_index` dependency on `serde` optional.

### DIFF
--- a/crates/oxc_index/Cargo.toml
+++ b/crates/oxc_index/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 doctest = false
 
 [dependencies]
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
 
 [features]
-serialize = []
+serialize = ["dep:serde"]


### PR DESCRIPTION
nothing fancy here, just a simple change.