### PR TITLE
fix(linter/react): fix loop hooks false positives.

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -257,15 +257,14 @@ impl RulesOfHooks {
     fn is_cyclic(&self, ctx: &LintContext, node: &AstNode, func: &AstNode) -> bool {
         // TODO: use cfg instead
         ctx.nodes().ancestors(node.id()).take_while(|id| *id != func.id()).any(|id| {
-            use AstKind::*;
             let maybe_loop = ctx.nodes().kind(id);
             matches! {
                 maybe_loop,
-                | DoWhileStatement(_)
-                | ForInStatement(_)
-                | ForOfStatement(_)
-                | ForStatement(_)
-                | WhileStatement(_)
+                | AstKind::DoWhileStatement(_)
+                | AstKind::ForInStatement(_)
+                | AstKind::ForOfStatement(_)
+                | AstKind::ForStatement(_)
+                | AstKind::WhileStatement(_)
             }
         })
     }

--- a/crates/oxc_linter/src/snapshots/rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/rules_of_hooks.snap
@@ -218,7 +218,7 @@ expression: rules_of_hooks
  5 │                         if (b) return;
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:25]
  5 │                         if (b) return;
  6 │                         useHook2();
@@ -234,7 +234,7 @@ expression: rules_of_hooks
  10 │                         if (d) return;
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook4" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:11:25]
  10 │                         if (d) return;
  11 │                         useHook4();
@@ -250,7 +250,7 @@ expression: rules_of_hooks
  5 │                     if (b) continue;
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:21]
  5 │                     if (b) continue;
  6 │                     useHook2();


### PR DESCRIPTION
It is a temporary fix for false positives like [this](https://github.com/oxc-project/oxc/issues/3257#issuecomment-2110199442).
Uses the node's ancestors for now instead of the cfg.