### PR TITLE
feat(tasks): add website tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,6 +2969,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "website"
+version = "0.0.0"
+dependencies = [
+ "bpaf",
+ "oxc_cli",
+ "oxc_linter",
+ "pico-args",
+ "schemars",
+ "serde_json",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/oxc_cli/src/command/mod.rs
+++ b/crates/oxc_cli/src/command/mod.rs
@@ -8,10 +8,10 @@ use std::path::PathBuf;
 pub use self::{
     format::{format_command, FormatOptions},
     ignore::IgnoreOptions,
-    lint::{lint_command, LintOptions, OutputFormat, OutputOptions, WarningOptions},
+    lint::{lint_command, lint_options, LintOptions, OutputFormat, OutputOptions, WarningOptions},
 };
 
-use self::{format::format_options, lint::lint_options};
+use self::format::format_options;
 
 const VERSION: &str = match option_env!("OXC_VERSION") {
     Some(v) => v,

--- a/tasks/website/Cargo.toml
+++ b/tasks/website/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name              = "website"
+version           = "0.0.0"
+publish           = false
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "website"
+test = false
+
+[dependencies]
+oxc_linter = { workspace = true }
+oxc_cli = { path = "../../crates/oxc_cli" }
+
+bpaf = { workspace = true, features = ["docgen"] }
+pico-args  = { workspace = true }
+serde_json = { workspace = true }
+schemars   = { workspace = true }

--- a/tasks/website/src/lib.rs
+++ b/tasks/website/src/lib.rs
@@ -1,0 +1,3 @@
+#![allow(clippy::missing_panics_doc)]
+
+pub mod linter;

--- a/tasks/website/src/linter.rs
+++ b/tasks/website/src/linter.rs
@@ -1,0 +1,23 @@
+// <https://oxc-project.github.io/docs/guide/usage/linter-cli.html>
+pub fn generate_cli() {
+    use bpaf::Parser;
+    use oxc_cli::lint_options;
+    let markdown = lint_options().to_options().render_markdown("oxlint");
+    println!("{markdown}");
+}
+
+// <https://oxc-project.github.io/docs/guide/usage/linter-rules.html>
+pub fn generate_rules() {
+    use oxc_linter::Linter;
+    let mut v = vec![];
+    Linter::print_rules(&mut v);
+    println!("{}", String::from_utf8(v).unwrap());
+}
+
+pub fn generate_json_schema() {
+    use schemars::schema_for;
+
+    use oxc_linter::ESLintConfig;
+    let schema = schema_for!(ESLintConfig);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}

--- a/tasks/website/src/main.rs
+++ b/tasks/website/src/main.rs
@@ -1,0 +1,17 @@
+use pico_args::Arguments;
+
+use website::linter;
+
+fn main() {
+    let mut args = Arguments::from_env();
+    let command = args.subcommand().expect("subcommands");
+
+    let task = command.as_deref().unwrap_or("default");
+
+    match task {
+        "linter-json-schema" => linter::generate_json_schema(),
+        "linter-cli" => linter::generate_cli(),
+        "linter-rules" => linter::generate_rules(),
+        _ => println!("Missing task command."),
+    }
+}


### PR DESCRIPTION
Adds the following tasks so we can use them in the website repo to generate documentations.

`cargo run -p website`
* linter-cli
* linter-rules
* linter-json-schema