### PR TITLE
chore(parser): code comment for cold trampoline function

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -308,6 +308,8 @@ impl<'a> Lexer<'a> {
 }
 
 /// Call a closure while hinting to compiler that this branch is rarely taken.
+/// "Cold trampoline function", suggested in:
+/// <https://users.rust-lang.org/t/is-cold-the-only-reliable-way-to-hint-to-branch-predictor/106509/2>
 #[cold]
 pub fn cold_branch<F: FnOnce() -> T, T>(f: F) -> T {
     f()


### PR DESCRIPTION
Add a comment to explain the "cold trampoline function" used in lexer.