### PR TITLE
fix(parser): parse const extends in arrow functions correctly

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -156,10 +156,13 @@ impl<'a> ParserImpl<'a> {
 
                 // JSX overrides
                 if self.source_type.is_jsx() {
-                    return match self.nth_kind(offset + 2) {
+                    // <const Ident extends Ident>
+                    //  ^^^^^ Optional
+                    offset += if second == Kind::Const { 3 } else { 2 };
+                    return match self.nth_kind(offset) {
                         Kind::Extends => {
-                            let third = self.nth_kind(offset + 3);
-                            if matches!(third, Kind::Eq | Kind::RAngle) {
+                            let third = self.nth_kind(offset + 1);
+                            if matches!(third, Kind::Eq | Kind::RAngle | Kind::Slash) {
                                 Tristate::False
                             } else if third.is_binding_identifier() {
                                 Tristate::Maybe

--- a/tasks/coverage/codegen_misc.snap
+++ b/tasks/coverage/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 17/17 (100.00%)
-Positive Passed: 17/17 (100.00%)
+AST Parsed     : 18/18 (100.00%)
+Positive Passed: 18/18 (100.00%)

--- a/tasks/coverage/misc/pass/oxc-3443.tsx
+++ b/tasks/coverage/misc/pass/oxc-3443.tsx
@@ -1,0 +1,2 @@
+const A = <const T extends F>() => {};
+const B = <const T extends keyof F>() => {};

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 17/17 (100.00%)
-Positive Passed: 17/17 (100.00%)
+AST Parsed     : 18/18 (100.00%)
+Positive Passed: 18/18 (100.00%)
 Negative Passed: 9/9 (100.00%)
 
   × Unexpected token

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 64d2eeea
 parser_typescript Summary:
 AST Parsed     : 5240/5243 (99.94%)
 Positive Passed: 5233/5243 (99.81%)
-Negative Passed: 1065/4879 (21.83%)
+Negative Passed: 1064/4879 (21.81%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
 Expect Syntax Error: "compiler/ClassDeclaration13.ts"
@@ -1388,6 +1388,7 @@ Expect Syntax Error: "compiler/paramterDestrcuturingDeclaration.ts"
 Expect Syntax Error: "compiler/parenthesizedJSDocCastDoesNotNarrow.ts"
 Expect Syntax Error: "compiler/parseCommaSeparatedNewlineNumber.ts"
 Expect Syntax Error: "compiler/parseCommaSeparatedNewlineString.ts"
+Expect Syntax Error: "compiler/parseJsxExtends2.ts"
 Expect Syntax Error: "compiler/parseTypes.ts"
 Expect Syntax Error: "compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts"
 Expect Syntax Error: "compiler/parseUnaryExpressionNoTypeAssertionInJsx3.ts"
@@ -8515,14 +8516,6 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
  4 │ !< {:>
    ·     ─
  5 │ 
-   ╰────
-
-  × Unexpected token
-   ╭─[compiler/parseJsxExtends2.ts:8:22]
- 7 │     // Error: T is not declared.
- 8 │     return <T extends/>
-   ·                      ─
- 9 │ }
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/prettier_misc.snap
+++ b/tasks/coverage/prettier_misc.snap
@@ -1,6 +1,6 @@
 prettier_misc Summary:
-AST Parsed     : 17/17 (100.00%)
-Positive Passed: 10/17 (58.82%)
+AST Parsed     : 18/18 (100.00%)
+Positive Passed: 11/18 (61.11%)
 Expect to Parse: "pass/oxc-1740.tsx"
 Expect to Parse: "pass/oxc-2087.ts"
 Expect to Parse: "pass/oxc-2394.ts"

--- a/tasks/coverage/transformer_misc.snap
+++ b/tasks/coverage/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 17/17 (100.00%)
-Positive Passed: 17/17 (100.00%)
+AST Parsed     : 18/18 (100.00%)
+Positive Passed: 18/18 (100.00%)


### PR DESCRIPTION
close: #3443
