### PR TITLE
improvement(semantic/cfg): add the `ControlFlowGraphBuilder`.

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -17,7 +17,7 @@ use crate::{
     checker::{EarlyErrorJavaScript, EarlyErrorTypeScript},
     class::ClassTableBuilder,
     control_flow::{
-        AssignmentValue, ControlFlowGraph, EdgeType, Register, StatementControlFlowType,
+        AssignmentValue, ControlFlowGraphBuilder, EdgeType, Register, StatementControlFlowType,
     },
     diagnostics::redeclaration,
     jsdoc::JSDocBuilder,
@@ -69,7 +69,7 @@ pub struct SemanticBuilder<'a> {
 
     check_syntax_error: bool,
 
-    pub cfg: ControlFlowGraph,
+    pub cfg: ControlFlowGraphBuilder,
 
     pub class_table_builder: ClassTableBuilder,
 }
@@ -105,7 +105,7 @@ impl<'a> SemanticBuilder<'a> {
             label_builder: LabelBuilder::default(),
             jsdoc: JSDocBuilder::new(source_text, &trivias),
             check_syntax_error: false,
-            cfg: ControlFlowGraph::new(),
+            cfg: ControlFlowGraphBuilder::default(),
             class_table_builder: ClassTableBuilder::new(),
         }
     }
@@ -164,7 +164,7 @@ impl<'a> SemanticBuilder<'a> {
             module_record: Arc::clone(&self.module_record),
             jsdoc: self.jsdoc.build(),
             unused_labels: self.label_builder.unused_node_ids,
-            cfg: self.cfg,
+            cfg: self.cfg.build(),
         };
         SemanticBuilderReturn { semantic, errors: self.errors.into_inner() }
     }
@@ -181,7 +181,7 @@ impl<'a> SemanticBuilder<'a> {
             module_record: Arc::new(ModuleRecord::default()),
             jsdoc: self.jsdoc.build(),
             unused_labels: self.label_builder.unused_node_ids,
-            cfg: self.cfg,
+            cfg: self.cfg.build(),
         }
     }
 

--- a/crates/oxc_semantic/src/control_flow/mod.rs
+++ b/crates/oxc_semantic/src/control_flow/mod.rs
@@ -1,0 +1,202 @@
+mod builder;
+
+use oxc_span::CompactStr;
+use oxc_syntax::operator::{
+    AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
+};
+use petgraph::{stable_graph::NodeIndex, Graph};
+
+use crate::AstNodeId;
+
+pub use builder::ControlFlowGraphBuilder;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Register {
+    Index(u32),
+    Return,
+}
+
+#[derive(Debug, Clone)]
+pub enum ObjectPropertyAccessBy {
+    PrivateProperty(CompactStr),
+    Property(CompactStr),
+    Expression(Register),
+}
+
+#[derive(Debug, Clone)]
+pub struct CollectionAssignmentValue {
+    pub id: AstNodeId,
+    pub elements: Vec<Register>,
+    pub spreads: Vec<usize>,
+    pub collection_type: CollectionType,
+}
+
+#[derive(Debug, Clone)]
+pub struct CalleeWithArgumentsAssignmentValue {
+    pub id: AstNodeId,
+    pub callee: Register,
+    pub arguments: Vec<Register>,
+    pub spreads: Vec<usize>,
+    pub call_type: CallType,
+}
+
+#[derive(Debug, Clone)]
+pub struct ObjectPropertyAccessAssignmentValue {
+    pub id: AstNodeId,
+    pub access_on: Register,
+    pub access_by: ObjectPropertyAccessBy,
+    pub optional: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BinaryAssignmentValue {
+    pub id: AstNodeId,
+    pub a: Register,
+    pub b: Register,
+    pub operator: BinaryOp,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateAssignmentValue {
+    pub id: AstNodeId,
+    pub expr: Register,
+    pub op: UpdateOperator,
+    pub prefix: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnaryExpressioneAssignmentValue(pub AstNodeId, pub UnaryOperator, pub Register);
+
+#[derive(Debug, Clone)]
+pub enum AssignmentValue {
+    ImplicitUndefined,
+    NotImplicitUndefined,
+}
+
+#[derive(Debug, Clone)]
+pub enum BinaryOp {
+    BinaryOperator(BinaryOperator),
+    LogicalOperator(LogicalOperator),
+    AssignmentOperator(AssignmentOperator),
+}
+
+#[derive(Debug, Clone)]
+pub enum CollectionType {
+    Array,
+    // Note: we do not currently track object names in objects.
+    Object,
+    JSXElement,
+    JSXFragment,
+    // doesn't use spreads
+    Class,
+    TemplateLiteral,
+}
+
+#[derive(Debug, Clone)]
+pub enum CallType {
+    New,
+    CallExpression,
+    // the callee is the yielded value, arguments are always empty
+    // spreads are always empty
+    Yield,
+    // spreads are always empty
+    TaggedTemplate,
+    // spreads are always empty
+    Import,
+}
+
+#[derive(Debug, Clone)]
+pub enum BasicBlockElement {
+    Unreachable,
+    Assignment(Register, AssignmentValue),
+    Throw(Register),
+    Break(Option<Register>),
+}
+
+#[derive(Debug, Clone)]
+pub enum EdgeType {
+    Normal,
+    Backedge,
+    NewFunction,
+}
+
+#[derive(Debug, Default)]
+pub struct ControlFlowGraph {
+    pub graph: Graph<usize, EdgeType>,
+    pub basic_blocks: Vec<Vec<BasicBlockElement>>,
+}
+
+impl ControlFlowGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// # Panics
+    pub fn basic_block_by_index(&self, index: NodeIndex) -> &Vec<BasicBlockElement> {
+        let idx =
+            *self.graph.node_weight(index).expect("expected a valid node index in self.graph");
+        self.basic_blocks.get(idx).expect("expected a valid node index in self.basic_blocks")
+    }
+
+    /// # Panics
+    pub fn basic_block_by_index_mut(&mut self, index: NodeIndex) -> &mut Vec<BasicBlockElement> {
+        let idx =
+            *self.graph.node_weight(index).expect("expected a valid node index in self.graph");
+        self.basic_blocks.get_mut(idx).expect("expected a valid node index in self.basic_blocks")
+    }
+}
+
+pub enum StatementControlFlowType {
+    DoesNotUseContinue,
+    UsesContinue,
+}
+
+pub struct PreservedStatementState {
+    put_label: bool,
+}
+
+pub struct PreservedExpressionState {
+    pub use_this_register: Option<Register>,
+    pub store_final_assignments_into_this_array: Vec<Vec<Register>>,
+}
+
+#[must_use]
+fn print_register(register: Register) -> String {
+    match &register {
+        Register::Index(i) => format!("${i}"),
+        Register::Return => "$return".into(),
+    }
+}
+
+#[must_use]
+pub fn print_basic_block(basic_block_elements: &Vec<BasicBlockElement>) -> String {
+    let mut output = String::new();
+    for basic_block in basic_block_elements {
+        match basic_block {
+            BasicBlockElement::Unreachable => output.push_str("Unreachable()\n"),
+            BasicBlockElement::Throw(reg) => {
+                output.push_str(&format!("throw {}\n", print_register(*reg)));
+            }
+
+            BasicBlockElement::Break(Some(reg)) => {
+                output.push_str(&format!("break {}\n", print_register(*reg)));
+            }
+            BasicBlockElement::Break(None) => {
+                output.push_str("break");
+            }
+            BasicBlockElement::Assignment(to, with) => {
+                output.push_str(&format!("{} = ", print_register(*to)));
+
+                match with {
+                    AssignmentValue::ImplicitUndefined => {
+                        output.push_str("<implicit undefined>");
+                    }
+                    AssignmentValue::NotImplicitUndefined => output.push_str("<value>"),
+                }
+
+                output.push('\n');
+            }
+        }
+    }
+    output
+}

--- a/crates/oxc_semantic/src/control_flow/mod.rs
+++ b/crates/oxc_semantic/src/control_flow/mod.rs
@@ -120,17 +120,13 @@ pub enum EdgeType {
     NewFunction,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ControlFlowGraph {
     pub graph: Graph<usize, EdgeType>,
     pub basic_blocks: Vec<Vec<BasicBlockElement>>,
 }
 
 impl ControlFlowGraph {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// # Panics
     pub fn basic_block_by_index(&self, index: NodeIndex) -> &Vec<BasicBlockElement> {
         let idx =


### PR DESCRIPTION
It is a simple change, Before this, we had a lot of fields in our control flow graph that were only used during the build process. This PR aims to simplify the ControlFlowGraph.

PS: Sorry for the long branch name, Apprerantly graphite gets confused when you write the commit body using the `gt create` command.