### PR TITLE
fix(linter): only report issues on top-level fragment

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -81,7 +81,6 @@ fn is_in_array_or_iter<'a, 'b>(
 
     loop {
         let parent = ctx.nodes().parent_node(node.id())?;
-
         match parent.kind() {
             AstKind::ArrowFunctionExpression(arrow_expr) => {
                 let is_arrow_expr_statement = matches!(
@@ -133,8 +132,8 @@ fn is_in_array_or_iter<'a, 'b>(
 
                 return None;
             }
-            AstKind::JSXElement(_) | AstKind::JSXOpeningElement(_) | AstKind::ObjectProperty(_) => {
-                return None
+            AstKind::JSXElement(_) | AstKind::JSXOpeningElement(_) | AstKind::ObjectProperty(_) | AstKind::JSXFragment(_) => {
+              return None
             }
             AstKind::ReturnStatement(_) => {
                 is_explicit_return = true;
@@ -313,6 +312,12 @@ fn test() {
 
             const directiveRanges = comments?.map(tryParseTSDirective)
             ",
+        r#"
+          const foo: (JSX.Element | string)[] = [
+            "text",
+            <Fragment key={1}>hello world<sup>superscript</sup></Fragment>,
+          ];
+        "#,
         r#"
             import { observable } from "mobx";
 

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -132,9 +132,10 @@ fn is_in_array_or_iter<'a, 'b>(
 
                 return None;
             }
-            AstKind::JSXElement(_) | AstKind::JSXOpeningElement(_) | AstKind::ObjectProperty(_) | AstKind::JSXFragment(_) => {
-              return None
-            }
+            AstKind::JSXElement(_)
+            | AstKind::JSXOpeningElement(_)
+            | AstKind::ObjectProperty(_)
+            | AstKind::JSXFragment(_) => return None,
             AstKind::ReturnStatement(_) => {
                 is_explicit_return = true;
             }

--- a/crates/oxc_linter/src/snapshots/jsx_key.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_key.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 161
 expression: jsx_key
 ---
   ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
@@ -124,15 +125,6 @@ expression: jsx_key
  1 │ [1, 2, 3]?.map(x => <><OxcCompilerHello /></>)
    ·            ─┬─      ─┬
    ·             │        ╰── Element generated here
-   ·             ╰── Iterator starts here
-   ╰────
-  help: Add a "key" prop to the element in the iterator (https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key).
-
-  ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in iterator.
-   ╭─[jsx_key.tsx:1:12]
- 1 │ [1, 2, 3]?.map(x => <><OxcCompilerHello /></>)
-   ·            ─┬─         ────────┬───────
-   ·             │                  ╰── Element generated here
    ·             ╰── Iterator starts here
    ╰────
   help: Add a "key" prop to the element in the iterator (https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key).


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/3388

The snapshots were conveying this bug already on the `fail` case with https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/react/jsx_key.rs#L410