### PR TITLE
refactor(sourcemap): using binary search to search original position

### DIFF
--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -325,7 +325,7 @@ mod test {
 
     #[test]
     fn builder_with_unordered_position() {
-        assert_mapping("ab", &[(0, 0, 0), (2, 0, 2), (1, 0, 1)]);
+        assert_mapping("\na\nb", &[(4, 2, 1), (0, 0, 0), (1, 1, 0), (2, 1, 1), (3, 2, 0)]);
     }
 
     fn assert_mapping(source: &str, mappings: &[(u32, u32, u32)]) {

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -323,6 +323,11 @@ mod test {
         assert_mapping("Ö\r\na", &[(0, 0, 0), (2, 0, 1), (3, 0, 2), (4, 1, 0), (5, 1, 1)]);
     }
 
+    #[test]
+    fn builder_with_unordered_position() {
+        assert_mapping("ab", &[(0, 0, 0), (2, 0, 2), (1, 0, 1)]);
+    }
+
     fn assert_mapping(source: &str, mappings: &[(u32, u32, u32)]) {
         let mut builder = SourcemapBuilder::default();
         builder.with_name_and_source("x.js", source);


### PR DESCRIPTION
The ast span is not ordering at rolldown, eg the module original ast is `a,b,c`, after mutate could be `b,c,a`. So here revert changes from [here](https://github.com/oxc-project/oxc/pull/2728).