### PR TITLE
refactor(semantic/cfg): alias petgraph's `NodeIndex` as `BasicBlockId`.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -182,7 +182,7 @@ impl GetterReturn {
 
         let output = neighbors_filtered_by_edge_weight(
             &cfg.graph,
-            node.cfg_ix(),
+            node.cfg_id(),
             &|edge| match edge {
                 EdgeType::Normal => None,
                 // We don't need to handle backedges because we would have already visited
@@ -229,7 +229,7 @@ impl GetterReturn {
                 }
 
                 // Scan through the values in this basic block.
-                for entry in cfg.basic_block_by_index(*basic_block_id) {
+                for entry in cfg.basic_block(*basic_block_id) {
                     match entry {
                         // If the element is an assignment.
                         //

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -94,7 +94,7 @@ fn contains_return_statement<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> b
     let cfg = ctx.semantic().cfg();
     let state = neighbors_filtered_by_edge_weight(
         &cfg.graph,
-        node.cfg_ix(),
+        node.cfg_id(),
         &|edge| match edge {
             // We only care about normal edges having a return statement.
             EdgeType::Normal => None,
@@ -109,7 +109,7 @@ fn contains_return_statement<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> b
                 }
             }
 
-            for entry in cfg.basic_block_by_index(*basic_block_id) {
+            for entry in cfg.basic_block(*basic_block_id) {
                 if let BasicBlockElement::Assignment(to_reg, val) = entry {
                     if matches!(to_reg, Register::Return)
                         && matches!(val, AssignmentValue::NotImplicitUndefined)

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -54,7 +54,7 @@ fn main() -> std::io::Result<()> {
 
     let mut ast_nodes_by_block = HashMap::<_, Vec<_>>::new();
     for node in semantic.semantic.nodes().iter() {
-        let block = node.cfg_ix();
+        let block = node.cfg_id();
         let block_ix = semantic.semantic.cfg().graph.node_weight(block).unwrap();
         ast_nodes_by_block.entry(*block_ix).or_default().push(node);
     }

--- a/crates/oxc_semantic/src/control_flow/mod.rs
+++ b/crates/oxc_semantic/src/control_flow/mod.rs
@@ -10,6 +10,8 @@ use crate::AstNodeId;
 
 pub use builder::ControlFlowGraphBuilder;
 
+pub type BasicBlockId = NodeIndex;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Register {
     Index(u32),
@@ -128,17 +130,15 @@ pub struct ControlFlowGraph {
 
 impl ControlFlowGraph {
     /// # Panics
-    pub fn basic_block_by_index(&self, index: NodeIndex) -> &Vec<BasicBlockElement> {
-        let idx =
-            *self.graph.node_weight(index).expect("expected a valid node index in self.graph");
-        self.basic_blocks.get(idx).expect("expected a valid node index in self.basic_blocks")
+    pub fn basic_block(&self, id: BasicBlockId) -> &Vec<BasicBlockElement> {
+        let ix = *self.graph.node_weight(id).expect("expected a valid node id in self.graph");
+        self.basic_blocks.get(ix).expect("expected a valid node id in self.basic_blocks")
     }
 
     /// # Panics
-    pub fn basic_block_by_index_mut(&mut self, index: NodeIndex) -> &mut Vec<BasicBlockElement> {
-        let idx =
-            *self.graph.node_weight(index).expect("expected a valid node index in self.graph");
-        self.basic_blocks.get_mut(idx).expect("expected a valid node index in self.basic_blocks")
+    pub fn basic_block_mut(&mut self, id: BasicBlockId) -> &mut Vec<BasicBlockElement> {
+        let ix = *self.graph.node_weight(id).expect("expected a valid node id in self.graph");
+        self.basic_blocks.get_mut(ix).expect("expected a valid node id in self.basic_blocks")
     }
 }
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -31,10 +31,10 @@ use rustc_hash::FxHashSet;
 
 pub use crate::{
     control_flow::{
-        print_basic_block, AssignmentValue, BasicBlockElement, BinaryAssignmentValue, BinaryOp,
-        CallType, CalleeWithArgumentsAssignmentValue, CollectionAssignmentValue, ControlFlowGraph,
-        EdgeType, ObjectPropertyAccessAssignmentValue, Register, UnaryExpressioneAssignmentValue,
-        UpdateAssignmentValue,
+        print_basic_block, AssignmentValue, BasicBlockElement, BasicBlockId, BinaryAssignmentValue,
+        BinaryOp, CallType, CalleeWithArgumentsAssignmentValue, CollectionAssignmentValue,
+        ControlFlowGraph, EdgeType, ObjectPropertyAccessAssignmentValue, Register,
+        UnaryExpressioneAssignmentValue, UpdateAssignmentValue,
     },
     node::{AstNode, AstNodeId, AstNodes},
     reference::{Reference, ReferenceFlag, ReferenceId},

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -1,9 +1,7 @@
-use petgraph::stable_graph::NodeIndex;
-
 use oxc_ast::AstKind;
 use oxc_index::IndexVec;
 
-use crate::scope::ScopeId;
+use crate::{control_flow::BasicBlockId, scope::ScopeId};
 
 pub use oxc_syntax::node::{AstNodeId, NodeFlags};
 
@@ -17,23 +15,28 @@ pub struct AstNode<'a> {
     /// Associated Scope (initialized by binding)
     scope_id: ScopeId,
 
-    /// Associated NodeIndex in CFG (initialized by control_flow)
-    cfg_ix: NodeIndex,
+    /// Associated `BasicBlockId` in CFG (initialized by control_flow)
+    cfg_id: BasicBlockId,
 
     flags: NodeFlags,
 }
 
 impl<'a> AstNode<'a> {
-    pub fn new(kind: AstKind<'a>, scope_id: ScopeId, cfg_ix: NodeIndex, flags: NodeFlags) -> Self {
-        Self { id: AstNodeId::new(0), kind, cfg_ix, scope_id, flags }
+    pub fn new(
+        kind: AstKind<'a>,
+        scope_id: ScopeId,
+        cfg_id: BasicBlockId,
+        flags: NodeFlags,
+    ) -> Self {
+        Self { id: AstNodeId::new(0), kind, cfg_id, scope_id, flags }
     }
 
     pub fn id(&self) -> AstNodeId {
         self.id
     }
 
-    pub fn cfg_ix(&self) -> NodeIndex {
-        self.cfg_ix
+    pub fn cfg_id(&self) -> BasicBlockId {
+        self.cfg_id
     }
 
     pub fn kind(&self) -> AstKind<'a> {

--- a/crates/oxc_semantic/src/pg.rs
+++ b/crates/oxc_semantic/src/pg.rs
@@ -1,15 +1,17 @@
-use petgraph::{stable_graph::NodeIndex, visit::EdgeRef, Direction, Graph};
+use petgraph::{visit::EdgeRef, Direction, Graph};
+
+use crate::BasicBlockId;
 
 /// # Panics
 pub fn neighbors_filtered_by_edge_weight<State: Default + Clone, NodeWeight, EdgeWeight, F, G>(
     graph: &Graph<NodeWeight, EdgeWeight>,
-    node: NodeIndex,
+    node: BasicBlockId,
     edge_filter: &F,
     visitor: &mut G,
 ) -> Vec<State>
 where
     F: Fn(&EdgeWeight) -> Option<State>,
-    G: FnMut(&NodeIndex, State) -> (State, bool),
+    G: FnMut(&BasicBlockId, State) -> (State, bool),
 {
     let mut q = vec![];
     let mut final_states = vec![];


### PR DESCRIPTION
Hides petgraph's general `NodeIndex` type behind `BasicBlockId`.