### PR TITLE
fix(index): add `example_generated` to create the docs.

### DIFF
--- a/crates/oxc_index/Cargo.toml
+++ b/crates/oxc_index/Cargo.toml
@@ -23,3 +23,7 @@ serde = { workspace = true, optional = true }
 
 [features]
 serialize = ["dep:serde"]
+example_generated = []
+
+[package.metadata.docs.rs]
+features = ["example_generated"]


### PR DESCRIPTION
This dummy feature is for generating the documentations made by macros, I've missed it in my initial fork.