### PR TITLE
refactor(linter): reduce llvm lines generated by `RuleEnum::read_json`

### DIFF
--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -98,7 +98,8 @@ impl ESLintConfig {
                                 .iter()
                                 .find(|r| r.name() == rule_name && r.plugin_name() == plugin_name)
                             {
-                                rules_to_replace.push(rule.read_json(rule_config.config.clone()));
+                                let config = rule_config.config.clone().unwrap_or_default();
+                                rules_to_replace.push(rule.read_json(config));
                             }
                         }
                         AllowWarnDeny::Allow => {
@@ -119,7 +120,8 @@ impl ESLintConfig {
                         rule_configs.iter().find(|r| r.severity.is_warn_deny())
                     {
                         if let Some(rule) = rules_for_override.iter().find(|r| r.name() == *name) {
-                            rules_to_replace.push(rule.read_json(rule_config.config.clone()));
+                            let config = rule_config.config.clone().unwrap_or_default();
+                            rules_to_replace.push(rule.read_json(config));
                         }
                     } else if rule_configs.iter().all(|r| r.severity.is_allow()) {
                         if let Some(rule) = rules_for_override.iter().find(|r| r.name() == *name) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -96,10 +96,11 @@ declare_oxc_lint!(
 
 impl Rule for AriaRole {
     fn from_configuration(value: serde_json::Value) -> Self {
+        let Some(value) = value.as_array() else { return Self::default() };
         let mut ignore_non_dom = false;
         let mut allowed_invalid_roles: Vec<String> = vec![];
 
-        let _ = value.as_array().unwrap().iter().find(|v| {
+        let _ = value.iter().find(|v| {
             if let serde_json::Value::Object(obj) = v {
                 if let Some(serde_json::Value::Bool(val)) = obj.get("ignoreNonDOM") {
                     ignore_non_dom = *val;

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -61,7 +61,7 @@ impl Rule for JsxNoUselessFragment {
         Self {
             allow_expressions: value
                 .and_then(|val| val.get("allowExpressions").and_then(serde_json::Value::as_bool))
-                .unwrap_or(true),
+                .unwrap_or(Self::default().allow_expressions),
         }
     }
 
@@ -236,7 +236,7 @@ fn test() {
         ",
             Some(json!([{ "allowExpressions": true }])),
         ),
-        (r"{1 && <>{1}</>}", Some(json!(["warn", {"allowExpressions": true}]))),
+        (r"{1 && <>{1}</>}", Some(json!([{"allowExpressions": true}]))),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -48,9 +48,10 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyInterface {
     fn from_configuration(value: Value) -> Self {
-        let allow_single_extends = value.get(0).map_or(true, |config| {
-            config.get("allow_single_extends").and_then(Value::as_bool).unwrap_or_default()
-        });
+        let allow_single_extends =
+            value.get(0).map_or(Self::default().allow_single_extends, |config| {
+                config.get("allow_single_extends").and_then(Value::as_bool).unwrap_or_default()
+            });
 
         Self { allow_single_extends }
     }

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -199,7 +199,7 @@ impl Tester {
         is_fix: bool,
     ) -> TestResult {
         let allocator = Allocator::default();
-        let rule = self.find_rule().read_json(rule_config);
+        let rule = self.find_rule().read_json(rule_config.unwrap_or_default());
         let options = LintOptions::default()
             .with_fix(is_fix)
             .with_import_plugin(self.import_plugin)

--- a/crates/oxc_macros/src/declare_all_lint_rules/mod.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules/mod.rs
@@ -98,10 +98,10 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub fn read_json(&self, maybe_value: Option<serde_json::Value>) -> Self {
+            pub fn read_json(&self, value: serde_json::Value) -> Self {
                 match self {
                     #(Self::#struct_names(_) => Self::#struct_names(
-                        maybe_value.map(#struct_names::from_configuration).unwrap_or_default(),
+                        #struct_names::from_configuration(value),
                     )),*
                 }
             }


### PR DESCRIPTION
Previous: 

```
  Lines                 Copies               Function name
  -----                 ------               -------------
    9150 (1.1%, 13.8%)      1 (0.0%,  8.2%)  oxc_linter::rules::RuleEnum::read_json
```

After:

```
    2285 (0.3%, 36.2%)      1 (0.0%, 40.3%)  oxc_linter::rules::RuleEnum::read_json
```

