### PR TITLE
feat(sourcemap): add Sourcemap#from_json method

### DIFF
--- a/crates/oxc_sourcemap/src/decode.rs
+++ b/crates/oxc_sourcemap/src/decode.rs
@@ -3,9 +3,9 @@
 use crate::error::{Error, Result};
 use crate::{SourceMap, Token};
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-struct JSONSourceMap {
+pub struct JSONSourceMap {
     // An optional name of the generated code that this source map is associated with.
     file: Option<String>,
     // A string with the encoded mapping data.
@@ -20,8 +20,7 @@ struct JSONSourceMap {
     names: Option<Vec<String>>,
 }
 
-pub fn decode(value: &str) -> Result<SourceMap> {
-    let json: JSONSourceMap = serde_json::from_str(value)?;
+pub fn decode(json: JSONSourceMap) -> Result<SourceMap> {
     let file = json.file.map(Into::into);
     let names =
         json.names.map(|v| v.into_iter().map(Into::into).collect::<Vec<_>>()).unwrap_or_default();
@@ -35,6 +34,10 @@ pub fn decode(value: &str) -> Result<SourceMap> {
         .map(|v| v.into_iter().map(Option::unwrap_or_default).map(Into::into).collect::<Vec<_>>());
     let tokens = decode_mapping(&json.mappings.unwrap_or_default(), names.len(), sources.len())?;
     Ok(SourceMap::new(file, names, source_root, sources, source_contents, tokens, None))
+}
+
+pub fn decode_from_string(value: &str) -> Result<SourceMap> {
+    decode(serde_json::from_str(value)?)
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/crates/oxc_sourcemap/src/lib.rs
+++ b/crates/oxc_sourcemap/src/lib.rs
@@ -9,6 +9,7 @@ mod sourcemap_visualizer;
 mod token;
 
 pub use concat_sourcemap_builder::ConcatSourceMapBuilder;
+pub use decode::JSONSourceMap;
 pub use error::Error;
 pub use sourcemap::SourceMap;
 pub use sourcemap_builder::SourceMapBuilder;

--- a/crates/oxc_sourcemap/src/sourcemap.rs
+++ b/crates/oxc_sourcemap/src/sourcemap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decode::decode,
+    decode::{decode, decode_from_string, JSONSourceMap},
     encode::encode,
     error::Result,
     token::{Token, TokenChunk},
@@ -45,15 +45,23 @@ impl SourceMap {
         }
     }
 
-    /// Convert `SourceMap` to vlq sourcemap string.
+    /// Convert the vlq sourcemap to to `SourceMap`.
     /// # Errors
     ///
     /// The `serde_json` deserialize Error.
-    pub fn from_json_string(value: &str) -> Result<Self> {
+    pub fn from_json(value: JSONSourceMap) -> Result<Self> {
         decode(value)
     }
 
     /// Convert the vlq sourcemap string to `SourceMap`.
+    /// # Errors
+    ///
+    /// The `serde_json` deserialize Error.
+    pub fn from_json_string(value: &str) -> Result<Self> {
+        decode_from_string(value)
+    }
+
+    /// Convert `SourceMap` to vlq sourcemap string.
     /// # Errors
     ///
     /// The `serde_json` serialization Error.


### PR DESCRIPTION
The rolldown plugin hook could return an object map, cast it to string at node, and decode it has unnecessary json overhead at rust. So here export an new function to let rolldown could using `JSONSourceMap` to generate `Sourcemap`.