### PR TITLE
refactor(traverse): `Traverse` produce scopes tree using `Semantic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "memoffset",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
  "trybuild",

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -25,7 +25,7 @@ use std::{path::Path, rc::Rc};
 
 use es2015::ES2015;
 use oxc_allocator::{Allocator, Vec};
-use oxc_ast::{ast::*, Trivias};
+use oxc_ast::{ast::*, AstBuilder, Trivias};
 use oxc_diagnostics::Error;
 use oxc_span::SourceType;
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
@@ -78,8 +78,9 @@ impl<'a> Transformer<'a> {
     ///
     /// Returns `Vec<Error>` if any errors were collected during the transformation.
     pub fn build(mut self, program: &mut Program<'a>) -> Result<(), std::vec::Vec<Error>> {
-        let allocator = self.ctx.ast.allocator;
-        traverse_mut(&mut self, program, allocator);
+        let TransformCtx { ast: AstBuilder { allocator }, source_text, source_type, .. } =
+            *self.ctx;
+        traverse_mut(&mut self, program, source_text, source_type, allocator);
 
         let errors = self.ctx.take_errors();
         if errors.is_empty() {

--- a/crates/oxc_transformer/src/react/jsx_self/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx_self/mod.rs
@@ -50,11 +50,11 @@ impl<'a> ReactJsxSelf<'a> {
 
     #[allow(clippy::unused_self)]
     fn is_inside_constructor(&self, ctx: &TraverseCtx<'a>) -> bool {
-        ctx.find_scope(|scope| {
-            if scope.is_block() || scope.is_arrow() {
+        ctx.find_scope_by_flags(|flags| {
+            if flags.is_block() || flags.is_arrow() {
                 return FinderRet::Continue;
             }
-            FinderRet::Found(scope.is_constructor())
+            FinderRet::Found(flags.is_constructor())
         })
         .unwrap_or(false)
     }

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -21,6 +21,7 @@ doctest = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast       = { workspace = true }
+oxc_semantic  = { workspace = true }
 oxc_span      = { workspace = true }
 oxc_syntax    = { workspace = true }
 

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -8,15 +8,15 @@
     clippy::semicolon_if_nothing_returned,
     clippy::ptr_as_ptr,
     clippy::borrow_as_ptr,
-    clippy::cast_ptr_alignment,
-    clippy::needless_borrow
+    clippy::cast_ptr_alignment
 )]
+
+use std::cell::Cell;
 
 use oxc_allocator::Vec;
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
-use oxc_span::SourceType;
-use oxc_syntax::scope::ScopeFlags;
+use oxc_syntax::scope::ScopeId;
 
 use crate::{
     ancestor::{self, AncestorType},
@@ -28,18 +28,16 @@ pub(crate) unsafe fn walk_program<'a, Tr: Traverse<'a>>(
     node: *mut Program<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_program(&mut *node, ctx);
     ctx.push_stack(Ancestor::ProgramDirectives(ancestor::ProgramWithoutDirectives(node)));
-    ctx.push_scope_stack(
-        ScopeFlags::Top.with_strict_mode(
-            (&*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_SOURCE_TYPE) as *mut SourceType))
-                .is_strict()
-                || (&*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES)
-                    as *mut Vec<Directive>))
-                    .iter()
-                    .any(Directive::is_use_strict),
-        ),
-    );
     for item in (*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES)
         as *mut Vec<Directive>))
         .iter_mut()
@@ -58,9 +56,11 @@ pub(crate) unsafe fn walk_program<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut Vec<Statement>,
         ctx,
     );
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_program(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_expression<'a, Tr: Traverse<'a>>(
@@ -1401,17 +1401,26 @@ pub(crate) unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
     node: *mut BlockStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_block_statement(&mut *node, ctx);
     ctx.push_stack(Ancestor::BlockStatementBody(ancestor::BlockStatementWithoutBody(node)));
-    ctx.push_scope_stack(ScopeFlags::empty());
     walk_statements(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut Vec<Statement>,
         ctx,
     );
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_block_statement(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_declaration<'a, Tr: Traverse<'a>>(
@@ -1614,15 +1623,16 @@ pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
     node: *mut ForStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_for_statement(&mut *node, ctx);
     ctx.push_stack(Ancestor::ForStatementInit(ancestor::ForStatementWithoutInit(node)));
-    let has_scope = (&*((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_INIT)
-        as *mut Option<ForStatementInit>))
-        .as_ref()
-        .is_some_and(ForStatementInit::is_lexical_declaration);
-    if has_scope {
-        ctx.push_scope_stack(ScopeFlags::empty());
-    }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_INIT)
         as *mut Option<ForStatementInit>)
     {
@@ -1646,11 +1656,11 @@ pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
-    if has_scope {
-        ctx.pop_scope_stack();
-    }
     ctx.pop_stack();
     traverser.exit_for_statement(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
@@ -1719,14 +1729,16 @@ pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
     node: *mut ForInStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_for_in_statement(&mut *node, ctx);
     ctx.push_stack(Ancestor::ForInStatementLeft(ancestor::ForInStatementWithoutLeft(node)));
-    let has_scope = (&*((node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_LEFT)
-        as *mut ForStatementLeft))
-        .is_lexical_declaration();
-    if has_scope {
-        ctx.push_scope_stack(ScopeFlags::empty());
-    }
     walk_for_statement_left(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_LEFT) as *mut ForStatementLeft,
@@ -1744,11 +1756,11 @@ pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
-    if has_scope {
-        ctx.pop_scope_stack();
-    }
     ctx.pop_stack();
     traverser.exit_for_in_statement(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
@@ -1756,14 +1768,16 @@ pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
     node: *mut ForOfStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_for_of_statement(&mut *node, ctx);
     ctx.push_stack(Ancestor::ForOfStatementLeft(ancestor::ForOfStatementWithoutLeft(node)));
-    let has_scope = (&*((node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_LEFT)
-        as *mut ForStatementLeft))
-        .is_lexical_declaration();
-    if has_scope {
-        ctx.push_scope_stack(ScopeFlags::empty());
-    }
     walk_for_statement_left(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_LEFT) as *mut ForStatementLeft,
@@ -1781,11 +1795,11 @@ pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_BODY) as *mut Statement,
         ctx,
     );
-    if has_scope {
-        ctx.pop_scope_stack();
-    }
     ctx.pop_stack();
     traverser.exit_for_of_statement(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
@@ -1904,7 +1918,14 @@ pub(crate) unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_DISCRIMINANT) as *mut Expression,
         ctx,
     );
-    ctx.push_scope_stack(ScopeFlags::empty());
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     ctx.retag_stack(AncestorType::SwitchStatementCases);
     for item in (*((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_CASES)
         as *mut Vec<SwitchCase>))
@@ -1912,9 +1933,11 @@ pub(crate) unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
     {
         walk_switch_case(traverser, item as *mut _, ctx);
     }
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_switch_statement(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
@@ -2011,14 +2034,16 @@ pub(crate) unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
     node: *mut CatchClause<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_catch_clause(&mut *node, ctx);
     ctx.push_stack(Ancestor::CatchClauseParam(ancestor::CatchClauseWithoutParam(node)));
-    let has_scope = (&*((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_PARAM)
-        as *mut Option<CatchParameter>))
-        .is_some();
-    if has_scope {
-        ctx.push_scope_stack(ScopeFlags::empty());
-    }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_PARAM)
         as *mut Option<CatchParameter>)
     {
@@ -2031,11 +2056,11 @@ pub(crate) unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
             as *mut Box<BlockStatement>)) as *mut _,
         ctx,
     );
-    if has_scope {
-        ctx.pop_scope_stack();
-    }
     ctx.pop_stack();
     traverser.exit_catch_clause(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
@@ -2226,19 +2251,16 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
     node: *mut Function<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FUNCTION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_function(&mut *node, ctx);
     ctx.push_stack(Ancestor::FunctionId(ancestor::FunctionWithoutId(node)));
-    let has_scope = !matches!(ctx.ancestor(2).unwrap(), Ancestor::MethodDefinitionValue(_));
-    if has_scope {
-        ctx.push_scope_stack(
-            ScopeFlags::Function.with_strict_mode(
-                (&*((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
-                    as *mut Option<Box<FunctionBody>>))
-                    .as_ref()
-                    .is_some_and(|body| body.has_use_strict_directive()),
-            ),
-        );
-    }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_ID)
         as *mut Option<BindingIdentifier>)
     {
@@ -2275,11 +2297,11 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::FunctionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    if has_scope {
-        ctx.pop_scope_stack();
-    }
     ctx.pop_stack();
     traverser.exit_function(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
@@ -2356,11 +2378,19 @@ pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     node: *mut ArrowFunctionExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8)
+        .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_arrow_function_expression(&mut *node, ctx);
     ctx.push_stack(Ancestor::ArrowFunctionExpressionParams(
         ancestor::ArrowFunctionExpressionWithoutParams(node),
     ));
-    ctx.push_scope_stack(ScopeFlags::Function | ScopeFlags::Arrow);
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
@@ -2388,9 +2418,11 @@ pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::ArrowFunctionExpressionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_arrow_function_expression(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_yield_expression<'a, Tr: Traverse<'a>>(
@@ -2423,7 +2455,14 @@ pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
-    ctx.push_scope_stack(ScopeFlags::StrictMode);
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_CLASS_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     if let Some(field) =
         &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_ID) as *mut Option<BindingIdentifier>)
     {
@@ -2463,9 +2502,11 @@ pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
             walk_ts_class_implements(traverser, item as *mut _, ctx);
         }
     }
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_class(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
@@ -2532,16 +2573,6 @@ pub(crate) unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_KEY) as *mut PropertyKey,
         ctx,
     );
-    ctx.push_scope_stack(
-        (&*((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_KIND)
-            as *mut MethodDefinitionKind))
-            .scope_flags()
-            .with_strict_mode(
-                (&*((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_VALUE)
-                    as *mut Box<Function>))
-                    .is_strict(),
-            ),
-    );
     ctx.retag_stack(AncestorType::MethodDefinitionValue);
     walk_function(
         traverser,
@@ -2549,7 +2580,6 @@ pub(crate) unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
             as *mut Box<Function>)) as *mut _,
         ctx,
     );
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_method_definition(&mut *node, ctx);
 }
@@ -2604,17 +2634,26 @@ pub(crate) unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
     node: *mut StaticBlock<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_static_block(&mut *node, ctx);
     ctx.push_stack(Ancestor::StaticBlockBody(ancestor::StaticBlockWithoutBody(node)));
-    ctx.push_scope_stack(ScopeFlags::ClassStaticBlock);
     walk_statements(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut Vec<Statement>,
         ctx,
     );
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_static_block(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_module_declaration<'a, Tr: Traverse<'a>>(
@@ -3589,7 +3628,14 @@ pub(crate) unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_ID) as *mut BindingIdentifier,
         ctx,
     );
-    ctx.push_scope_stack(ScopeFlags::empty());
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     ctx.retag_stack(AncestorType::TSEnumDeclarationMembers);
     for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_MEMBERS)
         as *mut Vec<TSEnumMember>))
@@ -3597,9 +3643,11 @@ pub(crate) unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
     {
         walk_ts_enum_member(traverser, item as *mut _, ctx);
     }
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_ts_enum_declaration(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_ts_enum_member<'a, Tr: Traverse<'a>>(
@@ -4318,9 +4366,16 @@ pub(crate) unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
     node: *mut TSTypeParameter<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_ts_type_parameter(&mut *node, ctx);
     ctx.push_stack(Ancestor::TSTypeParameterName(ancestor::TSTypeParameterWithoutName(node)));
-    ctx.push_scope_stack(ScopeFlags::empty());
     walk_binding_identifier(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_NAME) as *mut BindingIdentifier,
@@ -4338,9 +4393,11 @@ pub(crate) unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::TSTypeParameterDefault);
         walk_ts_type(traverser, field as *mut _, ctx);
     }
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_ts_type_parameter(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
@@ -4818,17 +4875,26 @@ pub(crate) unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
     node: *mut TSModuleBlock<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) {
+    let mut previous_scope_id = None;
+    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+    {
+        previous_scope_id = Some(ctx.current_scope_id());
+        ctx.set_current_scope_id(scope_id);
+    }
     traverser.enter_ts_module_block(&mut *node, ctx);
     ctx.push_stack(Ancestor::TSModuleBlockBody(ancestor::TSModuleBlockWithoutBody(node)));
-    ctx.push_scope_stack(ScopeFlags::TsModuleBlock);
     walk_statements(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut Vec<Statement>,
         ctx,
     );
-    ctx.pop_scope_stack();
     ctx.pop_stack();
     traverser.exit_ts_module_block(&mut *node, ctx);
+    if let Some(previous_scope_id) = previous_scope_id {
+        ctx.set_current_scope_id(previous_scope_id);
+    }
 }
 
 pub(crate) unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(


### PR DESCRIPTION
`Traverse` use `Semantic` to construct scopes tree and expose it to visitors via `TraverseCtx`.

Currently scopes tree is immutable. Will expose it as a mutable in a follow-on.

This is extremely inefficient. Semantic does all kinds of stuff (control flow graph etc) which `Traverse` doesn't need, and `Traverse` just throws away all that work after semantic has done it. Intent here is to get a working implementation first, and then to do another pass later on to improve performance.