### PR TITLE
fix(traverse): create scope for function nested in class method

### DIFF
--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -23,11 +23,8 @@ bitflags! {
         const Constructor      = 1 << 6;
         const GetAccessor      = 1 << 7;
         const SetAccessor      = 1 << 8;
-        // Only used in `Traverse`
-        const Method           = 1 << 9;
         const Var = Self::Top.bits() | Self::Function.bits() | Self::ClassStaticBlock.bits() | Self::TsModuleBlock.bits();
-        const Modifiers = Self::Constructor.bits() | Self::GetAccessor.bits()
-            | Self::SetAccessor.bits() | Self::Method.bits();
+        const Modifiers = Self::Constructor.bits() | Self::GetAccessor.bits() | Self::SetAccessor.bits();
     }
 }
 

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -2228,7 +2228,7 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_function(&mut *node, ctx);
     ctx.push_stack(Ancestor::FunctionId(ancestor::FunctionWithoutId(node)));
-    let has_scope = (ctx.scope() & ScopeFlags::Modifiers).is_empty();
+    let has_scope = matches!(ctx.ancestor(2).unwrap(), Ancestor::MethodDefinitionValue(_));
     if has_scope {
         ctx.push_scope_stack(
             ScopeFlags::Function.with_strict_mode(


### PR DESCRIPTION
Fixes a bug in #3229.

The logic to prevent a duplicate scope being created for a `Function` which is a `MethodDefinition` would also stop a scope being created for inner function in:

```rs
class X {
  foo() {
    function bar() {}
  }
}
```

or

```rs
class X {
  foo( bar = function() {} ) {}
}
```

This PR fixes that. This change also allows removing `ScopeFlags::Method` which #3229 added.