### PR TITLE
refactor(ast): add `is_strict` methods

### DIFF
--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -106,6 +106,10 @@ impl SourceType {
         self.always_strict
     }
 
+    pub fn is_strict(self) -> bool {
+        self.is_module() || self.always_strict
+    }
+
     #[must_use]
     pub fn with_script(mut self, yes: bool) -> Self {
         if yes {


### PR DESCRIPTION
De-duplicate logic for checking for `"use strict"` directives.