### PR TITLE
feat!(linter): enforce rule severity from the cli and configuration file

### DIFF
--- a/crates/oxc_cli/fixtures/eslintrc_env/eslintrc_no_env.json
+++ b/crates/oxc_cli/fixtures/eslintrc_env/eslintrc_no_env.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "no-undef": "error"
+    "no-undef": "warn"
   }
 }

--- a/crates/oxc_cli/fixtures/no_empty_disallow_empty_catch/eslintrc.json
+++ b/crates/oxc_cli/fixtures/no_empty_disallow_empty_catch/eslintrc.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "no-empty": ["error", { "allowEmptyCatch": false }]
+    "no-empty": ["warn", { "allowEmptyCatch": false }]
   }
 }

--- a/crates/oxc_cli/src/command/lint.rs
+++ b/crates/oxc_cli/src/command/lint.rs
@@ -98,6 +98,11 @@ pub enum LintFilter {
         #[bpaf(short('A'), long("allow"), argument("NAME"))]
         String,
     ),
+    Warn(
+        /// Deny the rule or category (emit a warning)
+        #[bpaf(short('W'), long("warn"), argument("NAME"))]
+        String,
+    ),
     Deny(
         /// Deny the rule or category (emit an error)
         #[bpaf(short('D'), long("deny"), argument("NAME"))]
@@ -109,6 +114,7 @@ impl LintFilter {
     fn into_tuple(self) -> (AllowWarnDeny, String) {
         match self {
             Self::Allow(s) => (AllowWarnDeny::Allow, s),
+            Self::Warn(s) => (AllowWarnDeny::Warn, s),
             Self::Deny(s) => (AllowWarnDeny::Deny, s),
         }
     }

--- a/crates/oxc_cli/src/lint/mod.rs
+++ b/crates/oxc_cli/src/lint/mod.rs
@@ -295,7 +295,7 @@ mod test {
 
     #[test]
     fn filter_allow_one() {
-        let args = &["-D", "correctness", "-A", "no-debugger", "fixtures/linter/debugger.js"];
+        let args = &["-W", "correctness", "-A", "no-debugger", "fixtures/linter/debugger.js"];
         let result = test(args);
         assert_eq!(result.number_of_files, 1);
         assert_eq!(result.number_of_warnings, 0);
@@ -314,7 +314,7 @@ mod test {
     #[test]
     fn eslintrc_no_undef() {
         let args = &[
-            "-D",
+            "-W",
             "no-undef",
             "-c",
             "fixtures/no_undef/eslintrc.json",
@@ -329,7 +329,7 @@ mod test {
     #[test]
     fn eslintrc_no_env() {
         let args = &[
-            "-D",
+            "-W",
             "no-undef",
             "-c",
             "fixtures/eslintrc_env/eslintrc_no_env.json",
@@ -359,7 +359,7 @@ mod test {
         let args = &[
             "-c",
             "fixtures/no_empty_allow_empty_catch/eslintrc.json",
-            "-D",
+            "-W",
             "no-empty",
             "fixtures/no_empty_allow_empty_catch/test.js",
         ];
@@ -374,7 +374,7 @@ mod test {
         let args = &[
             "-c",
             "fixtures/no_empty_disallow_empty_catch/eslintrc.json",
-            "-D",
+            "-W",
             "no-empty",
             "fixtures/no_empty_disallow_empty_catch/test.js",
         ];

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -99,6 +99,12 @@ impl OxcDiagnostic {
     }
 
     #[must_use]
+    pub fn with_severity(mut self, severity: Severity) -> Self {
+        self.inner.severity = severity;
+        self
+    }
+
+    #[must_use]
     pub fn with_help<T: Into<String>>(mut self, help: T) -> Self {
         self.inner.help = Some(help.into());
         self

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -118,7 +118,7 @@ impl DiagnosticService {
             for diagnostic in diagnostics {
                 let severity = diagnostic.severity();
                 let is_warning = severity == Some(Severity::Warning);
-                let is_error = severity.is_none() || severity == Some(Severity::Error);
+                let is_error = severity == Some(Severity::Error) || severity.is_none();
                 if is_warning || is_error {
                     if is_warning {
                         let warnings_count = self.warnings_count() + 1;

--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -152,7 +152,6 @@ pub struct FixedContent {
     pub range: Range,
 }
 
-#[derive(Debug)]
 pub struct IsolatedLintHandler {
     linter: Arc<Linter>,
 }
@@ -382,7 +381,6 @@ fn offset_to_position(offset: usize, source_text: &str) -> Option<Position> {
     Some(Position::new(line as u32, column as u32))
 }
 
-#[derive(Debug)]
 pub struct ServerLinter {
     linter: Arc<Linter>,
 }

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -27,7 +27,6 @@ use tower_lsp::lsp_types::{
 };
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-#[derive(Debug)]
 struct Backend {
     client: Client,
     root_uri: OnceCell<Option<Url>>,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::{
     config::ESLintConfig,
     context::LintContext,
     options::{AllowWarnDeny, LintOptions},
+    rule::RuleWithSeverity,
     service::{LintService, LintServiceOptions},
 };
 use crate::{
@@ -50,9 +51,8 @@ fn size_asserts() {
     assert_eq_size!(RuleEnum, [u8; 16]);
 }
 
-#[derive(Debug)]
 pub struct Linter {
-    rules: Vec<RuleEnum>,
+    rules: Vec<RuleWithSeverity>,
     options: LintOptions,
     eslint_config: Arc<ESLintConfig>,
 }
@@ -72,8 +72,9 @@ impl Linter {
         Ok(Self { rules, options, eslint_config: Arc::new(eslint_config) })
     }
 
+    #[cfg(test)]
     #[must_use]
-    pub fn with_rules(mut self, rules: Vec<RuleEnum>) -> Self {
+    pub fn with_rules(mut self, rules: Vec<RuleWithSeverity>) -> Self {
         self.rules = rules;
         self
     }
@@ -105,7 +106,9 @@ impl Linter {
         let rules = self
             .rules
             .iter()
-            .map(|rule| (rule, ctx.clone().with_rule_name(rule.name())))
+            .map(|rule| {
+                (rule, ctx.clone().with_rule_name(rule.name()).with_severity(rule.severity))
+            })
             .collect::<Vec<_>>();
 
         for (rule, ctx) in &rules {

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -1,8 +1,12 @@
-use std::fmt;
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 
 use oxc_semantic::SymbolId;
 
-use crate::{context::LintContext, AstNode};
+use crate::{context::LintContext, AllowWarnDeny, AstNode, RuleEnum};
 
 pub trait Rule: Sized + Default + fmt::Debug {
     /// Initialize from eslint json configuration
@@ -79,6 +83,40 @@ impl fmt::Display for RuleCategory {
             Self::Restriction => write!(f, "Restriction"),
             Self::Nursery => write!(f, "Nursery"),
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct RuleWithSeverity {
+    pub rule: RuleEnum,
+    pub severity: AllowWarnDeny,
+}
+
+impl Hash for RuleWithSeverity {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.rule.hash(state);
+    }
+}
+
+impl PartialEq for RuleWithSeverity {
+    fn eq(&self, other: &Self) -> bool {
+        self.rule == other.rule
+    }
+}
+
+impl Eq for RuleWithSeverity {}
+
+impl Deref for RuleWithSeverity {
+    type Target = RuleEnum;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rule
+    }
+}
+
+impl RuleWithSeverity {
+    pub fn new(rule: RuleEnum, severity: AllowWarnDeny) -> Self {
+        Self { rule, severity }
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -24,7 +24,7 @@ mod diagnostics {
     use oxc_span::Span;
 
     pub(super) fn function_error(span: Span, hook_name: &str, func_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             React Hook {hook_name:?} is called in function {func_name:?} that is neither \
             a React function component nor a custom React Hook function. \
@@ -35,7 +35,7 @@ mod diagnostics {
     }
 
     pub(super) fn conditional_hook(span: Span, hook_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             React Hook {hook_name:?} is called conditionally. React Hooks must be \
             called in the exact same order in every component render."
@@ -44,7 +44,7 @@ mod diagnostics {
     }
 
     pub(super) fn loop_hook(span: Span, hook_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             React Hook {hook_name:?} may be executed more than once. Possibly \
             because it is called in a loop. React Hooks must be called in the \
@@ -54,7 +54,7 @@ mod diagnostics {
     }
 
     pub(super) fn top_level_hook(span: Span, hook_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             React Hook {hook_name:?} cannot be called at the top level. React Hooks \
             must be called in a React function component or a custom React \
@@ -64,7 +64,7 @@ mod diagnostics {
     }
 
     pub(super) fn async_component(span: Span, func_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             message: `React Hook {func_name:?} cannot be called in an async function. "
         ))
@@ -72,7 +72,7 @@ mod diagnostics {
     }
 
     pub(super) fn class_component(span: Span, hook_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             React Hook {hook_name:?} cannot be called in a class component. React Hooks \
             must be called in a React function component or a custom React \
@@ -82,7 +82,7 @@ mod diagnostics {
     }
 
     pub(super) fn generic_error(span: Span, hook_name: &str) -> D {
-        D::error(format!(
+        D::warning(format!(
             "eslint-plugin-react-hooks(rules-of-hooks): \
             React Hook {hook_name:?} cannot be called inside a callback. React Hooks \
             must be called in a React function component or a custom React \

--- a/crates/oxc_linter/src/snapshots/rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/rules_of_hooks.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 expression: rules_of_hooks
 ---
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:15]
  3 │               if (a) return;
  4 │               useState();
@@ -10,7 +10,7 @@ expression: rules_of_hooks
  5 │             }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:15]
   8 │               }
   9 │               useState();
@@ -18,7 +18,7 @@ expression: rules_of_hooks
  10 │             }
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:7:15]
  6 │ 
  7 │               useHook();
@@ -26,7 +26,7 @@ expression: rules_of_hooks
  8 │             }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:18]
  3 │                if (cond) {
  4 │                  useConditionalHook();
@@ -34,7 +34,7 @@ expression: rules_of_hooks
  5 │                }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
  1 │ 
  2 │             Hook.useState();
@@ -42,7 +42,7 @@ expression: rules_of_hooks
  3 │             Hook._useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:13]
  4 │             Hook.use42();
  5 │             Hook.useHook();
@@ -50,7 +50,7 @@ expression: rules_of_hooks
  6 │             Hook.use_hook();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:22]
  3 │                  m() {
  4 │                      This.useHook();
@@ -58,7 +58,7 @@ expression: rules_of_hooks
  5 │                      Super.useHook();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:22]
  4 │                      This.useHook();
  5 │                      Super.useHook();
@@ -66,7 +66,7 @@ expression: rules_of_hooks
  6 │                  }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:25]
  4 │                     if (cond) {
  5 │                         FooStore.useFeatureFlag();
@@ -74,7 +74,7 @@ expression: rules_of_hooks
  6 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
  3 │                 if (cond) {
  4 │                     Namespace.useConditionalHook();
@@ -82,7 +82,7 @@ expression: rules_of_hooks
  5 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:29]
  4 │                         if (cond) {
  5 │                             useConditionalHook();
@@ -90,7 +90,7 @@ expression: rules_of_hooks
  6 │                         }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     if (cond) {
  4 │                         useConditionalHook();
@@ -98,7 +98,7 @@ expression: rules_of_hooks
  5 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:29]
  4 │                         if (cond) {
  5 │                             useConditionalHook();
@@ -106,7 +106,7 @@ expression: rules_of_hooks
  6 │                         }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useTernaryHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useTernaryHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:28]
  2 │                 function ComponentWithTernaryHook() {
  3 │                     cond ? useTernaryHook() : null;
@@ -114,7 +114,7 @@ expression: rules_of_hooks
  4 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     useEffect(() => {
  4 │                         useHookInsideCallback();
@@ -122,7 +122,7 @@ expression: rules_of_hooks
  5 │                     });
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:29]
  4 │                         useEffect(() => {
  5 │                             useHookInsideCallback();
@@ -130,7 +130,7 @@ expression: rules_of_hooks
  6 │                         });
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     useEffect(() => {
  4 │                         useHookInsideCallback();
@@ -138,7 +138,7 @@ expression: rules_of_hooks
  5 │                     });
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     useEffect(() => {
  4 │                         useHookInsideCallback();
@@ -146,7 +146,7 @@ expression: rules_of_hooks
  5 │                     });
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:30]
  2 │                 function ComponentWithHookInsideCallback() {
  3 │                     function handleClick() {
@@ -154,7 +154,7 @@ expression: rules_of_hooks
  4 │                         useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:4:34]
  3 │                     return function ComponentWithHookInsideCallback() {
  4 │                         function handleClick() {
@@ -162,7 +162,7 @@ expression: rules_of_hooks
  5 │                             useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     while (cond) {
  4 │                         useHookInsideLoop();
@@ -170,7 +170,7 @@ expression: rules_of_hooks
  5 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "renderItem" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "renderItem" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │                 function renderItem() {
@@ -178,7 +178,7 @@ expression: rules_of_hooks
  3 │                     useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │                 function normalFunctionWithHook() {
@@ -186,7 +186,7 @@ expression: rules_of_hooks
  3 │                     useHookInsideNormalFunction();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "_normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "_normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │                 function _normalFunctionWithHook() {
@@ -194,7 +194,7 @@ expression: rules_of_hooks
  3 │                     useHookInsideNormalFunction();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "_useNotAHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "_useNotAHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:5:26]
  4 │                 }
  5 │                 function _useNotAHook() {
@@ -202,7 +202,7 @@ expression: rules_of_hooks
  6 │                     useHookInsideNormalFunction();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithConditionalHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithConditionalHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │                 function normalFunctionWithConditionalHook() {
@@ -210,7 +210,7 @@ expression: rules_of_hooks
  3 │                     if (cond) {
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     while (a) {
  4 │                         useHook1();
@@ -218,7 +218,7 @@ expression: rules_of_hooks
  5 │                         if (b) return;
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:25]
  5 │                         if (b) return;
  6 │                         useHook2();
@@ -226,7 +226,7 @@ expression: rules_of_hooks
  7 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:25]
   8 │                     while (c) {
   9 │                         useHook3();
@@ -234,7 +234,7 @@ expression: rules_of_hooks
  10 │                         if (d) return;
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:11:25]
  10 │                         if (d) return;
  11 │                         useHook4();
@@ -242,7 +242,7 @@ expression: rules_of_hooks
  12 │                     }
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
  3 │                 while (a) {
  4 │                     useHook1();
@@ -250,7 +250,7 @@ expression: rules_of_hooks
  5 │                     if (b) continue;
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:21]
  5 │                     if (b) continue;
  6 │                     useHook2();
@@ -258,7 +258,7 @@ expression: rules_of_hooks
  7 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:25]
  4 │                         if (a) break label;
  5 │                         useHook();
@@ -266,7 +266,7 @@ expression: rules_of_hooks
  6 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "a" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "a" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:22]
  1 │ 
  2 │             function a() { useState(); }
@@ -274,7 +274,7 @@ expression: rules_of_hooks
  3 │             const whatever = function b() { useState(); };
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "b" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "b" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:39]
  2 │             function a() { useState(); }
  3 │             const whatever = function b() { useState(); };
@@ -282,7 +282,7 @@ expression: rules_of_hooks
  4 │             const c = () => { useState(); };
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:4:23]
  3 │             const whatever = function b() { useState(); };
  4 │             const c = () => { useState(); };
@@ -290,7 +290,7 @@ expression: rules_of_hooks
  5 │             let d = () => useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:5:21]
  4 │             const c = () => { useState(); };
  5 │             let d = () => useState();
@@ -298,7 +298,7 @@ expression: rules_of_hooks
  6 │             e = () => { useState(); };
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:6:17]
  5 │             let d = () => useState();
  6 │             e = () => { useState(); };
@@ -306,7 +306,7 @@ expression: rules_of_hooks
  7 │             ({f: () => { useState(); }});
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:7:18]
  6 │             e = () => { useState(); };
  7 │             ({f: () => { useState(); }});
@@ -314,7 +314,7 @@ expression: rules_of_hooks
  8 │             ({g() { useState(); }});
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:8:16]
  7 │             ({f: () => { useState(); }});
  8 │             ({g() { useState(); }});
@@ -322,7 +322,7 @@ expression: rules_of_hooks
  9 │             const {j = () => { useState(); }} = {};
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
     ╭─[rules_of_hooks.tsx:9:24]
   8 │             ({g() { useState(); }});
   9 │             const {j = () => { useState(); }} = {};
@@ -330,7 +330,7 @@ expression: rules_of_hooks
  10 │             ({k = () => { useState(); }} = {});
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
  3 │                     if (a) return;
  4 │                     useState();
@@ -338,7 +338,7 @@ expression: rules_of_hooks
  5 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:21]
   8 │                     }
   9 │                     useState();
@@ -346,7 +346,7 @@ expression: rules_of_hooks
  10 │                 }
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:21]
   8 │                     if (a) return;
   9 │                     useState();
@@ -354,7 +354,7 @@ expression: rules_of_hooks
  10 │                 }
     ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:26]
  2 │                 function useHook() {
  3 │                     a && useHook1();
@@ -362,7 +362,7 @@ expression: rules_of_hooks
  4 │                     b && useHook2();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:26]
  3 │                     a && useHook1();
  4 │                     b && useHook2();
@@ -370,7 +370,7 @@ expression: rules_of_hooks
  5 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:25]
  4 │                         f();
  5 │                         useState();
@@ -378,7 +378,7 @@ expression: rules_of_hooks
  6 │                     } catch {}
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:39]
  2 │                 function useHook({ bar }) {
  3 │                     let foo1 = bar && useState();
@@ -386,7 +386,7 @@ expression: rules_of_hooks
  4 │                     let foo2 = bar || useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:39]
  3 │                     let foo1 = bar && useState();
  4 │                     let foo2 = bar || useState();
@@ -394,7 +394,7 @@ expression: rules_of_hooks
  5 │                     let foo3 = bar ?? useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:39]
  4 │                     let foo2 = bar || useState();
  5 │                     let foo3 = bar ?? useState();
@@ -402,7 +402,7 @@ expression: rules_of_hooks
  6 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     if (props.fancy) {
  4 │                         useCustomHook();
@@ -410,7 +410,7 @@ expression: rules_of_hooks
  5 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     if (props.fancy) {
  4 │                         useCustomHook();
@@ -418,7 +418,7 @@ expression: rules_of_hooks
  5 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     if (props.fancy) {
  4 │                         useCustomHook();
@@ -426,7 +426,7 @@ expression: rules_of_hooks
  5 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useProbablyAHook" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useProbablyAHook" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:48]
  1 │ 
  2 │                 React.unknownFunction(function notAComponent(foo, bar) {
@@ -434,7 +434,7 @@ expression: rules_of_hooks
  3 │                     useProbablyAHook(bar)
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
  1 │ 
  2 │             useState();
@@ -442,7 +442,7 @@ expression: rules_of_hooks
  3 │             if (foo) {
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCallback" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCallback" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:29]
  3 │             if (foo) {
  4 │                 const foo = React.useCallback(() => {});
@@ -450,7 +450,7 @@ expression: rules_of_hooks
  5 │             }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:6:13]
  5 │             }
  6 │             useCustomHook();
@@ -458,7 +458,7 @@ expression: rules_of_hooks
  7 │         
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useBasename" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useBasename" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:3:36]
  2 │             const {createHistory, useBasename} = require('history-2.1.2');
  3 │             const browserHistory = useBasename(createHistory)({
@@ -466,7 +466,7 @@ expression: rules_of_hooks
  4 │                 basename: '/',
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:29]
  4 │                         if (foo) {
  5 │                             useFeatureFlag();
@@ -474,7 +474,7 @@ expression: rules_of_hooks
  6 │                         }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     render() {
  4 │                         React.useState();
@@ -482,31 +482,31 @@ expression: rules_of_hooks
  5 │                     }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:27]
  1 │ (class {useHook = () => { useState(); }});
    ·                           ──────────
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:21]
  1 │ (class {useHook() { useState(); }});
    ·                     ──────────
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:21]
  1 │ (class {h = () => { useState(); }});
    ·                     ──────────
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:15]
  1 │ (class {i() { useState(); }});
    ·               ──────────
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "AsyncComponent" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "AsyncComponent" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:32]
  1 │ 
  2 │                 async function AsyncComponent() {
@@ -514,7 +514,7 @@ expression: rules_of_hooks
  3 │                     useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "Anonymous" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "Anonymous" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:40]
  1 │     
  2 │ ╭─▶                 const AsyncComponent = async () => {
@@ -523,7 +523,7 @@ expression: rules_of_hooks
  5 │             
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "useAsyncHook" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "useAsyncHook" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:32]
  1 │ 
  2 │                 async function useAsyncHook() {
@@ -531,7 +531,7 @@ expression: rules_of_hooks
  3 │                     useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
  1 │ 
  2 │             Hook.use();
@@ -539,7 +539,7 @@ expression: rules_of_hooks
  3 │             Hook._use();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:13]
  3 │             Hook._use();
  4 │             Hook.useState();
@@ -547,7 +547,7 @@ expression: rules_of_hooks
  5 │             Hook._useState();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:7:13]
  6 │             Hook.use42();
  7 │             Hook.useHook();
@@ -555,7 +555,7 @@ expression: rules_of_hooks
  8 │             Hook.use_hook();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │                 function notAComponent() {
@@ -563,7 +563,7 @@ expression: rules_of_hooks
  3 │                     use(promise);
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │             const text = use(promise);
@@ -571,7 +571,7 @@ expression: rules_of_hooks
  3 │             function App() {
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:21]
  3 │                 m() {
  4 │                     use(promise);
@@ -579,7 +579,7 @@ expression: rules_of_hooks
  5 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "AsyncComponent" cannot be called in an async function.
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): message: `React Hook "AsyncComponent" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:28]
  1 │ 
  2 │             async function AsyncComponent() {
@@ -587,7 +587,7 @@ expression: rules_of_hooks
  3 │                     use();
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:24]
  2 │                 export const notAComponent = () => {
  3 │ ╭─▶                 return () => {
@@ -596,7 +596,7 @@ expression: rules_of_hooks
  6 │                 }
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:35]
  1 │     
  2 │ ╭─▶             const notAComponent = () => {
@@ -605,7 +605,7 @@ expression: rules_of_hooks
  5 │             
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:28]
  1 │     
  2 │ ╭─▶             export default () => {
@@ -616,7 +616,7 @@ expression: rules_of_hooks
  7 │             
    ╰────
 
-  × eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:28]
  1 │     
  2 │ ╭─▶             export default function() {

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    rules::RULES, ESLintConfig, Fixer, LintOptions, LintService, LintServiceOptions, Linter,
-    RuleEnum,
+    rules::RULES, AllowWarnDeny, ESLintConfig, Fixer, LintOptions, LintService, LintServiceOptions,
+    Linter, RuleEnum, RuleWithSeverity,
 };
 
 #[derive(Eq, PartialEq)]
@@ -211,7 +211,7 @@ impl Tester {
             .map_or_else(ESLintConfig::default, |v| ESLintConfig::deserialize(v).unwrap());
         let linter = Linter::from_options(options)
             .unwrap()
-            .with_rules(vec![rule])
+            .with_rules(vec![RuleWithSeverity::new(rule, AllowWarnDeny::Warn)])
             .with_eslint_config(eslint_config);
         let path_to_lint = if self.import_plugin {
             assert!(path.is_none(), "import plugin does not support path");


### PR DESCRIPTION
closes #2059

Breaking change:

* `--deny` / `-D` from the CLI and `error` from configuration file will report diagnostics as severity "error".
* `--warn` / `-W` from the CLI and `warn` from configuration file will report diagnostics as severity "warning".