### PR TITLE
fix(semantic): incorrect reference flag for TSTypeParameter

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -336,15 +336,21 @@ impl<'a> SemanticBuilder<'a> {
         // type Array<T> = T[];
         //           ^^^ TypeParameters
         let symbol_id = {
-            self.scope.get_child_ids(current_scope_id).and_then(|child_ids| {
-                child_ids.iter().rev().find_map(|scope_id| {
-                    if self.scope.get_flags(*scope_id).is_type_parameters() {
-                        self.scope.get_binding(*scope_id, &name)
-                    } else {
-                        None
-                    }
+            let has_type_reference =
+                reference_ids.iter().any(|id| self.symbols.references[*id].is_type());
+            if has_type_reference {
+                self.scope.get_child_ids(current_scope_id).and_then(|child_ids| {
+                    child_ids.iter().rev().find_map(|scope_id| {
+                        if self.scope.get_flags(*scope_id).is_type_parameters() {
+                            self.scope.get_binding(*scope_id, &name)
+                        } else {
+                            None
+                        }
+                    })
                 })
-            })
+            } else {
+                None
+            }
         };
 
         if let Some(symbol_id) =

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1820,36 +1820,36 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_scope();
     }
 
-    // fn visit_ts_type_alias_declaration(&mut self, decl: &TSTypeAliasDeclaration<'a>) {
-    //     let kind = AstKind::TSTypeAliasDeclaration(self.alloc(decl));
-    //     self.enter_node(kind);
-    //     self.enter_scope(ScopeFlags::empty());
-    //     decl.scope_id.set(Some(self.current_scope_id));
-    //     self.visit_binding_identifier(&decl.id);
-    //     if let Some(parameters) = &decl.type_parameters {
-    //         self.visit_ts_type_parameter_declaration(parameters);
-    //     }
-    //     self.visit_ts_type(&decl.type_annotation);
-    //     self.leave_scope();
-    //     self.leave_node(kind);
-    // }
+    fn visit_ts_type_alias_declaration(&mut self, decl: &TSTypeAliasDeclaration<'a>) {
+        let kind = AstKind::TSTypeAliasDeclaration(self.alloc(decl));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty());
+        decl.scope_id.set(Some(self.current_scope_id));
+        self.visit_binding_identifier(&decl.id);
+        if let Some(parameters) = &decl.type_parameters {
+            self.visit_ts_type_parameter_declaration(parameters);
+        }
+        self.visit_ts_type(&decl.type_annotation);
+        self.leave_scope();
+        self.leave_node(kind);
+    }
 
-    // fn visit_ts_interface_declaration(&mut self, decl: &TSInterfaceDeclaration<'a>) {
-    //     let kind = AstKind::TSInterfaceDeclaration(self.alloc(decl));
-    //     self.enter_node(kind);
-    //     self.enter_scope(ScopeFlags::empty());
-    //     decl.scope_id.set(Some(self.current_scope_id));
-    //     self.visit_binding_identifier(&decl.id);
-    //     if let Some(parameters) = &decl.type_parameters {
-    //         self.visit_ts_type_parameter_declaration(parameters);
-    //     }
+    fn visit_ts_interface_declaration(&mut self, decl: &TSInterfaceDeclaration<'a>) {
+        let kind = AstKind::TSInterfaceDeclaration(self.alloc(decl));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty());
+        decl.scope_id.set(Some(self.current_scope_id));
+        self.visit_binding_identifier(&decl.id);
+        if let Some(parameters) = &decl.type_parameters {
+            self.visit_ts_type_parameter_declaration(parameters);
+        }
 
-    //     for body_decl in &decl.body.body {
-    //         self.visit_ts_signature(body_decl);
-    //     }
-    //     self.leave_scope();
-    //     self.leave_node(kind);
-    // }
+        for body_decl in &decl.body.body {
+            self.visit_ts_signature(body_decl);
+        }
+        self.leave_scope();
+        self.leave_node(kind);
+    }
 }
 
 impl<'a> SemanticBuilder<'a> {

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -87,6 +87,10 @@ impl ScopeTree {
         &self.unresolved_references[self.root_scope_id()]
     }
 
+    pub fn flags(&self) -> &IndexVec<ScopeId, ScopeFlags> {
+        &self.flags
+    }
+
     pub fn get_flags(&self, scope_id: ScopeId) -> ScopeFlags {
         self.flags[scope_id]
     }

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -201,6 +201,7 @@ fn test_class_with_type_parameter() {
     tester.has_symbol("T").has_number_of_references(4).test();
     tester.has_symbol("K").has_number_of_references(1).test();
     tester.has_symbol("D").has_number_of_references(0).test();
+
     // type B is not referenced
     tester.has_symbol("B").has_number_of_references(0).test();
 }
@@ -210,11 +211,17 @@ fn test_ts_mapped_type() {
     let tester = SemanticTester::ts(
         "
         type M<T> = { [K in keyof T]: T[K] };
+
+        type Y = any;
+        type X<T> = { [Y in keyof T]: T[Y] };
         ",
     );
 
     tester.has_symbol("T").has_number_of_references(2).test();
     tester.has_symbol("K").has_number_of_references(1).test();
+
+    // type Y is not referenced
+    tester.has_symbol("Y").has_number_of_references(0).test();
 }
 
 #[test]
@@ -231,8 +238,10 @@ fn test_ts_interface_declaration_with_type_parameter() {
         ",
     );
 
-    tester.has_symbol("A").has_number_of_references(0).test();
     tester.has_symbol("B").has_number_of_references(1).test();
+
+    // type A is not referenced
+    tester.has_symbol("A").has_number_of_references(0).test();
 }
 
 #[test]
@@ -240,9 +249,15 @@ fn test_ts_infer_type() {
     let tester = SemanticTester::ts(
         "
         type T = T extends infer U ? U : never;
+        
+        type C = any;
+        type K = K extends infer C ? K : never;
         ",
     );
 
     tester.has_symbol("T").has_number_of_references(1).test();
     tester.has_symbol("U").has_number_of_references(1).test();
+
+    // type C is not referenced
+    tester.has_symbol("C").has_number_of_references(0).test();
 }

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -190,12 +190,19 @@ fn test_class_with_type_parameter() {
                 return null as D
             }
         }
+
+        type B = any;
+        class ClassB<B> {
+            b: B;
+        }
         ",
     );
 
     tester.has_symbol("T").has_number_of_references(4).test();
     tester.has_symbol("K").has_number_of_references(1).test();
     tester.has_symbol("D").has_number_of_references(0).test();
+    // type B is not referenced
+    tester.has_symbol("B").has_number_of_references(0).test();
 }
 
 #[test]

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -141,6 +141,15 @@ impl<'a> SemanticTester<'a> {
         )
     }
 
+    /// Find first symbol by name in the source code.
+    ///
+    /// ## Fails
+    /// 1. No symbol with the given name exists,
+    #[allow(dead_code)]
+    pub fn has_symbol(&self, name: &str) -> SymbolTester {
+        SymbolTester::new_first_binding(self, self.build(), name)
+    }
+
     /// Tests that a symbol with the given name exists at the top-level scope and provides a
     /// wrapper for writing assertions about the found symbol.
     ///

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use oxc_diagnostics::{Error, OxcDiagnostic};
-use oxc_semantic::{Reference, ScopeFlags, Semantic, SymbolFlags, SymbolId};
-use oxc_span::Atom;
+use oxc_semantic::{Reference, ScopeFlags, ScopeId, Semantic, SymbolFlags, SymbolId};
+use oxc_span::{Atom, CompactStr};
 
 use super::{Expect, SemanticTester};
 
@@ -65,6 +65,27 @@ impl<'a> SymbolTester<'a> {
     /// Get inner resources without consuming `self`
     pub fn inner(&self) -> (Rc<Semantic<'a>>, SymbolId) {
         (Rc::clone(&self.semantic), *self.test_result.as_ref().unwrap())
+    }
+
+    pub(super) fn new_first_binding(
+        parent: &'a SemanticTester,
+        semantic: Semantic<'a>,
+        target: &str,
+    ) -> Self {
+        let symbols_with_target_name: Option<(ScopeId, SymbolId, &CompactStr)> =
+            semantic.scopes().iter_bindings().find(|(_, _, name)| name.as_str() == target);
+
+        let data = match symbols_with_target_name {
+            Some((_, symbol_id, _)) => Ok(symbol_id),
+            None => Err(OxcDiagnostic::error(format!("Could not find declaration for {target}"))),
+        };
+
+        SymbolTester {
+            parent,
+            semantic: Rc::new(semantic),
+            target_symbol_name: target.to_string(),
+            test_result: data,
+        }
     }
 
     /// Checks if the resolved symbol contains all flags in `flags`, using [`SymbolFlags::contains()`]


### PR DESCRIPTION
Supersedes #2070

fix: https://github.com/oxc-project/oxc/issues/2023

`ScopeFlags::TypeParameters` is used to wrap all type parameters. This way we can find the parameters of the TypeParameterDeclaration when resolving the reference.

There may be a better solution, but I haven't thought of it yet