### PR TITLE
fix(transform): implement `transform-react-display-name` with bottom-up lookup

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -115,8 +115,9 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x0_typescript.transform_binding_pattern(pat);
     }
 
-    fn enter_call_expression(&mut self, expr: &mut CallExpression<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_call_expression(&mut self, expr: &mut CallExpression<'a>, ctx: &TraverseCtx<'a>) {
         self.x0_typescript.transform_call_expression(expr);
+        self.x1_react.transform_call_expression(expr, ctx);
     }
 
     fn enter_class(&mut self, class: &mut Class<'a>, _ctx: &TraverseCtx<'a>) {
@@ -130,14 +131,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
 
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, _ctx: &TraverseCtx<'a>) {
         self.x0_typescript.transform_class_body(body);
-    }
-
-    fn enter_export_default_declaration(
-        &mut self,
-        decl: &mut ExportDefaultDeclaration<'a>,
-        _ctx: &TraverseCtx<'a>,
-    ) {
-        self.x1_react.transform_export_default_declaration(decl);
     }
 
     fn enter_export_named_declaration(
@@ -191,10 +184,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x0_typescript.transform_new_expression(expr);
     }
 
-    fn enter_object_property(&mut self, prop: &mut ObjectProperty<'a>, _ctx: &TraverseCtx<'a>) {
-        self.x1_react.transform_object_property(prop);
-    }
-
     fn enter_property_definition(
         &mut self,
         def: &mut PropertyDefinition<'a>,
@@ -214,14 +203,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         _ctx: &TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_tagged_template_expression(expr);
-    }
-
-    fn enter_variable_declarator(
-        &mut self,
-        declarator: &mut VariableDeclarator<'a>,
-        _ctx: &TraverseCtx<'a>,
-    ) {
-        self.x1_react.transform_variable_declarator(declarator);
     }
 
     fn enter_identifier_reference(

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -8,6 +8,7 @@ mod utils;
 use std::rc::Rc;
 
 use oxc_ast::ast::*;
+use oxc_traverse::TraverseCtx;
 
 use crate::context::Ctx;
 
@@ -58,11 +59,6 @@ impl<'a> React<'a> {
 
     pub fn transform_expression(&mut self, expr: &mut Expression<'a>) {
         match expr {
-            Expression::AssignmentExpression(e) => {
-                if self.options.display_name_plugin {
-                    self.display_name.transform_assignment_expression(e);
-                }
-            }
             Expression::JSXElement(e) => {
                 if self.options.is_jsx_plugin_enabled() {
                     *expr = self.jsx.transform_jsx_element(e);
@@ -77,21 +73,13 @@ impl<'a> React<'a> {
         }
     }
 
-    pub fn transform_variable_declarator(&self, declarator: &mut VariableDeclarator<'a>) {
+    pub fn transform_call_expression(
+        &self,
+        call_expr: &mut CallExpression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) {
         if self.options.display_name_plugin {
-            self.display_name.transform_variable_declarator(declarator);
-        }
-    }
-
-    pub fn transform_object_property(&self, prop: &mut ObjectProperty<'a>) {
-        if self.options.display_name_plugin {
-            self.display_name.transform_object_property(prop);
-        }
-    }
-
-    pub fn transform_export_default_declaration(&self, decl: &mut ExportDefaultDeclaration<'a>) {
-        if self.options.display_name_plugin {
-            self.display_name.transform_export_default_declaration(decl);
+            self.display_name.transform_call_expression(call_expr, ctx);
         }
     }
 

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,7 @@
-Passed: 294/362
+Passed: 295/362
 
 # All Passed:
+* babel-plugin-transform-react-display-name
 * babel-plugin-transform-react-jsx-source
 
 
@@ -68,9 +69,6 @@ Passed: 294/362
 # babel-plugin-transform-react-jsx (141/143)
 * autoImport/complicated-scope-module/input.js
 * react-automatic/should-throw-when-filter-is-specified/input.js
-
-# babel-plugin-transform-react-display-name (15/16)
-* display-name/nested/input.js
 
 # babel-plugin-transform-react-jsx-self (1/3)
 * react-source/arrow-function/input.js


### PR DESCRIPTION
Sliced off from #3152.

Re-implement `transform-react-display-name` using bottom-up lookup provided by `Traverse` trait.

This fixes the 1 remaining failing test case for this plugin (see #2937).

`Traverse` is not complete yet (see #3182), so this is also not ready to merge yet.