### PR TITLE
ci: run all linter benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -160,6 +160,9 @@ jobs:
         fixture:
           - 0
           - 1
+          - 2
+          - 3
+          - 4
 
     steps:
       - name: Checkout Branch


### PR DESCRIPTION
After #3221 we can re-enable the linter benchmarks which were disabled in #3172, as they won't hog so much CI time any more.