### PR TITLE
refactor(transformer): explicit skip TS statements in TS namespace transform

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -253,12 +253,10 @@ impl<'a> TypeScript<'a> {
                         }
                     }
                 }
-                stmt => {
-                    if let Some(decl) = stmt.as_declaration() {
-                        if decl.is_typescript_syntax() {
-                            continue;
-                        }
-                    }
+                Statement::TSTypeAliasDeclaration(_)
+                | Statement::TSInterfaceDeclaration(_)
+                | Statement::TSImportEqualsDeclaration(_) => {}
+                _ => {
                     new_stmts.push(stmt);
                 }
             }


### PR DESCRIPTION
No substantive change. This should just be slightly more efficient as we've already handled most of the other variants earlier in the match.