### PR TITLE
chore(linter): expose `Message:start` and `Message:end`

### DIFF
--- a/crates/oxc_linter/src/fixer.rs
+++ b/crates/oxc_linter/src/fixer.rs
@@ -27,8 +27,8 @@ pub struct FixResult<'a> {
 
 pub struct Message<'a> {
     pub error: OxcDiagnostic,
-    start: u32,
-    end: u32,
+    pub start: u32,
+    pub end: u32,
     pub fix: Option<Fix<'a>>,
     fixed: bool,
 }


### PR DESCRIPTION
Expose the `start` and `end` field for modification in downstream projects.