### PR TITLE
performance(semantic): use non-zero index vec in `AstNodes`.

### DIFF
--- a/crates/oxc_ast/src/ast_kind.rs
+++ b/crates/oxc_ast/src/ast_kind.rs
@@ -11,8 +11,10 @@ macro_rules! ast_kinds {
         }
 
         /// Untyped AST Node Kind
-        #[derive(Debug, Clone, Copy)]
+        #[derive(Default, Debug, Clone, Copy)]
         pub enum AstKind<'a> {
+            #[default]
+            Dummy,
             $($ident($type),)*
         }
     )
@@ -533,6 +535,7 @@ impl<'a> GetSpan for AstKind<'a> {
             Self::TSNamedTupleMember(x) => x.span,
 
             Self::TSPropertySignature(x) => x.span,
+            Self::Dummy => Span::default(),
         }
     }
 }
@@ -735,6 +738,7 @@ impl<'a> AstKind<'a> {
             Self::TSNamedTupleMember(_) => "TSNamedTupleMember".into(),
 
             Self::TSPropertySignature(_) => "TSPropertySignature".into(),
+            Self::Dummy => "Dummy".into(),
         }
     }
 }

--- a/crates/oxc_index/src/non_zero/vec.rs
+++ b/crates/oxc_index/src/non_zero/vec.rs
@@ -59,12 +59,12 @@ impl<I: NonZeroIdx, T: Default> NonZeroIndexVec<I, T> {
     ///
     /// Panics if it's length is too large for our index type.
     #[inline]
-    pub fn from_vec(vec: Vec<T>) -> Self {
-        // we add one since we always keep the first element uninitialized.
-        let len = vec.len() + 1;
-        // See if `I::from_usize` might be upset by this length.
-        let _ = I::from_usize(len);
-        panic!("HERE");
+    pub fn from_vec(_: Vec<T>) -> Self {
+        todo!()
+        // // we add one since we always keep the first element uninitialized.
+        // let len = vec.len() + 1;
+        // // See if `I::from_usize` might be upset by this length.
+        // let _ = I::from_usize(len);
         // // TODO: we should wrap our elements in `MaybeUninit` instead of enforcing default trait.
         // vec.insert(0, T::default());
         // NonZeroIndexVec {

--- a/crates/oxc_index/src/non_zero/vec.rs
+++ b/crates/oxc_index/src/non_zero/vec.rs
@@ -59,19 +59,19 @@ impl<I: NonZeroIdx, T: Default> NonZeroIndexVec<I, T> {
     ///
     /// Panics if it's length is too large for our index type.
     #[inline]
-    pub fn from_vec(mut vec: Vec<T>) -> Self {
+    pub fn from_vec(vec: Vec<T>) -> Self {
         // we add one since we always keep the first element uninitialized.
         let len = vec.len() + 1;
         // See if `I::from_usize` might be upset by this length.
         let _ = I::from_usize(len);
         panic!("HERE");
-        // TODO: we should wrap our elements in `MaybeUninit` instead of enforcing default trait.
-        vec.insert(0, T::default());
-        NonZeroIndexVec {
-            // TODO: replace me with transmutation.
-            raw: vec,
-            _marker: PhantomData,
-        }
+        // // TODO: we should wrap our elements in `MaybeUninit` instead of enforcing default trait.
+        // vec.insert(0, T::default());
+        // NonZeroIndexVec {
+        //     // TODO: replace me with transmutation.
+        //     raw: vec,
+        //     _marker: PhantomData,
+        // }
     }
 
     /// Construct an NonZeroIndexVec that can hold at least `capacity` items before

--- a/crates/oxc_index/src/non_zero/vec.rs
+++ b/crates/oxc_index/src/non_zero/vec.rs
@@ -60,6 +60,7 @@ impl<I: NonZeroIdx, T: Default> NonZeroIndexVec<I, T> {
     /// Panics if it's length is too large for our index type.
     #[inline]
     pub fn from_vec(_: Vec<T>) -> Self {
+        #![allow(clippy::todo)]
         todo!()
         // // we add one since we always keep the first element uninitialized.
         // let len = vec.len() + 1;

--- a/crates/oxc_index/src/non_zero/vec.rs
+++ b/crates/oxc_index/src/non_zero/vec.rs
@@ -64,6 +64,7 @@ impl<I: NonZeroIdx, T: Default> NonZeroIndexVec<I, T> {
         let len = vec.len() + 1;
         // See if `I::from_usize` might be upset by this length.
         let _ = I::from_usize(len);
+        panic!("HERE");
         // TODO: we should wrap our elements in `MaybeUninit` instead of enforcing default trait.
         vec.insert(0, T::default());
         NonZeroIndexVec {

--- a/crates/oxc_index/src/non_zero/vec.rs
+++ b/crates/oxc_index/src/non_zero/vec.rs
@@ -59,20 +59,18 @@ impl<I: NonZeroIdx, T: Default> NonZeroIndexVec<I, T> {
     ///
     /// Panics if it's length is too large for our index type.
     #[inline]
-    pub fn from_vec(_: Vec<T>) -> Self {
-        #![allow(clippy::todo)]
-        todo!()
-        // // we add one since we always keep the first element uninitialized.
-        // let len = vec.len() + 1;
-        // // See if `I::from_usize` might be upset by this length.
-        // let _ = I::from_usize(len);
-        // // TODO: we should wrap our elements in `MaybeUninit` instead of enforcing default trait.
-        // vec.insert(0, T::default());
-        // NonZeroIndexVec {
-        //     // TODO: replace me with transmutation.
-        //     raw: vec,
-        //     _marker: PhantomData,
-        // }
+    pub fn from_vec(mut vec: Vec<T>) -> Self {
+        // we add one since we always keep the first element uninitialized.
+        let len = vec.len() + 1;
+        // See if `I::from_usize` might be upset by this length.
+        let _ = I::from_usize(len);
+        // TODO: we should wrap our elements in `MaybeUninit` instead of enforcing default trait.
+        vec.insert(0, T::default());
+        NonZeroIndexVec {
+            // TODO: replace me with transmutation.
+            raw: vec,
+            _marker: PhantomData,
+        }
     }
 
     /// Construct an NonZeroIndexVec that can hold at least `capacity` items before

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -90,7 +90,7 @@ impl<'a> SemanticBuilder<'a> {
             source_type,
             trivias: Rc::clone(&trivias),
             errors: RefCell::new(vec![]),
-            current_node_id: AstNodeId::new(0),
+            current_node_id: AstNodeId::default(),
             current_node_flags: NodeFlags::empty(),
             current_symbol_flags: SymbolFlags::empty(),
             in_type_definition: false,

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,14 +1,14 @@
 use petgraph::stable_graph::NodeIndex;
 
 use oxc_ast::AstKind;
-use oxc_index::IndexVec;
+use oxc_index::{IndexVec, NonZeroIndexVec};
 
 use crate::scope::ScopeId;
 
 pub use oxc_syntax::node::{AstNodeId, NodeFlags};
 
 /// Semantic node contains all the semantic information about an ast node.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct AstNode<'a> {
     id: AstNodeId,
     /// A pointer to the ast node, which resides in the `bumpalo` memory arena.
@@ -25,7 +25,7 @@ pub struct AstNode<'a> {
 
 impl<'a> AstNode<'a> {
     pub fn new(kind: AstKind<'a>, scope_id: ScopeId, cfg_ix: NodeIndex, flags: NodeFlags) -> Self {
-        Self { id: AstNodeId::new(0), kind, cfg_ix, scope_id, flags }
+        Self { id: AstNodeId::default(), kind, cfg_ix, scope_id, flags }
     }
 
     pub fn id(&self) -> AstNodeId {
@@ -57,8 +57,8 @@ impl<'a> AstNode<'a> {
 #[derive(Debug, Default)]
 pub struct AstNodes<'a> {
     root: Option<AstNodeId>,
-    nodes: IndexVec<AstNodeId, AstNode<'a>>,
-    parent_ids: IndexVec<AstNodeId, Option<AstNodeId>>,
+    nodes: NonZeroIndexVec<AstNodeId, AstNode<'a>>,
+    parent_ids: NonZeroIndexVec<AstNodeId, Option<AstNodeId>>,
 }
 
 impl<'a> AstNodes<'a> {

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,7 +1,7 @@
 use petgraph::stable_graph::NodeIndex;
 
 use oxc_ast::AstKind;
-use oxc_index::{IndexVec, NonZeroIndexVec};
+use oxc_index::NonZeroIndexVec;
 
 use crate::scope::ScopeId;
 

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -4,7 +4,8 @@ use oxc_index::define_index_type;
 define_index_type! {
     #[non_zero]
     pub struct AstNodeId = usize;
-    DEFAULT = AstNodeId::new(1);
+    // SAFETY: 1 > 0.
+    DEFAULT =  #[allow(unsafe_code)] unsafe {AstNodeId::from_usize_unchecked(1)};
 }
 
 #[cfg(feature = "serialize")]

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -2,7 +2,9 @@ use bitflags::bitflags;
 use oxc_index::define_index_type;
 
 define_index_type! {
+    #[non_zero]
     pub struct AstNodeId = usize;
+    DEFAULT = AstNodeId::new(1);
 }
 
 #[cfg(feature = "serialize")]
@@ -18,7 +20,7 @@ export type NodeFlags = {
 "#;
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct NodeFlags: u8 {
         const JSDoc     = 1 << 0; // If the Node has a JSDoc comment attached
         const Class     = 1 << 1; // If Node is inside a class

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -3,6 +3,7 @@ use oxc_index::define_index_type;
 
 define_index_type! {
     pub struct ScopeId = u32;
+    DEFAULT = ScopeId::new(0);
 }
 
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
State:

It works, and #3104 is safe to use(well most API calls; haven't gone through them all yet) Although I'm not getting the same performance gains as I found in #3086 after making the API more general-purpose.


I'd spend a bit more time on it in case I can find a way to squeeze a bit more performance out of it otherwise I'll close it since the current performance gain doesn't justify the technical debt required for creating and maintaining a brand new API for index_vec.