### PR TITLE
fix(linter/react): `rules_of_hooks` add support for property hooks/components.

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1135,6 +1135,12 @@ pub enum AssignmentTarget<'a> {
 }
 }
 
+impl<'a> AssignmentTarget<'a> {
+    pub fn get_identifier(&self) -> Option<&str> {
+        self.as_simple_assignment_target().and_then(|it| it.get_identifier())
+    }
+}
+
 /// Macro for matching `AssignmentTarget`'s variants.
 /// Includes `SimpleAssignmentTarget`'s and `AssignmentTargetPattern`'s variants.
 #[macro_export]
@@ -1197,6 +1203,14 @@ macro_rules! match_simple_assignment_target {
 pub use match_simple_assignment_target;
 
 impl<'a> SimpleAssignmentTarget<'a> {
+    pub fn get_identifier(&self) -> Option<&str> {
+        match self {
+            Self::AssignmentTargetIdentifier(ident) => Some(ident.name.as_str()),
+            match_member_expression!(Self) => self.to_member_expression().static_property_name(),
+            _ => None,
+        }
+    }
+
     pub fn get_expression(&self) -> Option<&Expression<'a>> {
         match self {
             Self::TSAsExpression(expr) => Some(&expr.expression),

--- a/crates/oxc_linter/src/snapshots/rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/rules_of_hooks.snap
@@ -298,6 +298,38 @@ expression: rules_of_hooks
  6 │             e = () => { useState(); };
    ╰────
 
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+   ╭─[rules_of_hooks.tsx:6:17]
+ 5 │             let d = () => useState();
+ 6 │             e = () => { useState(); };
+   ·                 ─────────────────────
+ 7 │             ({f: () => { useState(); }});
+   ╰────
+
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+   ╭─[rules_of_hooks.tsx:7:18]
+ 6 │             e = () => { useState(); };
+ 7 │             ({f: () => { useState(); }});
+   ·                  ─────────────────────
+ 8 │             ({g() { useState(); }});
+   ╰────
+
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+   ╭─[rules_of_hooks.tsx:8:16]
+ 7 │             ({f: () => { useState(); }});
+ 8 │             ({g() { useState(); }});
+   ·                ──────────────────
+ 9 │             const {j = () => { useState(); }} = {};
+   ╰────
+
+  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+    ╭─[rules_of_hooks.tsx:9:24]
+  8 │             ({g() { useState(); }});
+  9 │             const {j = () => { useState(); }} = {};
+    ·                        ─────────────────────
+ 10 │             ({k = () => { useState(); }} = {});
+    ╰────
+
   × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
  3 │                     if (a) return;


### PR DESCRIPTION
related to #3257 