### PR TITLE
refactor(traverse): simplify build script

### DIFF
--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -45,14 +45,14 @@ export default function generateAncestorsCode(types) {
             }
 
             const fieldNameCamel = snakeToCamel(field.name),
-                lifetime = type.hasLifetime ? "<'a>" : '',
+                lifetime = type.rawName.slice(type.name.length),
                 structName = `${type.name}Without${fieldNameCamel}${lifetime}`;
 
             thisAncestorTypes += `
                 #[repr(transparent)]
                 #[derive(Debug)]
                 pub struct ${structName}(
-                    pub(crate) *const ${type.name}${lifetime}
+                    pub(crate) *const ${type.rawName}
                 );
 
                 impl${lifetime} ${structName} {

--- a/crates/oxc_traverse/scripts/lib/parse.mjs
+++ b/crates/oxc_traverse/scripts/lib/parse.mjs
@@ -44,11 +44,10 @@ function parseFile(code, filename, types) {
 
         let match;
         while (true) {
-            match = lines[++lineIndex].match(/^pub (enum|struct) (.+?)(<'a>)? \{/);
+            match = lines[++lineIndex].match(/^pub (enum|struct) ((.+?)(?:<'a>)?) \{/);
             if (match) break;
         }
-        const [, kind, name, lifetimeStr] = match,
-            hasLifetime = !!lifetimeStr,
+        const [, kind, rawName, name] = match,
             startLineIndex = lineIndex;
 
         const itemLines = [];
@@ -59,14 +58,14 @@ function parseFile(code, filename, types) {
         }
 
         if (kind === 'struct') {
-            types[name] = parseStruct(name, hasLifetime, itemLines, scopeArgs, filename, startLineIndex);
+            types[name] = parseStruct(name, rawName, itemLines, scopeArgs, filename, startLineIndex);
         } else {
-            types[name] = parseEnum(name, hasLifetime, itemLines, filename, startLineIndex);
+            types[name] = parseEnum(name, rawName, itemLines, filename, startLineIndex);
         }
     }
 }
 
-function parseStruct(name, hasLifetime, lines, scopeArgs, filename, startLineIndex) {
+function parseStruct(name, rawName, lines, scopeArgs, filename, startLineIndex) {
     const fields = [];
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -88,10 +87,10 @@ function parseStruct(name, hasLifetime, lines, scopeArgs, filename, startLineInd
         
         fields.push({name, typeName, rawName, rawTypeName, innerTypeName, wrappers});
     }
-    return {kind: 'struct', name, hasLifetime, fields, scopeArgs};
+    return {kind: 'struct', name, rawName, fields, scopeArgs};
 }
 
-function parseEnum(name, hasLifetime, lines, filename, startLineIndex) {
+function parseEnum(name, rawName, lines, filename, startLineIndex) {
     const variants = [],
         inherits = [];
     for (const [lineIndex, line] of lines.entries()) {
@@ -111,7 +110,7 @@ function parseEnum(name, hasLifetime, lines, filename, startLineIndex) {
             inherits.push(match2[1]);
         }
     }
-    return {kind: 'enum', name, hasLifetime, variants, inherits};
+    return {kind: 'enum', name, rawName, variants, inherits};
 }
 
 function parseScopeArgs(argsStr, filename, lineIndex) {

--- a/crates/oxc_traverse/scripts/lib/traverse.mjs
+++ b/crates/oxc_traverse/scripts/lib/traverse.mjs
@@ -1,15 +1,17 @@
-import {camelToSnake, toTypeName} from './utils.mjs';
+import {camelToSnake} from './utils.mjs';
 
 export default function generateTraverseTraitCode(types) {
+    const typesArr = Object.values(types);
+    typesArr.push({name: 'Statements', rawName: "Vec<'a, Statement<'a>>"});
+
     let traverseMethods = '';
-    for (const type of Object.values(types)) {
-        const snakeName = camelToSnake(type.name),
-            typeName = toTypeName(type);
+    for (const type of typesArr) {
+        const snakeName = camelToSnake(type.name);
         traverseMethods += `
             #[inline]
-            fn enter_${snakeName}(&mut self, node: &mut ${typeName}, ctx: &TraverseCtx<'a>) {}
+            fn enter_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &TraverseCtx<'a>) {}
             #[inline]
-            fn exit_${snakeName}(&mut self, node: &mut ${typeName}, ctx: &TraverseCtx<'a>) {}
+            fn exit_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &TraverseCtx<'a>) {}
         `;
     }
 
@@ -23,11 +25,6 @@ export default function generateTraverseTraitCode(types) {
         #[allow(unused_variables)]
         pub trait Traverse<'a> {
             ${traverseMethods}
-
-            #[inline]
-            fn enter_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &TraverseCtx<'a>) {}
-            #[inline]
-            fn exit_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &TraverseCtx<'a>) {}
         }
     `;
 }

--- a/crates/oxc_traverse/scripts/lib/utils.mjs
+++ b/crates/oxc_traverse/scripts/lib/utils.mjs
@@ -9,12 +9,6 @@ export function typeAndWrappers(name) {
     return {name, wrappers};
 }
 
-export function toTypeName(type) {
-    let ty = type.name;
-    if (type.hasLifetime) ty += "<'a>";
-    return ty;
-}
-
 export function camelToSnake(name) {
     let prefixLen = 1;
     for (const prefix of ['TS', 'JSX', 'JS']) {

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import {toTypeName, camelToSnake, snakeToCamel} from './utils.mjs';
+import {camelToSnake, snakeToCamel} from './utils.mjs';
 
 export default function generateWalkFunctionsCode(types) {
     let walkMethods = '';
@@ -195,7 +195,7 @@ function generateWalkForStruct(type, types) {
     return `
         pub(crate) unsafe fn walk_${typeSnakeName}<'a, Tr: Traverse<'a>>(
             traverser: &mut Tr,
-            node: *mut ${toTypeName(type)},
+            node: *mut ${type.rawName},
             ctx: &mut TraverseCtx<'a>
         ) {
             traverser.enter_${typeSnakeName}(&mut *node, ctx);
@@ -255,7 +255,7 @@ function generateWalkForEnum(type, types) {
     return `
         pub(crate) unsafe fn walk_${typeSnakeName}<'a, Tr: Traverse<'a>>(
             traverser: &mut Tr,
-            node: *mut ${toTypeName(type)},
+            node: *mut ${type.rawName},
             ctx: &mut TraverseCtx<'a>
         ) {
             traverser.enter_${typeSnakeName}(&mut *node, ctx);


### PR DESCRIPTION
Refactor build script to simplify it. No changes to the `.rs` files the script creates, only the script itself.