### PR TITLE
refactor(traverse): do not expose `TraverseCtx::new`

### DIFF
--- a/crates/oxc_traverse/src/context.rs
+++ b/crates/oxc_traverse/src/context.rs
@@ -34,7 +34,7 @@ pub enum FinderRet<T> {
 // Public methods
 impl<'a> TraverseCtx<'a> {
     /// Create new traversal context.
-    pub fn new(allocator: &'a Allocator) -> Self {
+    pub(crate) fn new(allocator: &'a Allocator) -> Self {
         let mut stack = Vec::with_capacity(INITIAL_STACK_CAPACITY);
         stack.push(Ancestor::None);
         Self { stack, ast: AstBuilder::new(allocator) }


### PR DESCRIPTION
Creating a `TraverseCtx` with `TraverseCtx::new` should be an internal API within `oxc_traverse`. Don't expose it outside the crate.