### PR TITLE
refactor(traverse): move `parent` method etc into `TraverseAncestry`

### DIFF
--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -68,7 +68,7 @@ use oxc_span::SourceType;
 pub mod ancestor;
 pub use ancestor::Ancestor;
 mod context;
-pub use context::{FinderRet, TraverseCtx, TraverseScoping};
+pub use context::{FinderRet, TraverseAncestry, TraverseCtx, TraverseScoping};
 #[allow(clippy::module_inception)]
 mod traverse;
 pub use traverse::Traverse;


### PR DESCRIPTION
Move the ancestry stack into it's own type `TraverseAncestry`, and expose it via `ctx.ancestry` "namespace".

The "namespaced" way of getting parent etc (`ctx.ancestry.parent()` rather than just `ctx.parent()`) will come in useful once we introduce methods which require a `&mut TraverseCtx`.