### PR TITLE
deps(allocator): disable `serde` dep by default

### DIFF
--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -19,8 +19,13 @@ doctest = false
 
 [dependencies]
 bumpalo        = { workspace = true, features = ["collections", "allocator-api2"] }
-serde          = { workspace = true }
 allocator-api2 = { workspace = true }
 
+serde = { workspace = true, optional = true }
+
 [dev-dependencies]
+serde      = { workspace = true }
 serde_json = { workspace = true }
+
+[features]
+serialize = ["dep:serde"]

--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -13,6 +13,7 @@ use std::{
 use allocator_api2::vec;
 pub use bumpalo::collections::String;
 use bumpalo::Bump;
+#[cfg(any(feature = "serialize", test))]
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 
 use crate::Allocator;
@@ -84,6 +85,7 @@ impl<'alloc, T: ?Sized + Debug> Debug for Box<'alloc, T> {
 // }
 // }
 
+#[cfg(any(feature = "serialize", test))]
 impl<'alloc, T> Serialize for Box<'alloc, T>
 where
     T: Serialize,
@@ -180,6 +182,7 @@ impl<'alloc, T> ops::Index<usize> for &'alloc Vec<'alloc, T> {
 // }
 // }
 
+#[cfg(any(feature = "serialize", test))]
 impl<'alloc, T> Serialize for Vec<'alloc, T>
 where
     T: Serialize,

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -37,6 +37,7 @@ static_assertions = { workspace = true }
 [features]
 default = []
 serialize = [
+  "oxc_allocator/serialize",
   "dep:serde",
   "dep:serde_json",
   "dep:ryu-js",


### PR DESCRIPTION
`oxc_allocator` currently depends on `serde`, although it's generally not required.

This PR puts the dependency behind a feature `serialize`.

NB: `serde` is needed for the crate's tests, but this can be enabled by adding it to `dev-dependencies` and putting the impls behind `#[cfg(any(feature = "serialize", test))]`.
