### PR TITLE
refactor(ast): remove defunct hashing of `Span`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -73,7 +73,6 @@ impl<'a> Program<'a> {
 
 impl<'a> Hash for Program<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.source_type.hash(state);
         self.directives.hash(state);
         self.hashbang.hash(state);
@@ -455,7 +454,6 @@ pub struct IdentifierReference<'a> {
 
 impl<'a> Hash for IdentifierReference<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.name.hash(state);
     }
 }
@@ -481,7 +479,6 @@ pub struct BindingIdentifier<'a> {
 
 impl<'a> Hash for BindingIdentifier<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.name.hash(state);
     }
 }
@@ -1580,7 +1577,6 @@ impl<'a> BlockStatement<'a> {
 
 impl<'a> Hash for BlockStatement<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.body.hash(state);
     }
 }
@@ -1834,7 +1830,6 @@ impl<'a> ForStatement<'a> {
 
 impl<'a> Hash for ForStatement<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.init.hash(state);
         self.test.hash(state);
         self.update.hash(state);
@@ -1896,7 +1891,6 @@ impl<'a> ForInStatement<'a> {
 
 impl<'a> Hash for ForInStatement<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.left.hash(state);
         self.right.hash(state);
         self.body.hash(state);
@@ -1932,7 +1926,6 @@ impl<'a> ForOfStatement<'a> {
 
 impl<'a> Hash for ForOfStatement<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.r#await.hash(state);
         self.left.hash(state);
         self.right.hash(state);
@@ -2033,7 +2026,6 @@ impl<'a> SwitchStatement<'a> {
 
 impl<'a> Hash for SwitchStatement<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.discriminant.hash(state);
         self.cases.hash(state);
     }
@@ -2116,7 +2108,6 @@ impl<'a> CatchClause<'a> {
 
 impl<'a> Hash for CatchClause<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.param.hash(state);
         self.body.hash(state);
     }
@@ -2402,7 +2393,6 @@ impl<'a> Function<'a> {
 impl<'a> Hash for Function<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.r#type.hash(state);
-        self.span.hash(state);
         self.id.hash(state);
         self.generator.hash(state);
         self.r#async.hash(state);
@@ -2572,7 +2562,6 @@ impl<'a> ArrowFunctionExpression<'a> {
 
 impl<'a> Hash for ArrowFunctionExpression<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.expression.hash(state);
         self.r#async.hash(state);
         self.params.hash(state);
@@ -2664,7 +2653,6 @@ impl<'a> Class<'a> {
 impl<'a> Hash for Class<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.r#type.hash(state);
-        self.span.hash(state);
         self.decorators.hash(state);
         self.id.hash(state);
         self.super_class.hash(state);
@@ -2921,7 +2909,6 @@ impl<'a> StaticBlock<'a> {
 
 impl<'a> Hash for StaticBlock<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.body.hash(state);
     }
 }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -73,7 +73,6 @@ impl<'a> TSEnumDeclaration<'a> {
 
 impl<'a> Hash for TSEnumDeclaration<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.id.hash(state);
         self.members.hash(state);
         self.modifiers.hash(state);
@@ -653,7 +652,6 @@ impl<'a> TSTypeParameter<'a> {
 
 impl<'a> Hash for TSTypeParameter<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.name.hash(state);
         self.constraint.hash(state);
         self.default.hash(state);
@@ -952,7 +950,6 @@ impl<'a> TSModuleBlock<'a> {
 
 impl<'a> Hash for TSModuleBlock<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.body.hash(state);
     }
 }


### PR DESCRIPTION
`Span` has a no-op `Hash` impl.

https://github.com/oxc-project/oxc/blob/ea532679560bb0bd0ae76e9dde4611b595a3ea28/crates/oxc_span/src/span.rs#L50-L54

So remove pointless `self.span.hash(state)` operations from `Hash` impls for AST nodes. 