### PR TITLE
feat(linter/tree-shaking): support While/Switch/Yield Statement

### DIFF
--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -339,22 +339,22 @@ fn test() {
         // SequenceExpression
         "let x = 1; x++, x++",
         "if (ext, false) ext()",
-        // // SwitchCase
-        // "switch(ext){case ext:const x = 1;break;default:}",
-        // // SwitchStatement
-        // "switch(ext){}",
-        // "const x = ()=>{}; switch(ext){case 1:const x = ext}; x()",
-        // "const x = ext; switch(ext){case 1:const x = ()=>{}; x()}",
-        // // TaggedTemplateExpression
-        // "const x = ()=>{}; const y = x``",
-        // // TemplateLiteral
-        // "const x = ``",
-        // "const x = `Literal`",
-        // "const x = `Literal ${ext}`",
-        // r#"const x = ()=>"a"; const y = `Literal ${x()}`"#,
-        // // ThisExpression
+        // SwitchCase
+        "switch(ext){case ext:const x = 1;break;default:}",
+        // SwitchStatement
+        "switch(ext){}",
+        "const x = ()=>{}; switch(ext){case 1:const x = ext}; x()",
+        "const x = ext; switch(ext){case 1:const x = ()=>{}; x()}",
+        // TaggedTemplateExpression
+        "const x = ()=>{}; const y = x``",
+        // TemplateLiteral
+        "const x = ``",
+        "const x = `Literal`",
+        "const x = `Literal ${ext}`",
+        r#"const x = ()=>"a"; const y = `Literal ${x()}`"#,
+        // ThisExpression
         "const y = this.x",
-        // // ThisExpression when mutated
+        // ThisExpression when mutated
         "const y = new (function (){this.x = 1})()",
         "const y = new (function (){{this.x = 1}})()",
         "const y = new (function (){(()=>{this.x = 1})()})()",
@@ -370,23 +370,23 @@ fn test() {
         // UpdateExpression
         "let x=1;x++",
         "const x = {};x.y++",
-        // // VariableDeclaration
-        // "const x = 1",
-        // // VariableDeclarator
-        // "var x, y",
-        // "var x = 1, y = 2",
-        // "const x = 1, y = 2",
-        // "let x = 1, y = 2",
-        // "const {x} = {}",
-        // // WhileStatement
-        // "while(true){}",
-        // "while(ext > 0){}",
-        // "const x = ()=>{}; while(true)x()",
-        // // YieldExpression
-        // "function* x(){const a = yield}; x()",
-        // "function* x(){yield ext}; x()",
-        // // Supports TypeScript nodes
-        // "interface Blub {}",
+        // VariableDeclaration
+        "const x = 1",
+        // VariableDeclarator
+        "var x, y",
+        "var x = 1, y = 2",
+        "const x = 1, y = 2",
+        "let x = 1, y = 2",
+        "const {x} = {}",
+        // WhileStatement
+        "while(true){}",
+        "while(ext > 0){}",
+        "const x = ()=>{}; while(true)x()",
+        // YieldExpression
+        "function* x(){const a = yield}; x()",
+        "function* x(){yield ext}; x()",
+        // Supports TypeScript nodes
+        "interface Blub {}",
     ];
 
     let fail = vec![
@@ -622,22 +622,22 @@ fn test() {
         "1, ext()",
         "if (1, true) ext()",
         "if (1, ext) ext()",
-        // // Super when called
-        // "class y {constructor(){ext()}}; class x extends y {constructor(){super()}}; const z = new x()",
-        // "class y{}; class x extends y{constructor(){super(); super.test()}}; const z = new x()",
-        // "class y{}; class x extends y{constructor(){super()}}; const z = new x()",
-        // // SwitchCase
-        // "switch(ext){case ext():}",
-        // "switch(ext){case 1:ext()}",
-        // // SwitchStatement
-        // "switch(ext()){}",
+        // Super when called
+        "class y {constructor(){ext()}}; class x extends y {constructor(){super()}}; const z = new x()",
+        "class y{}; class x extends y{constructor(){super(); super.test()}}; const z = new x()",
+        "class y{}; class x extends y{constructor(){super()}}; const z = new x()",
+        // SwitchCase
+        "switch(ext){case ext():}",
+        "switch(ext){case 1:ext()}",
+        // SwitchStatement
+        "switch(ext()){}",
         // "var x=()=>{}; switch(ext){case 1:var x=ext}; x()",
-        // // TaggedTemplateExpression
-        // "const x = ext``",
-        // "ext``",
-        // "const x = ()=>{}; const y = x`${ext()}`",
-        // // TemplateLiteral
-        // "const x = `Literal ${ext()}`",
+        // TaggedTemplateExpression
+        "const x = ext``",
+        "ext``",
+        "const x = ()=>{}; const y = x`${ext()}`",
+        // TemplateLiteral
+        "const x = `Literal ${ext()}`",
         // ThisExpression when mutated
         "this.x = 1",
         "(()=>{this.x = 1})()",
@@ -657,21 +657,21 @@ fn test() {
         // UpdateExpression
         "ext++",
         "const x = {};x[ext()]++",
-        // // VariableDeclaration
-        // "const x = ext()",
-        // // VariableDeclarator
-        // "var x = ext(),y = ext()",
-        // "const x = ext(),y = ext()",
-        // "let x = ext(),y = ext()",
-        // "const {x = ext()} = {}",
-        // // WhileStatement
-        // "while(ext()){}",
-        // "while(true)ext()",
-        // "while(true){ext()}",
-        // // YieldExpression
-        // "function* x(){yield ext()}; x()",
-        // // YieldExpression when called
-        // "function* x(){yield ext()}; x()"
+        // VariableDeclaration
+        "const x = ext()",
+        // VariableDeclarator
+        "var x = ext(),y = ext()",
+        "const x = ext(),y = ext()",
+        "let x = ext(),y = ext()",
+        "const {x = ext()} = {}",
+        // WhileStatement
+        "while(ext()){}",
+        "while(true)ext()",
+        "while(true){ext()}",
+        // YieldExpression
+        "function* x(){yield ext()}; x()",
+        // YieldExpression when called
+        "function* x(){yield ext()}; x()"
     ];
 
     Tester::new(NoSideEffectsInInitialization::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_side_effects_in_initialization.snap
+++ b/crates/oxc_linter/src/snapshots/no_side_effects_in_initialization.snap
@@ -1070,6 +1070,78 @@ expression: no_side_effects_in_initialization
    ·             ───
    ╰────
 
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:24]
+ 1 │ class y {constructor(){ext()}}; class x extends y {constructor(){super()}}; const z = new x()
+   ·                        ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling
+   ╭─[no_side_effects_in_initialization.tsx:1:66]
+ 1 │ class y {constructor(){ext()}}; class x extends y {constructor(){super()}}; const z = new x()
+   ·                                                                  ─────
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling
+   ╭─[no_side_effects_in_initialization.tsx:1:44]
+ 1 │ class y{}; class x extends y{constructor(){super(); super.test()}}; const z = new x()
+   ·                                            ─────
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling member function
+   ╭─[no_side_effects_in_initialization.tsx:1:53]
+ 1 │ class y{}; class x extends y{constructor(){super(); super.test()}}; const z = new x()
+   ·                                                     ─────
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling
+   ╭─[no_side_effects_in_initialization.tsx:1:44]
+ 1 │ class y{}; class x extends y{constructor(){super()}}; const z = new x()
+   ·                                            ─────
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:18]
+ 1 │ switch(ext){case ext():}
+   ·                  ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:20]
+ 1 │ switch(ext){case 1:ext()}
+   ·                    ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:8]
+ 1 │ switch(ext()){}
+   ·        ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:11]
+ 1 │ const x = ext``
+   ·           ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:1]
+ 1 │ ext``
+   · ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:33]
+ 1 │ const x = ()=>{}; const y = x`${ext()}`
+   ·                                 ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:22]
+ 1 │ const x = `Literal ${ext()}`
+   ·                      ───
+   ╰────
+
   ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating unknown this value
    ╭─[no_side_effects_in_initialization.tsx:1:1]
  1 │ this.x = 1
@@ -1152,4 +1224,82 @@ expression: no_side_effects_in_initialization
    ╭─[no_side_effects_in_initialization.tsx:1:16]
  1 │ const x = {};x[ext()]++
    ·                ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:11]
+ 1 │ const x = ext()
+   ·           ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:9]
+ 1 │ var x = ext(),y = ext()
+   ·         ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:19]
+ 1 │ var x = ext(),y = ext()
+   ·                   ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:11]
+ 1 │ const x = ext(),y = ext()
+   ·           ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:21]
+ 1 │ const x = ext(),y = ext()
+   ·                     ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:9]
+ 1 │ let x = ext(),y = ext()
+   ·         ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:19]
+ 1 │ let x = ext(),y = ext()
+   ·                   ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:12]
+ 1 │ const {x = ext()} = {}
+   ·            ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:7]
+ 1 │ while(ext()){}
+   ·       ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:12]
+ 1 │ while(true)ext()
+   ·            ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:13]
+ 1 │ while(true){ext()}
+   ·             ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:21]
+ 1 │ function* x(){yield ext()}; x()
+   ·                     ───
+   ╰────
+
+  ⚠ eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `ext`
+   ╭─[no_side_effects_in_initialization.tsx:1:21]
+ 1 │ function* x(){yield ext()}; x()
+   ·                     ───
    ╰────


### PR DESCRIPTION
All test cases passed now. There are something remain. I'll change the category when it's ready.

- [x] Port [`isPureFuncion`](https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/96f0d1c8258732070894887a30ffa42d2952e3fc/src/utils/helpers.ts#L53-L67), [pure-function](https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/198432ecc9b341d10d20639e83b68055f3d72d13/src/utils/pure-functions.ts) 
- [ ] Support [options](https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/463fa1f0bef7caa2b231a38b9c3557051f506c92/src/rules/no-side-effects-in-initialization.ts#L1130-L1138)
- [ ] Clean TODO
- [ ] Add more support of operator computation. [The original version](https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/463fa1f0bef7caa2b231a38b9c3557051f506c92/src/rules/no-side-effects-in-initialization.ts#L139-L210) is straightforward benefit of JS. We only [support Number](https://github.com/oxc-project/oxc/blob/f91a063616b70b2fb7c1e8966d57620ee025d810/crates/oxc_linter/src/utils/tree_shaking.rs#L194) now.

