### PR TITLE
improvement(semantic/cfg): add explicit break block element.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -288,6 +288,8 @@ impl GetterReturn {
 
                             return (DefinitelyReturnsOrThrowsOrUnreachable::Yes, false);
                         }
+                        // Ignore irrelevant elements.
+                        BasicBlockElement::Break(_) => {}
                     }
                 }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -489,14 +489,25 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_break_statement(&mut self, stmt: &BreakStatement<'a>) {
         let kind = AstKind::BreakStatement(self.alloc(stmt));
         self.enter_node(kind);
+        let maybe_label = stmt.label.as_ref();
 
         /* cfg */
         let statement_state = self
             .cfg
             .before_statement(self.current_node_id, StatementControlFlowType::DoesNotUseContinue);
+        let break_label = maybe_label.and_then(|_| {
+            let reg = Some(self.cfg.new_register());
+            self.cfg.use_this_register = reg;
+            reg
+        });
         /* cfg */
 
-        if let Some(break_target) = &stmt.label {
+        if let Some(break_target) = maybe_label {
+            /* cfg */
+            let break_label = self.cfg.new_register();
+            self.cfg.use_this_register = Some(break_label);
+            /* cfg */
+
             self.visit_label_identifier(break_target);
 
             /* cfg */
@@ -527,6 +538,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         }
         self.cfg.put_unreachable();
 
+        self.cfg.put_break(break_label);
         self.cfg.after_statement(
             &statement_state,
             self.current_node_id,

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -503,11 +503,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         /* cfg */
 
         if let Some(break_target) = maybe_label {
-            /* cfg */
-            let break_label = self.cfg.new_register();
-            self.cfg.use_this_register = Some(break_label);
-            /* cfg */
-
             self.visit_label_identifier(break_target);
 
             /* cfg */

--- a/crates/oxc_semantic/src/control_flow.rs
+++ b/crates/oxc_semantic/src/control_flow.rs
@@ -106,6 +106,7 @@ pub enum BasicBlockElement {
     Unreachable,
     Assignment(Register, AssignmentValue),
     Throw(Register),
+    Break(Option<Register>),
 }
 
 #[derive(Debug, Clone)]
@@ -237,6 +238,10 @@ impl ControlFlowGraph {
 
     pub fn put_throw(&mut self, throw_expr: Register) {
         self.current_basic_block().push(BasicBlockElement::Throw(throw_expr));
+    }
+
+    pub fn put_break(&mut self, label: Option<Register>) {
+        self.current_basic_block().push(BasicBlockElement::Break(label));
     }
 
     pub fn put_unreachable(&mut self) {
@@ -379,6 +384,13 @@ pub fn print_basic_block(basic_block_elements: &Vec<BasicBlockElement>) -> Strin
             BasicBlockElement::Unreachable => output.push_str("Unreachable()\n"),
             BasicBlockElement::Throw(reg) => {
                 output.push_str(&format!("throw {}\n", print_register(*reg)));
+            }
+
+            BasicBlockElement::Break(Some(reg)) => {
+                output.push_str(&format!("break {}\n", print_register(*reg)));
+            }
+            BasicBlockElement::Break(None) => {
+                output.push_str("break");
             }
             BasicBlockElement::Assignment(to, with) => {
                 output.push_str(&format!("{} = ", print_register(*to)));

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@break_from_a_label_in_global_scope.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@break_from_a_label_in_global_scope.js-2.snap
@@ -5,8 +5,7 @@ input_file: crates/oxc_semantic/tests/cfg_fixtures/break_from_a_label_in_global_
 ---
 digraph {
     0 [ label = ""]
-    1 [ label = "Unreachable()"]
+    1 [ label = "Unreachable()\nbreak $0"]
     0 -> 1 [ ]
     0 -> 1 [ ]
 }
-

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@break_from_a_label_in_global_scope.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@break_from_a_label_in_global_scope.js.snap
@@ -9,4 +9,5 @@ bb0: {
 
 bb1: {
 	Unreachable()
+	break $0
 }

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@do_while_break.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@do_while_break.js-2.snap
@@ -9,13 +9,13 @@ digraph {
     2 [ label = ""]
     3 [ label = ""]
     4 [ label = ""]
-    5 [ label = "Unreachable()"]
+    5 [ label = "Unreachable()\nbreak"]
     6 [ label = ""]
     7 [ label = ""]
     8 [ label = "Unreachable()"]
     9 [ label = ""]
     10 [ label = ""]
-    11 [ label = "Unreachable()"]
+    11 [ label = "Unreachable()\nbreak"]
     12 [ label = ""]
     13 [ label = ""]
     14 [ label = ""]
@@ -41,4 +41,3 @@ digraph {
     13 -> 14 [ ]
     0 -> 15 [ ]
 }
-

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@do_while_break.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@do_while_break.js.snap
@@ -25,6 +25,7 @@ bb4: {
 
 bb5: {
 	Unreachable()
+	break
 }
 
 bb6: {
@@ -49,6 +50,7 @@ bb10: {
 
 bb11: {
 	Unreachable()
+	break
 }
 
 bb12: {

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@if_stmt_in_for_in.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@if_stmt_in_for_in.js-2.snap
@@ -10,7 +10,7 @@ digraph {
     3 [ label = ""]
     4 [ label = ""]
     5 [ label = ""]
-    6 [ label = "Unreachable()"]
+    6 [ label = "Unreachable()\nbreak"]
     7 [ label = ""]
     8 [ label = ""]
     9 [ label = "Unreachable()"]
@@ -42,4 +42,3 @@ digraph {
     9 -> 3 [ ]
     0 -> 15 [ ]
 }
-

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@if_stmt_in_for_in.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@if_stmt_in_for_in.js.snap
@@ -29,6 +29,7 @@ bb5: {
 
 bb6: {
 	Unreachable()
+	break
 }
 
 bb7: {

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labeled_block_break.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labeled_block_break.js-2.snap
@@ -8,7 +8,7 @@ digraph {
     1 [ label = ""]
     2 [ label = ""]
     3 [ label = ""]
-    4 [ label = "Unreachable()"]
+    4 [ label = "Unreachable()\nbreak $0"]
     5 [ label = ""]
     6 [ label = ""]
     0 -> 1 [ ]
@@ -21,4 +21,3 @@ digraph {
     3 -> 5 [ ]
     5 -> 6 [ ]
 }
-

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labeled_block_break.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labeled_block_break.js.snap
@@ -21,6 +21,7 @@ bb3: {
 
 bb4: {
 	Unreachable()
+	break $0
 }
 
 bb5: {

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js-2.snap
@@ -10,10 +10,10 @@ digraph {
     3 [ label = ""]
     4 [ label = ""]
     5 [ label = "Unreachable()"]
-    6 [ label = "Unreachable()"]
+    6 [ label = "Unreachable()\nbreak $0"]
     7 [ label = "Unreachable()"]
     8 [ label = ""]
-    9 [ label = "Unreachable()"]
+    9 [ label = "Unreachable()\nbreak $2"]
     10 [ label = "$return = <value>"]
     11 [ label = ""]
     12 [ label = "Unreachable()"]
@@ -35,4 +35,3 @@ digraph {
     11 -> 12 [ ]
     0 -> 13 [ ]
 }
-

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js-2.snap
@@ -13,7 +13,7 @@ digraph {
     6 [ label = "Unreachable()\nbreak $0"]
     7 [ label = "Unreachable()"]
     8 [ label = ""]
-    9 [ label = "Unreachable()\nbreak $2"]
+    9 [ label = "Unreachable()\nbreak $1"]
     10 [ label = "$return = <value>"]
     11 [ label = ""]
     12 [ label = "Unreachable()"]

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js.snap
@@ -42,7 +42,7 @@ bb8: {
 
 bb9: {
 	Unreachable()
-	break $2
+	break $1
 }
 
 bb10: {

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@labelled_try_break.js.snap
@@ -29,6 +29,7 @@ bb5: {
 
 bb6: {
 	Unreachable()
+	break $0
 }
 
 bb7: {
@@ -41,6 +42,7 @@ bb8: {
 
 bb9: {
 	Unreachable()
+	break $2
 }
 
 bb10: {

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@switch_statement.js-2.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@switch_statement.js-2.snap
@@ -8,12 +8,12 @@ digraph {
     1 [ label = ""]
     2 [ label = ""]
     3 [ label = ""]
-    4 [ label = "Unreachable()"]
+    4 [ label = "Unreachable()\nbreak"]
     5 [ label = ""]
     6 [ label = ""]
     7 [ label = ""]
     8 [ label = ""]
-    9 [ label = "Unreachable()"]
+    9 [ label = "Unreachable()\nbreak"]
     10 [ label = ""]
     11 [ label = "$return = <value>"]
     12 [ label = ""]
@@ -70,4 +70,3 @@ digraph {
     20 -> 21 [ ]
     0 -> 22 [ ]
 }
-

--- a/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@switch_statement.js.snap
+++ b/crates/oxc_semantic/tests/snapshots/cfg__cfg_files@switch_statement.js.snap
@@ -21,6 +21,7 @@ bb3: {
 
 bb4: {
 	Unreachable()
+	break
 }
 
 bb5: {
@@ -41,6 +42,7 @@ bb8: {
 
 bb9: {
 	Unreachable()
+	break
 }
 
 bb10: {


### PR DESCRIPTION
Works similar to how `throw` is working but is done for `break` statements.