### PR TITLE
fix(parser): parse `DecoratorCallExpression` when `Arguments` contains `MemberExpression`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -750,7 +750,10 @@ impl<'a> ParserImpl<'a> {
     ) -> Result<Expression<'a>> {
         // ArgumentList[Yield, Await] :
         //   AssignmentExpression[+In, ?Yield, ?Await]
-        let call_arguments = self.with_context(Context::In, CallArguments::parse)?;
+        let ctx = self.ctx;
+        self.ctx = ctx.and_in(true).and_decorator(false);
+        let call_arguments = CallArguments::parse(self)?;
+        self.ctx = ctx;
         Ok(self.ast.call_expression(
             self.end_span(lhs_span),
             lhs,

--- a/tasks/coverage/codegen_misc.snap
+++ b/tasks/coverage/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 15/15 (100.00%)
-Positive Passed: 15/15 (100.00%)
+AST Parsed     : 16/16 (100.00%)
+Positive Passed: 16/16 (100.00%)

--- a/tasks/coverage/misc/pass/oxc-3262.js
+++ b/tasks/coverage/misc/pass/oxc-3262.js
@@ -1,0 +1,4 @@
+class Foo {
+    @Bar({ x: Map['String'] })
+    quaz() {}
+}

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 15/15 (100.00%)
-Positive Passed: 15/15 (100.00%)
+AST Parsed     : 16/16 (100.00%)
+Positive Passed: 16/16 (100.00%)
 Negative Passed: 8/8 (100.00%)
 
   × Unexpected token

--- a/tasks/coverage/prettier_misc.snap
+++ b/tasks/coverage/prettier_misc.snap
@@ -1,6 +1,6 @@
 prettier_misc Summary:
-AST Parsed     : 15/15 (100.00%)
-Positive Passed: 8/15 (53.33%)
+AST Parsed     : 16/16 (100.00%)
+Positive Passed: 9/16 (56.25%)
 Expect to Parse: "pass/oxc-1740.tsx"
 Expect to Parse: "pass/oxc-2087.ts"
 Expect to Parse: "pass/oxc-2394.ts"

--- a/tasks/coverage/transformer_misc.snap
+++ b/tasks/coverage/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 15/15 (100.00%)
-Positive Passed: 15/15 (100.00%)
+AST Parsed     : 16/16 (100.00%)
+Positive Passed: 16/16 (100.00%)


### PR DESCRIPTION
closes #3261
closes #3262

```
DecoratorCallExpression[Yield, Await] :
  DecoratorMemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
```