### PR TITLE
fix(tasks/lint_rules): Integrate react and react-hooks rules

### DIFF
--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -219,7 +219,7 @@ const loadPluginNextRules = (linter) => {
 
 /**
  * @typedef {{
- *   npm: Array<string>;
+ *   npm: string[];
  *   issueNo: number;
  * }} TargetPluginMeta
  * @type {Map<string, TargetPluginMeta>}

--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -181,12 +181,12 @@ const loadPluginReactRules = (linter) => {
 
     linter.defineRule(prefixedName, rule);
   }
-};
 
-/** @param {import("eslint").Linter} linter */
-const loadPluginReactHooksRules = (linter) => {
+  // `react-hooks` plugin is available along with `react` plugin
   for (const [name, rule] of Object.entries(pluginReactHooksAllRules)) {
-    const prefixedName = `react-hooks/${name}`;
+    // This may be conflict with `react` plugin
+    // (but `react-hooks` plugin has only 2 rules, so it's fine...!)
+    const prefixedName = `react/${name}`;
 
     // @ts-expect-error: The types of 'meta.type', 'string' is not assignable to type '"problem" | "suggestion" | "layout" | undefined'.
     linter.defineRule(prefixedName, rule);
@@ -219,24 +219,29 @@ const loadPluginNextRules = (linter) => {
 
 /**
  * @typedef {{
- *   npm: string;
+ *   npm: Array<string>;
  *   issueNo: number;
  * }} TargetPluginMeta
  * @type {Map<string, TargetPluginMeta>}
  */
 exports.ALL_TARGET_PLUGINS = new Map([
-  ["eslint", { npm: "eslint", issueNo: 479 }],
-  ["typescript", { npm: "@typescript-eslint/eslint-plugin", issueNo: 2180 }],
-  ["n", { npm: "eslint-plugin-n", issueNo: 493 }],
-  ["unicorn", { npm: "eslint-plugin-unicorn", issueNo: 684 }],
-  ["jsdoc", { npm: "eslint-plugin-jsdoc", issueNo: 1170 }],
-  ["import", { npm: "eslint-plugin-import", issueNo: 1117 }],
-  ["jsx-a11y", { npm: "eslint-plugin-jsx-a11y", issueNo: 1141 }],
-  ["jest", { npm: "eslint-plugin-jest", issueNo: 492 }],
-  ["react", { npm: "eslint-plugin-react", issueNo: 1022 }],
-  ["react-hooks", { npm: "eslint-plugin-react-hooks", issueNo: 2174 }],
-  ["react-perf", { npm: "eslint-plugin-react-perf", issueNo: 2041 }],
-  ["nextjs", { npm: "@next/eslint-plugin-next", issueNo: 1929 }],
+  ["eslint", { npm: ["eslint"], issueNo: 479 }],
+  ["typescript", { npm: ["@typescript-eslint/eslint-plugin"], issueNo: 2180 }],
+  ["n", { npm: ["eslint-plugin-n"], issueNo: 493 }],
+  ["unicorn", { npm: ["eslint-plugin-unicorn"], issueNo: 684 }],
+  ["jsdoc", { npm: ["eslint-plugin-jsdoc"], issueNo: 1170 }],
+  ["import", { npm: ["eslint-plugin-import"], issueNo: 1117 }],
+  ["jsx-a11y", { npm: ["eslint-plugin-jsx-a11y"], issueNo: 1141 }],
+  ["jest", { npm: ["eslint-plugin-jest"], issueNo: 492 }],
+  [
+    "react",
+    {
+      npm: ["eslint-plugin-react", "eslint-plugin-react-hooks"],
+      issueNo: 1022,
+    },
+  ],
+  ["react-perf", { npm: ["eslint-plugin-react-perf"], issueNo: 2041 }],
+  ["nextjs", { npm: ["@next/eslint-plugin-next"], issueNo: 1929 }],
 ]);
 
 // All rules(including deprecated, recommended) are loaded initially.
@@ -255,7 +260,6 @@ exports.loadTargetPluginRules = (linter) => {
   loadPluginJSXA11yRules(linter);
   loadPluginJestRules(linter);
   loadPluginReactRules(linter);
-  loadPluginReactHooksRules(linter);
   loadPluginReactPerfRules(linter);
   loadPluginNextRules(linter);
 };

--- a/tasks/lint_rules/src/markdown-renderer.cjs
+++ b/tasks/lint_rules/src/markdown-renderer.cjs
@@ -3,13 +3,13 @@
  * @typedef {{ isImplemented: number; isNotSupported: number; total: number }} CounterView
  */
 
-/** @param {{ npm: string; }} props */
+/** @param {{ npm: string[]; }} props */
 const renderIntroduction = ({ npm }) => `
 > [!WARNING]
 > This comment is maintained by CI. Do not edit this comment directly.
 > To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules
 
-This is tracking issue for \`${npm}\`.
+This is tracking issue for ${npm.map(n => "`" + n + "`").join(", ")}.
 `;
 
 /**


### PR DESCRIPTION
Fixes #2174 , now `react-hooks` plugin and its rules are managed by `react` plugin issue.