### PR TITLE
fix(traverse): create scopes for functions

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2136,7 +2136,7 @@ pub struct BindingRestElement<'a> {
     // Don't create scope if this is a method - `MethodDefinition` already created one.
     // `ctx.ancestor(2).unwrap()` not `ctx.parent()` because this code is inserted
     // into `walk_function` *after* `Function` is added to stack.
-    scope_if(matches!(ctx.ancestor(2).unwrap(), Ancestor::MethodDefinitionValue(_))),
+    scope_if(!matches!(ctx.ancestor(2).unwrap(), Ancestor::MethodDefinitionValue(_))),
     strict_if(self.body.as_ref().is_some_and(|body| body.has_use_strict_directive()))
 )]
 #[derive(Debug, Hash)]

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -2228,7 +2228,7 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_function(&mut *node, ctx);
     ctx.push_stack(Ancestor::FunctionId(ancestor::FunctionWithoutId(node)));
-    let has_scope = matches!(ctx.ancestor(2).unwrap(), Ancestor::MethodDefinitionValue(_));
+    let has_scope = !matches!(ctx.ancestor(2).unwrap(), Ancestor::MethodDefinitionValue(_));
     if has_scope {
         ctx.push_scope_stack(
             ScopeFlags::Function.with_strict_mode(


### PR DESCRIPTION
Fix bug with:

1. scopes not being created for functions.
2. too many scopes being created for class methods.

i.e. Logic for when `Function` creates a scope was opposite of what it should be.

Discovered by @Dunqing in https://github.com/oxc-project/oxc/pull/3258#pullrequestreview-2054259476.