### PR TITLE
feat(linter): implement @typescript-eslint/explicit-function-return-type

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -30,3 +30,4 @@ labeledby = "labeledby"
 
 [default.extend-identifiers]
 IIFEs = "IIFEs"
+allowIIFEs = "allowIIFEs"

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -126,6 +126,7 @@ mod typescript {
     pub mod ban_types;
     pub mod consistent_indexed_object_style;
     pub mod consistent_type_definitions;
+    pub mod explicit_function_return_type;
     pub mod no_duplicate_enum_values;
     pub mod no_empty_interface;
     pub mod no_explicit_any;
@@ -531,6 +532,7 @@ oxc_macros::declare_all_lint_rules! {
     typescript::prefer_ts_expect_error,
     typescript::triple_slash_reference,
     typescript::prefer_literal_enum_member,
+    typescript::explicit_function_return_type,
     jest::expect_expect,
     jest::max_expects,
     jest::max_nested_describe,

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -57,8 +57,7 @@ declare_oxc_lint!(
     /// ```javascript
     /// ```
     ExplicitFunctionReturnType,
-    restriction, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
-             // See <https://oxc-project.github.io/docs/contribute/linter.html#rule-category> for details
+    restriction,
 );
 
 fn explicit_function_return_type_diagnostic(span0: Span) -> OxcDiagnostic {
@@ -113,6 +112,7 @@ impl Rule for ExplicitFunctionReturnType {
                 .unwrap_or(false),
         }))
     }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(func) => {
@@ -265,6 +265,7 @@ impl ExplicitFunctionReturnType {
         let Expression::UnaryExpression(unary_expr) = expr else { return false };
         matches!(unary_expr.operator, UnaryOperator::Void)
     }
+
     fn is_allowed_function<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
         match node.kind() {
             AstKind::Function(func) => {
@@ -298,6 +299,7 @@ impl ExplicitFunctionReturnType {
             _ => false,
         }
     }
+
     fn check_parent_for_is_allowed_function<'a>(
         &self,
         node: &AstNode<'a>,
@@ -310,25 +312,25 @@ impl ExplicitFunctionReturnType {
                     return false;
                 };
 
-                return self.allowed_names.contains(id.name.as_str());
+                self.allowed_names.contains(id.name.as_str())
             }
             AstKind::MethodDefinition(def) => {
                 let Some(name) = def.key.name() else { return false };
-                return def.key.is_identifier()
+                def.key.is_identifier()
                     && !def.computed
-                    && self.allowed_names.contains(name.as_str());
+                    && self.allowed_names.contains(name.as_str())
             }
             AstKind::PropertyDefinition(def) => {
                 let Some(name) = def.key.name() else { return false };
-                return def.key.is_identifier()
+                def.key.is_identifier()
                     && !def.computed
-                    && self.allowed_names.contains(name.as_str());
+                    && self.allowed_names.contains(name.as_str())
             }
             AstKind::ObjectProperty(prop) => {
                 let Some(name) = prop.key.name() else { return false };
-                return prop.key.is_identifier()
+                prop.key.is_identifier()
                     && !prop.computed
-                    && self.allowed_names.contains(name.as_str());
+                    && self.allowed_names.contains(name.as_str())
             }
             _ => false,
         }
@@ -357,6 +359,7 @@ impl ExplicitFunctionReturnType {
                     | AstKind::PropertyDefinition(_)
             )
     }
+
     fn returns_const_assertion_directly(&self, node: &AstNode) -> bool {
         if !self.allow_direct_const_assertion_in_arrow_functions {
             return false;
@@ -549,6 +552,7 @@ fn is_typed_jsx(node: &AstNode) -> bool {
 fn is_function(expr: &Expression) -> bool {
     matches!(expr, Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_))
 }
+
 fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
     let Some(parent) = get_parent_node(node, ctx) else { return false };
 
@@ -594,6 +598,7 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
 
     false
 }
+
 fn all_return_statements_are_functions(node: &AstNode) -> bool {
     match node.kind() {
         AstKind::ArrowFunctionExpression(arrow_func_expr) => {

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -583,11 +583,8 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
             AstKind::PropertyDefinition(def) => {
                 return def.type_annotation.is_some();
             }
-            AstKind::ExpressionStatement(_) => {
-                let Some(expr_parent) = get_parent_node(ctx.nodes().get_node(ancestor), ctx) else {
-                    return false;
-                };
-                if !matches!(expr_parent.kind(), AstKind::FunctionBody(_)) {
+            AstKind::ExpressionStatement(expr) => {
+                if !matches!(expr.expression, Expression::ArrowFunctionExpression(_)) {
                     return false;
                 }
             }
@@ -1627,19 +1624,19 @@ fn test() {
             None,
             None,
         ),
-        // (
-        //     "
-        // 	let anyValue: any;
-        // 	function foo(): any {
-        // 	  anyValue = () => () => console.log('aa');
-        // 	}
-        // 	      ",
-        //     Some(
-        //         serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-        //     ),
-        //     None,
-        //     None,
-        // ),
+        (
+            "
+        	let anyValue: any;
+        	function foo(): any {
+        	  anyValue = () => () => console.log('aa');
+        	}
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
         (
             "
         	class Foo {

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -1,0 +1,2134 @@
+use std::collections::HashSet;
+
+use oxc_ast::{
+    ast::{
+        ArrowFunctionExpression, BindingPatternKind, Expression, FunctionType, JSXAttributeItem,
+        PropertyKind, Statement, TSType, TSTypeName,
+    },
+    AstKind,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use oxc_syntax::operator::UnaryOperator;
+
+use crate::{
+    ast_util::outermost_paren_parent,
+    context::LintContext,
+    rule::Rule,
+    rules::eslint::array_callback_return::return_checker::{
+        check_statement, StatementReturnStatus,
+    },
+    AstNode,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct ExplicitFunctionReturnType(Box<ExplicitFunctionReturnTypeConfig>);
+
+#[derive(Debug, Default, Clone)]
+pub struct ExplicitFunctionReturnTypeConfig {
+    allow_expressions: bool,
+    allow_typed_function_expressions: bool,
+    allow_direct_const_assertion_in_arrow_functions: bool,
+    allow_concise_arrow_function_expressions_starting_with_void: bool,
+    allow_functions_without_type_parameters: bool,
+    allowed_names: HashSet<String>,
+    allow_higher_order_functions: bool,
+    allow_iifes: bool,
+}
+
+impl std::ops::Deref for ExplicitFunctionReturnType {
+    type Target = ExplicitFunctionReturnTypeConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// This rule enforces that functions do have an explicit return type annotation.
+    ///
+    /// ### Why is this bad?
+    /// Explicit return types do make it visually more clear what type is returned by a function.
+    /// They can also speed up TypeScript type checking performance in large codebases with many large functions.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// ```
+    ExplicitFunctionReturnType,
+    restriction, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+             // See <https://oxc-project.github.io/docs/contribute/linter.html#rule-category> for details
+);
+
+fn explicit_function_return_type_diagnostic(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "typescript-eslint(explicit-function-return-type): Missing return type on function.",
+    )
+    .with_help("Require explicit return types on functions and class methods.")
+    .with_labels([span0.into()])
+}
+
+impl Rule for ExplicitFunctionReturnType {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let options: Option<&serde_json::Value> = value.get(0);
+        Self(Box::new(ExplicitFunctionReturnTypeConfig {
+            allow_expressions: options
+                .and_then(|x| x.get("allowExpressions"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            allow_typed_function_expressions: options
+                .and_then(|x| x.get("allowTypedFunctionExpressions"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            allow_direct_const_assertion_in_arrow_functions: options
+                .and_then(|x| x.get("allowDirectConstAssertionInArrowFunctions"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            allow_concise_arrow_function_expressions_starting_with_void: options
+                .and_then(|x| x.get("allowConciseArrowFunctionExpressionsStartingWithVoid"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            allow_functions_without_type_parameters: options
+                .and_then(|x| x.get("allowFunctionsWithoutTypeParameters"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            allowed_names: options
+                .and_then(|x| x.get("allowedNames"))
+                .and_then(serde_json::Value::as_array)
+                .map(|v| {
+                    v.iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(ToString::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            allow_higher_order_functions: options
+                .and_then(|x| x.get("allowHigherOrderFunctions"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            allow_iifes: options
+                .and_then(|x| x.get("allowIIFEs"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        }))
+    }
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Function(func) => {
+                if !func.is_declaration() & !func.is_expression() {
+                    return;
+                }
+
+                if func.return_type.is_some() || is_constructor_or_setter(node, ctx) {
+                    return;
+                }
+                if self.is_allowed_function(node, ctx) {
+                    return;
+                }
+                if matches!(func.r#type, FunctionType::FunctionDeclaration) {
+                    if self.allow_typed_function_expressions && func.return_type.is_some() {
+                        return;
+                    }
+                    if self.does_immediately_return_function_expression(node) {
+                        return;
+                    }
+                } else {
+                    if self.allow_typed_function_expressions
+                        && (self.is_valid_function_expression_return_type(node, ctx)
+                            || ancestor_has_return_type(node, ctx))
+                    {
+                        return;
+                    }
+
+                    if self.does_immediately_return_function_expression(node) {
+                        return;
+                    }
+                }
+
+                if let Some(parent) = get_parent_node(node, ctx) {
+                    match parent.kind() {
+                        AstKind::MethodDefinition(def) => {
+                            ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                                def.span.start,
+                                def.value.params.span.start,
+                            )));
+                            return;
+                        }
+                        AstKind::PropertyDefinition(def) => {
+                            ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                                def.span.start,
+                                func.params.span.start,
+                            )));
+
+                            return;
+                        }
+                        AstKind::ObjectProperty(prop) => {
+                            ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                                prop.span.start,
+                                func.params.span.start,
+                            )));
+
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+                if func.is_expression() {
+                    ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                        func.span.start,
+                        func.params.span.start,
+                    )));
+                } else if let Some(id) = &func.id {
+                    ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                        func.span.start,
+                        id.span.end,
+                    )));
+                } else {
+                    ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                        func.span.start,
+                        func.params.span.start,
+                    )));
+                }
+            }
+            AstKind::ArrowFunctionExpression(func) => {
+                if func.return_type.is_some() {
+                    return;
+                }
+                if self.check_arrow_function_with_void(func) {
+                    return;
+                }
+                if self.is_allowed_function(node, ctx) {
+                    return;
+                }
+                if self.allow_typed_function_expressions
+                    && (self.is_valid_function_expression_return_type(node, ctx)
+                        || ancestor_has_return_type(node, ctx))
+                {
+                    return;
+                }
+                if self.returns_const_assertion_directly(node) {
+                    return;
+                }
+
+                if self.does_immediately_return_function_expression(node) {
+                    return;
+                }
+
+                if let Some(parent) = get_parent_node(node, ctx) {
+                    match parent.kind() {
+                        AstKind::MethodDefinition(def) => {
+                            ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                                def.span.start,
+                                def.value.params.span.start,
+                            )));
+                            return;
+                        }
+                        AstKind::PropertyDefinition(def) => {
+                            ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                                def.span.start,
+                                func.params.span.start,
+                            )));
+
+                            return;
+                        }
+                        AstKind::ObjectProperty(prop) => {
+                            ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                                prop.span.start,
+                                func.params.span.start,
+                            )));
+
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+                ctx.diagnostic(explicit_function_return_type_diagnostic(Span::new(
+                    func.params.span.end + 1,
+                    func.params.span.end + 3,
+                )));
+            }
+            _ => {}
+        }
+    }
+}
+
+impl ExplicitFunctionReturnType {
+    fn check_arrow_function_with_void(&self, func: &ArrowFunctionExpression) -> bool {
+        if !self.allow_concise_arrow_function_expressions_starting_with_void {
+            return false;
+        }
+        if !func.expression {
+            return false;
+        }
+        let Some(expr) = func.get_expression() else { return false };
+        let Expression::UnaryExpression(unary_expr) = expr else { return false };
+        matches!(unary_expr.operator, UnaryOperator::Void)
+    }
+    fn is_allowed_function<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+        match node.kind() {
+            AstKind::Function(func) => {
+                if self.allow_functions_without_type_parameters && func.type_parameters.is_none() {
+                    return true;
+                }
+                if self.allow_iifes && is_iife(node, ctx) {
+                    return true;
+                }
+                if self.allowed_names.is_empty() {
+                    return false;
+                }
+                if let Some(id) = &func.id {
+                    return self.allowed_names.contains(id.name.as_str());
+                }
+                self.check_parent_for_is_allowed_function(node, ctx)
+            }
+            AstKind::ArrowFunctionExpression(func) => {
+                if self.allow_functions_without_type_parameters && func.type_parameters.is_none() {
+                    return true;
+                }
+                if self.allow_iifes && is_iife(node, ctx) {
+                    return true;
+                }
+                if self.allowed_names.is_empty() {
+                    return false;
+                }
+
+                self.check_parent_for_is_allowed_function(node, ctx)
+            }
+            _ => false,
+        }
+    }
+    fn check_parent_for_is_allowed_function<'a>(
+        &self,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> bool {
+        let Some(parent) = get_parent_node(node, ctx) else { return false };
+        match parent.kind() {
+            AstKind::VariableDeclarator(decl) => {
+                let BindingPatternKind::BindingIdentifier(id) = &decl.id.kind else {
+                    return false;
+                };
+
+                return self.allowed_names.contains(id.name.as_str());
+            }
+            AstKind::MethodDefinition(def) => {
+                let Some(name) = def.key.name() else { return false };
+                return def.key.is_identifier()
+                    && !def.computed
+                    && self.allowed_names.contains(name.as_str());
+            }
+            AstKind::PropertyDefinition(def) => {
+                let Some(name) = def.key.name() else { return false };
+                return def.key.is_identifier()
+                    && !def.computed
+                    && self.allowed_names.contains(name.as_str());
+            }
+            AstKind::ObjectProperty(prop) => {
+                let Some(name) = prop.key.name() else { return false };
+                return prop.key.is_identifier()
+                    && !prop.computed
+                    && self.allowed_names.contains(name.as_str());
+            }
+            _ => false,
+        }
+    }
+    fn is_valid_function_expression_return_type<'a>(
+        &self,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> bool {
+        if check_typed_function_expression(node, ctx) {
+            return true;
+        }
+        self.check_allow_expressions(node, ctx)
+    }
+
+    fn check_allow_expressions(&self, node: &AstNode, ctx: &LintContext) -> bool {
+        let Some(parent) = ctx.nodes().parent_node(node.id()) else {
+            return false;
+        };
+        self.allow_expressions
+            && !matches!(
+                parent.kind(),
+                AstKind::VariableDeclarator(_)
+                    | AstKind::MethodDefinition(_)
+                    | AstKind::ExportDefaultDeclaration(_)
+                    | AstKind::PropertyDefinition(_)
+            )
+    }
+    fn returns_const_assertion_directly(&self, node: &AstNode) -> bool {
+        if !self.allow_direct_const_assertion_in_arrow_functions {
+            return false;
+        }
+        let AstKind::ArrowFunctionExpression(func) = node.kind() else { return false };
+        let Some(expr) = func.get_expression() else { return false };
+
+        match expr {
+            Expression::TSAsExpression(ts_expr) => {
+                let TSType::TSTypeReference(ts_type) = &ts_expr.type_annotation else {
+                    return false;
+                };
+                let TSTypeName::IdentifierReference(id_ref) = &ts_type.type_name else {
+                    return false;
+                };
+
+                id_ref.name == "const"
+            }
+            Expression::TSTypeAssertion(ts_expr) => {
+                let TSType::TSTypeReference(ts_type) = &ts_expr.type_annotation else {
+                    return false;
+                };
+                let TSTypeName::IdentifierReference(id_ref) = &ts_type.type_name else {
+                    return false;
+                };
+
+                id_ref.name == "const"
+            }
+            _ => false,
+        }
+    }
+
+    /**
+     * Checks if a function belongs to:
+     * ```
+     * () => () => ...
+     * () => function () { ... }
+     * () => { return () => ... }
+     * () => { return function () { ... } }
+     * function fn() { return () => ... }
+     * function fn() { return function() { ... } }
+     * ```
+     */
+    fn does_immediately_return_function_expression(&self, node: &AstNode) -> bool {
+        if !self.allow_higher_order_functions {
+            return false;
+        }
+        if let AstKind::ArrowFunctionExpression(arrow_func_expr) = node.kind() {
+            if let Some(func_body_expr) = arrow_func_expr.get_expression() {
+                return is_function(func_body_expr);
+            };
+        }
+        all_return_statements_are_functions(node)
+    }
+}
+
+// check function is IIFE (Immediately Invoked Function Expression)
+fn is_iife<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let Some(parent) = get_parent_node(node, ctx) else {
+        return false;
+    };
+    matches!(parent.kind(), AstKind::CallExpression(_))
+}
+/**
+ * Checks if a node belongs to:
+ * ```
+ * new Foo(() => {})
+ *         ^^^^^^^^
+ * ```
+ */
+fn is_constructor_argument(node: &AstNode) -> bool {
+    matches!(node.kind(), AstKind::NewExpression(_))
+}
+
+fn is_constructor_or_setter(node: &AstNode, ctx: &LintContext) -> bool {
+    let Some(parent) = ctx.nodes().parent_node(node.id()) else {
+        return false;
+    };
+    is_constructor(parent) || is_setter(parent)
+}
+
+fn is_constructor(node: &AstNode) -> bool {
+    let AstKind::MethodDefinition(method_def) = node.kind() else { return false };
+    method_def.kind.is_constructor()
+}
+
+fn is_setter(node: &AstNode) -> bool {
+    match node.kind() {
+        AstKind::MethodDefinition(method_def) => method_def.kind.is_set(),
+        AstKind::ObjectProperty(obj_prop) => {
+            matches!(obj_prop.kind, PropertyKind::Set)
+        }
+        _ => false,
+    }
+}
+
+fn get_parent_node<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b AstNode<'a>> {
+    let parent = outermost_paren_parent(node, ctx)?;
+    match parent.kind() {
+        AstKind::Argument(_) => outermost_paren_parent(parent, ctx),
+        _ => Some(parent),
+    }
+}
+
+fn check_typed_function_expression<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let Some(parent) = get_parent_node(node, ctx) else { return false };
+    is_typed_parent(parent, Some(node))
+        || is_property_of_object_with_type(parent, ctx)
+        || is_constructor_argument(parent)
+}
+
+fn is_typed_parent(parent: &AstNode, callee: Option<&AstNode>) -> bool {
+    is_type_assertion(parent)
+        || is_variable_declarator_with_type_annotation(parent)
+        || is_default_function_parameter_with_type_annotation(parent)
+        || is_property_definition_with_type_annotation(parent)
+        || is_function_argument(parent, callee)
+        || is_typed_jsx(parent)
+}
+
+fn is_variable_declarator_with_type_annotation(node: &AstNode) -> bool {
+    let AstKind::VariableDeclarator(var_decl) = node.kind() else { return false };
+
+    var_decl.id.type_annotation.is_some()
+}
+
+fn is_function_argument(parent: &AstNode, callee: Option<&AstNode>) -> bool {
+    let AstKind::CallExpression(call_expr) = parent.kind() else { return false };
+
+    if callee.is_none() {
+        return true;
+    }
+
+    match call_expr.callee.without_parenthesized() {
+        Expression::FunctionExpression(func_expr) => {
+            let AstKind::Function(callee_func_expr) = callee.unwrap().kind() else { return false };
+            func_expr.span != callee_func_expr.span
+        }
+        Expression::ArrowFunctionExpression(arrow_func_expr) => {
+            let AstKind::ArrowFunctionExpression(callee_arrow_func_expr) = callee.unwrap().kind()
+            else {
+                return false;
+            };
+            arrow_func_expr.span != callee_arrow_func_expr.span
+        }
+        _ => true,
+    }
+}
+
+fn is_type_assertion(node: &AstNode) -> bool {
+    matches!(node.kind(), AstKind::TSAsExpression(_) | AstKind::TSTypeAssertion(_))
+}
+fn is_default_function_parameter_with_type_annotation(node: &AstNode) -> bool {
+    let AstKind::AssignmentPattern(assign) = node.kind() else { return false };
+
+    assign.left.type_annotation.is_some()
+}
+
+/**
+ * Checks if a node is a class property with a type annotation.
+ * ```
+ * public x: Foo = ...
+ * ```
+ */
+fn is_property_definition_with_type_annotation(node: &AstNode) -> bool {
+    let AstKind::PropertyDefinition(prop_def) = node.kind() else { return false };
+    prop_def.type_annotation.is_some()
+}
+
+/**
+ * Checks if a node is type-constrained in JSX
+ * ```
+ * <Foo x={() => {}} />
+ * <Bar>{() => {}}</Bar>
+ * <Baz {...props} />
+ * ```
+ */
+fn is_typed_jsx(node: &AstNode) -> bool {
+    if matches!(node.kind(), AstKind::JSXExpressionContainer(_) | AstKind::JSXSpreadAttribute(_)) {
+        return true;
+    }
+
+    let AstKind::JSXAttributeItem(jsx_attr_item) = node.kind() else { return false };
+    matches!(jsx_attr_item, JSXAttributeItem::SpreadAttribute(_))
+}
+
+fn is_function(expr: &Expression) -> bool {
+    matches!(expr, Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_))
+}
+fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let Some(parent) = get_parent_node(node, ctx) else { return false };
+
+    if let AstKind::ObjectProperty(prop) = parent.kind() {
+        if let Expression::ArrowFunctionExpression(func) = &prop.value {
+            if func.body.statements.is_empty() {
+                return false;
+            }
+            if func.return_type.is_some() {
+                return true;
+            }
+        }
+    } else if check_return_statement_and_bodyless(parent) {
+        return false;
+    }
+
+    for ancestor in ctx.nodes().ancestors(node.id()).skip(1) {
+        match ctx.nodes().kind(ancestor) {
+            AstKind::ArrowFunctionExpression(func) => {
+                if func.return_type.is_some() {
+                    return true;
+                }
+            }
+            AstKind::Function(func) => {
+                if func.return_type.is_some() {
+                    return true;
+                }
+            }
+            AstKind::VariableDeclarator(decl) => {
+                return decl.id.type_annotation.is_some();
+            }
+            AstKind::PropertyDefinition(def) => {
+                return def.type_annotation.is_some();
+            }
+            AstKind::ExpressionStatement(_) => {
+                let Some(expr_parent) = get_parent_node(ctx.nodes().get_node(ancestor), ctx) else {
+                    return false;
+                };
+                if !matches!(expr_parent.kind(), AstKind::FunctionBody(_)) {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+fn all_return_statements_are_functions(node: &AstNode) -> bool {
+    match node.kind() {
+        AstKind::ArrowFunctionExpression(arrow_func_expr) => {
+            check_return_statements(&arrow_func_expr.body.statements)
+        }
+        AstKind::Function(func) => {
+            if let Some(func_body) = &func.body {
+                check_return_statements(&func_body.statements)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn check_return_statement_and_bodyless(node: &AstNode) -> bool {
+    match node.kind() {
+        AstKind::ReturnStatement(_) => true,
+        AstKind::ArrowFunctionExpression(func) => func.body.statements.is_empty(),
+        _ => false,
+    }
+}
+
+fn check_return_statements<'a>(statements: &'a [Statement<'a>]) -> bool {
+    if statements.is_empty() {
+        return false;
+    }
+
+    let mut has_return = false;
+
+    let all_statements_valid = statements.iter().all(|stmt| {
+        if let Statement::ReturnStatement(return_stmt) = stmt {
+            if let Some(arg) = &return_stmt.argument {
+                has_return = true;
+                return is_function(arg);
+            }
+            false
+        } else {
+            let status = check_statement(stmt);
+            if status == StatementReturnStatus::AlwaysExplicit {
+                has_return = true;
+            }
+            matches!(
+                status,
+                StatementReturnStatus::NotReturn | StatementReturnStatus::AlwaysExplicit
+            )
+        }
+    });
+
+    has_return && all_statements_valid
+}
+
+/**
+ * Checks if a node is a property or a nested property of a typed object:
+ * ```
+ * const x: Foo = { prop: () => {} }
+ * const x = { prop: () => {} } as Foo
+ * const x = <Foo>{ prop: () => {} }
+ * const x: Foo = { bar: { prop: () => {} } }
+ * ```
+ */
+fn is_property_of_object_with_type(node: &AstNode, ctx: &LintContext) -> bool {
+    if !matches!(node.kind(), AstKind::ObjectProperty(_)) {
+        return false;
+    }
+    if !matches!(node.kind(), AstKind::ObjectProperty(_)) {
+        return false;
+    }
+    let Some(parent) = ctx.nodes().parent_node(node.id()) else {
+        return false;
+    };
+    if !matches!(parent.kind(), AstKind::ObjectExpression(_)) {
+        return false;
+    }
+    let Some(obj_expr_parent) = get_parent_node(parent, ctx) else {
+        return false;
+    };
+    is_typed_parent(obj_expr_parent, None) || is_property_of_object_with_type(obj_expr_parent, ctx)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        ("return;", None, None, None),
+        (
+            "
+        	function test(): void {
+        	  return;
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	var fn = function (): number {
+        	  return 1;
+        	};
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	var arrowFn = (): string => 'test';
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	class Test {
+        	  constructor() {}
+        	  get prop(): number {
+        	    return 1;
+        	  }
+        	  set prop() {}
+        	  method(): void {
+        	    return;
+        	  }
+        	  arrow = (): string => 'arrow';
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "fn(() => {});",
+            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "fn(function () {});",
+            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "[function () {}, () => {}];",
+            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "(function () {});",
+            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "(() => {})();",
+            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "export default (): void => {};",
+            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	var arrowFn: Foo = () => 'test';
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	var funcExpr: Foo = function () {
+        	  return 'test';
+        	};
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "const x = (() => {}) as Foo;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const x = <Foo>(() => {});",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            Some(PathBuf::from("test.ts")),
+        ),
+        (
+            "
+        	const x = {
+        	  foo: () => {},
+        	} as Foo;
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const x = <Foo>{
+        	  foo: () => {},
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            Some(PathBuf::from("test.ts")),
+        ),
+        (
+            "
+        	const x: Foo = {
+        	  foo: () => {},
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const x = {
+        	  foo: { bar: () => {} },
+        	} as Foo;
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const x = <Foo>{
+        	  foo: { bar: () => {} },
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            Some(PathBuf::from("test.ts")),
+        ),
+        (
+            "
+        	const x: Foo = {
+        	  foo: { bar: () => {} },
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type MethodType = () => void;
+
+        	class App {
+        	  private method: MethodType = () => {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <button onClick={() => {}} />;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <button on={{ click: () => {} }} />;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <Bar>{() => {}}</Bar>;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <Bar>{{ on: () => {} }}</Bar>;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <button {...{ onClick: () => {} }} />;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const myObj = {
+        	  set myProp(val) {
+        	    this.myProp = val;
+        	  },
+        	};
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	() => (): void => {};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => function (): void {};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => {
+        	  return (): void => {};
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => {
+        	  return function (): void {};
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => {
+        	  const foo = 'foo';
+        	  return function (): string {
+        	    return foo;
+        	  };
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn() {
+        	  return (): void => {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn() {
+        	  return function (): void {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn() {
+        	  const bar = () => (): number => 1;
+        	  return function (): void {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn(arg: boolean) {
+        	  if (arg) {
+        	    return () => (): number => 1;
+        	  } else {
+        	    return function (): string {
+        	      return 'foo';
+        	    };
+        	  }
+
+        	  return function (): void {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function FunctionDeclaration() {
+        	  return function FunctionExpression_Within_FunctionDeclaration() {
+        	    return function FunctionExpression_Within_FunctionExpression() {
+        	      return () => {
+        	        // ArrowFunctionExpression_Within_FunctionExpression
+        	        return () =>
+        	          // ArrowFunctionExpression_Within_ArrowFunctionExpression
+        	          (): number =>
+        	            1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+        	      };
+        	    };
+        	  };
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => () => {
+        	  return (): void => {
+        	    return;
+        	  };
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	declare function foo(arg: () => void): void;
+        	foo(() => 1);
+        	foo(() => {});
+        	foo(() => null);
+        	foo(() => true);
+        	foo(() => '');
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	declare function foo(arg: () => void): void;
+        	foo?.(() => 1);
+        	foo?.bar(() => {});
+        	foo?.bar?.(() => null);
+        	foo.bar?.(() => true);
+        	foo?.(() => '');
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	class Accumulator {
+        	  private count: number = 0;
+
+        	  public accumulate(fn: () => number): void {
+        	    this.count += fn();
+        	  }
+        	}
+
+        	new Accumulator().accumulate(() => 1);
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	declare function foo(arg: { meth: () => number }): void;
+        	foo({
+        	  meth() {
+        	    return 1;
+        	  },
+        	});
+        	foo({
+        	  meth: function () {
+        	    return 1;
+        	  },
+        	});
+        	foo({
+        	  meth: () => {
+        	    return 1;
+        	  },
+        	});
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const func1 = (value: number) => ({ type: 'X', value }) as const;
+        	const func2 = (value: number) => ({ type: 'X', value }) as const;
+        	const func3 = (value: number) => x as const;
+        	const func4 = (value: number) => x as const;
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	new Promise(resolve => {});
+        	new Foo(1, () => {});
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "const log = (message: string) => void console.log(message);",
+            Some(
+                serde_json::json!([{ "allowConciseArrowFunctionExpressionsStartingWithVoid": true }]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "const log = (a: string) => a;",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "const log = <A,>(a: A): A => a;",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function log<A>(a: A): A {
+        	  return a;
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function log(a: string) {
+        	  return a;
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const log = function <A>(a: A): A {
+        	  return a;
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const log = function (a: A): string {
+        	  return a;
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function test1() {
+        	  return;
+        	}
+
+        	const foo = function test2() {
+        	  return;
+        	};
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowedNames": ["test1", "test2"],        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const test1 = function () {
+        	  return;
+        	};
+        	const foo = function () {
+        	  return function test2() {};
+        	};
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowedNames": ["test1", "test2"],        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const test1 = () => {
+        	  return;
+        	};
+        	export const foo = {
+        	  test2() {
+        	    return 0;
+        	  },
+        	};
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowedNames": ["test1", "test2"],        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	class Test {
+        	  constructor() {}
+        	  get prop() {
+        	    return 1;
+        	  }
+        	  set prop() {}
+        	  method() {
+        	    return;
+        	  }
+        	  arrow = () => 'arrow';
+        	  private method() {
+        	    return;
+        	  }
+        	}
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowedNames": ["prop", "method", "arrow"],        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const x = {
+        	  arrowFn: () => {
+        	    return;
+        	  },
+        	  fn: function () {
+        	    return;
+        	  },
+        	};
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowedNames": ["arrowFn", "fn"],        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	interface Foo {
+        	  foo: string;
+        	  arrowFn: () => string;
+        	}
+
+        	function foo(): Foo {
+        	  return {
+        	    foo: 'foo',
+        	    arrowFn: () => 'test',
+        	  };
+        	}
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	type Foo = (arg1: string) => string;
+        	type Bar<T> = (arg2: string) => T;
+        	const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = function (): number {
+        	  return 1;
+        	};
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const foo = (function () {
+        	  return 1;
+        	})();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const foo = (() => {
+        	  return 1;
+        	})();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const foo = ((arg: number): number => {
+        	  return arg;
+        	})(0);
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const foo = (() => (() => 'foo')())();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = (() => (): string => {
+        	  return 'foo';
+        	})()();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = (() => (): string => {
+        	  return 'foo';
+        	})();
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowIIFEs": true,          "allowHigherOrderFunctions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = (() => (): string => {
+        	  return 'foo';
+        	})()();
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowIIFEs": true,          "allowHigherOrderFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = (() => (): void => {})()();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = (() => (() => {})())();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	class Bar {
+        	  bar: Foo = {
+        	    foo: x => x + 1,
+        	  };
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	class Bar {
+        	  bar: Foo[] = [
+        	    {
+        	      foo: x => x + 1,
+        	    },
+        	  ];
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	type CallBack = () => void;
+
+        	function f(gotcha: CallBack = () => {}): void {}
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type CallBack = () => void;
+
+        	const f = (gotcha: CallBack = () => {}): void => {};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type ObjectWithCallback = { callback: () => void };
+
+        	const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+        	function test(a: number, b: number) {
+        	  return;
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	function test() {
+        	  return;
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	var fn = function () {
+        	  return 1;
+        	};
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	var arrowFn = () => 'test';
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	class Test {
+        	  constructor() {}
+        	  get prop() {
+        	    return 1;
+        	  }
+        	  set prop() {}
+        	  method() {
+        	    return;
+        	  }
+        	  arrow = () => 'arrow';
+        	  private method() {
+        	    return;
+        	  }
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	function test() {
+        	  return;
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = () => {};",
+            Some(serde_json::json!([{ "allowExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = function () {};",
+            Some(serde_json::json!([{ "allowExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "export default () => {};",
+            Some(serde_json::json!([{ "allowExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "export default function () {}",
+            Some(serde_json::json!([{ "allowExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	class Foo {
+        	  public a = () => {};
+        	  public b = function () {};
+        	  public c = function test() {};
+
+        	  static d = () => {};
+        	  static e = function () {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "var arrowFn = () => 'test';",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function foo(): any {
+        	  const bar = () => () => console.log('aa');
+        	}
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        // (
+        //     "
+        // 	let anyValue: any;
+        // 	function foo(): any {
+        // 	  anyValue = () => () => console.log('aa');
+        // 	}
+        // 	      ",
+        //     Some(
+        //         serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+        //     ),
+        //     None,
+        //     None,
+        // ),
+        (
+            "
+        	class Foo {
+        	  foo(): any {
+        	    const bar = () => () => {
+        	      return console.log('foo');
+        	    };
+        	  }
+        	}
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	var funcExpr = function () {
+        	  return 'test';
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "const x = (() => {}) as Foo;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	interface Foo {}
+        	const x = {
+        	  foo: () => {},
+        	} as Foo;
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	interface Foo {}
+        	const x: Foo = {
+        	  foo: () => {},
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <button onClick={() => {}} />;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <button on={{ click: () => {} }} />;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <Bar>{() => {}}</Bar>;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <Bar>{{ on: () => {} }}</Bar>;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "const foo = <button {...{ onClick: () => {} }} />;",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function foo(): any {
+        	  class Foo {
+        	    foo = () => () => {
+        	      return console.log('foo');
+        	    };
+        	  }
+        	}
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "() => () => {};",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "() => function () {};",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => {
+        	  return () => {};
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => {
+        	  return function () {};
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn() {
+        	  return () => {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn() {
+        	  return function () {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn() {
+        	  const bar = () => (): number => 1;
+        	  const baz = () => () => 'baz';
+        	  return function (): void {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function fn(arg: boolean) {
+        	  if (arg) return 'string';
+        	  return function (): void {};
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function FunctionDeclaration() {
+        	  return function FunctionExpression_Within_FunctionDeclaration() {
+        	    return function FunctionExpression_Within_FunctionExpression() {
+        	      return () => {
+        	        // ArrowFunctionExpression_Within_FunctionExpression
+        	        return () =>
+        	          // ArrowFunctionExpression_Within_ArrowFunctionExpression
+        	          () =>
+        	            1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+        	      };
+        	    };
+        	  };
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	() => () => {
+        	  return () => {
+        	    return;
+        	  };
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	declare function foo(arg: () => void): void;
+        	foo(() => 1);
+        	foo(() => {});
+        	foo(() => null);
+        	foo(() => true);
+        	foo(() => '');
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	class Accumulator {
+        	  private count: number = 0;
+
+        	  public accumulate(fn: () => number): void {
+        	    this.count += fn();
+        	  }
+        	}
+
+        	new Accumulator().accumulate(() => 1);
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "(() => true)();",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	declare function foo(arg: { meth: () => number }): void;
+        	foo({
+        	  meth() {
+        	    return 1;
+        	  },
+        	});
+        	foo({
+        	  meth: function () {
+        	    return 1;
+        	  },
+        	});
+        	foo({
+        	  meth: () => {
+        	    return 1;
+        	  },
+        	});
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": false,          "allowHigherOrderFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowTypedFunctionExpressions": false,          "allowHigherOrderFunctions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const func1 = (value: number) => ({ type: 'X', value }) as any;
+        	const func2 = (value: number) => ({ type: 'X', value }) as Action;
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const func = (value: number) => ({ type: 'X', value }) as const;
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": false,        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "const log = (message: string) => void console.log(message);",
+            Some(
+                serde_json::json!([        { "allowConciseArrowFunctionExpressionsStartingWithVoid": false },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	        const log = (message: string) => {
+        	          void console.log(message);
+        	        };
+        	      ",
+            Some(
+                serde_json::json!([{ "allowConciseArrowFunctionExpressionsStartingWithVoid": true }]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "const log = <A,>(a: A) => a;",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function log<A>(a: A) {
+        	  return a;
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const log = function <A>(a: A) {
+        	  return a;
+        	};
+        	      ",
+            Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	function hoge() {
+        	  return;
+        	}
+        	const foo = () => {
+        	  return;
+        	};
+        	const baz = function () {
+        	  return;
+        	};
+        	let [test, test2] = function () {
+        	  return;
+        	};
+        	class X {
+        	  [test] = function () {
+        	    return;
+        	  };
+        	}
+        	const x = {
+        	  1: function () {
+        	    return;
+        	  },
+        	};
+        	      ",
+            Some(
+                serde_json::json!([        {          "allowedNames": ["test", "1"],        },      ]),
+            ),
+            None,
+            None,
+        ),
+        (
+            "
+        	const ignoredName = 'notIgnoredName';
+        	class Foo {
+        	  [ignoredName]() {}
+        	}
+        	      ",
+            Some(serde_json::json!([{ "allowedNames": ["ignoredName"] }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	class Bar {
+        	  bar = [
+        	    {
+        	      foo: x => x + 1,
+        	    },
+        	  ];
+        	}
+        	      ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+        	const foo = (function () {
+        	  return 'foo';
+        	})();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": false,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	const foo = (function () {
+        	  return () => {
+        	    return 1;
+        	  };
+        	})();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = function () {
+        	  return 'foo';
+        	};
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	let foo = (() => () => {})()();
+        	      ",
+            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type CallBack = () => void;
+
+        	function f(gotcha: CallBack = () => {}): void {}
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type CallBack = () => void;
+
+        	const f = (gotcha: CallBack = () => {}): void => {};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type ObjectWithCallback = { callback: () => void };
+
+        	const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+        	      ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
+            None,
+            None,
+        ),
+    ];
+
+    Tester::new(ExplicitFunctionReturnType::NAME, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/explicit_function_return_type.snap
@@ -1,0 +1,673 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: explicit_function_return_type
+---
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:10]
+ 1 │ 
+ 2 │             function test(a: number, b: number) {
+   ·             ─────────────
+ 3 │               return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:10]
+ 1 │ 
+ 2 │             function test() {
+   ·             ─────────────
+ 3 │               return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:19]
+ 1 │ 
+ 2 │             var fn = function () {
+   ·                      ─────────
+ 3 │               return 1;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:27]
+ 1 │ 
+ 2 │             var arrowFn = () => 'test';
+   ·                              ──
+ 3 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:12]
+ 3 │               constructor() {}
+ 4 │               get prop() {
+   ·               ────────
+ 5 │                 return 1;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:8:12]
+ 7 │               set prop() {}
+ 8 │               method() {
+   ·               ──────
+ 9 │                 return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:11:12]
+ 10 │               }
+ 11 │               arrow = () => 'arrow';
+    ·               ────────
+ 12 │               private method() {
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:12:12]
+ 11 │               arrow = () => 'arrow';
+ 12 │               private method() {
+    ·               ──────────────
+ 13 │                 return;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:10]
+ 1 │ 
+ 2 │             function test() {
+   ·             ─────────────
+ 3 │               return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:16]
+ 1 │ const foo = () => {};
+   ·                ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:13]
+ 1 │ const foo = function () {};
+   ·             ─────────
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:19]
+ 1 │ export default () => {};
+   ·                   ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:16]
+ 1 │ export default function () {}
+   ·                ─────────
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:12]
+ 2 │             class Foo {
+ 3 │               public a = () => {};
+   ·               ───────────
+ 4 │               public b = function () {};
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:12]
+ 3 │               public a = () => {};
+ 4 │               public b = function () {};
+   ·               ────────────────────
+ 5 │               public c = function test() {};
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:5:12]
+ 4 │               public b = function () {};
+ 5 │               public c = function test() {};
+   ·               ────────────────────────
+ 6 │ 
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:7:12]
+ 6 │ 
+ 7 │               static d = () => {};
+   ·               ───────────
+ 8 │               static e = function () {};
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:8:12]
+ 7 │               static d = () => {};
+ 8 │               static e = function () {};
+   ·               ────────────────────
+ 9 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:18]
+ 1 │ var arrowFn = () => 'test';
+   ·                  ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:33]
+ 2 │             function foo(): any {
+ 3 │               const bar = () => () => console.log('aa');
+   ·                                    ──
+ 4 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:35]
+ 3 │               foo(): any {
+ 4 │                 const bar = () => () => {
+   ·                                      ──
+ 5 │                   return console.log('foo');
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:25]
+ 1 │ 
+ 2 │             var funcExpr = function () {
+   ·                            ─────────
+ 3 │               return 'test';
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:15]
+ 1 │ const x = (() => {}) as Foo;
+   ·               ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:12]
+ 3 │             const x = {
+ 4 │               foo: () => {},
+   ·               ─────
+ 5 │             } as Foo;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:12]
+ 3 │             const x: Foo = {
+ 4 │               foo: () => {},
+   ·               ─────
+ 5 │             };
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:33]
+ 1 │ const foo = <button onClick={() => {}} />;
+   ·                                 ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:27]
+ 1 │ const foo = <button on={{ click: () => {} }} />;
+   ·                           ───────
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:22]
+ 1 │ const foo = <Bar>{() => {}}</Bar>;
+   ·                      ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:21]
+ 1 │ const foo = <Bar>{{ on: () => {} }}</Bar>;
+   ·                     ────
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:27]
+ 1 │ const foo = <button {...{ onClick: () => {} }} />;
+   ·                           ─────────
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:29]
+ 3 │               class Foo {
+ 4 │                 foo = () => () => {
+   ·                                ──
+ 5 │                   return console.log('foo');
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:10]
+ 1 │ () => () => {};
+   ·          ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:7]
+ 1 │ () => function () {};
+   ·       ─────────
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:22]
+ 2 │             () => {
+ 3 │               return () => {};
+   ·                         ──
+ 4 │             };
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:19]
+ 2 │             () => {
+ 3 │               return function () {};
+   ·                      ─────────
+ 4 │             };
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:22]
+ 2 │             function fn() {
+ 3 │               return () => {};
+   ·                         ──
+ 4 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:19]
+ 2 │             function fn() {
+ 3 │               return function () {};
+   ·                      ─────────
+ 4 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:33]
+ 3 │               const bar = () => (): number => 1;
+ 4 │               const baz = () => () => 'baz';
+   ·                                    ──
+ 5 │               return function (): void {};
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:10]
+ 1 │ 
+ 2 │             function fn(arg: boolean) {
+   ·             ───────────
+ 3 │               if (arg) return 'string';
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:9:23]
+  8 │                       // ArrowFunctionExpression_Within_ArrowFunctionExpression
+  9 │                       () =>
+    ·                          ──
+ 10 │                         1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:22]
+ 2 │             () => () => {
+ 3 │               return () => {
+   ·                         ──
+ 4 │                 return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:17]
+ 2 │             declare function foo(arg: () => void): void;
+ 3 │             foo(() => 1);
+   ·                    ──
+ 4 │             foo(() => {});
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:17]
+ 3 │             foo(() => 1);
+ 4 │             foo(() => {});
+   ·                    ──
+ 5 │             foo(() => null);
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:5:17]
+ 4 │             foo(() => {});
+ 5 │             foo(() => null);
+   ·                    ──
+ 6 │             foo(() => true);
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:6:17]
+ 5 │             foo(() => null);
+ 6 │             foo(() => true);
+   ·                    ──
+ 7 │             foo(() => '');
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:7:17]
+ 6 │             foo(() => true);
+ 7 │             foo(() => '');
+   ·                    ──
+ 8 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:10:42]
+  9 │ 
+ 10 │             new Accumulator().accumulate(() => 1);
+    ·                                             ──
+ 11 │                   
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:5]
+ 1 │ (() => true)();
+   ·     ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:12]
+ 3 │             foo({
+ 4 │               meth() {
+   ·               ────
+ 5 │                 return 1;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:9:12]
+  8 │             foo({
+  9 │               meth: function () {
+    ·               ───────────────
+ 10 │                 return 1;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:14:12]
+ 13 │             foo({
+ 14 │               meth: () => {
+    ·               ──────
+ 15 │                 return 1;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:56]
+ 2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+ 3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+   ·                                                           ──
+ 4 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:40]
+ 2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+ 3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+   ·                                           ──
+ 4 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:48]
+ 2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+ 3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+   ·                                                   ──
+ 4 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:56]
+ 2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+ 3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+   ·                                                           ──
+ 4 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:40]
+ 1 │ 
+ 2 │             const func1 = (value: number) => ({ type: 'X', value }) as any;
+   ·                                           ──
+ 3 │             const func2 = (value: number) => ({ type: 'X', value }) as Action;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:40]
+ 2 │             const func1 = (value: number) => ({ type: 'X', value }) as any;
+ 3 │             const func2 = (value: number) => ({ type: 'X', value }) as Action;
+   ·                                           ──
+ 4 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:39]
+ 1 │ 
+ 2 │             const func = (value: number) => ({ type: 'X', value }) as const;
+   ·                                          ──
+ 3 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:31]
+ 1 │ const log = (message: string) => void console.log(message);
+   ·                               ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:48]
+ 1 │ 
+ 2 │                     const log = (message: string) => {
+   ·                                                   ──
+ 3 │                       void console.log(message);
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:1:24]
+ 1 │ const log = <A,>(a: A) => a;
+   ·                        ──
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:10]
+ 1 │ 
+ 2 │             function log<A>(a: A) {
+   ·             ────────────
+ 3 │               return a;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:22]
+ 1 │ 
+ 2 │             const log = function <A>(a: A) {
+   ·                         ────────────
+ 3 │               return a;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:10]
+ 1 │ 
+ 2 │             function hoge() {
+   ·             ─────────────
+ 3 │               return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:5:25]
+ 4 │             }
+ 5 │             const foo = () => {
+   ·                            ──
+ 6 │               return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:8:22]
+ 7 │             };
+ 8 │             const baz = function () {
+   ·                         ─────────
+ 9 │               return;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:11:30]
+ 10 │             };
+ 11 │             let [test, test2] = function () {
+    ·                                 ─────────
+ 12 │               return;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:15:12]
+ 14 │             class X {
+ 15 │               [test] = function () {
+    ·               ──────────────────
+ 16 │                 return;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:20:12]
+ 19 │             const x = {
+ 20 │               1: function () {
+    ·               ────────────
+ 21 │                 return;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:12]
+ 3 │             class Foo {
+ 4 │               [ignoredName]() {}
+   ·               ─────────────
+ 5 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:5:16]
+ 4 │                 {
+ 5 │                   foo: x => x + 1,
+   ·                   ─────
+ 6 │                 },
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:23]
+ 1 │ 
+ 2 │             const foo = (function () {
+   ·                          ─────────
+ 3 │               return 'foo';
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:22]
+ 2 │             const foo = (function () {
+ 3 │               return () => {
+   ·                         ──
+ 4 │                 return 1;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:20]
+ 1 │ 
+ 2 │             let foo = function () {
+   ·                       ─────────
+ 3 │               return 'foo';
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:2:30]
+ 1 │ 
+ 2 │             let foo = (() => () => {})()();
+   ·                                 ──
+ 3 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:43]
+ 3 │ 
+ 4 │             function f(gotcha: CallBack = () => {}): void {}
+   ·                                              ──
+ 5 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:43]
+ 3 │ 
+ 4 │             const f = (gotcha: CallBack = () => {}): void => {};
+   ·                                              ──
+ 5 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:52]
+ 3 │ 
+ 4 │             const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+   ·                                                       ──────────
+ 5 │                   
+   ╰────
+  help: Require explicit return types on functions and class methods.

--- a/crates/oxc_linter/src/snapshots/explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/explicit_function_return_type.snap
@@ -173,6 +173,15 @@ expression: explicit_function_return_type
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:4:32]
+ 3 │             function foo(): any {
+ 4 │               anyValue = () => () => console.log('aa');
+   ·                                   ──
+ 5 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:4:35]
  3 │               foo(): any {
  4 │                 const bar = () => () => {


### PR DESCRIPTION
Related issue: https://github.com/oxc-project/oxc/issues/2180

original implementation

- code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
- test: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
- doc: https://typescript-eslint.io/rules/explicit-function-return-type/