### PR TITLE
feat(linter) improve `prefer-string-starts-ends-with` rule

### DIFF
--- a/crates/oxc_linter/src/snapshots/prefer_string_starts_ends_with.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_string_starts_ends_with.snap
@@ -247,3 +247,15 @@ expression: prefer_string_starts_ends_with
  1 │ const a = /^你/.test('a');
    ·           ──────────
    ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-string-starts-ends-with): Prefer String#startsWith over a regex with a caret.
+   ╭─[prefer_string_starts_ends_with.tsx:1:5]
+ 1 │ if (/^#/i.test(hex)) {}
+   ·     ──────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-string-starts-ends-with): Prefer String#endsWith over a regex with a dollar sign.
+   ╭─[prefer_string_starts_ends_with.tsx:1:5]
+ 1 │ if (/#$/i.test(hex)) {}
+   ·     ──────────
+   ╰────


### PR DESCRIPTION
basically:
`^#/i.test(hex)` is the same as `/^#/.test(hex)`
so, in this case the `i` flag does nothing and we can safely ignore it


inspired by https://x.com/the_moisrex/status/1787444601571221892


---

This could potentially lead a new `oxc` rule called `no_useless_case_insensitive_regex_flag` that reports if you have a regex with the `i` flag with no ascii alphabetic chars.