### PR TITLE
chore(tasks): add commit sha to snapshots to make sure submodules are not outdated

### DIFF
--- a/tasks/common/src/lib.rs
+++ b/tasks/common/src/lib.rs
@@ -3,11 +3,13 @@ use std::path::{Path, PathBuf};
 mod babel;
 mod diff;
 mod request;
+mod snapshot;
 mod test_file;
 
 pub use crate::{
     babel::{BabelOptions, TestOs},
     request::agent,
+    snapshot::Snapshot,
     test_file::*,
 };
 pub use diff::print_diff_in_terminal;

--- a/tasks/common/src/snapshot.rs
+++ b/tasks/common/src/snapshot.rs
@@ -1,0 +1,58 @@
+use std::{
+    borrow::Cow,
+    env,
+    fs::{self, File},
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub struct Snapshot {
+    git_repo_path: PathBuf,
+    sha: Option<String>,
+}
+
+impl Snapshot {
+    /// # Panics
+    ///
+    /// * Git operation fails
+    pub fn new(git_repo_path: &Path, show_commit: bool) -> Self {
+        let sha = show_commit.then(|| {
+            let path = git_repo_path.to_str().unwrap();
+            let output = Command::new("git")
+                .args(["-C", path, "rev-parse", "--short=8", "HEAD"])
+                .output()
+                .unwrap()
+                .stdout;
+            String::from_utf8(output).unwrap().trim().to_string()
+        });
+        Self { git_repo_path: git_repo_path.to_path_buf(), sha }
+    }
+
+    /// # Panics
+    ///
+    /// * File operation fails
+    pub fn save(&self, path: &Path, content: &str) {
+        let content = if let Some(new_sha) = &self.sha {
+            if path.exists() {
+                let file = fs::read_to_string(path).unwrap();
+                let line =
+                    file.lines().next().unwrap_or_else(|| panic!("{path:?} content is empty."));
+                if let Some(old_sha) = line.strip_prefix("commit: ") {
+                    let outdated = new_sha != old_sha && env::var("UPDATE_SNAPSHOT").is_err();
+                    assert!(
+                        !outdated,
+                        "\nRepository {:?} is outdated for {path:?}.\nsha from file = {old_sha}, sha from repo = {new_sha}\nPlease run `just submodules` to update it.\n",
+                        self.git_repo_path
+                    );
+                }
+            }
+            Cow::Owned(format!("commit: {new_sha}\n\n{content}"))
+        } else {
+            Cow::Borrowed(content)
+        };
+
+        let mut file = File::create(path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+    }
+}

--- a/tasks/coverage/codegen_babel.snap
+++ b/tasks/coverage/codegen_babel.snap
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 codegen_babel Summary:
 AST Parsed     : 2099/2099 (100.00%)
 Positive Passed: 2099/2099 (100.00%)

--- a/tasks/coverage/codegen_test262.snap
+++ b/tasks/coverage/codegen_test262.snap
@@ -1,3 +1,5 @@
+commit: 17ba9aea
+
 codegen_test262 Summary:
 AST Parsed     : 45836/45836 (100.00%)
 Positive Passed: 45836/45836 (100.00%)

--- a/tasks/coverage/codegen_typescript.snap
+++ b/tasks/coverage/codegen_typescript.snap
@@ -1,3 +1,5 @@
+commit: 64d2eeea
+
 codegen_typescript Summary:
 AST Parsed     : 5243/5243 (100.00%)
 Positive Passed: 5228/5243 (99.71%)

--- a/tasks/coverage/minifier_babel.snap
+++ b/tasks/coverage/minifier_babel.snap
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 minifier_babel Summary:
 AST Parsed     : 1638/1638 (100.00%)
 Positive Passed: 1638/1638 (100.00%)

--- a/tasks/coverage/minifier_test262.snap
+++ b/tasks/coverage/minifier_test262.snap
@@ -1,3 +1,5 @@
+commit: 17ba9aea
+
 minifier_test262 Summary:
 AST Parsed     : 45836/45836 (100.00%)
 Positive Passed: 45836/45836 (100.00%)

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 parser_babel Summary:
 AST Parsed     : 2093/2099 (99.71%)
 Positive Passed: 2086/2099 (99.38%)

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -1,3 +1,5 @@
+commit: 17ba9aea
+
 parser_test262 Summary:
 AST Parsed     : 45289/45289 (100.00%)
 Positive Passed: 45289/45289 (100.00%)

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -1,3 +1,5 @@
+commit: 64d2eeea
+
 parser_typescript Summary:
 AST Parsed     : 5240/5243 (99.94%)
 Positive Passed: 5233/5243 (99.81%)

--- a/tasks/coverage/prettier_babel.snap
+++ b/tasks/coverage/prettier_babel.snap
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 prettier_babel Summary:
 AST Parsed     : 2099/2099 (100.00%)
 Positive Passed: 1893/2099 (90.19%)

--- a/tasks/coverage/prettier_test262.snap
+++ b/tasks/coverage/prettier_test262.snap
@@ -1,3 +1,5 @@
+commit: 17ba9aea
+
 prettier_test262 Summary:
 AST Parsed     : 45836/45836 (100.00%)
 Positive Passed: 42686/45836 (93.13%)

--- a/tasks/coverage/prettier_typescript.snap
+++ b/tasks/coverage/prettier_typescript.snap
@@ -1,3 +1,5 @@
+commit: 64d2eeea
+
 prettier_typescript Summary:
 AST Parsed     : 5243/5243 (100.00%)
 Positive Passed: 2434/5243 (46.42%)

--- a/tasks/coverage/src/suite.rs
+++ b/tasks/coverage/src/suite.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    fs::{self, File},
+    fs,
     io::{stdout, Read, Write},
     panic::UnwindSafe,
     path::{Path, PathBuf},
@@ -22,7 +22,7 @@ use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::{SourceType, Span};
-use oxc_tasks_common::normalize_path;
+use oxc_tasks_common::{normalize_path, Snapshot};
 
 use crate::{project_root, AppArgs};
 
@@ -241,8 +241,9 @@ pub trait Suite<T: Case> {
 
     /// # Errors
     fn snapshot_errors(&self, name: &str, report: &CoverageReport<T>) -> std::io::Result<()> {
-        let path = project_root().join(format!("tasks/coverage/{}.snap", name.to_lowercase()));
-        let mut file = File::create(path).unwrap();
+        let snapshot_path = self.get_test_root();
+        let show_commit = !snapshot_path.to_string_lossy().contains("misc");
+        let snapshot = Snapshot::new(snapshot_path, show_commit);
 
         let mut tests = self
             .get_test_cases()
@@ -252,18 +253,20 @@ pub trait Suite<T: Case> {
 
         tests.sort_by_key(|case| case.path());
 
-        let args = AppArgs { detail: true, ..AppArgs::default() };
-        self.print_coverage(name, &args, report, &mut file)?;
+        let mut out: Vec<u8> = vec![];
 
-        let mut out = String::new();
+        let args = AppArgs { detail: true, ..AppArgs::default() };
+        self.print_coverage(name, &args, report, &mut out)?;
+
         for case in &tests {
             if let TestResult::CorrectError(error, _) = &case.test_result() {
-                out.push_str(error);
+                out.extend(error.as_bytes());
             }
         }
 
-        file.write_all(out.as_bytes())?;
-        file.flush()?;
+        let path = project_root().join(format!("tasks/coverage/{}.snap", name.to_lowercase()));
+        let out = String::from_utf8(out).unwrap();
+        snapshot.save(&path, &out);
         Ok(())
     }
 }

--- a/tasks/coverage/transformer_babel.snap
+++ b/tasks/coverage/transformer_babel.snap
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 transformer_babel Summary:
 AST Parsed     : 2099/2099 (100.00%)
 Positive Passed: 2099/2099 (100.00%)

--- a/tasks/coverage/transformer_test262.snap
+++ b/tasks/coverage/transformer_test262.snap
@@ -1,3 +1,5 @@
+commit: 17ba9aea
+
 transformer_test262 Summary:
 AST Parsed     : 45836/45836 (100.00%)
 Positive Passed: 45836/45836 (100.00%)

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -1,3 +1,5 @@
+commit: 64d2eeea
+
 transformer_typescript Summary:
 AST Parsed     : 5243/5243 (100.00%)
 Positive Passed: 5243/5243 (100.00%)

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 Passed: 308/362
 
 # All Passed:

--- a/tasks/transform_conformance/babel_exec.snap.md
+++ b/tasks/transform_conformance/babel_exec.snap.md
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 Passed: 1/3
 
 # All Passed:

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 Passed: 2/2
 
 # All Passed:

--- a/tasks/transform_conformance/oxc_exec.snap.md
+++ b/tasks/transform_conformance/oxc_exec.snap.md
@@ -1,3 +1,5 @@
+commit: 4bd1b2c2
+
 Passed: 0/0
 
 # All Passed:


### PR DESCRIPTION
If submodules are outdated, it'll panic with the following message

```
Repository is outdated, please run `just submodules` to update it.
```

For us maintainers, we'll need the env `UPDATE_SNAPSHOT` to force an update.