### PR TITLE
ci: build each benchmark only with deps it needs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,3 +1,16 @@
+# Benchmarks are sharded.
+#
+# Each benchmark (parser, transformer, etc) runs in parallel in a separate job.
+# Linter benchmarks are much slower to build and run than the rest, so linter benchmark
+# is built in 1 job, and then run on each fixture in parallel in separate jobs.
+# When all jobs are complete, a final job uploads all the results to CodSpeed.
+#
+# Sharding is not natively supported by CodSpeed, so we use a hacky method to achieve it.
+# 1. Intercept the data which `CodSpeedHQ/action` would normally upload to CodSpeed for each job.
+# 2. Once all runs are complete, combine the data for all the runs together.
+# 3. Upload the combined data to CodSpeed as one.
+# This is performed by some short NodeJS scripts in `tasks/benchmark/codspeed`.
+
 name: Benchmark
 
 on:
@@ -27,45 +40,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build Benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Branch
-        uses: taiki-e/checkout-action@v1
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          shared-key: 'benchmark'
-          save-cache: ${{ github.ref_name == 'main' }}
-
-      - name: Build benchmark
-        env:
-          RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
-        shell: bash
-        run: |
-          cargo build --release -p oxc_benchmark --benches --features codspeed
-          rm target/release/deps/*.d
-          mkdir -p target/codspeed/oxc_benchmark/
-          mv target/release/deps/lexer-* target/codspeed/oxc_benchmark/lexer
-          mv target/release/deps/parser-* target/codspeed/oxc_benchmark/parser
-          mv target/release/deps/transformer-* target/codspeed/oxc_benchmark/transformer
-          mv target/release/deps/semantic-* target/codspeed/oxc_benchmark/semantic
-          mv target/release/deps/minifier-* target/codspeed/oxc_benchmark/minifier
-          mv target/release/deps/codegen_sourcemap-* target/codspeed/oxc_benchmark/codegen_sourcemap
-          mv target/release/deps/sourcemap-* target/codspeed/oxc_benchmark/sourcemap
-          mv target/release/deps/linter-* target/codspeed/oxc_benchmark/linter
-
-      - name: Upload Binary
-        uses: actions/upload-artifact@v4
-        with:
-          if-no-files-found: error
-          name: benchmark
-          path: ./target/codspeed/oxc_benchmark
-
+  # Build and run benchmarks for all components except linter
   benchmark:
-    needs: build
     name: Benchmark
     runs-on: ubuntu-latest
     strategy:
@@ -79,23 +55,16 @@ jobs:
           - minifier
           - codegen_sourcemap
           - sourcemap
-          - linter
 
     steps:
       - name: Checkout Branch
         uses: taiki-e/checkout-action@v1
 
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
         with:
-          name: benchmark
-          path: ./target/codspeed/oxc_benchmark
-
-      - name: Fix permission loss
-        shell: bash
-        run: |
-          ls ./target/codspeed/oxc_benchmark
-          chmod +x ./target/codspeed/oxc_benchmark/${{ matrix.component }}
+          shared-key: benchmark-${{ matrix.component }}
+          save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Install codspeed
         uses: taiki-e/install-action@v2
@@ -117,6 +86,17 @@ jobs:
           pnpm install
           node capture.mjs &
 
+      - name: Build benchmark
+        env:
+          RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
+        shell: bash
+        run: |
+          cargo build --release -p oxc_benchmark --bench ${{ matrix.component }} \
+            --no-default-features --features ${{ matrix.component }} --features codspeed
+          mkdir -p target/codspeed/oxc_benchmark
+          mv target/release/deps/${{ matrix.component }}-* target/codspeed/oxc_benchmark
+          rm target/codspeed/oxc_benchmark/*.d
+
       - name: Run benchmark
         uses: CodSpeedHQ/action@v2
         timeout-minutes: 30
@@ -124,13 +104,116 @@ jobs:
           # Dummy token for tokenless runs, to suppress logging hash of metadata JSON (see `upload.mjs`)
           token: ${{ secrets.CODSPEED_TOKEN || 'dummy' }}
           upload-url: http://localhost:${{ env.INTERCEPT_PORT }}/upload
-          run: cargo codspeed run ${{ matrix.component }}
+          run: cargo codspeed run
 
       - name: Upload bench data artefact
         uses: actions/upload-artifact@v4
         with:
           name: result-${{ matrix.component }}
-          path: ${{ env.DATA_DIR }} # # env.DEFAULT_PORT from capture.mjs
+          path: ${{ env.DATA_DIR }} # env.DATA_DIR from `capture.mjs`
+          if-no-files-found: error
+          retention-days: 1
+
+  # Build linter benchmark.
+  # Linter benchmarks are much slower than the rest, so we run each fixture in a separate job.
+  # But only build the linter benchmark once.
+  build-linter:
+    name: Build Linter Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: taiki-e/checkout-action@v1
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          shared-key: benchmark-linter
+          save-cache: ${{ github.ref_name == 'main' }}
+
+      - name: Build benchmark
+        env:
+          RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
+        shell: bash
+        run: |
+          cargo build --release -p oxc_benchmark --bench linter \
+            --no-default-features --features linter --features codspeed
+          mkdir -p target/codspeed/oxc_benchmark
+          mv target/release/deps/linter-* target/codspeed/oxc_benchmark
+          rm target/codspeed/oxc_benchmark/*.d
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: benchmark-linter
+          path: ./target/codspeed/oxc_benchmark
+          retention-days: 1
+
+  # Run linter benchmarks. Each fixture in a separate job.
+  benchmark-linter:
+    name: Benchmark linter
+    needs: build-linter
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        fixture:
+          - 0
+          - 1
+
+    steps:
+      - name: Checkout Branch
+        uses: taiki-e/checkout-action@v1
+
+      - name: Download Binary
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-linter
+          path: ./target/codspeed/oxc_benchmark
+
+      - name: Fix permission loss
+        shell: bash
+        run: |
+          ls ./target/codspeed/oxc_benchmark
+          chmod +x ./target/codspeed/oxc_benchmark/*
+
+      - name: Install codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Start bench results interceptor server
+        working-directory: ./tasks/benchmark/codspeed
+        env:
+          COMPONENT: linter
+          FIXTURE: ${{ matrix.fixture }}
+        run: |
+          corepack enable
+          pnpm install
+          node capture.mjs &
+
+      - name: Run benchmark
+        uses: CodSpeedHQ/action@v2
+        timeout-minutes: 30
+        env:
+          FIXTURE: ${{ matrix.fixture }}
+        with:
+          # Dummy token for tokenless runs, to suppress logging hash of metadata JSON (see `upload.mjs`)
+          token: ${{ secrets.CODSPEED_TOKEN || 'dummy' }}
+          upload-url: http://localhost:${{ env.INTERCEPT_PORT }}/upload
+          run: cargo codspeed run
+
+      - name: Upload bench data artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-linter${{ matrix.fixture }}
+          path: ${{ env.DATA_DIR }} # env.DATA_DIR from `capture.mjs`
           if-no-files-found: error
           retention-days: 1
 
@@ -211,10 +294,11 @@ jobs:
           # if-no-files-found: error
           # retention-days: 1
 
+  # Upload combined benchmark results to CodSpeed
   upload:
     name: Upload benchmarks
-    # needs: [benchmark, benchmark-napi]
-    needs: [benchmark]
+    # needs: [benchmark, benchmark-linter, benchmark-napi]
+    needs: [benchmark, benchmark-linter]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Branch
@@ -238,10 +322,18 @@ jobs:
         with:
           merge-multiple: true
           pattern: result-*
-          path: ${{ env.DATA_DIR }} # env.DEFAULT_PORT from create_temp_dir.mjs
+          path: ${{ env.DATA_DIR }} # env.DATA_DIR from `create_temp_dir.mjs`
 
       - name: Upload to Codspeed
         working-directory: ./tasks/benchmark/codspeed
         env:
           CODSPEED_TOKEN: ${{ secrets.CODSPEED_TOKEN }}
         run: node upload.mjs
+
+      - name: Delete temporary artefacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            result-*
+            benchmark-linter
+          failOnError: false

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -62,9 +62,8 @@ harness = false
 bench   = false
 
 [dependencies]
-# All optional as `parser_napi` pseudo-benchmark doesn't need any of them,
-# and including them in compilation adds 1 minute to building that benchmark on CI.
-# See `tasks/benchmark/benches/parser_napi.rs`.
+# All `oxc_*` dependencies optional as on CI we build each benchmark separately
+# with only the crates it needs, to speed up the builds
 oxc_allocator    = { workspace = true, optional = true }
 oxc_linter       = { workspace = true, optional = true }
 oxc_minifier     = { workspace = true, optional = true }
@@ -77,7 +76,9 @@ oxc_transformer  = { workspace = true, optional = true }
 oxc_codegen      = { workspace = true, optional = true }
 oxc_sourcemap    = { workspace = true, features = ["rayon"], optional = true }
 
-criterion  = { package = "criterion2", version = "0.8.0", default-features = false }
+criterion = { package = "criterion2", version = "0.8.0", default-features = false }
+
+# Only for NAPI benchmark
 serde      = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
@@ -97,3 +98,29 @@ default = [
 ]
 codspeed = ["criterion/codspeed"]
 codspeed_napi = ["criterion/codspeed", "dep:serde", "dep:serde_json"]
+
+# Features for running each benchmark separately with minimum dependencies that benchmark needs.
+# e.g. `cargo build --release -p oxc_benchmark --bench parser --no-default-features --features parser`
+lexer = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
+parser = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
+transformer = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common", "dep:oxc_transformer"]
+semantic = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_semantic", "dep:oxc_span", "dep:oxc_tasks_common"]
+minifier = ["dep:oxc_allocator", "dep:oxc_minifier", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
+codegen_sourcemap = ["dep:oxc_allocator", "dep:oxc_codegen", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
+sourcemap = [
+  "dep:oxc_allocator",
+  "dep:oxc_codegen",
+  "dep:oxc_parser",
+  "dep:oxc_sourcemap",
+  "dep:oxc_span",
+  "dep:oxc_tasks_common",
+]
+linter = [
+  "dep:oxc_allocator",
+  "dep:oxc_linter",
+  "dep:oxc_parser",
+  "dep:oxc_semantic",
+  "dep:oxc_span",
+  "dep:oxc_tasks_common",
+]
+prettier = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_prettier", "dep:oxc_span", "dep:oxc_tasks_common"]

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, rc::Rc};
+use std::{env, path::PathBuf, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -11,7 +11,15 @@ use oxc_tasks_common::TestFiles;
 fn bench_linter(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("linter");
 
-    for file in TestFiles::linter().files() {
+    // If `FIXTURE` env is set, only run the specified benchmark. This is used for sharding in CI.
+    let test_files = if let Ok(fixture_index) = env::var("FIXTURE") {
+        let fixture_index = fixture_index.parse::<usize>().unwrap();
+        TestFiles::complicated_one(fixture_index)
+    } else {
+        TestFiles::complicated()
+    };
+
+    for file in test_files.files() {
         let source_type = SourceType::from_path(&file.file_name).unwrap();
         group.bench_with_input(
             BenchmarkId::from_parameter(&file.file_name),

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -52,11 +52,6 @@ impl TestFiles {
         Self { files: vec![file] }
     }
 
-    pub fn linter() -> Self {
-        let files = Self::complicated_urls().into_iter().take(2).map(TestFile::new).collect();
-        Self { files }
-    }
-
     fn complicated_urls() -> [&'static str; 5] {
         [
             // TypeScript syntax (2.81MB)


### PR DESCRIPTION
This PR builds on #3201 to further speed up the benchmarks and reduce CI time.

* Build and run each benchmark as separate job (like before).
* But now each bench is only built with the dependencies it needs.
* For linter benchmarks, build benchmark in 1 job (like #3201 does).
* Run each linter fixture in a separate job as they're slow.

This reduces total time to complete benchmarks from between 6m-7m to ~4m40s.

All the individual jobs complete in under 1m30s, except for building linter benchmark which takes 2m30s. So there won't be the problem of blocking the CI queue that there was before.

NB: I did try this before, and didn't see a benefit. But I realized today what I was doing wrong - it only works once the caches are populated by a previous run on main branch.

So the CI times in this PR won't look good, but once it's merged to main, it will take effect. Here it is running on main branch of my fork:

https://github.com/overlookmotel/oxc/actions/runs/9030511348

I also added a step to delete the temp artefacts which aren't needed once the run has completed.