### PR TITLE
fix(traverse): set `ScopeFlags::Function` bit for class methods

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2588,10 +2588,10 @@ impl MethodDefinitionKind {
 
     pub fn scope_flags(self) -> ScopeFlags {
         match self {
-            Self::Constructor => ScopeFlags::Constructor,
-            Self::Method => ScopeFlags::empty(),
-            Self::Get => ScopeFlags::GetAccessor,
-            Self::Set => ScopeFlags::SetAccessor,
+            Self::Constructor => ScopeFlags::Constructor | ScopeFlags::Function,
+            Self::Method => ScopeFlags::Function,
+            Self::Get => ScopeFlags::GetAccessor | ScopeFlags::Function,
+            Self::Set => ScopeFlags::SetAccessor | ScopeFlags::Function,
         }
     }
 }


### PR DESCRIPTION
Fix `ScopeFlags` in `Traverse` for class methods to include `ScopeFlags::Function` bit.

I mis-translated the logic for this from `VisitMut` in #3229.