### PR TITLE
test(parser): add snapshot test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "globset",
  "lazy_static",
  "linked-hash-map",
+ "serde",
  "similar",
  "walkdir",
 ]
@@ -1504,6 +1505,7 @@ version = "0.12.5"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.5.0",
+ "insta",
  "memchr",
  "num-bigint",
  "ouroboros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ walkdir             = "2.5.0"
 indexmap            = "2.2.6"
 static_assertions   = "1.1.0"
 tracing-subscriber  = "0.3"
-insta               = "1.38.0"
+insta               = { version = "1.38.0", features = ["glob", "json"] }
 mime_guess          = "2.0.4"
 language-tags       = "0.3.2"
 tsify               = "0.4.5"
@@ -180,6 +180,11 @@ ignored = ["napi", "oxc_traverse"]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.
 debug = false
+
+[profile.dev.package]
+# compile Insta in release mode for faster snapshot tests
+insta.opt-level   = 3
+similar.opt-level = 3
 
 [profile.release.package.oxc_wasm]
 opt-level = 'z'

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -34,9 +34,10 @@ seq-macro         = { workspace = true }
 memchr = { workspace = true }
 
 [dev-dependencies]
+insta      = { workspace = true }
+ouroboros  = { workspace = true }                           # for `multi-thread` example
 oxc_ast    = { workspace = true, features = ["serialize"] }
 serde_json = { workspace = true }
-ouroboros  = { workspace = true }                           # for `multi-thread` example
 
 [features]
 # Expose Lexer for benchmarks

--- a/crates/oxc_parser/tests/fixtures/ts/false_fail/member-computed-decorator.ts
+++ b/crates/oxc_parser/tests/fixtures/ts/false_fail/member-computed-decorator.ts
@@ -1,0 +1,27 @@
+// Using legacy decorators with computed member access
+/// <reference lib="decorators.legacy" />
+declare namespace Reflect {
+	function defineMetadata(metadataKey: any, metadataValue: any, target: any, propertyKey: any): void
+}
+const ApiQuery = (options: any) => (
+	target: Object,
+	propertyKey: string | symbol,
+	descriptor: PropertyDescriptor
+): void => {
+	Reflect.defineMetadata('api:query', options, target, propertyKey)
+}
+const SomeTypeMap = {
+	String: String,
+	Int: Number,
+	Float: Number,
+} as const
+
+class Bar {
+	@ApiQuery({
+		name: 'a',
+		type: SomeTypeMap['String']
+	})
+	getFoo() {
+		return 'foo'
+	} 
+}

--- a/crates/oxc_parser/tests/fixtures/ts/true_fail/var_decl_empty_assignment.ts
+++ b/crates/oxc_parser/tests/fixtures/ts/true_fail/var_decl_empty_assignment.ts
@@ -1,0 +1,1 @@
+let x: number = 

--- a/crates/oxc_parser/tests/fixtures/ts/true_pass/class_expr.ts
+++ b/crates/oxc_parser/tests/fixtures/ts/true_pass/class_expr.ts
@@ -1,0 +1,4 @@
+// Classes can be assigned to a variable
+const Foo = class {
+    constructor(a: number, private readonly e: number) {}
+}

--- a/crates/oxc_parser/tests/fixtures/ts/true_pass/member-computed-type-annotation.ts
+++ b/crates/oxc_parser/tests/fixtures/ts/true_pass/member-computed-type-annotation.ts
@@ -1,0 +1,20 @@
+type Foo = {
+    a: number
+    b: string
+}
+
+interface Bar {
+    a: number
+    b: string
+}
+
+class Baz {
+    a: number
+    b: string
+
+}
+
+const x: Foo['a'] = 1
+const y: Bar['a'] = 1
+const z: Baz['a'] = 1
+

--- a/crates/oxc_parser/tests/fixtures/ts/true_pass/member-static-decorator.ts
+++ b/crates/oxc_parser/tests/fixtures/ts/true_pass/member-static-decorator.ts
@@ -1,0 +1,25 @@
+// Using legacy decorators with computed member access
+/// <reference lib="decorators.legacy" />
+declare namespace Reflect {
+	function defineMetadata(metadataKey: any, metadataValue: any, target: any, propertyKey: any): void
+}
+const ApiQuery = (options: any) => (
+	target: Object,
+	propertyKey: string | symbol,
+	descriptor: PropertyDescriptor
+): void => {
+	Reflect.defineMetadata('api:query', options, target, propertyKey)
+}
+const SomeTypeMap = {
+	String: String,
+}
+
+class Bar {
+	@ApiQuery({
+		name: 'a',
+		type: SomeTypeMap.String
+	})
+	getFoo() {
+		return 'foo'
+	} 
+}

--- a/crates/oxc_parser/tests/snapshots/ts/false_fail/do_test@member-computed-decorator.ts.snap
+++ b/crates/oxc_parser/tests/snapshots/ts/false_fail/do_test@member-computed-decorator.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_parser/tests/ts.rs
+expression: snapshot_str
+info: "Should parse but doesn't"
+input_file: crates/oxc_parser/tests/fixtures/ts/false_fail/member-computed-decorator.ts
+---
+============= ERRORS =============
+- error: Expected `,` but found `[` (offset: 564, len: 1)
+
+============= PROGRAM =============
+{
+  "type": "Program",
+  "start": 0,
+  "end": 0,
+  "sourceType": {
+    "language": "typescript",
+    "moduleKind": "module",
+    "variant": "standard",
+    "alwaysStrict": false
+  },
+  "directives": [],
+  "hashbang": null,
+  "body": []
+}

--- a/crates/oxc_parser/tests/snapshots/ts/true_fail/do_test@var_decl_empty_assignment.ts.snap
+++ b/crates/oxc_parser/tests/snapshots/ts/true_fail/do_test@var_decl_empty_assignment.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_parser/tests/ts.rs
+expression: snapshot_str
+info: Correctly fails to parse
+input_file: crates/oxc_parser/tests/fixtures/ts/true_fail/var_decl_empty_assignment.ts
+---
+============= ERRORS =============
+- error: Unexpected token (offset: 17, len: 0)
+
+============= PROGRAM =============
+{
+  "type": "Program",
+  "start": 0,
+  "end": 0,
+  "sourceType": {
+    "language": "typescript",
+    "moduleKind": "module",
+    "variant": "standard",
+    "alwaysStrict": false
+  },
+  "directives": [],
+  "hashbang": null,
+  "body": []
+}

--- a/crates/oxc_parser/tests/snapshots/ts/true_pass/do_test@class_expr.ts.snap
+++ b/crates/oxc_parser/tests/snapshots/ts/true_pass/do_test@class_expr.ts.snap
@@ -1,0 +1,160 @@
+---
+source: crates/oxc_parser/tests/ts.rs
+expression: ret.program
+info: Correctly parses without errors
+input_file: crates/oxc_parser/tests/fixtures/ts/true_pass/class_expr.ts
+---
+{
+  "type": "Program",
+  "start": 0,
+  "end": 121,
+  "sourceType": {
+    "language": "typescript",
+    "moduleKind": "module",
+    "variant": "standard",
+    "alwaysStrict": false
+  },
+  "directives": [],
+  "hashbang": null,
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "start": 41,
+      "end": 120,
+      "kind": "const",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 47,
+          "end": 120,
+          "id": {
+            "type": "Identifier",
+            "start": 47,
+            "end": 50,
+            "name": "Foo",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "init": {
+            "type": "ClassExpression",
+            "start": 53,
+            "end": 120,
+            "decorators": [],
+            "id": null,
+            "superClass": null,
+            "body": {
+              "type": "ClassBody",
+              "start": 59,
+              "end": 120,
+              "body": [
+                {
+                  "type": "MethodDefinition",
+                  "start": 65,
+                  "end": 118,
+                  "decorators": [],
+                  "key": {
+                    "type": "Identifier",
+                    "start": 65,
+                    "end": 76,
+                    "name": "constructor"
+                  },
+                  "value": {
+                    "type": "FunctionExpression",
+                    "start": 76,
+                    "end": 118,
+                    "id": null,
+                    "generator": false,
+                    "async": false,
+                    "thisParam": null,
+                    "params": {
+                      "type": "FormalParameters",
+                      "start": 76,
+                      "end": 115,
+                      "kind": "FormalParameter",
+                      "items": [
+                        {
+                          "type": "FormalParameter",
+                          "start": 77,
+                          "end": 86,
+                          "pattern": {
+                            "type": "Identifier",
+                            "start": 77,
+                            "end": 86,
+                            "name": "a",
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 78,
+                              "end": 86,
+                              "typeAnnotation": {
+                                "type": "TSNumberKeyword",
+                                "start": 80,
+                                "end": 86
+                              }
+                            },
+                            "optional": false
+                          },
+                          "accessibility": null,
+                          "readonly": false,
+                          "override": false,
+                          "decorators": []
+                        },
+                        {
+                          "type": "FormalParameter",
+                          "start": 88,
+                          "end": 114,
+                          "pattern": {
+                            "type": "Identifier",
+                            "start": 105,
+                            "end": 114,
+                            "name": "e",
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 106,
+                              "end": 114,
+                              "typeAnnotation": {
+                                "type": "TSNumberKeyword",
+                                "start": 108,
+                                "end": 114
+                              }
+                            },
+                            "optional": false
+                          },
+                          "accessibility": "private",
+                          "readonly": true,
+                          "override": false,
+                          "decorators": []
+                        }
+                      ]
+                    },
+                    "body": {
+                      "type": "FunctionBody",
+                      "start": 116,
+                      "end": 118,
+                      "directives": [],
+                      "statements": []
+                    },
+                    "typeParameters": null,
+                    "returnType": null,
+                    "modifiers": null
+                  },
+                  "kind": "constructor",
+                  "computed": false,
+                  "static": false,
+                  "override": false,
+                  "optional": false,
+                  "accessibility": null
+                }
+              ]
+            },
+            "typeParameters": null,
+            "superTypeParameters": null,
+            "implements": null,
+            "modifiers": null
+          },
+          "definite": false
+        }
+      ],
+      "modifiers": null
+    }
+  ]
+}

--- a/crates/oxc_parser/tests/snapshots/ts/true_pass/do_test@member-computed-type-annotation.ts.snap
+++ b/crates/oxc_parser/tests/snapshots/ts/true_pass/do_test@member-computed-type-annotation.ts.snap
@@ -1,0 +1,430 @@
+---
+source: crates/oxc_parser/tests/ts.rs
+expression: ret.program
+info: Correctly parses without errors
+input_file: crates/oxc_parser/tests/fixtures/ts/true_pass/member-computed-type-annotation.ts
+---
+{
+  "type": "Program",
+  "start": 0,
+  "end": 202,
+  "sourceType": {
+    "language": "typescript",
+    "moduleKind": "module",
+    "variant": "standard",
+    "alwaysStrict": false
+  },
+  "directives": [],
+  "hashbang": null,
+  "body": [
+    {
+      "type": "TSTypeAliasDeclaration",
+      "start": 0,
+      "end": 42,
+      "id": {
+        "type": "Identifier",
+        "start": 5,
+        "end": 8,
+        "name": "Foo"
+      },
+      "typeAnnotation": {
+        "type": "TSTypeLiteral",
+        "start": 11,
+        "end": 42,
+        "members": [
+          {
+            "type": "TSPropertySignature",
+            "start": 17,
+            "end": 26,
+            "computed": false,
+            "optional": false,
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "start": 17,
+              "end": 18,
+              "name": "a"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 18,
+              "end": 26,
+              "typeAnnotation": {
+                "type": "TSNumberKeyword",
+                "start": 20,
+                "end": 26
+              }
+            }
+          },
+          {
+            "type": "TSPropertySignature",
+            "start": 31,
+            "end": 40,
+            "computed": false,
+            "optional": false,
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "start": 31,
+              "end": 32,
+              "name": "b"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 32,
+              "end": 40,
+              "typeAnnotation": {
+                "type": "TSStringKeyword",
+                "start": 34,
+                "end": 40
+              }
+            }
+          }
+        ]
+      },
+      "typeParameters": null,
+      "modifiers": []
+    },
+    {
+      "type": "TSInterfaceDeclaration",
+      "start": 44,
+      "end": 89,
+      "id": {
+        "type": "Identifier",
+        "start": 54,
+        "end": 57,
+        "name": "Bar"
+      },
+      "body": {
+        "type": "TSInterfaceBody",
+        "start": 58,
+        "end": 89,
+        "body": [
+          {
+            "type": "TSPropertySignature",
+            "start": 64,
+            "end": 73,
+            "computed": false,
+            "optional": false,
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "start": 64,
+              "end": 65,
+              "name": "a"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 65,
+              "end": 73,
+              "typeAnnotation": {
+                "type": "TSNumberKeyword",
+                "start": 67,
+                "end": 73
+              }
+            }
+          },
+          {
+            "type": "TSPropertySignature",
+            "start": 78,
+            "end": 87,
+            "computed": false,
+            "optional": false,
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "start": 78,
+              "end": 79,
+              "name": "b"
+            },
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 79,
+              "end": 87,
+              "typeAnnotation": {
+                "type": "TSStringKeyword",
+                "start": 81,
+                "end": 87
+              }
+            }
+          }
+        ]
+      },
+      "typeParameters": null,
+      "extends": null,
+      "modifiers": []
+    },
+    {
+      "type": "ClassDeclaration",
+      "start": 91,
+      "end": 133,
+      "decorators": [],
+      "id": {
+        "type": "Identifier",
+        "start": 97,
+        "end": 100,
+        "name": "Baz"
+      },
+      "superClass": null,
+      "body": {
+        "type": "ClassBody",
+        "start": 101,
+        "end": 133,
+        "body": [
+          {
+            "type": "PropertyDefinition",
+            "start": 107,
+            "end": 116,
+            "key": {
+              "type": "Identifier",
+              "start": 107,
+              "end": 108,
+              "name": "a"
+            },
+            "value": null,
+            "computed": false,
+            "static": false,
+            "declare": false,
+            "override": false,
+            "optional": false,
+            "definite": false,
+            "readonly": false,
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 108,
+              "end": 116,
+              "typeAnnotation": {
+                "type": "TSNumberKeyword",
+                "start": 110,
+                "end": 116
+              }
+            },
+            "accessibility": null,
+            "decorators": []
+          },
+          {
+            "type": "PropertyDefinition",
+            "start": 121,
+            "end": 130,
+            "key": {
+              "type": "Identifier",
+              "start": 121,
+              "end": 122,
+              "name": "b"
+            },
+            "value": null,
+            "computed": false,
+            "static": false,
+            "declare": false,
+            "override": false,
+            "optional": false,
+            "definite": false,
+            "readonly": false,
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 122,
+              "end": 130,
+              "typeAnnotation": {
+                "type": "TSStringKeyword",
+                "start": 124,
+                "end": 130
+              }
+            },
+            "accessibility": null,
+            "decorators": []
+          }
+        ]
+      },
+      "typeParameters": null,
+      "superTypeParameters": null,
+      "implements": null,
+      "modifiers": null
+    },
+    {
+      "type": "VariableDeclaration",
+      "start": 135,
+      "end": 156,
+      "kind": "const",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 141,
+          "end": 156,
+          "id": {
+            "type": "Identifier",
+            "start": 141,
+            "end": 152,
+            "name": "x",
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 142,
+              "end": 152,
+              "typeAnnotation": {
+                "type": "TSIndexedAccessType",
+                "start": 144,
+                "end": 152,
+                "objectType": {
+                  "type": "TSTypeReference",
+                  "start": 144,
+                  "end": 147,
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 144,
+                    "end": 147,
+                    "name": "Foo"
+                  },
+                  "typeParameters": null
+                },
+                "indexType": {
+                  "type": "TSLiteralType",
+                  "start": 148,
+                  "end": 151,
+                  "literal": {
+                    "type": "StringLiteral",
+                    "start": 148,
+                    "end": 151,
+                    "value": "a"
+                  }
+                }
+              }
+            },
+            "optional": false
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "start": 155,
+            "end": 156,
+            "value": 1.0,
+            "raw": "1"
+          },
+          "definite": false
+        }
+      ],
+      "modifiers": null
+    },
+    {
+      "type": "VariableDeclaration",
+      "start": 157,
+      "end": 178,
+      "kind": "const",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 163,
+          "end": 178,
+          "id": {
+            "type": "Identifier",
+            "start": 163,
+            "end": 174,
+            "name": "y",
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 164,
+              "end": 174,
+              "typeAnnotation": {
+                "type": "TSIndexedAccessType",
+                "start": 166,
+                "end": 174,
+                "objectType": {
+                  "type": "TSTypeReference",
+                  "start": 166,
+                  "end": 169,
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 166,
+                    "end": 169,
+                    "name": "Bar"
+                  },
+                  "typeParameters": null
+                },
+                "indexType": {
+                  "type": "TSLiteralType",
+                  "start": 170,
+                  "end": 173,
+                  "literal": {
+                    "type": "StringLiteral",
+                    "start": 170,
+                    "end": 173,
+                    "value": "a"
+                  }
+                }
+              }
+            },
+            "optional": false
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "start": 177,
+            "end": 178,
+            "value": 1.0,
+            "raw": "1"
+          },
+          "definite": false
+        }
+      ],
+      "modifiers": null
+    },
+    {
+      "type": "VariableDeclaration",
+      "start": 179,
+      "end": 200,
+      "kind": "const",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 185,
+          "end": 200,
+          "id": {
+            "type": "Identifier",
+            "start": 185,
+            "end": 196,
+            "name": "z",
+            "typeAnnotation": {
+              "type": "TSTypeAnnotation",
+              "start": 186,
+              "end": 196,
+              "typeAnnotation": {
+                "type": "TSIndexedAccessType",
+                "start": 188,
+                "end": 196,
+                "objectType": {
+                  "type": "TSTypeReference",
+                  "start": 188,
+                  "end": 191,
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 188,
+                    "end": 191,
+                    "name": "Baz"
+                  },
+                  "typeParameters": null
+                },
+                "indexType": {
+                  "type": "TSLiteralType",
+                  "start": 192,
+                  "end": 195,
+                  "literal": {
+                    "type": "StringLiteral",
+                    "start": 192,
+                    "end": 195,
+                    "value": "a"
+                  }
+                }
+              }
+            },
+            "optional": false
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "start": 199,
+            "end": 200,
+            "value": 1.0,
+            "raw": "1"
+          },
+          "definite": false
+        }
+      ],
+      "modifiers": null
+    }
+  ]
+}

--- a/crates/oxc_parser/tests/snapshots/ts/true_pass/do_test@member-static-decorator.ts.snap
+++ b/crates/oxc_parser/tests/snapshots/ts/true_pass/do_test@member-static-decorator.ts.snap
@@ -1,0 +1,676 @@
+---
+source: crates/oxc_parser/tests/ts.rs
+expression: ret.program
+info: Correctly parses without errors
+input_file: crates/oxc_parser/tests/fixtures/ts/true_pass/member-static-decorator.ts
+---
+{
+  "type": "Program",
+  "start": 0,
+  "end": 570,
+  "sourceType": {
+    "language": "typescript",
+    "moduleKind": "module",
+    "variant": "standard",
+    "alwaysStrict": false
+  },
+  "directives": [],
+  "hashbang": null,
+  "body": [
+    {
+      "type": "TSModuleDeclaration",
+      "start": 97,
+      "end": 226,
+      "id": {
+        "type": "Identifier",
+        "start": 115,
+        "end": 122,
+        "name": "Reflect"
+      },
+      "body": {
+        "type": "TSModuleBlock",
+        "start": 123,
+        "end": 226,
+        "body": [
+          {
+            "type": "TSDeclareFunction",
+            "start": 126,
+            "end": 224,
+            "id": {
+              "type": "Identifier",
+              "start": 135,
+              "end": 149,
+              "name": "defineMetadata"
+            },
+            "generator": false,
+            "async": false,
+            "thisParam": null,
+            "params": {
+              "type": "FormalParameters",
+              "start": 149,
+              "end": 218,
+              "kind": "FormalParameter",
+              "items": [
+                {
+                  "type": "FormalParameter",
+                  "start": 150,
+                  "end": 166,
+                  "pattern": {
+                    "type": "Identifier",
+                    "start": 150,
+                    "end": 166,
+                    "name": "metadataKey",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 161,
+                      "end": 166,
+                      "typeAnnotation": {
+                        "type": "TSAnyKeyword",
+                        "start": 163,
+                        "end": 166
+                      }
+                    },
+                    "optional": false
+                  },
+                  "accessibility": null,
+                  "readonly": false,
+                  "override": false,
+                  "decorators": []
+                },
+                {
+                  "type": "FormalParameter",
+                  "start": 168,
+                  "end": 186,
+                  "pattern": {
+                    "type": "Identifier",
+                    "start": 168,
+                    "end": 186,
+                    "name": "metadataValue",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 181,
+                      "end": 186,
+                      "typeAnnotation": {
+                        "type": "TSAnyKeyword",
+                        "start": 183,
+                        "end": 186
+                      }
+                    },
+                    "optional": false
+                  },
+                  "accessibility": null,
+                  "readonly": false,
+                  "override": false,
+                  "decorators": []
+                },
+                {
+                  "type": "FormalParameter",
+                  "start": 188,
+                  "end": 199,
+                  "pattern": {
+                    "type": "Identifier",
+                    "start": 188,
+                    "end": 199,
+                    "name": "target",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 194,
+                      "end": 199,
+                      "typeAnnotation": {
+                        "type": "TSAnyKeyword",
+                        "start": 196,
+                        "end": 199
+                      }
+                    },
+                    "optional": false
+                  },
+                  "accessibility": null,
+                  "readonly": false,
+                  "override": false,
+                  "decorators": []
+                },
+                {
+                  "type": "FormalParameter",
+                  "start": 201,
+                  "end": 217,
+                  "pattern": {
+                    "type": "Identifier",
+                    "start": 201,
+                    "end": 217,
+                    "name": "propertyKey",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 212,
+                      "end": 217,
+                      "typeAnnotation": {
+                        "type": "TSAnyKeyword",
+                        "start": 214,
+                        "end": 217
+                      }
+                    },
+                    "optional": false
+                  },
+                  "accessibility": null,
+                  "readonly": false,
+                  "override": false,
+                  "decorators": []
+                }
+              ]
+            },
+            "body": null,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TSTypeAnnotation",
+              "start": 218,
+              "end": 224,
+              "typeAnnotation": {
+                "type": "TSVoidKeyword",
+                "start": 220,
+                "end": 224
+              }
+            },
+            "modifiers": null
+          }
+        ]
+      },
+      "kind": "namespace",
+      "modifiers": [
+        {
+          "type": "Modifier",
+          "start": 97,
+          "end": 104,
+          "kind": "declare"
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "start": 227,
+      "end": 425,
+      "kind": "const",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 233,
+          "end": 425,
+          "id": {
+            "type": "Identifier",
+            "start": 233,
+            "end": 241,
+            "name": "ApiQuery",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "start": 244,
+            "end": 425,
+            "expression": true,
+            "async": false,
+            "params": {
+              "type": "FormalParameters",
+              "start": 244,
+              "end": 258,
+              "kind": "ArrowFormalParameters",
+              "items": [
+                {
+                  "type": "FormalParameter",
+                  "start": 245,
+                  "end": 257,
+                  "pattern": {
+                    "type": "Identifier",
+                    "start": 245,
+                    "end": 257,
+                    "name": "options",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 252,
+                      "end": 257,
+                      "typeAnnotation": {
+                        "type": "TSAnyKeyword",
+                        "start": 254,
+                        "end": 257
+                      }
+                    },
+                    "optional": false
+                  },
+                  "accessibility": null,
+                  "readonly": false,
+                  "override": false,
+                  "decorators": []
+                }
+              ]
+            },
+            "body": {
+              "type": "FunctionBody",
+              "start": 262,
+              "end": 425,
+              "directives": [],
+              "statements": [
+                {
+                  "type": "ExpressionStatement",
+                  "start": 262,
+                  "end": 425,
+                  "expression": {
+                    "type": "ArrowFunctionExpression",
+                    "start": 262,
+                    "end": 425,
+                    "expression": false,
+                    "async": false,
+                    "params": {
+                      "type": "FormalParameters",
+                      "start": 262,
+                      "end": 345,
+                      "kind": "ArrowFormalParameters",
+                      "items": [
+                        {
+                          "type": "FormalParameter",
+                          "start": 265,
+                          "end": 279,
+                          "pattern": {
+                            "type": "Identifier",
+                            "start": 265,
+                            "end": 279,
+                            "name": "target",
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 271,
+                              "end": 279,
+                              "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "start": 273,
+                                "end": 279,
+                                "typeName": {
+                                  "type": "Identifier",
+                                  "start": 273,
+                                  "end": 279,
+                                  "name": "Object"
+                                },
+                                "typeParameters": null
+                              }
+                            },
+                            "optional": false
+                          },
+                          "accessibility": null,
+                          "readonly": false,
+                          "override": false,
+                          "decorators": []
+                        },
+                        {
+                          "type": "FormalParameter",
+                          "start": 282,
+                          "end": 310,
+                          "pattern": {
+                            "type": "Identifier",
+                            "start": 282,
+                            "end": 310,
+                            "name": "propertyKey",
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 293,
+                              "end": 310,
+                              "typeAnnotation": {
+                                "type": "TSUnionType",
+                                "start": 295,
+                                "end": 310,
+                                "types": [
+                                  {
+                                    "type": "TSStringKeyword",
+                                    "start": 295,
+                                    "end": 301
+                                  },
+                                  {
+                                    "type": "TSSymbolKeyword",
+                                    "start": 304,
+                                    "end": 310
+                                  }
+                                ]
+                              }
+                            },
+                            "optional": false
+                          },
+                          "accessibility": null,
+                          "readonly": false,
+                          "override": false,
+                          "decorators": []
+                        },
+                        {
+                          "type": "FormalParameter",
+                          "start": 313,
+                          "end": 343,
+                          "pattern": {
+                            "type": "Identifier",
+                            "start": 313,
+                            "end": 343,
+                            "name": "descriptor",
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 323,
+                              "end": 343,
+                              "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "start": 325,
+                                "end": 343,
+                                "typeName": {
+                                  "type": "Identifier",
+                                  "start": 325,
+                                  "end": 343,
+                                  "name": "PropertyDescriptor"
+                                },
+                                "typeParameters": null
+                              }
+                            },
+                            "optional": false
+                          },
+                          "accessibility": null,
+                          "readonly": false,
+                          "override": false,
+                          "decorators": []
+                        }
+                      ]
+                    },
+                    "body": {
+                      "type": "FunctionBody",
+                      "start": 355,
+                      "end": 425,
+                      "directives": [],
+                      "statements": [
+                        {
+                          "type": "ExpressionStatement",
+                          "start": 358,
+                          "end": 423,
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 358,
+                            "end": 423,
+                            "callee": {
+                              "type": "StaticMemberExpression",
+                              "start": 358,
+                              "end": 380,
+                              "object": {
+                                "type": "Identifier",
+                                "start": 358,
+                                "end": 365,
+                                "name": "Reflect"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "start": 366,
+                                "end": 380,
+                                "name": "defineMetadata"
+                              },
+                              "optional": false
+                            },
+                            "arguments": [
+                              {
+                                "type": "StringLiteral",
+                                "start": 381,
+                                "end": 392,
+                                "value": "api:query"
+                              },
+                              {
+                                "type": "Identifier",
+                                "start": 394,
+                                "end": 401,
+                                "name": "options"
+                              },
+                              {
+                                "type": "Identifier",
+                                "start": 403,
+                                "end": 409,
+                                "name": "target"
+                              },
+                              {
+                                "type": "Identifier",
+                                "start": 411,
+                                "end": 422,
+                                "name": "propertyKey"
+                              }
+                            ],
+                            "optional": false,
+                            "typeParameters": null
+                          }
+                        }
+                      ]
+                    },
+                    "typeParameters": null,
+                    "returnType": {
+                      "type": "TSTypeAnnotation",
+                      "start": 345,
+                      "end": 351,
+                      "typeAnnotation": {
+                        "type": "TSVoidKeyword",
+                        "start": 347,
+                        "end": 351
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "typeParameters": null,
+            "returnType": null
+          },
+          "definite": false
+        }
+      ],
+      "modifiers": null
+    },
+    {
+      "type": "VariableDeclaration",
+      "start": 426,
+      "end": 466,
+      "kind": "const",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 432,
+          "end": 466,
+          "id": {
+            "type": "Identifier",
+            "start": 432,
+            "end": 443,
+            "name": "SomeTypeMap",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "init": {
+            "type": "ObjectExpression",
+            "start": 446,
+            "end": 466,
+            "properties": [
+              {
+                "type": "ObjectProperty",
+                "start": 449,
+                "end": 463,
+                "kind": "init",
+                "key": {
+                  "type": "Identifier",
+                  "start": 449,
+                  "end": 455,
+                  "name": "String"
+                },
+                "value": {
+                  "type": "Identifier",
+                  "start": 457,
+                  "end": 463,
+                  "name": "String"
+                },
+                "init": null,
+                "method": false,
+                "shorthand": false,
+                "computed": false
+              }
+            ]
+          },
+          "definite": false
+        }
+      ],
+      "modifiers": null
+    },
+    {
+      "type": "ClassDeclaration",
+      "start": 468,
+      "end": 569,
+      "decorators": [],
+      "id": {
+        "type": "Identifier",
+        "start": 474,
+        "end": 477,
+        "name": "Bar"
+      },
+      "superClass": null,
+      "body": {
+        "type": "ClassBody",
+        "start": 478,
+        "end": 569,
+        "body": [
+          {
+            "type": "MethodDefinition",
+            "start": 481,
+            "end": 566,
+            "decorators": [
+              {
+                "type": "Decorator",
+                "start": 481,
+                "end": 536,
+                "expression": {
+                  "type": "CallExpression",
+                  "start": 482,
+                  "end": 536,
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 482,
+                    "end": 490,
+                    "name": "ApiQuery"
+                  },
+                  "arguments": [
+                    {
+                      "type": "ObjectExpression",
+                      "start": 491,
+                      "end": 535,
+                      "properties": [
+                        {
+                          "type": "ObjectProperty",
+                          "start": 495,
+                          "end": 504,
+                          "kind": "init",
+                          "key": {
+                            "type": "Identifier",
+                            "start": 495,
+                            "end": 499,
+                            "name": "name"
+                          },
+                          "value": {
+                            "type": "StringLiteral",
+                            "start": 501,
+                            "end": 504,
+                            "value": "a"
+                          },
+                          "init": null,
+                          "method": false,
+                          "shorthand": false,
+                          "computed": false
+                        },
+                        {
+                          "type": "ObjectProperty",
+                          "start": 508,
+                          "end": 532,
+                          "kind": "init",
+                          "key": {
+                            "type": "Identifier",
+                            "start": 508,
+                            "end": 512,
+                            "name": "type"
+                          },
+                          "value": {
+                            "type": "StaticMemberExpression",
+                            "start": 514,
+                            "end": 532,
+                            "object": {
+                              "type": "Identifier",
+                              "start": 514,
+                              "end": 525,
+                              "name": "SomeTypeMap"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 526,
+                              "end": 532,
+                              "name": "String"
+                            },
+                            "optional": false
+                          },
+                          "init": null,
+                          "method": false,
+                          "shorthand": false,
+                          "computed": false
+                        }
+                      ]
+                    }
+                  ],
+                  "optional": false,
+                  "typeParameters": null
+                }
+              }
+            ],
+            "key": {
+              "type": "Identifier",
+              "start": 538,
+              "end": 544,
+              "name": "getFoo"
+            },
+            "value": {
+              "type": "FunctionExpression",
+              "start": 544,
+              "end": 566,
+              "id": null,
+              "generator": false,
+              "async": false,
+              "thisParam": null,
+              "params": {
+                "type": "FormalParameters",
+                "start": 544,
+                "end": 546,
+                "kind": "FormalParameter",
+                "items": []
+              },
+              "body": {
+                "type": "FunctionBody",
+                "start": 547,
+                "end": 566,
+                "directives": [],
+                "statements": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 551,
+                    "end": 563,
+                    "argument": {
+                      "type": "StringLiteral",
+                      "start": 558,
+                      "end": 563,
+                      "value": "foo"
+                    }
+                  }
+                ]
+              },
+              "typeParameters": null,
+              "returnType": null,
+              "modifiers": null
+            },
+            "kind": "method",
+            "computed": false,
+            "static": false,
+            "override": false,
+            "optional": false,
+            "accessibility": null
+          }
+        ]
+      },
+      "typeParameters": null,
+      "superTypeParameters": null,
+      "implements": null,
+      "modifiers": null
+    }
+  ]
+}

--- a/crates/oxc_parser/tests/ts.rs
+++ b/crates/oxc_parser/tests/ts.rs
@@ -1,0 +1,139 @@
+use insta::{glob, Settings};
+use oxc_diagnostics::{Error, OxcDiagnostic, Severity};
+use std::{
+    fmt::{self, Write},
+    fs,
+    path::Path,
+};
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+
+use oxc_span::SourceType;
+
+#[test]
+fn test_does_parse() {
+    fn do_test(path: &Path) {
+        let allocator = Allocator::default();
+        let source_text = fs::read_to_string(path).unwrap();
+        let source_type = SourceType::from_path(&path)
+            .map_err(|e| {
+                Error::msg(format!(
+                    "Failed to parse source type from path: {:?} unknown extension {}",
+                    path.display(),
+                    e.0
+                ))
+            })
+            .unwrap();
+        let ret = Parser::new(&allocator, &source_text, source_type).parse();
+        assert_eq!(
+            ret.errors.len(),
+            0,
+            "{} failed to parse with {} errors: {:?}",
+            path.display(),
+            ret.errors.len(),
+            ret.errors
+        );
+
+        let filename = path.file_name().and_then(|f| f.to_str()).unwrap();
+        let mut settings = Settings::clone_current();
+        settings.set_snapshot_suffix(filename);
+        settings.bind(|| insta::assert_json_snapshot!(ret.program));
+    }
+
+    let mut settings = Settings::clone_current();
+    settings.set_prepend_module_to_snapshot(false);
+    settings.set_allow_empty_glob(true);
+
+    settings.set_info(&"Correctly parses without errors");
+    settings.set_snapshot_path("snapshots/ts/true_pass");
+    settings.bind(|| {
+        glob!("fixtures/ts", "true_pass/*.ts", |path| do_test(path));
+        glob!("fixtures/ts", "true_pass/*.tsx", |path| do_test(path));
+    });
+
+    settings.set_info(&"Incorrectly parses without errors when it shouldn't");
+    settings.set_snapshot_path("snapshots/ts/false_pass");
+    settings.bind(|| {
+        glob!("fixtures/ts", "false_pass/*.ts", |path| do_test(path));
+        glob!("fixtures/ts", "false_pass/*.tsx", |path| do_test(path));
+    });
+}
+
+#[test]
+fn test_does_not_parse() {
+    fn do_test(path: &Path) {
+        /// Just a ballpark for initializing the error message string with a
+        /// reasonable capacity.
+        const AVG_ERROR_MSG_LEN: usize = 512;
+
+        let allocator = Allocator::default();
+        let source_text = fs::read_to_string(path).unwrap();
+        let source_type = SourceType::from_path(&path)
+            .map_err(|e| {
+                Error::msg(format!(
+                    "Failed to parse source type from path: {:?} unknown extension {}",
+                    path.display(),
+                    e.0
+                ))
+            })
+            .unwrap();
+
+        let ret = Parser::new(&allocator, &source_text, source_type).parse();
+        assert!(
+            ret.errors.len() > 0,
+            "File '{}' should not parse",
+            path.file_name().and_then(|f| f.to_str()).unwrap()
+        );
+        let program_json = serde_json::to_string_pretty(&ret.program).unwrap();
+        let mut error_str = String::with_capacity(ret.errors.len() * AVG_ERROR_MSG_LEN);
+        format_errors(&mut error_str, &ret.errors).unwrap();
+        let snapshot_str = format!(
+            "============= ERRORS =============\n{}\n============= PROGRAM =============\n{}",
+            error_str, program_json,
+        );
+        let mut settings = Settings::clone_current();
+        settings.set_snapshot_suffix(path.file_name().and_then(|f| f.to_str()).unwrap());
+        settings.bind(|| insta::assert_snapshot!(snapshot_str));
+    }
+
+    let mut settings = Settings::clone_current();
+    settings.set_prepend_module_to_snapshot(false);
+    settings.set_allow_empty_glob(true);
+
+    settings.set_info(&"Correctly fails to parse");
+    settings.set_snapshot_path("snapshots/ts/true_fail");
+    settings.bind(|| {
+        glob!("fixtures/ts", "true_fail/*.ts", |path| do_test(path));
+        glob!("fixtures/ts", "true_fail/*.tsx", |path| do_test(path));
+    });
+
+    settings.set_info(&"Should parse but doesn't");
+    settings.set_snapshot_path("snapshots/ts/false_fail");
+    settings.bind(|| {
+        glob!("fixtures/ts", "false_fail/*.ts", |path| do_test(path));
+        glob!("fixtures/ts", "false_fail/*.tsx", |path| do_test(path));
+    })
+}
+
+fn format_errors(out: &mut String, err: &Vec<OxcDiagnostic>) -> fmt::Result {
+    for error in err {
+        out.push_str("- ");
+        format_error(out, error)?;
+        out.push('\n');
+    }
+    Ok(())
+}
+
+fn format_error<W: Write>(out: &mut W, err: &OxcDiagnostic) -> fmt::Result {
+    let severity: &'static str = match err.severity {
+        Severity::Advice => "advice",
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    };
+    write!(out, "{}: {}", severity, err.message)?;
+    for label in err.labels.iter().map(|ls| ls.iter()).flatten() {
+        write!(out, " (offset: {}, len: {})", label.offset(), label.len())?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## What This PR Does

Adds a test suite to `oxc_parser`  that contains programs that should and should not parse, both correctly and incorrectly (e.g. false negatives). Test cases are read from a fixtures folder. I only added some test cases, and only for parsing TypeScript. We should add more in the future.

This was motivated by me finding a parsing bug while lining my codebase. You can find the offending program in `crates/oxc_parser/tests/fixtures/ts/false_fail/member-computed-decorator.ts`.

### Misc Changes
- build: compile `insta` in release mode during development for faster snapshot tests
- build: enable `json` and `glob` features on `insta`