### PR TITLE
fix: Wrap more types in `Box<'a>`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -843,7 +843,7 @@ pub struct PrivateFieldExpression<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
     pub object: Expression<'a>,
-    pub field: PrivateIdentifier<'a>,
+    pub field: Box<'a, PrivateIdentifier<'a>>,
     pub optional: bool, // for optional chaining
 }
 
@@ -1004,7 +1004,7 @@ pub struct BinaryExpression<'a> {
 pub struct PrivateInExpression<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub left: PrivateIdentifier<'a>,
+    pub left: Box<'a, PrivateIdentifier<'a>>,
     pub operator: BinaryOperator, // BinaryOperator::In
     pub right: Expression<'a>,
 }

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2025,7 +2025,7 @@ pub struct Function<'a> {
     ///   return this.admin;
     /// });
     /// ```
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub body: Option<Box<'a, FunctionBody<'a>>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2522,7 +2522,7 @@ impl<'a> ModuleDeclaration<'a> {
         }
     }
 
-    pub fn with_clause(&self) -> Option<&WithClause<'a>> {
+    pub fn with_clause(&self) -> Option<&Box<'a, WithClause<'a>>> {
         match self {
             Self::ImportDeclaration(decl) => decl.with_clause.as_ref(),
             Self::ExportAllDeclaration(decl) => decl.with_clause.as_ref(),
@@ -2567,7 +2567,7 @@ pub struct ImportDeclaration<'a> {
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
     /// Some(vec![]) for empty assertion
-    pub with_clause: Option<WithClause<'a>>,
+    pub with_clause: Option<Box<'a, WithClause<'a>>>,
     /// `import type { foo } from 'bar'`
     pub import_kind: ImportOrExportKind,
 }
@@ -2667,7 +2667,7 @@ pub struct ExportNamedDeclaration<'a> {
     /// `export type { foo }`
     pub export_kind: ImportOrExportKind,
     /// Some(vec![]) for empty assertion
-    pub with_clause: Option<WithClause<'a>>,
+    pub with_clause: Option<Box<'a, WithClause<'a>>>,
 }
 
 impl<'a> ExportNamedDeclaration<'a> {
@@ -2705,8 +2705,8 @@ pub struct ExportAllDeclaration<'a> {
     pub span: Span,
     pub exported: Option<ModuleExportName<'a>>,
     pub source: StringLiteral<'a>,
-    pub with_clause: Option<WithClause<'a>>, // Some(vec![]) for empty assertion
-    pub export_kind: ImportOrExportKind,     // `export type *`
+    pub with_clause: Option<Box<'a, WithClause<'a>>>, // Some(vec![]) for empty assertion
+    pub export_kind: ImportOrExportKind,              // `export type *`
 }
 
 impl<'a> ExportAllDeclaration<'a> {

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1731,7 +1731,7 @@ impl<'a> ForStatementLeft<'a> {
 pub struct ContinueStatement<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub label: Option<LabelIdentifier<'a>>,
+    pub label: Option<Box<'a, LabelIdentifier<'a>>>,
 }
 
 /// Break Statement
@@ -1741,7 +1741,7 @@ pub struct ContinueStatement<'a> {
 pub struct BreakStatement<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub label: Option<LabelIdentifier<'a>>,
+    pub label: Option<Box<'a, LabelIdentifier<'a>>>,
 }
 
 /// Return Statement
@@ -1799,7 +1799,7 @@ impl<'a> SwitchCase<'a> {
 pub struct LabeledStatement<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub label: LabelIdentifier<'a>,
+    pub label: Box<'a, LabelIdentifier<'a>>,
     pub body: Statement<'a>,
 }
 

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -674,7 +674,7 @@ pub struct TaggedTemplateExpression<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
     pub tag: Expression<'a>,
-    pub quasi: TemplateLiteral<'a>,
+    pub quasi: Box<'a, TemplateLiteral<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -99,8 +99,8 @@ pub enum JSXElementName<'a> {
 pub struct JSXNamespacedName<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub namespace: JSXIdentifier<'a>,
-    pub property: JSXIdentifier<'a>,
+    pub namespace: Box<'a, JSXIdentifier<'a>>,
+    pub property: Box<'a, JSXIdentifier<'a>>,
 }
 
 impl<'a> std::fmt::Display for JSXNamespacedName<'a> {
@@ -117,11 +117,11 @@ pub struct JSXMemberExpression<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
     pub object: JSXMemberExpressionObject<'a>,
-    pub property: JSXIdentifier<'a>,
+    pub property: Box<'a, JSXIdentifier<'a>>,
 }
 
 impl<'a> JSXMemberExpression<'a> {
-    pub fn get_object_identifier(&self) -> &JSXIdentifier {
+    pub fn get_object_identifier(&self) -> &Box<'a, JSXIdentifier> {
         match &self.object {
             JSXMemberExpressionObject::Identifier(ident) => ident,
             JSXMemberExpressionObject::MemberExpression(expr) => expr.get_object_identifier(),

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -155,7 +155,7 @@ inherit_variants! {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 pub enum JSXExpression<'a> {
-    EmptyExpression(JSXEmptyExpression) = 64,
+    EmptyExpression(Box<'a, JSXEmptyExpression>) = 64,
     // `Expression` variants added here by `inherit_variants!` macro
     @inherit Expression
 }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -875,7 +875,7 @@ pub struct TSImportType<'a> {
     pub span: Span,
     pub argument: TSType<'a>,
     pub qualifier: Option<TSTypeName<'a>>,
-    pub attributes: Option<TSImportAttributes<'a>>,
+    pub attributes: Option<Box<'a, TSImportAttributes<'a>>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -675,7 +675,7 @@ pub struct TSIndexSignature<'a> {
 pub struct TSCallSignatureDeclaration<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -700,7 +700,7 @@ pub struct TSMethodSignature<'a> {
     pub computed: bool,
     pub optional: bool,
     pub kind: TSMethodSignatureKind,
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -912,7 +912,7 @@ pub enum TSImportAttributeName<'a> {
 pub struct TSFunctionType<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -756,7 +756,7 @@ pub struct TSTypePredicate<'a> {
 #[cfg_attr(feature = "serialize", serde(untagged, rename_all = "camelCase"))]
 pub enum TSTypePredicateName<'a> {
     Identifier(Box<'a, IdentifierName<'a>>),
-    This(TSThisType),
+    This(Box<'a, TSThisType>),
 }
 
 #[derive(Debug, Hash)]

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -854,8 +854,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         this: IdentifierName<'a>,
         type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
-    ) -> TSThisParameter<'a> {
-        TSThisParameter { span, this, type_annotation }
+    ) -> Box<'a, TSThisParameter<'a>> {
+        self.alloc(TSThisParameter { span, this, type_annotation })
     }
 
     pub fn plain_function(
@@ -888,7 +888,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
-        this_param: Option<TSThisParameter<'a>>,
+        this_param: Option<Box<'a, TSThisParameter<'a>>>,
         params: Box<'a, FormalParameters<'a>>,
         body: Option<Box<'a, FunctionBody<'a>>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -1512,7 +1512,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_call_signature_declaration(
         &self,
         span: Span,
-        this_param: Option<TSThisParameter<'a>>,
+        this_param: Option<Box<'a, TSThisParameter<'a>>>,
         params: Box<'a, FormalParameters<'a>>,
         return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -1548,7 +1548,7 @@ impl<'a> AstBuilder<'a> {
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: Option<TSThisParameter<'a>>,
+        this_param: Option<Box<'a, TSThisParameter<'a>>>,
         params: Box<'a, FormalParameters<'a>>,
         return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -1834,7 +1834,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_function_type(
         &self,
         span: Span,
-        this_param: Option<TSThisParameter<'a>>,
+        this_param: Option<Box<'a, TSThisParameter<'a>>>,
         params: Box<'a, FormalParameters<'a>>,
         return_type: Box<'a, TSTypeAnnotation<'a>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1157,7 +1157,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
-        with_clause: Option<WithClause<'a>>,
+        with_clause: Option<Box<'a, WithClause<'a>>>,
         import_kind: ImportOrExportKind,
     ) -> Box<'a, ImportDeclaration<'a>> {
         self.alloc(ImportDeclaration { span, specifiers, source, with_clause, import_kind })
@@ -1168,7 +1168,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
-        with_clause: Option<WithClause<'a>>,
+        with_clause: Option<Box<'a, WithClause<'a>>>,
         export_kind: ImportOrExportKind,
     ) -> Box<'a, ExportAllDeclaration<'a>> {
         self.alloc(ExportAllDeclaration { span, exported, source, with_clause, export_kind })
@@ -1190,7 +1190,7 @@ impl<'a> AstBuilder<'a> {
         specifiers: Vec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
-        with_clause: Option<WithClause<'a>>,
+        with_clause: Option<Box<'a, WithClause<'a>>>,
     ) -> Box<'a, ExportNamedDeclaration<'a>> {
         self.alloc(ExportNamedDeclaration {
             span,

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1284,8 +1284,8 @@ impl<'a> AstBuilder<'a> {
     pub fn jsx_namespaced_name(
         &self,
         span: Span,
-        namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
+        namespace: Box<'a, JSXIdentifier<'a>>,
+        property: Box<'a, JSXIdentifier<'a>>,
     ) -> Box<'a, JSXNamespacedName<'a>> {
         self.alloc(JSXNamespacedName { span, namespace, property })
     }
@@ -1294,7 +1294,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
-        property: JSXIdentifier<'a>,
+        property: Box<'a, JSXIdentifier<'a>>,
     ) -> Box<'a, JSXMemberExpression<'a>> {
         self.alloc(JSXMemberExpression { span, object, property })
     }
@@ -1336,8 +1336,8 @@ impl<'a> AstBuilder<'a> {
         self.alloc(JSXSpreadAttribute { span, argument })
     }
 
-    pub fn jsx_identifier(&self, span: Span, name: Atom<'a>) -> JSXIdentifier<'a> {
-        JSXIdentifier { span, name }
+    pub fn jsx_identifier(&self, span: Span, name: Atom<'a>) -> Box<'a, JSXIdentifier<'a>> {
+        self.alloc(JSXIdentifier { span, name })
     }
 
     pub fn jsx_text(&self, span: Span, value: Atom<'a>) -> Box<'a, JSXText<'a>> {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1802,7 +1802,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
-        attributes: Option<TSImportAttributes<'a>>,
+        attributes: Option<Box<'a, TSImportAttributes<'a>>>,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> TSType<'a> {
         TSType::TSImportType(self.alloc(TSImportType {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -759,7 +759,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         tag: Expression<'a>,
-        quasi: TemplateLiteral<'a>,
+        quasi: Box<'a, TemplateLiteral<'a>>,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> Expression<'a> {
         Expression::TaggedTemplateExpression(self.alloc(TaggedTemplateExpression {

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -664,7 +664,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         object: Expression<'a>,
-        field: PrivateIdentifier<'a>,
+        field: Box<'a, PrivateIdentifier<'a>>,
         optional: bool,
     ) -> MemberExpression<'a> {
         MemberExpression::PrivateFieldExpression(self.alloc(PrivateFieldExpression {
@@ -678,7 +678,7 @@ impl<'a> AstBuilder<'a> {
     pub fn private_in_expression(
         &self,
         span: Span,
-        left: PrivateIdentifier<'a>,
+        left: Box<'a, PrivateIdentifier<'a>>,
         right: Expression<'a>,
     ) -> Expression<'a> {
         Expression::PrivateInExpression(self.alloc(PrivateInExpression {
@@ -693,7 +693,7 @@ impl<'a> AstBuilder<'a> {
         &self,
         span: Span,
         object: Expression<'a>,
-        field: PrivateIdentifier<'a>,
+        field: Box<'a, PrivateIdentifier<'a>>,
         optional: bool,
     ) -> Expression<'a> {
         self.member_expression(self.private_field(span, object, field, optional))

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1914,7 +1914,7 @@ impl<'a> AstBuilder<'a> {
     }
 
     pub fn ts_type_predicate_name_this(&self, ty: TSThisType) -> TSTypePredicateName<'a> {
-        TSTypePredicateName::This(ty)
+        TSTypePredicateName::This(self.alloc(ty))
     }
 
     pub fn ts_type_predicate_name_identifier(

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -259,14 +259,18 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    pub fn break_statement(&self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
+    pub fn break_statement(
+        &self,
+        span: Span,
+        label: Option<Box<'a, LabelIdentifier<'a>>>,
+    ) -> Statement<'a> {
         Statement::BreakStatement(self.alloc(BreakStatement { span, label }))
     }
 
     pub fn continue_statement(
         &self,
         span: Span,
-        label: Option<LabelIdentifier<'a>>,
+        label: Option<Box<'a, LabelIdentifier<'a>>>,
     ) -> Statement<'a> {
         Statement::ContinueStatement(self.alloc(ContinueStatement { span, label }))
     }
@@ -346,7 +350,7 @@ impl<'a> AstBuilder<'a> {
     pub fn labeled_statement(
         &self,
         span: Span,
-        label: LabelIdentifier<'a>,
+        label: Box<'a, LabelIdentifier<'a>>,
         body: Statement<'a>,
     ) -> Statement<'a> {
         Statement::LabeledStatement(self.alloc(LabeledStatement { span, label, body }))

--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -1315,8 +1315,8 @@ impl<'a> AstBuilder<'a> {
         self.alloc(JSXSpreadChild { span, expression })
     }
 
-    pub fn jsx_empty_expression(&self, span: Span) -> JSXEmptyExpression {
-        JSXEmptyExpression { span }
+    pub fn jsx_empty_expression(&self, span: Span) -> Box<'a, JSXEmptyExpression> {
+        self.alloc(JSXEmptyExpression { span })
     }
 
     pub fn jsx_attribute(

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -810,7 +810,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for ImportDeclaration<'a> {
     }
 }
 
-impl<'a, const MINIFY: bool> Gen<MINIFY> for Option<WithClause<'a>> {
+impl<'a, const MINIFY: bool> Gen<MINIFY> for Option<Box<'a, WithClause<'a>>> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         if let Some(with_clause) = self {
             with_clause.gen(p, ctx);

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -330,7 +330,7 @@ impl<'a> ParserImpl<'a> {
         match self.cur_kind() {
             Kind::PrivateIdentifier => {
                 let private_ident = self.parse_private_identifier();
-                Ok((PropertyKey::PrivateIdentifier(self.ast.alloc(private_ident)), false))
+                Ok((PropertyKey::PrivateIdentifier(private_ident), false))
             }
             _ => self.parse_property_name(),
         }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -129,11 +129,11 @@ impl<'a> ParserImpl<'a> {
     /// `PrivateIdentifier` ::
     ///     # `IdentifierName`
     /// # Panics
-    pub(crate) fn parse_private_identifier(&mut self) -> PrivateIdentifier<'a> {
+    pub(crate) fn parse_private_identifier(&mut self) -> Box<'a, PrivateIdentifier<'a>> {
         let span = self.start_span();
         let name = Atom::from(self.cur_string());
         self.bump_any();
-        PrivateIdentifier { span: self.end_span(span), name }
+        self.ast.alloc(PrivateIdentifier { span: self.end_span(span), name })
     }
 
     /// Section [Primary Expression](https://tc39.es/ecma262/#sec-primary-expression)

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -439,7 +439,7 @@ impl<'a> ParserImpl<'a> {
         if in_optional_chain {
             self.error(diagnostics::OptionalChainTaggedTemplate(quasi.span));
         }
-        Ok(self.ast.tagged_template_expression(span, lhs, quasi, type_parameters))
+        Ok(self.ast.tagged_template_expression(span, lhs, self.ast.alloc(quasi), type_parameters))
     }
 
     pub(crate) fn parse_template_element(&mut self, tagged: bool) -> TemplateElement<'a> {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -83,13 +83,13 @@ impl<'a> ParserImpl<'a> {
         Ok(BindingIdentifier { span, name, symbol_id: Cell::default() })
     }
 
-    pub(crate) fn parse_label_identifier(&mut self) -> Result<LabelIdentifier<'a>> {
+    pub(crate) fn parse_label_identifier(&mut self) -> Result<Box<'a, LabelIdentifier<'a>>> {
         if !self.cur_kind().is_label_identifier(self.ctx.has_yield(), self.ctx.has_await()) {
             return Err(self.unexpected());
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         self.check_identifier(span, &name);
-        Ok(LabelIdentifier { span, name })
+        Ok(self.ast.alloc(LabelIdentifier { span, name }))
     }
 
     pub(crate) fn parse_identifier_name(&mut self) -> Result<IdentifierName<'a>> {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -68,7 +68,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_formal_parameters(
         &mut self,
         params_kind: FormalParameterKind,
-    ) -> Result<(Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>)> {
+    ) -> Result<(Option<Box<'a, TSThisParameter<'a>>>, Box<'a, FormalParameters<'a>>)> {
         let span = self.start_span();
         let list: FormalParameterList<'_> = FormalParameterList::parse(self)?;
         let formal_parameters =

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -238,7 +238,7 @@ impl<'a> SeparatedList<'a> for SequenceExpressionList<'a> {
 pub struct FormalParameterList<'a> {
     pub elements: Vec<'a, FormalParameter<'a>>,
     pub rest: Option<oxc_allocator::Box<'a, BindingRestElement<'a>>>,
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<oxc_allocator::Box<'a, TSThisParameter<'a>>>,
 }
 
 impl<'a> SeparatedList<'a> for FormalParameterList<'a> {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -133,7 +133,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// [Import Attributes](https://tc39.es/proposal-import-attributes)
-    fn parse_import_attributes(&mut self) -> Result<Option<WithClause<'a>>> {
+    fn parse_import_attributes(&mut self) -> Result<Option<Box<'a, WithClause<'a>>>> {
         let attributes_keyword = match self.cur_kind() {
             Kind::Assert if !self.cur_token().is_on_new_line => self.parse_identifier_name()?,
             Kind::With => self.parse_identifier_name()?,
@@ -147,7 +147,11 @@ impl<'a> ParserImpl<'a> {
         let with_entries = AssertEntries::parse(self)?.elements;
         self.ctx = ctx;
 
-        Ok(Some(WithClause { span: self.end_span(span), attributes_keyword, with_entries }))
+        Ok(Some(self.ast.alloc(WithClause {
+            span: self.end_span(span),
+            attributes_keyword,
+            with_entries,
+        })))
     }
 
     pub(crate) fn parse_ts_export_assignment_declaration(

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -151,7 +151,11 @@ impl<'a> ParserImpl<'a> {
             if self.eat(Kind::Colon) {
                 let label = LabelIdentifier { span: ident.span, name: ident.name.clone() };
                 let body = self.parse_statement_list_item(StatementContext::Label)?;
-                return Ok(self.ast.labeled_statement(self.end_span(span), label, body));
+                return Ok(self.ast.labeled_statement(
+                    self.end_span(span),
+                    self.ast.alloc(label),
+                    body,
+                ));
             }
         }
         self.parse_expression_statement(span, expr)

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -144,7 +144,7 @@ impl<'a> ParserImpl<'a> {
                 .map(JSXElementName::MemberExpression);
         }
 
-        Ok(JSXElementName::Identifier(self.ast.alloc(identifier)))
+        Ok(JSXElementName::Identifier(identifier))
     }
 
     /// `JSXMemberExpression` :
@@ -153,10 +153,10 @@ impl<'a> ParserImpl<'a> {
     fn parse_jsx_member_expression(
         &mut self,
         span: Span,
-        object: JSXIdentifier<'a>,
+        object: Box<'a, JSXIdentifier<'a>>,
     ) -> Result<Box<'a, JSXMemberExpression<'a>>> {
         let mut span = span;
-        let mut object = JSXMemberExpressionObject::Identifier(self.ast.alloc(object));
+        let mut object = JSXMemberExpressionObject::Identifier(object);
         let mut property = None;
 
         while self.eat(Kind::Dot) && !self.at(Kind::Eof) {
@@ -337,7 +337,7 @@ impl<'a> ParserImpl<'a> {
             )));
         }
 
-        Ok(JSXAttributeName::Identifier(self.ast.alloc(identifier)))
+        Ok(JSXAttributeName::Identifier(identifier))
     }
 
     fn parse_jsx_attribute_value(&mut self) -> Result<JSXAttributeValue<'a>> {
@@ -364,7 +364,7 @@ impl<'a> ParserImpl<'a> {
     ///   `IdentifierStart`
     ///   `JSXIdentifier` `IdentifierPart`
     ///   `JSXIdentifier` [no `WhiteSpace` or Comment here] -
-    fn parse_jsx_identifier(&mut self) -> Result<JSXIdentifier<'a>> {
+    fn parse_jsx_identifier(&mut self) -> Result<Box<'a, JSXIdentifier<'a>>> {
         let span = self.start_span();
         if !self.at(Kind::Ident) && !self.cur_kind().is_all_keyword() {
             return Err(self.unexpected());

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -401,7 +401,7 @@ impl<'a> ParserImpl<'a> {
         ))
     }
 
-    pub(crate) fn parse_ts_this_parameter(&mut self) -> Result<TSThisParameter<'a>> {
+    pub(crate) fn parse_ts_this_parameter(&mut self) -> Result<Box<'a, TSThisParameter<'a>>> {
         let span = self.start_span();
 
         let this = {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -793,7 +793,7 @@ impl<'a> ParserImpl<'a> {
         })
     }
 
-    fn parse_ts_import_attributes(&mut self) -> Result<TSImportAttributes<'a>> {
+    fn parse_ts_import_attributes(&mut self) -> Result<Box<'a, TSImportAttributes<'a>>> {
         let span = self.start_span();
         // { with:
         self.expect(Kind::LCurly)?;
@@ -801,7 +801,8 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Colon)?;
         let elements = TSImportAttributeList::parse(self)?.elements;
         self.expect(Kind::RCurly)?;
-        Ok(TSImportAttributes { span, elements })
+
+        Ok(self.ast.alloc(TSImportAttributes { span, elements }))
     }
 
     fn parse_ts_constructor_type(&mut self) -> Result<TSType<'a>> {

--- a/crates/oxc_transformer/src/react/jsx_source/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx_source/mod.rs
@@ -80,9 +80,7 @@ impl<'a> ReactJsxSource<'a> {
 
         self.should_add_jsx_file_name_variable = true;
 
-        let key = JSXAttributeName::Identifier(
-            self.ctx.ast.alloc(self.ctx.ast.jsx_identifier(SPAN, SOURCE.into())),
-        );
+        let key = JSXAttributeName::Identifier(self.ctx.ast.jsx_identifier(SPAN, SOURCE.into()));
         let object = self.get_source_object();
         let expr = self.ctx.ast.jsx_expression_container(SPAN, JSXExpression::from(object));
         let value = JSXAttributeValue::ExpressionContainer(expr);


### PR DESCRIPTION
Everything here except `StringLiteral`: https://github.com/oxc-project/oxc/pull/2987#issuecomment-2081177143