### PR TITLE
feat(traverse): pass `&mut TraverseCtx` to visitors

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -92,11 +92,11 @@ impl<'a> Transformer<'a> {
 }
 
 impl<'a> Traverse<'a> for Transformer<'a> {
-    fn enter_program(&mut self, program: &mut Program<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_program(program);
     }
 
-    fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &TraverseCtx<'a>) {
+    fn exit_program(&mut self, program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x1_react.transform_program_on_exit(program);
         self.x0_typescript.transform_program_on_exit(program);
     }
@@ -106,102 +106,114 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn enter_arrow_function_expression(
         &mut self,
         expr: &mut ArrowFunctionExpression<'a>,
-        _ctx: &TraverseCtx<'a>,
+        _ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_arrow_expression(expr);
     }
 
-    fn enter_binding_pattern(&mut self, pat: &mut BindingPattern<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_binding_pattern(&mut self, pat: &mut BindingPattern<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_binding_pattern(pat);
     }
 
-    fn enter_call_expression(&mut self, expr: &mut CallExpression<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_call_expression(&mut self, expr: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_call_expression(expr);
         self.x1_react.transform_call_expression(expr, ctx);
     }
 
-    fn enter_class(&mut self, class: &mut Class<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_class(&mut self, class: &mut Class<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_class(class);
         self.x3_es2015.transform_class(class);
     }
 
-    fn exit_class(&mut self, class: &mut Class<'a>, _ctx: &TraverseCtx<'a>) {
+    fn exit_class(&mut self, class: &mut Class<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x3_es2015.transform_class_on_exit(class);
     }
 
-    fn enter_class_body(&mut self, body: &mut ClassBody<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_class_body(&mut self, body: &mut ClassBody<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_class_body(body);
     }
 
     fn enter_export_named_declaration(
         &mut self,
         decl: &mut ExportNamedDeclaration<'a>,
-        _ctx: &TraverseCtx<'a>,
+        _ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_export_named_declaration(decl);
     }
 
-    fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_expression(expr);
         self.x1_react.transform_expression(expr, ctx);
         self.x3_es2015.transform_expression(expr);
     }
 
-    fn exit_expression(&mut self, expr: &mut Expression<'a>, _ctx: &TraverseCtx<'a>) {
+    fn exit_expression(&mut self, expr: &mut Expression<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x3_es2015.transform_expression_on_exit(expr);
     }
 
-    fn enter_formal_parameter(&mut self, param: &mut FormalParameter<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_formal_parameter(
+        &mut self,
+        param: &mut FormalParameter<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
         self.x0_typescript.transform_formal_parameter(param);
     }
 
-    fn enter_function(&mut self, func: &mut Function<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_function(&mut self, func: &mut Function<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_function(func);
     }
 
-    fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_jsx_element(node);
     }
 
-    fn enter_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_jsx_fragment(node);
     }
 
     fn enter_jsx_opening_element(
         &mut self,
         elem: &mut JSXOpeningElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_jsx_opening_element(elem);
         self.x1_react.transform_jsx_opening_element(elem, ctx);
         self.x3_es2015.transform_jsx_opening_element(elem);
     }
 
-    fn enter_method_definition(&mut self, def: &mut MethodDefinition<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_method_definition(
+        &mut self,
+        def: &mut MethodDefinition<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
         self.x0_typescript.transform_method_definition(def);
     }
 
-    fn exit_method_definition(&mut self, def: &mut MethodDefinition<'a>, _ctx: &TraverseCtx<'a>) {
+    fn exit_method_definition(
+        &mut self,
+        def: &mut MethodDefinition<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
         self.x0_typescript.transform_method_definition_on_exit(def);
     }
 
-    fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_new_expression(expr);
     }
 
     fn enter_property_definition(
         &mut self,
         def: &mut PropertyDefinition<'a>,
-        _ctx: &TraverseCtx<'a>,
+        _ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_property_definition(def);
     }
 
-    fn enter_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, _ctx: &TraverseCtx<'a>) {
+    fn enter_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, _ctx: &mut TraverseCtx<'a>) {
         self.x3_es2015.enter_statements(stmts);
     }
 
-    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, _ctx: &TraverseCtx<'a>) {
+    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_statements_on_exit(stmts);
         self.x3_es2015.exit_statements(stmts);
     }
@@ -209,7 +221,7 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn enter_tagged_template_expression(
         &mut self,
         expr: &mut TaggedTemplateExpression<'a>,
-        _ctx: &TraverseCtx<'a>,
+        _ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_tagged_template_expression(expr);
     }
@@ -217,32 +229,32 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn enter_identifier_reference(
         &mut self,
         ident: &mut IdentifierReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_identifier_reference(ident, ctx);
     }
 
-    fn enter_statement(&mut self, stmt: &mut Statement<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_statement(&mut self, stmt: &mut Statement<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_statement(stmt);
     }
 
-    fn enter_declaration(&mut self, decl: &mut Declaration<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_declaration(&mut self, decl: &mut Declaration<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_declaration(decl);
         self.x3_es2015.transform_declaration(decl);
     }
 
-    fn exit_declaration(&mut self, decl: &mut Declaration<'a>, _ctx: &TraverseCtx<'a>) {
+    fn exit_declaration(&mut self, decl: &mut Declaration<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x3_es2015.transform_declaration_on_exit(decl);
     }
 
-    fn enter_if_statement(&mut self, stmt: &mut IfStatement<'a>, _ctx: &TraverseCtx<'a>) {
+    fn enter_if_statement(&mut self, stmt: &mut IfStatement<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_if_statement(stmt);
     }
 
     fn enter_module_declaration(
         &mut self,
         decl: &mut ModuleDeclaration<'a>,
-        _ctx: &TraverseCtx<'a>,
+        _ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_module_declaration(decl);
     }

--- a/crates/oxc_traverse/scripts/lib/traverse.mjs
+++ b/crates/oxc_traverse/scripts/lib/traverse.mjs
@@ -9,9 +9,9 @@ export default function generateTraverseTraitCode(types) {
         const snakeName = camelToSnake(type.name);
         traverseMethods += `
             #[inline]
-            fn enter_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &TraverseCtx<'a>) {}
+            fn enter_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &mut TraverseCtx<'a>) {}
             #[inline]
-            fn exit_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &TraverseCtx<'a>) {}
+            fn exit_${snakeName}(&mut self, node: &mut ${type.rawName}, ctx: &mut TraverseCtx<'a>) {}
         `;
     }
 

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -114,7 +114,7 @@ mod walk;
 /// struct MyTransform;
 ///
 /// impl<'a> Traverse<'a> for MyTransform {
-///     fn enter_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &TraverseCtx<'a>) {
+///     fn enter_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
 ///         // Read parent
 ///         if let Ancestor::BinaryExpressionRight(bin_expr_ref) = ctx.parent() {
 ///             // This is legal

--- a/crates/oxc_traverse/src/traverse.rs
+++ b/crates/oxc_traverse/src/traverse.rs
@@ -9,32 +9,32 @@ use crate::TraverseCtx;
 #[allow(unused_variables)]
 pub trait Traverse<'a> {
     #[inline]
-    fn enter_program(&mut self, node: &mut Program<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_program(&mut self, node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_program(&mut self, node: &mut Program<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_program(&mut self, node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_expression(&mut self, node: &mut Expression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_expression(&mut self, node: &mut Expression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_identifier_name(&mut self, node: &mut IdentifierName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_identifier_name(&mut self, node: &mut IdentifierName<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_identifier_name(&mut self, node: &mut IdentifierName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_identifier_name(&mut self, node: &mut IdentifierName<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_identifier_reference(
         &mut self,
         node: &mut IdentifierReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_identifier_reference(
         &mut self,
         node: &mut IdentifierReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -42,120 +42,168 @@ pub trait Traverse<'a> {
     fn enter_binding_identifier(
         &mut self,
         node: &mut BindingIdentifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_binding_identifier(&mut self, node: &mut BindingIdentifier<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_binding_identifier(
+        &mut self,
+        node: &mut BindingIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
-    fn enter_label_identifier(&mut self, node: &mut LabelIdentifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_label_identifier(
+        &mut self,
+        node: &mut LabelIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_label_identifier(&mut self, node: &mut LabelIdentifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_label_identifier(&mut self, node: &mut LabelIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_this_expression(&mut self, node: &mut ThisExpression, ctx: &TraverseCtx<'a>) {}
+    fn enter_this_expression(&mut self, node: &mut ThisExpression, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_this_expression(&mut self, node: &mut ThisExpression, ctx: &TraverseCtx<'a>) {}
+    fn exit_this_expression(&mut self, node: &mut ThisExpression, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_array_expression(&mut self, node: &mut ArrayExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_array_expression(
+        &mut self,
+        node: &mut ArrayExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_array_expression(&mut self, node: &mut ArrayExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_array_expression(&mut self, node: &mut ArrayExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
     fn enter_array_expression_element(
         &mut self,
         node: &mut ArrayExpressionElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_array_expression_element(
         &mut self,
         node: &mut ArrayExpressionElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_elision(&mut self, node: &mut Elision, ctx: &TraverseCtx<'a>) {}
+    fn enter_elision(&mut self, node: &mut Elision, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_elision(&mut self, node: &mut Elision, ctx: &TraverseCtx<'a>) {}
+    fn exit_elision(&mut self, node: &mut Elision, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_object_expression(&mut self, node: &mut ObjectExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_object_expression(
+        &mut self,
+        node: &mut ObjectExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_object_expression(&mut self, node: &mut ObjectExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_object_expression(
+        &mut self,
+        node: &mut ObjectExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_object_property_kind(
         &mut self,
         node: &mut ObjectPropertyKind<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_object_property_kind(
         &mut self,
         node: &mut ObjectPropertyKind<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_object_property(&mut self, node: &mut ObjectProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_object_property(&mut self, node: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_object_property(&mut self, node: &mut ObjectProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_object_property(&mut self, node: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_property_key(&mut self, node: &mut PropertyKey<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_property_key(&mut self, node: &mut PropertyKey<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_property_key(&mut self, node: &mut PropertyKey<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_property_key(&mut self, node: &mut PropertyKey<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_template_literal(&mut self, node: &mut TemplateLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_template_literal(
+        &mut self,
+        node: &mut TemplateLiteral<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_template_literal(&mut self, node: &mut TemplateLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_template_literal(&mut self, node: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
     fn enter_tagged_template_expression(
         &mut self,
         node: &mut TaggedTemplateExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_tagged_template_expression(
         &mut self,
         node: &mut TaggedTemplateExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_template_element(&mut self, node: &mut TemplateElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_template_element(
+        &mut self,
+        node: &mut TemplateElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_template_element(&mut self, node: &mut TemplateElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_template_element(&mut self, node: &mut TemplateElement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_member_expression(&mut self, node: &mut MemberExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_member_expression(
+        &mut self,
+        node: &mut MemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_member_expression(&mut self, node: &mut MemberExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_member_expression(
+        &mut self,
+        node: &mut MemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_computed_member_expression(
         &mut self,
         node: &mut ComputedMemberExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_computed_member_expression(
         &mut self,
         node: &mut ComputedMemberExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -163,14 +211,14 @@ pub trait Traverse<'a> {
     fn enter_static_member_expression(
         &mut self,
         node: &mut StaticMemberExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_static_member_expression(
         &mut self,
         node: &mut StaticMemberExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -178,69 +226,95 @@ pub trait Traverse<'a> {
     fn enter_private_field_expression(
         &mut self,
         node: &mut PrivateFieldExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_private_field_expression(
         &mut self,
         node: &mut PrivateFieldExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_call_expression(&mut self, node: &mut CallExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_call_expression(&mut self, node: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_call_expression(&mut self, node: &mut CallExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_call_expression(&mut self, node: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_new_expression(&mut self, node: &mut NewExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_new_expression(&mut self, node: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_new_expression(&mut self, node: &mut NewExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_new_expression(&mut self, node: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_meta_property(&mut self, node: &mut MetaProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_meta_property(&mut self, node: &mut MetaProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_meta_property(&mut self, node: &mut MetaProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_meta_property(&mut self, node: &mut MetaProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_spread_element(&mut self, node: &mut SpreadElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_spread_element(&mut self, node: &mut SpreadElement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_spread_element(&mut self, node: &mut SpreadElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_spread_element(&mut self, node: &mut SpreadElement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_argument(&mut self, node: &mut Argument<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_argument(&mut self, node: &mut Argument<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_argument(&mut self, node: &mut Argument<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_argument(&mut self, node: &mut Argument<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_update_expression(&mut self, node: &mut UpdateExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_update_expression(
+        &mut self,
+        node: &mut UpdateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_update_expression(&mut self, node: &mut UpdateExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_update_expression(
+        &mut self,
+        node: &mut UpdateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_unary_expression(&mut self, node: &mut UnaryExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_unary_expression(
+        &mut self,
+        node: &mut UnaryExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_unary_expression(&mut self, node: &mut UnaryExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_unary_expression(&mut self, node: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_binary_expression(&mut self, node: &mut BinaryExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_binary_expression(
+        &mut self,
+        node: &mut BinaryExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_binary_expression(&mut self, node: &mut BinaryExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_binary_expression(
+        &mut self,
+        node: &mut BinaryExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_private_in_expression(
         &mut self,
         node: &mut PrivateInExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_private_in_expression(
         &mut self,
         node: &mut PrivateInExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -248,25 +322,29 @@ pub trait Traverse<'a> {
     fn enter_logical_expression(
         &mut self,
         node: &mut LogicalExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_logical_expression(&mut self, node: &mut LogicalExpression<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_logical_expression(
+        &mut self,
+        node: &mut LogicalExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
     fn enter_conditional_expression(
         &mut self,
         node: &mut ConditionalExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_conditional_expression(
         &mut self,
         node: &mut ConditionalExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -274,34 +352,44 @@ pub trait Traverse<'a> {
     fn enter_assignment_expression(
         &mut self,
         node: &mut AssignmentExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_expression(
         &mut self,
         node: &mut AssignmentExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_assignment_target(&mut self, node: &mut AssignmentTarget<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_assignment_target(
+        &mut self,
+        node: &mut AssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_assignment_target(&mut self, node: &mut AssignmentTarget<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_assignment_target(
+        &mut self,
+        node: &mut AssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_simple_assignment_target(
         &mut self,
         node: &mut SimpleAssignmentTarget<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_simple_assignment_target(
         &mut self,
         node: &mut SimpleAssignmentTarget<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -309,14 +397,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_pattern(
         &mut self,
         node: &mut AssignmentTargetPattern<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_pattern(
         &mut self,
         node: &mut AssignmentTargetPattern<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -324,14 +412,14 @@ pub trait Traverse<'a> {
     fn enter_array_assignment_target(
         &mut self,
         node: &mut ArrayAssignmentTarget<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_array_assignment_target(
         &mut self,
         node: &mut ArrayAssignmentTarget<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -339,14 +427,14 @@ pub trait Traverse<'a> {
     fn enter_object_assignment_target(
         &mut self,
         node: &mut ObjectAssignmentTarget<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_object_assignment_target(
         &mut self,
         node: &mut ObjectAssignmentTarget<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -354,14 +442,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_rest(
         &mut self,
         node: &mut AssignmentTargetRest<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_rest(
         &mut self,
         node: &mut AssignmentTargetRest<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -369,14 +457,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_maybe_default(
         &mut self,
         node: &mut AssignmentTargetMaybeDefault<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_maybe_default(
         &mut self,
         node: &mut AssignmentTargetMaybeDefault<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -384,14 +472,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_with_default(
         &mut self,
         node: &mut AssignmentTargetWithDefault<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_with_default(
         &mut self,
         node: &mut AssignmentTargetWithDefault<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -399,14 +487,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_property(
         &mut self,
         node: &mut AssignmentTargetProperty<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_property(
         &mut self,
         node: &mut AssignmentTargetProperty<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -414,14 +502,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_property_identifier(
         &mut self,
         node: &mut AssignmentTargetPropertyIdentifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_property_identifier(
         &mut self,
         node: &mut AssignmentTargetPropertyIdentifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -429,14 +517,14 @@ pub trait Traverse<'a> {
     fn enter_assignment_target_property_property(
         &mut self,
         node: &mut AssignmentTargetPropertyProperty<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_assignment_target_property_property(
         &mut self,
         node: &mut AssignmentTargetPropertyProperty<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -444,89 +532,101 @@ pub trait Traverse<'a> {
     fn enter_sequence_expression(
         &mut self,
         node: &mut SequenceExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_sequence_expression(
         &mut self,
         node: &mut SequenceExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_super(&mut self, node: &mut Super, ctx: &TraverseCtx<'a>) {}
+    fn enter_super(&mut self, node: &mut Super, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_super(&mut self, node: &mut Super, ctx: &TraverseCtx<'a>) {}
+    fn exit_super(&mut self, node: &mut Super, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_await_expression(&mut self, node: &mut AwaitExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_await_expression(
+        &mut self,
+        node: &mut AwaitExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_await_expression(&mut self, node: &mut AwaitExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_await_expression(&mut self, node: &mut AwaitExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_chain_expression(&mut self, node: &mut ChainExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_chain_expression(
+        &mut self,
+        node: &mut ChainExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_chain_expression(&mut self, node: &mut ChainExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_chain_expression(&mut self, node: &mut ChainExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_chain_element(&mut self, node: &mut ChainElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_chain_element(&mut self, node: &mut ChainElement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_chain_element(&mut self, node: &mut ChainElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_chain_element(&mut self, node: &mut ChainElement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_parenthesized_expression(
         &mut self,
         node: &mut ParenthesizedExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_parenthesized_expression(
         &mut self,
         node: &mut ParenthesizedExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_statement(&mut self, node: &mut Statement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_statement(&mut self, node: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_statement(&mut self, node: &mut Statement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_statement(&mut self, node: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_directive(&mut self, node: &mut Directive<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_directive(&mut self, node: &mut Directive<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_directive(&mut self, node: &mut Directive<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_directive(&mut self, node: &mut Directive<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_hashbang(&mut self, node: &mut Hashbang<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_hashbang(&mut self, node: &mut Hashbang<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_hashbang(&mut self, node: &mut Hashbang<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_hashbang(&mut self, node: &mut Hashbang<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_declaration(&mut self, node: &mut Declaration<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_declaration(&mut self, node: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_declaration(&mut self, node: &mut Declaration<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_declaration(&mut self, node: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_variable_declaration(
         &mut self,
         node: &mut VariableDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_variable_declaration(
         &mut self,
         node: &mut VariableDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -534,168 +634,239 @@ pub trait Traverse<'a> {
     fn enter_variable_declarator(
         &mut self,
         node: &mut VariableDeclarator<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_variable_declarator(
         &mut self,
         node: &mut VariableDeclarator<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_using_declaration(&mut self, node: &mut UsingDeclaration<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_using_declaration(
+        &mut self,
+        node: &mut UsingDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_using_declaration(&mut self, node: &mut UsingDeclaration<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_using_declaration(
+        &mut self,
+        node: &mut UsingDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_empty_statement(&mut self, node: &mut EmptyStatement, ctx: &TraverseCtx<'a>) {}
+    fn enter_empty_statement(&mut self, node: &mut EmptyStatement, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_empty_statement(&mut self, node: &mut EmptyStatement, ctx: &TraverseCtx<'a>) {}
+    fn exit_empty_statement(&mut self, node: &mut EmptyStatement, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_expression_statement(
         &mut self,
         node: &mut ExpressionStatement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_expression_statement(
         &mut self,
         node: &mut ExpressionStatement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_if_statement(&mut self, node: &mut IfStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_if_statement(&mut self, node: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_if_statement(&mut self, node: &mut IfStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_if_statement(&mut self, node: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_do_while_statement(&mut self, node: &mut DoWhileStatement<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_do_while_statement(
+        &mut self,
+        node: &mut DoWhileStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_do_while_statement(&mut self, node: &mut DoWhileStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_do_while_statement(
+        &mut self,
+        node: &mut DoWhileStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_while_statement(&mut self, node: &mut WhileStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_while_statement(&mut self, node: &mut WhileStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_while_statement(&mut self, node: &mut WhileStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_while_statement(&mut self, node: &mut WhileStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_for_statement(&mut self, node: &mut ForStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_for_statement(&mut self, node: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_for_statement(&mut self, node: &mut ForStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_for_statement(&mut self, node: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_for_statement_init(&mut self, node: &mut ForStatementInit<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_for_statement_init(
+        &mut self,
+        node: &mut ForStatementInit<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_for_statement_init(&mut self, node: &mut ForStatementInit<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_for_statement_init(
+        &mut self,
+        node: &mut ForStatementInit<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_for_in_statement(&mut self, node: &mut ForInStatement<'a>, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_for_in_statement(&mut self, node: &mut ForInStatement<'a>, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_for_of_statement(&mut self, node: &mut ForOfStatement<'a>, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_for_of_statement(&mut self, node: &mut ForOfStatement<'a>, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_for_statement_left(&mut self, node: &mut ForStatementLeft<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_for_in_statement(&mut self, node: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {
     }
     #[inline]
-    fn exit_for_statement_left(&mut self, node: &mut ForStatementLeft<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_for_in_statement(&mut self, node: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_for_of_statement(&mut self, node: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_for_of_statement(&mut self, node: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_for_statement_left(
+        &mut self,
+        node: &mut ForStatementLeft<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_for_statement_left(
+        &mut self,
+        node: &mut ForStatementLeft<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_continue_statement(
         &mut self,
         node: &mut ContinueStatement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_continue_statement(&mut self, node: &mut ContinueStatement<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_continue_statement(
+        &mut self,
+        node: &mut ContinueStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
-    fn enter_break_statement(&mut self, node: &mut BreakStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_break_statement(&mut self, node: &mut BreakStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_break_statement(&mut self, node: &mut BreakStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_break_statement(&mut self, node: &mut BreakStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_return_statement(&mut self, node: &mut ReturnStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_return_statement(
+        &mut self,
+        node: &mut ReturnStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_return_statement(&mut self, node: &mut ReturnStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_return_statement(&mut self, node: &mut ReturnStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_with_statement(&mut self, node: &mut WithStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_with_statement(&mut self, node: &mut WithStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_with_statement(&mut self, node: &mut WithStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_with_statement(&mut self, node: &mut WithStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_switch_statement(&mut self, node: &mut SwitchStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_switch_statement(
+        &mut self,
+        node: &mut SwitchStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_switch_statement(&mut self, node: &mut SwitchStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_switch_statement(&mut self, node: &mut SwitchStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_switch_case(&mut self, node: &mut SwitchCase<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_switch_case(&mut self, node: &mut SwitchCase<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_switch_case(&mut self, node: &mut SwitchCase<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_switch_case(&mut self, node: &mut SwitchCase<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_labeled_statement(&mut self, node: &mut LabeledStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_labeled_statement(
+        &mut self,
+        node: &mut LabeledStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_labeled_statement(&mut self, node: &mut LabeledStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_labeled_statement(
+        &mut self,
+        node: &mut LabeledStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_throw_statement(&mut self, node: &mut ThrowStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_throw_statement(&mut self, node: &mut ThrowStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_throw_statement(&mut self, node: &mut ThrowStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_throw_statement(&mut self, node: &mut ThrowStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_try_statement(&mut self, node: &mut TryStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_try_statement(&mut self, node: &mut TryStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_try_statement(&mut self, node: &mut TryStatement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_try_statement(&mut self, node: &mut TryStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_catch_clause(&mut self, node: &mut CatchClause<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_catch_clause(&mut self, node: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_catch_clause(&mut self, node: &mut CatchClause<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_catch_clause(&mut self, node: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_catch_parameter(&mut self, node: &mut CatchParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_catch_parameter(&mut self, node: &mut CatchParameter<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_catch_parameter(&mut self, node: &mut CatchParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_catch_parameter(&mut self, node: &mut CatchParameter<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_debugger_statement(&mut self, node: &mut DebuggerStatement, ctx: &TraverseCtx<'a>) {}
+    fn enter_debugger_statement(
+        &mut self,
+        node: &mut DebuggerStatement,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_debugger_statement(&mut self, node: &mut DebuggerStatement, ctx: &TraverseCtx<'a>) {}
+    fn exit_debugger_statement(&mut self, node: &mut DebuggerStatement, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_binding_pattern(&mut self, node: &mut BindingPattern<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_binding_pattern(&mut self, node: &mut BindingPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_binding_pattern(&mut self, node: &mut BindingPattern<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_binding_pattern(&mut self, node: &mut BindingPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_binding_pattern_kind(
         &mut self,
         node: &mut BindingPatternKind<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_binding_pattern_kind(
         &mut self,
         node: &mut BindingPatternKind<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -703,115 +874,157 @@ pub trait Traverse<'a> {
     fn enter_assignment_pattern(
         &mut self,
         node: &mut AssignmentPattern<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_assignment_pattern(&mut self, node: &mut AssignmentPattern<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_assignment_pattern(
+        &mut self,
+        node: &mut AssignmentPattern<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
-    fn enter_object_pattern(&mut self, node: &mut ObjectPattern<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_object_pattern(&mut self, node: &mut ObjectPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_object_pattern(&mut self, node: &mut ObjectPattern<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_object_pattern(&mut self, node: &mut ObjectPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_binding_property(&mut self, node: &mut BindingProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_binding_property(
+        &mut self,
+        node: &mut BindingProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_binding_property(&mut self, node: &mut BindingProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_binding_property(&mut self, node: &mut BindingProperty<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_array_pattern(&mut self, node: &mut ArrayPattern<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_array_pattern(&mut self, node: &mut ArrayPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_array_pattern(&mut self, node: &mut ArrayPattern<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_array_pattern(&mut self, node: &mut ArrayPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_binding_rest_element(
         &mut self,
         node: &mut BindingRestElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_binding_rest_element(
         &mut self,
         node: &mut BindingRestElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_function(&mut self, node: &mut Function<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_function(&mut self, node: &mut Function<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_formal_parameters(&mut self, node: &mut FormalParameters<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_formal_parameters(
+        &mut self,
+        node: &mut FormalParameters<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_formal_parameters(&mut self, node: &mut FormalParameters<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_formal_parameters(
+        &mut self,
+        node: &mut FormalParameters<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_formal_parameter(&mut self, node: &mut FormalParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_formal_parameter(
+        &mut self,
+        node: &mut FormalParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_formal_parameter(&mut self, node: &mut FormalParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_formal_parameter(&mut self, node: &mut FormalParameter<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_function_body(&mut self, node: &mut FunctionBody<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_function_body(&mut self, node: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_function_body(&mut self, node: &mut FunctionBody<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_function_body(&mut self, node: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_arrow_function_expression(
         &mut self,
         node: &mut ArrowFunctionExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_arrow_function_expression(
         &mut self,
         node: &mut ArrowFunctionExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_yield_expression(&mut self, node: &mut YieldExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_yield_expression(
+        &mut self,
+        node: &mut YieldExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_yield_expression(&mut self, node: &mut YieldExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_yield_expression(&mut self, node: &mut YieldExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_class(&mut self, node: &mut Class<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_class(&mut self, node: &mut Class<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_class_body(&mut self, node: &mut ClassBody<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_class_body(&mut self, node: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_class_body(&mut self, node: &mut ClassBody<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_class_body(&mut self, node: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_class_element(&mut self, node: &mut ClassElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_class_element(&mut self, node: &mut ClassElement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_class_element(&mut self, node: &mut ClassElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_class_element(&mut self, node: &mut ClassElement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_method_definition(&mut self, node: &mut MethodDefinition<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_method_definition(
+        &mut self,
+        node: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_method_definition(&mut self, node: &mut MethodDefinition<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_method_definition(
+        &mut self,
+        node: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_property_definition(
         &mut self,
         node: &mut PropertyDefinition<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_property_definition(
         &mut self,
         node: &mut PropertyDefinition<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -819,82 +1032,120 @@ pub trait Traverse<'a> {
     fn enter_private_identifier(
         &mut self,
         node: &mut PrivateIdentifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_private_identifier(&mut self, node: &mut PrivateIdentifier<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_private_identifier(
+        &mut self,
+        node: &mut PrivateIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
-    fn enter_static_block(&mut self, node: &mut StaticBlock<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_static_block(&mut self, node: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_static_block(&mut self, node: &mut StaticBlock<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_static_block(&mut self, node: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_module_declaration(
         &mut self,
         node: &mut ModuleDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_module_declaration(&mut self, node: &mut ModuleDeclaration<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_module_declaration(
+        &mut self,
+        node: &mut ModuleDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
-    fn enter_accessor_property(&mut self, node: &mut AccessorProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_accessor_property(
+        &mut self,
+        node: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_accessor_property(&mut self, node: &mut AccessorProperty<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_accessor_property(
+        &mut self,
+        node: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_import_expression(&mut self, node: &mut ImportExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_import_expression(
+        &mut self,
+        node: &mut ImportExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_import_expression(&mut self, node: &mut ImportExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_import_expression(
+        &mut self,
+        node: &mut ImportExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_import_declaration(
         &mut self,
         node: &mut ImportDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_import_declaration(&mut self, node: &mut ImportDeclaration<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_import_declaration(
+        &mut self,
+        node: &mut ImportDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
     fn enter_import_declaration_specifier(
         &mut self,
         node: &mut ImportDeclarationSpecifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_import_declaration_specifier(
         &mut self,
         node: &mut ImportDeclarationSpecifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_import_specifier(&mut self, node: &mut ImportSpecifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_import_specifier(
+        &mut self,
+        node: &mut ImportSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_import_specifier(&mut self, node: &mut ImportSpecifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_import_specifier(&mut self, node: &mut ImportSpecifier<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
     fn enter_import_default_specifier(
         &mut self,
         node: &mut ImportDefaultSpecifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_import_default_specifier(
         &mut self,
         node: &mut ImportDefaultSpecifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -902,39 +1153,45 @@ pub trait Traverse<'a> {
     fn enter_import_namespace_specifier(
         &mut self,
         node: &mut ImportNamespaceSpecifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_import_namespace_specifier(
         &mut self,
         node: &mut ImportNamespaceSpecifier<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_with_clause(&mut self, node: &mut WithClause<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_with_clause(&mut self, node: &mut WithClause<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_with_clause(&mut self, node: &mut WithClause<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_with_clause(&mut self, node: &mut WithClause<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_import_attribute(&mut self, node: &mut ImportAttribute<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_import_attribute(
+        &mut self,
+        node: &mut ImportAttribute<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_import_attribute(&mut self, node: &mut ImportAttribute<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_import_attribute(&mut self, node: &mut ImportAttribute<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
     fn enter_import_attribute_key(
         &mut self,
         node: &mut ImportAttributeKey<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_import_attribute_key(
         &mut self,
         node: &mut ImportAttributeKey<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -942,14 +1199,14 @@ pub trait Traverse<'a> {
     fn enter_export_named_declaration(
         &mut self,
         node: &mut ExportNamedDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_export_named_declaration(
         &mut self,
         node: &mut ExportNamedDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -957,14 +1214,14 @@ pub trait Traverse<'a> {
     fn enter_export_default_declaration(
         &mut self,
         node: &mut ExportDefaultDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_export_default_declaration(
         &mut self,
         node: &mut ExportDefaultDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -972,60 +1229,75 @@ pub trait Traverse<'a> {
     fn enter_export_all_declaration(
         &mut self,
         node: &mut ExportAllDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_export_all_declaration(
         &mut self,
         node: &mut ExportAllDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_export_specifier(&mut self, node: &mut ExportSpecifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_export_specifier(
+        &mut self,
+        node: &mut ExportSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_export_specifier(&mut self, node: &mut ExportSpecifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_export_specifier(&mut self, node: &mut ExportSpecifier<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
     fn enter_export_default_declaration_kind(
         &mut self,
         node: &mut ExportDefaultDeclarationKind<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_export_default_declaration_kind(
         &mut self,
         node: &mut ExportDefaultDeclarationKind<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_module_export_name(&mut self, node: &mut ModuleExportName<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_module_export_name(
+        &mut self,
+        node: &mut ModuleExportName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_module_export_name(&mut self, node: &mut ModuleExportName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_module_export_name(
+        &mut self,
+        node: &mut ModuleExportName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_jsx_opening_element(
         &mut self,
         node: &mut JSXOpeningElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_opening_element(
         &mut self,
         node: &mut JSXOpeningElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1033,39 +1305,40 @@ pub trait Traverse<'a> {
     fn enter_jsx_closing_element(
         &mut self,
         node: &mut JSXClosingElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_closing_element(
         &mut self,
         node: &mut JSXClosingElement<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_jsx_namespaced_name(
         &mut self,
         node: &mut JSXNamespacedName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_namespaced_name(
         &mut self,
         node: &mut JSXNamespacedName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1073,14 +1346,14 @@ pub trait Traverse<'a> {
     fn enter_jsx_member_expression(
         &mut self,
         node: &mut JSXMemberExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_member_expression(
         &mut self,
         node: &mut JSXMemberExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1088,14 +1361,14 @@ pub trait Traverse<'a> {
     fn enter_jsx_member_expression_object(
         &mut self,
         node: &mut JSXMemberExpressionObject<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_member_expression_object(
         &mut self,
         node: &mut JSXMemberExpressionObject<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1103,390 +1376,485 @@ pub trait Traverse<'a> {
     fn enter_jsx_expression_container(
         &mut self,
         node: &mut JSXExpressionContainer<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_expression_container(
         &mut self,
         node: &mut JSXExpressionContainer<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_jsx_expression(&mut self, node: &mut JSXExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_expression(&mut self, node: &mut JSXExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_expression(&mut self, node: &mut JSXExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_expression(&mut self, node: &mut JSXExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_jsx_empty_expression(&mut self, node: &mut JSXEmptyExpression, ctx: &TraverseCtx<'a>) {
+    fn enter_jsx_empty_expression(
+        &mut self,
+        node: &mut JSXEmptyExpression,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_jsx_empty_expression(&mut self, node: &mut JSXEmptyExpression, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_empty_expression(
+        &mut self,
+        node: &mut JSXEmptyExpression,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_jsx_attribute_item(&mut self, node: &mut JSXAttributeItem<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_jsx_attribute_item(
+        &mut self,
+        node: &mut JSXAttributeItem<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_jsx_attribute_item(&mut self, node: &mut JSXAttributeItem<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_attribute_item(
+        &mut self,
+        node: &mut JSXAttributeItem<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_jsx_attribute(&mut self, node: &mut JSXAttribute<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_attribute(&mut self, node: &mut JSXAttribute<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_attribute(&mut self, node: &mut JSXAttribute<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_attribute(&mut self, node: &mut JSXAttribute<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_jsx_spread_attribute(
         &mut self,
         node: &mut JSXSpreadAttribute<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_spread_attribute(
         &mut self,
         node: &mut JSXSpreadAttribute<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_jsx_attribute_name(&mut self, node: &mut JSXAttributeName<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_jsx_attribute_name(
+        &mut self,
+        node: &mut JSXAttributeName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_jsx_attribute_name(&mut self, node: &mut JSXAttributeName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_attribute_name(
+        &mut self,
+        node: &mut JSXAttributeName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_jsx_attribute_value(
         &mut self,
         node: &mut JSXAttributeValue<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_jsx_attribute_value(
         &mut self,
         node: &mut JSXAttributeValue<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_jsx_identifier(&mut self, node: &mut JSXIdentifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_identifier(&mut self, node: &mut JSXIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_identifier(&mut self, node: &mut JSXIdentifier<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_identifier(&mut self, node: &mut JSXIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_jsx_child(&mut self, node: &mut JSXChild<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_child(&mut self, node: &mut JSXChild<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_child(&mut self, node: &mut JSXChild<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_child(&mut self, node: &mut JSXChild<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_jsx_spread_child(&mut self, node: &mut JSXSpreadChild<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_spread_child(&mut self, node: &mut JSXSpreadChild<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_jsx_spread_child(&mut self, node: &mut JSXSpreadChild<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_spread_child(&mut self, node: &mut JSXSpreadChild<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_jsx_text(&mut self, node: &mut JSXText<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_jsx_text(&mut self, node: &mut JSXText<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_jsx_text(&mut self, node: &mut JSXText<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_jsx_text(&mut self, node: &mut JSXText<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_boolean_literal(&mut self, node: &mut BooleanLiteral, ctx: &TraverseCtx<'a>) {}
+    fn enter_boolean_literal(&mut self, node: &mut BooleanLiteral, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_boolean_literal(&mut self, node: &mut BooleanLiteral, ctx: &TraverseCtx<'a>) {}
+    fn exit_boolean_literal(&mut self, node: &mut BooleanLiteral, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_null_literal(&mut self, node: &mut NullLiteral, ctx: &TraverseCtx<'a>) {}
+    fn enter_null_literal(&mut self, node: &mut NullLiteral, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_null_literal(&mut self, node: &mut NullLiteral, ctx: &TraverseCtx<'a>) {}
+    fn exit_null_literal(&mut self, node: &mut NullLiteral, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_this_parameter(&mut self, node: &mut TSThisParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_this_parameter(
+        &mut self,
+        node: &mut TSThisParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_ts_this_parameter(&mut self, node: &mut TSThisParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_this_parameter(
+        &mut self,
+        node: &mut TSThisParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_enum_declaration(
         &mut self,
         node: &mut TSEnumDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_enum_declaration(
         &mut self,
         node: &mut TSEnumDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_enum_member(&mut self, node: &mut TSEnumMember<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_enum_member(&mut self, node: &mut TSEnumMember<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_enum_member(&mut self, node: &mut TSEnumMember<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_enum_member(&mut self, node: &mut TSEnumMember<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_enum_member_name(
         &mut self,
         node: &mut TSEnumMemberName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
-    fn exit_ts_enum_member_name(&mut self, node: &mut TSEnumMemberName<'a>, ctx: &TraverseCtx<'a>) {
+    fn exit_ts_enum_member_name(
+        &mut self,
+        node: &mut TSEnumMemberName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
 
     #[inline]
-    fn enter_ts_type_annotation(&mut self, node: &mut TSTypeAnnotation<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_ts_type_annotation(
+        &mut self,
+        node: &mut TSTypeAnnotation<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_ts_type_annotation(&mut self, node: &mut TSTypeAnnotation<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_annotation(
+        &mut self,
+        node: &mut TSTypeAnnotation<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
-    fn enter_ts_literal_type(&mut self, node: &mut TSLiteralType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_literal_type(&mut self, node: &mut TSLiteralType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_literal_type(&mut self, node: &mut TSLiteralType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_literal_type(&mut self, node: &mut TSLiteralType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_literal(&mut self, node: &mut TSLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_literal(&mut self, node: &mut TSLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_literal(&mut self, node: &mut TSLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_literal(&mut self, node: &mut TSLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_type(&mut self, node: &mut TSType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type(&mut self, node: &mut TSType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_type(&mut self, node: &mut TSType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type(&mut self, node: &mut TSType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_conditional_type(
         &mut self,
         node: &mut TSConditionalType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_conditional_type(
         &mut self,
         node: &mut TSConditionalType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_union_type(&mut self, node: &mut TSUnionType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_union_type(&mut self, node: &mut TSUnionType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_union_type(&mut self, node: &mut TSUnionType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_union_type(&mut self, node: &mut TSUnionType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_intersection_type(
         &mut self,
         node: &mut TSIntersectionType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_intersection_type(
         &mut self,
         node: &mut TSIntersectionType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_type_operator(&mut self, node: &mut TSTypeOperator<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type_operator(&mut self, node: &mut TSTypeOperator<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_ts_type_operator(&mut self, node: &mut TSTypeOperator<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_operator(&mut self, node: &mut TSTypeOperator<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_array_type(&mut self, node: &mut TSArrayType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_array_type(&mut self, node: &mut TSArrayType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_array_type(&mut self, node: &mut TSArrayType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_array_type(&mut self, node: &mut TSArrayType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_indexed_access_type(
         &mut self,
         node: &mut TSIndexedAccessType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_indexed_access_type(
         &mut self,
         node: &mut TSIndexedAccessType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_tuple_type(&mut self, node: &mut TSTupleType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_tuple_type(&mut self, node: &mut TSTupleType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_tuple_type(&mut self, node: &mut TSTupleType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_tuple_type(&mut self, node: &mut TSTupleType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_named_tuple_member(
         &mut self,
         node: &mut TSNamedTupleMember<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_named_tuple_member(
         &mut self,
         node: &mut TSNamedTupleMember<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_optional_type(&mut self, node: &mut TSOptionalType<'a>, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_optional_type(&mut self, node: &mut TSOptionalType<'a>, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_rest_type(&mut self, node: &mut TSRestType<'a>, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_rest_type(&mut self, node: &mut TSRestType<'a>, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_tuple_element(&mut self, node: &mut TSTupleElement<'a>, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_tuple_element(&mut self, node: &mut TSTupleElement<'a>, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_any_keyword(&mut self, node: &mut TSAnyKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_any_keyword(&mut self, node: &mut TSAnyKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_string_keyword(&mut self, node: &mut TSStringKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_string_keyword(&mut self, node: &mut TSStringKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_boolean_keyword(&mut self, node: &mut TSBooleanKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_boolean_keyword(&mut self, node: &mut TSBooleanKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_number_keyword(&mut self, node: &mut TSNumberKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_number_keyword(&mut self, node: &mut TSNumberKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_never_keyword(&mut self, node: &mut TSNeverKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_never_keyword(&mut self, node: &mut TSNeverKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_unknown_keyword(&mut self, node: &mut TSUnknownKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_unknown_keyword(&mut self, node: &mut TSUnknownKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_null_keyword(&mut self, node: &mut TSNullKeyword, ctx: &TraverseCtx<'a>) {}
-    #[inline]
-    fn exit_ts_null_keyword(&mut self, node: &mut TSNullKeyword, ctx: &TraverseCtx<'a>) {}
-
-    #[inline]
-    fn enter_ts_undefined_keyword(&mut self, node: &mut TSUndefinedKeyword, ctx: &TraverseCtx<'a>) {
+    fn enter_ts_optional_type(&mut self, node: &mut TSOptionalType<'a>, ctx: &mut TraverseCtx<'a>) {
     }
     #[inline]
-    fn exit_ts_undefined_keyword(&mut self, node: &mut TSUndefinedKeyword, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_optional_type(&mut self, node: &mut TSOptionalType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_void_keyword(&mut self, node: &mut TSVoidKeyword, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_rest_type(&mut self, node: &mut TSRestType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_void_keyword(&mut self, node: &mut TSVoidKeyword, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_rest_type(&mut self, node: &mut TSRestType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_symbol_keyword(&mut self, node: &mut TSSymbolKeyword, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_tuple_element(&mut self, node: &mut TSTupleElement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_ts_symbol_keyword(&mut self, node: &mut TSSymbolKeyword, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_tuple_element(&mut self, node: &mut TSTupleElement<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_this_type(&mut self, node: &mut TSThisType, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_any_keyword(&mut self, node: &mut TSAnyKeyword, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_this_type(&mut self, node: &mut TSThisType, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_any_keyword(&mut self, node: &mut TSAnyKeyword, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_object_keyword(&mut self, node: &mut TSObjectKeyword, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_string_keyword(&mut self, node: &mut TSStringKeyword, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_object_keyword(&mut self, node: &mut TSObjectKeyword, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_string_keyword(&mut self, node: &mut TSStringKeyword, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_big_int_keyword(&mut self, node: &mut TSBigIntKeyword, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_boolean_keyword(&mut self, node: &mut TSBooleanKeyword, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_ts_big_int_keyword(&mut self, node: &mut TSBigIntKeyword, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_boolean_keyword(&mut self, node: &mut TSBooleanKeyword, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_type_reference(&mut self, node: &mut TSTypeReference<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_number_keyword(&mut self, node: &mut TSNumberKeyword, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_type_reference(&mut self, node: &mut TSTypeReference<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_number_keyword(&mut self, node: &mut TSNumberKeyword, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_type_name(&mut self, node: &mut TSTypeName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_never_keyword(&mut self, node: &mut TSNeverKeyword, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_type_name(&mut self, node: &mut TSTypeName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_never_keyword(&mut self, node: &mut TSNeverKeyword, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_qualified_name(&mut self, node: &mut TSQualifiedName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_unknown_keyword(&mut self, node: &mut TSUnknownKeyword, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_ts_qualified_name(&mut self, node: &mut TSQualifiedName<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_unknown_keyword(&mut self, node: &mut TSUnknownKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_null_keyword(&mut self, node: &mut TSNullKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_null_keyword(&mut self, node: &mut TSNullKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_undefined_keyword(
+        &mut self,
+        node: &mut TSUndefinedKeyword,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_undefined_keyword(
+        &mut self,
+        node: &mut TSUndefinedKeyword,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_void_keyword(&mut self, node: &mut TSVoidKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_void_keyword(&mut self, node: &mut TSVoidKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_symbol_keyword(&mut self, node: &mut TSSymbolKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_symbol_keyword(&mut self, node: &mut TSSymbolKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_this_type(&mut self, node: &mut TSThisType, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_this_type(&mut self, node: &mut TSThisType, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_object_keyword(&mut self, node: &mut TSObjectKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_object_keyword(&mut self, node: &mut TSObjectKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_big_int_keyword(&mut self, node: &mut TSBigIntKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_big_int_keyword(&mut self, node: &mut TSBigIntKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_type_reference(
+        &mut self,
+        node: &mut TSTypeReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_reference(
+        &mut self,
+        node: &mut TSTypeReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_name(&mut self, node: &mut TSTypeName<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_type_name(&mut self, node: &mut TSTypeName<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_qualified_name(
+        &mut self,
+        node: &mut TSQualifiedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_qualified_name(
+        &mut self,
+        node: &mut TSQualifiedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_type_parameter_instantiation(
         &mut self,
         node: &mut TSTypeParameterInstantiation<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_type_parameter_instantiation(
         &mut self,
         node: &mut TSTypeParameterInstantiation<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_type_parameter(&mut self, node: &mut TSTypeParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type_parameter(
+        &mut self,
+        node: &mut TSTypeParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_ts_type_parameter(&mut self, node: &mut TSTypeParameter<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_parameter(
+        &mut self,
+        node: &mut TSTypeParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_type_parameter_declaration(
         &mut self,
         node: &mut TSTypeParameterDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_type_parameter_declaration(
         &mut self,
         node: &mut TSTypeParameterDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1494,14 +1862,14 @@ pub trait Traverse<'a> {
     fn enter_ts_type_alias_declaration(
         &mut self,
         node: &mut TSTypeAliasDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_type_alias_declaration(
         &mut self,
         node: &mut TSTypeAliasDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1509,14 +1877,14 @@ pub trait Traverse<'a> {
     fn enter_ts_class_implements(
         &mut self,
         node: &mut TSClassImplements<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_class_implements(
         &mut self,
         node: &mut TSClassImplements<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1524,60 +1892,79 @@ pub trait Traverse<'a> {
     fn enter_ts_interface_declaration(
         &mut self,
         node: &mut TSInterfaceDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_interface_declaration(
         &mut self,
         node: &mut TSInterfaceDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_interface_body(&mut self, node: &mut TSInterfaceBody<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_interface_body(
+        &mut self,
+        node: &mut TSInterfaceBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_ts_interface_body(&mut self, node: &mut TSInterfaceBody<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_interface_body(
+        &mut self,
+        node: &mut TSInterfaceBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_property_signature(
         &mut self,
         node: &mut TSPropertySignature<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_property_signature(
         &mut self,
         node: &mut TSPropertySignature<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_signature(&mut self, node: &mut TSSignature<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_signature(&mut self, node: &mut TSSignature<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_signature(&mut self, node: &mut TSSignature<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_signature(&mut self, node: &mut TSSignature<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_index_signature(&mut self, node: &mut TSIndexSignature<'a>, ctx: &TraverseCtx<'a>) {
+    fn enter_ts_index_signature(
+        &mut self,
+        node: &mut TSIndexSignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
     }
     #[inline]
-    fn exit_ts_index_signature(&mut self, node: &mut TSIndexSignature<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_index_signature(
+        &mut self,
+        node: &mut TSIndexSignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_call_signature_declaration(
         &mut self,
         node: &mut TSCallSignatureDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_call_signature_declaration(
         &mut self,
         node: &mut TSCallSignatureDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1585,14 +1972,14 @@ pub trait Traverse<'a> {
     fn enter_ts_method_signature(
         &mut self,
         node: &mut TSMethodSignature<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_method_signature(
         &mut self,
         node: &mut TSMethodSignature<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1600,14 +1987,14 @@ pub trait Traverse<'a> {
     fn enter_ts_construct_signature_declaration(
         &mut self,
         node: &mut TSConstructSignatureDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_construct_signature_declaration(
         &mut self,
         node: &mut TSConstructSignatureDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1615,14 +2002,14 @@ pub trait Traverse<'a> {
     fn enter_ts_index_signature_name(
         &mut self,
         node: &mut TSIndexSignatureName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_index_signature_name(
         &mut self,
         node: &mut TSIndexSignatureName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1630,34 +2017,44 @@ pub trait Traverse<'a> {
     fn enter_ts_interface_heritage(
         &mut self,
         node: &mut TSInterfaceHeritage<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_interface_heritage(
         &mut self,
         node: &mut TSInterfaceHeritage<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_type_predicate(&mut self, node: &mut TSTypePredicate<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type_predicate(
+        &mut self,
+        node: &mut TSTypePredicate<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_ts_type_predicate(&mut self, node: &mut TSTypePredicate<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_predicate(
+        &mut self,
+        node: &mut TSTypePredicate<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_type_predicate_name(
         &mut self,
         node: &mut TSTypePredicateName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_type_predicate_name(
         &mut self,
         node: &mut TSTypePredicateName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1665,14 +2062,14 @@ pub trait Traverse<'a> {
     fn enter_ts_module_declaration(
         &mut self,
         node: &mut TSModuleDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_module_declaration(
         &mut self,
         node: &mut TSModuleDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1680,14 +2077,14 @@ pub trait Traverse<'a> {
     fn enter_ts_module_declaration_name(
         &mut self,
         node: &mut TSModuleDeclarationName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_module_declaration_name(
         &mut self,
         node: &mut TSModuleDeclarationName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1695,69 +2092,69 @@ pub trait Traverse<'a> {
     fn enter_ts_module_declaration_body(
         &mut self,
         node: &mut TSModuleDeclarationBody<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_module_declaration_body(
         &mut self,
         node: &mut TSModuleDeclarationBody<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_module_block(&mut self, node: &mut TSModuleBlock<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_module_block(&mut self, node: &mut TSModuleBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_module_block(&mut self, node: &mut TSModuleBlock<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_module_block(&mut self, node: &mut TSModuleBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_type_literal(&mut self, node: &mut TSTypeLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type_literal(&mut self, node: &mut TSTypeLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_type_literal(&mut self, node: &mut TSTypeLiteral<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_literal(&mut self, node: &mut TSTypeLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_infer_type(&mut self, node: &mut TSInferType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_infer_type(&mut self, node: &mut TSInferType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_infer_type(&mut self, node: &mut TSInferType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_infer_type(&mut self, node: &mut TSInferType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_type_query(&mut self, node: &mut TSTypeQuery<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type_query(&mut self, node: &mut TSTypeQuery<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_type_query(&mut self, node: &mut TSTypeQuery<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_query(&mut self, node: &mut TSTypeQuery<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_type_query_expr_name(
         &mut self,
         node: &mut TSTypeQueryExprName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_type_query_expr_name(
         &mut self,
         node: &mut TSTypeQueryExprName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_import_attributes(
         &mut self,
         node: &mut TSImportAttributes<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_import_attributes(
         &mut self,
         node: &mut TSImportAttributes<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1765,14 +2162,14 @@ pub trait Traverse<'a> {
     fn enter_ts_import_attribute(
         &mut self,
         node: &mut TSImportAttribute<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_import_attribute(
         &mut self,
         node: &mut TSImportAttribute<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1780,94 +2177,106 @@ pub trait Traverse<'a> {
     fn enter_ts_import_attribute_name(
         &mut self,
         node: &mut TSImportAttributeName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_import_attribute_name(
         &mut self,
         node: &mut TSImportAttributeName<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_constructor_type(
         &mut self,
         node: &mut TSConstructorType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_constructor_type(
         &mut self,
         node: &mut TSConstructorType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_mapped_type(&mut self, node: &mut TSMappedType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_mapped_type(&mut self, node: &mut TSMappedType<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_ts_mapped_type(&mut self, node: &mut TSMappedType<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_mapped_type(&mut self, node: &mut TSMappedType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_template_literal_type(
         &mut self,
         node: &mut TSTemplateLiteralType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_template_literal_type(
         &mut self,
         node: &mut TSTemplateLiteralType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_as_expression(&mut self, node: &mut TSAsExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_as_expression(&mut self, node: &mut TSAsExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
     #[inline]
-    fn exit_ts_as_expression(&mut self, node: &mut TSAsExpression<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_as_expression(&mut self, node: &mut TSAsExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_satisfies_expression(
         &mut self,
         node: &mut TSSatisfiesExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_satisfies_expression(
         &mut self,
         node: &mut TSSatisfiesExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_ts_type_assertion(&mut self, node: &mut TSTypeAssertion<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_ts_type_assertion(
+        &mut self,
+        node: &mut TSTypeAssertion<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_ts_type_assertion(&mut self, node: &mut TSTypeAssertion<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_ts_type_assertion(
+        &mut self,
+        node: &mut TSTypeAssertion<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 
     #[inline]
     fn enter_ts_import_equals_declaration(
         &mut self,
         node: &mut TSImportEqualsDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_import_equals_declaration(
         &mut self,
         node: &mut TSImportEqualsDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1875,14 +2284,14 @@ pub trait Traverse<'a> {
     fn enter_ts_module_reference(
         &mut self,
         node: &mut TSModuleReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_module_reference(
         &mut self,
         node: &mut TSModuleReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1890,14 +2299,14 @@ pub trait Traverse<'a> {
     fn enter_ts_external_module_reference(
         &mut self,
         node: &mut TSExternalModuleReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_external_module_reference(
         &mut self,
         node: &mut TSExternalModuleReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1905,34 +2314,34 @@ pub trait Traverse<'a> {
     fn enter_ts_non_null_expression(
         &mut self,
         node: &mut TSNonNullExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_non_null_expression(
         &mut self,
         node: &mut TSNonNullExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_decorator(&mut self, node: &mut Decorator<'a>, ctx: &TraverseCtx<'a>) {}
+    fn enter_decorator(&mut self, node: &mut Decorator<'a>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_decorator(&mut self, node: &mut Decorator<'a>, ctx: &TraverseCtx<'a>) {}
+    fn exit_decorator(&mut self, node: &mut Decorator<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
     fn enter_ts_export_assignment(
         &mut self,
         node: &mut TSExportAssignment<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_export_assignment(
         &mut self,
         node: &mut TSExportAssignment<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1940,14 +2349,14 @@ pub trait Traverse<'a> {
     fn enter_ts_namespace_export_declaration(
         &mut self,
         node: &mut TSNamespaceExportDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_namespace_export_declaration(
         &mut self,
         node: &mut TSNamespaceExportDeclaration<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1955,14 +2364,14 @@ pub trait Traverse<'a> {
     fn enter_ts_instantiation_expression(
         &mut self,
         node: &mut TSInstantiationExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_ts_instantiation_expression(
         &mut self,
         node: &mut TSInstantiationExpression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
@@ -1970,24 +2379,30 @@ pub trait Traverse<'a> {
     fn enter_js_doc_nullable_type(
         &mut self,
         node: &mut JSDocNullableType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
     #[inline]
     fn exit_js_doc_nullable_type(
         &mut self,
         node: &mut JSDocNullableType<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
     }
 
     #[inline]
-    fn enter_js_doc_unknown_type(&mut self, node: &mut JSDocUnknownType, ctx: &TraverseCtx<'a>) {}
+    fn enter_js_doc_unknown_type(
+        &mut self,
+        node: &mut JSDocUnknownType,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_js_doc_unknown_type(&mut self, node: &mut JSDocUnknownType, ctx: &TraverseCtx<'a>) {}
+    fn exit_js_doc_unknown_type(&mut self, node: &mut JSDocUnknownType, ctx: &mut TraverseCtx<'a>) {
+    }
 
     #[inline]
-    fn enter_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &TraverseCtx<'a>) {}
+    fn enter_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {}
     #[inline]
-    fn exit_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &TraverseCtx<'a>) {}
+    fn exit_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {}
 }

--- a/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime1.rs
+++ b/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime1.rs
@@ -9,7 +9,7 @@ impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
     fn enter_identifier_reference(
         &mut self,
         _node: &mut IdentifierReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
         self.ancestor = Some(ctx.parent());
     }

--- a/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime1.stderr
+++ b/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime1.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 8  | impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
    |          -- lifetime `'b` defined here
 ...
-12 |         ctx: &TraverseCtx<'a>,
+12 |         ctx: &mut TraverseCtx<'a>,
    |              - let's call the lifetime of this reference `'1`
 13 |     ) {
 14 |         self.ancestor = Some(ctx.parent());

--- a/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime2.rs
+++ b/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime2.rs
@@ -9,7 +9,7 @@ impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
     fn enter_identifier_reference(
         &mut self,
         _node: &mut IdentifierReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
         if let Ancestor::ProgramDirectives(program) = ctx.parent() {
             self.program = Some(program);

--- a/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime2.stderr
+++ b/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime2.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 8  | impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
    |          -- lifetime `'b` defined here
 ...
-12 |         ctx: &TraverseCtx<'a>,
+12 |         ctx: &mut TraverseCtx<'a>,
    |              - let's call the lifetime of this reference `'1`
 ...
 15 |             self.program = Some(program);

--- a/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime3.rs
+++ b/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime3.rs
@@ -10,7 +10,7 @@ impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
     fn enter_identifier_reference(
         &mut self,
         _node: &mut IdentifierReference<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
         if let Ancestor::ProgramDirectives(program) = ctx.parent() {
             self.program_body = Some(program.body());

--- a/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime3.stderr
+++ b/crates/oxc_traverse/tests/compile_fail/ancestor_lifetime3.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 9  | impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
    |          -- lifetime `'b` defined here
 ...
-13 |         ctx: &TraverseCtx<'a>,
+13 |         ctx: &mut TraverseCtx<'a>,
    |              - let's call the lifetime of this reference `'1`
 ...
 16 |             self.program_body = Some(program.body());


### PR DESCRIPTION
Pass `&mut TraverseCtx` to `Traverse::enter_*` and `Traverse::exit_*` visitor methods. Previously was immutable `&TraverseCtx`.

This is a step towards exposing mutable scope tree + symbol table to visitors.