### PR TITLE
refactor(linter): find return statement by using CFG in `react/require-render-return`

### DIFF
--- a/crates/oxc_linter/src/snapshots/require_render_return.snap
+++ b/crates/oxc_linter/src/snapshots/require_render_return.snap
@@ -37,3 +37,21 @@ expression: require_render_return
  4 │                         <div>Hello {this.props.name}</div>
    ╰────
   help: When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the return statement is missing.
+
+  ⚠ eslint-plugin-react(require-render-return): Your render method should have a return statement
+   ╭─[require_render_return.tsx:3:15]
+ 2 │             class Hello extends React.Component {
+ 3 │               render() {
+   ·               ──────
+ 4 │                 function foo() {
+   ╰────
+  help: When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the return statement is missing.
+
+  ⚠ eslint-plugin-react(require-render-return): Your render method should have a return statement
+   ╭─[require_render_return.tsx:3:15]
+ 2 │             class Hello extends React.Component {
+ 3 │               render() {
+   ·               ──────
+ 4 │                 return
+   ╰────
+  help: When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the return statement is missing.

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -29,6 +29,6 @@ oxc_transformer  = { workspace = true }
 oxc_tasks_common = { workspace = true }
 oxc_diagnostics  = { workspace = true }
 
-walkdir    = { workspace = true }
-pico-args  = { workspace = true }
-indexmap   = { workspace = true }
+walkdir   = { workspace = true }
+pico-args = { workspace = true }
+indexmap  = { workspace = true }


### PR DESCRIPTION
Maybe currently Class components are relatively few in quantity, didn't see performance changed.