### PR TITLE
refactor(transformer/typescript): use a memory-safe implementation instead

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -337,18 +337,20 @@ impl<'a> TypeScriptAnnotations<'a> {
 
         // Add assignments after super calls
         if !self.assignments.is_empty() {
-            let mut super_indexes = vec![];
-            for (index, stmt) in stmts.iter().rev().enumerate() {
-                if matches!(stmt, Statement::ExpressionStatement(stmt) if stmt.expression.is_super_call_expression())
-                {
-                    super_indexes.push(index);
+            let has_super_call = stmts.iter().any(|stmt| {
+                matches!(stmt, Statement::ExpressionStatement(stmt) if stmt.expression.is_super_call_expression())
+            });
+            if has_super_call {
+                let mut new_stmts = self.ctx.ast.new_vec();
+                for stmt in stmts.drain(..) {
+                    let is_super_call = matches!(stmt, Statement::ExpressionStatement(ref stmt) if stmt.expression.is_super_call_expression());
+                    new_stmts.push(stmt);
+                    if is_super_call {
+                        new_stmts.extend(self.ctx.ast.copy(&self.assignments));
+                    }
                 }
-            }
-            if !super_indexes.is_empty() {
                 self.has_super_call = true;
-                for index in super_indexes.iter().rev() {
-                    stmts.splice((index + 1)..=*index, self.ctx.ast.copy(&self.assignments));
-                }
+                *stmts = new_stmts;
             }
         }
     }

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,13 +2,10 @@ commit: 64d2eeea
 
 transformer_typescript Summary:
 AST Parsed     : 5243/5243 (100.00%)
-Positive Passed: 5234/5243 (99.83%)
+Positive Passed: 5237/5243 (99.89%)
 Mismatch: "compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts"
 Mismatch: "compiler/jsxComplexSignatureHasApplicabilityError.tsx"
 Mismatch: "compiler/jsxEmptyExpressionNotCountedAsChild.tsx"
 Mismatch: "compiler/sourceMapValidationClasses.ts"
 Mismatch: "compiler/styledComponentsInstantiaionLimitNotReached.ts"
 Mismatch: "compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx"
-Mismatch: "conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall.ts"
-Mismatch: "conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields.ts"
-Mismatch: "conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.11.ts"


### PR DESCRIPTION
The previous implementation causes memory double free, but I don't know why.