### PR TITLE
refactor(transformer): remove unreachable code from TS namespace transform

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -227,6 +227,8 @@ impl<'a> TypeScript<'a> {
                     new_stmts.push(Statement::VariableDeclaration(decl));
                 }
                 Statement::ExportNamedDeclaration(export_decl) => {
+                    // NB: `ExportNamedDeclaration` with no declaration (e.g. `export {x}`) is not
+                    // legal syntax in TS namespaces
                     let export_decl = export_decl.unbox();
                     if let Some(decl) = export_decl.declaration {
                         if decl.modifiers().is_some_and(Modifiers::is_contains_declare) {
@@ -294,13 +296,6 @@ impl<'a> TypeScript<'a> {
                             }
                             _ => {}
                         }
-                    } else {
-                        let stmt = self.ctx.ast.module_declaration(
-                            ModuleDeclaration::ExportNamedDeclaration(
-                                self.ctx.ast.alloc(export_decl),
-                            ),
-                        );
-                        new_stmts.push(stmt);
                     }
                 }
                 stmt => {


### PR DESCRIPTION
As discussed in https://github.com/oxc-project/oxc/pull/3468#discussion_r1619782711, `export {x}` is not legal inside a TS namespace. So remove the code which handles this impossible case.