### PR TITLE
refactor(linter): remove unnecessary check in `eslint/no-global-assign`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -68,7 +68,7 @@ impl Rule for NoGlobalAssign {
         for reference_id_list in ctx.scopes().root_unresolved_references().values() {
             for &reference_id in reference_id_list {
                 let reference = symbol_table.get_reference(reference_id);
-                if reference.is_write() && symbol_table.is_global_reference(reference_id) {
+                if reference.is_write() {
                     let name = reference.name();
                     if !self.excludes.contains(name) && ctx.env_contains_var(name) {
                         ctx.diagnostic(no_global_assign_diagnostic(name, reference.span()));


### PR DESCRIPTION
Looks like we don't need check this, as unresolved references don't have `symbolId`: https://github.com/oxc-project/oxc/blob/bb25c54b94ff778e3598bb0f528d43a0c78333a0/crates/oxc_semantic/src/builder.rs#L292-L303
