### PR TITLE
feat(transformer): add preset-env

### DIFF
--- a/crates/oxc_transformer/src/env/mod.rs
+++ b/crates/oxc_transformer/src/env/mod.rs
@@ -1,0 +1,21 @@
+mod options;
+
+use std::rc::Rc;
+
+pub use self::options::EnvOptions;
+/// [Preset Env](https://babel.dev/docs/babel-preset-env)
+///
+/// This preset is a smart preset that allows you to use the latest JavaScript without needing to micromanage
+/// which syntax transforms (and optionally, browser polyfills) are needed by your target environment(s).
+/// This both makes your life easier and JavaScript bundles smaller!
+pub struct Env {
+    #[allow(unused)]
+    options: Rc<EnvOptions>,
+}
+
+impl Env {
+    pub fn new(options: EnvOptions) -> Self {
+        let options = Rc::new(options);
+        Self { options }
+    }
+}

--- a/crates/oxc_transformer/src/env/options.rs
+++ b/crates/oxc_transformer/src/env/options.rs
@@ -1,0 +1,2 @@
+#[derive(Default, Debug, Clone)]
+pub struct EnvOptions;

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -13,6 +13,7 @@ mod compiler_assumptions;
 mod context;
 mod options;
 // Presets: <https://babel.dev/docs/presets>
+mod env;
 mod es2015;
 mod react;
 mod typescript;
@@ -23,6 +24,7 @@ mod helpers {
 
 use std::{path::Path, rc::Rc};
 
+use env::Env;
 use es2015::ES2015;
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::{ast::*, Trivias};
@@ -31,8 +33,8 @@ use oxc_span::SourceType;
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
 
 pub use crate::{
-    compiler_assumptions::CompilerAssumptions, es2015::ES2015Options, options::TransformOptions,
-    react::ReactOptions, typescript::TypeScriptOptions,
+    compiler_assumptions::CompilerAssumptions, env::EnvOptions, es2015::ES2015Options,
+    options::TransformOptions, react::ReactOptions, typescript::TypeScriptOptions,
 };
 
 use crate::{
@@ -46,6 +48,8 @@ pub struct Transformer<'a> {
     // NOTE: all callbacks must run in order.
     x0_typescript: TypeScript<'a>,
     x1_react: React<'a>,
+    #[allow(unused)]
+    x2_env: Env,
     x3_es2015: ES2015<'a>,
 }
 
@@ -70,6 +74,7 @@ impl<'a> Transformer<'a> {
             ctx: Rc::clone(&ctx),
             x0_typescript: TypeScript::new(options.typescript, &ctx),
             x1_react: React::new(options.react, &ctx),
+            x2_env: Env::new(options.env),
             x3_es2015: ES2015::new(options.es2015, &ctx),
         }
     }

--- a/crates/oxc_transformer/src/options.rs
+++ b/crates/oxc_transformer/src/options.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use crate::{
-    compiler_assumptions::CompilerAssumptions, es2015::ES2015Options, react::ReactOptions,
-    typescript::TypeScriptOptions,
+    compiler_assumptions::CompilerAssumptions, env::EnvOptions, es2015::ES2015Options,
+    react::ReactOptions, typescript::TypeScriptOptions,
 };
 
 /// <https://babel.dev/docs/options>
@@ -20,6 +20,8 @@ pub struct TransformOptions {
     pub assumptions: CompilerAssumptions,
 
     // Plugins
+    /// [preset-env](https://babeljs.io/docs/babel-preset-env)
+    pub env: EnvOptions,
     /// [preset-typescript](https://babeljs.io/docs/babel-preset-typescript)
     pub typescript: TypeScriptOptions,
 

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -1,4 +1,6 @@
 pub(crate) const PLUGINS: &[&str] = &[
+    // Env
+    // "babel-preset-env",
     // // ES2024
     // "babel-plugin-transform-unicode-sets-regex",
     // // ES2022

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -13,7 +13,7 @@ use oxc_parser::Parser;
 use oxc_span::{SourceType, VALID_EXTENSIONS};
 use oxc_tasks_common::{normalize_path, print_diff_in_terminal, BabelOptions};
 use oxc_transformer::{
-    ES2015Options, ReactOptions, TransformOptions, Transformer, TypeScriptOptions,
+    ES2015Options, EnvOptions, ReactOptions, TransformOptions, Transformer, TypeScriptOptions,
 };
 
 use crate::{
@@ -121,6 +121,7 @@ fn transform_options(options: &BabelOptions) -> serde_json::Result<TransformOpti
             .unwrap_or_default(),
         react,
         es2015,
+        env: EnvOptions,
     })
 }
 


### PR DESCRIPTION
Related issues: https://github.com/oxc-project/oxc/issues/2870

The `targets` is an option for preset-env

This preset has a lot of test failures, so let's skip it for now.