### PR TITLE
refactor(ast): rename function params

### DIFF
--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -13,10 +13,13 @@ use walk::*;
 
 /// Syntax tree traversal
 pub trait Visit<'a>: Sized {
-    fn enter_node(&mut self, _kind: AstKind<'a>) {}
-    fn leave_node(&mut self, _kind: AstKind<'a>) {}
+    #[allow(unused_variables)]
+    fn enter_node(&mut self, kind: AstKind<'a>) {}
+    #[allow(unused_variables)]
+    fn leave_node(&mut self, kind: AstKind<'a>) {}
 
-    fn enter_scope(&mut self, _flags: ScopeFlags) {}
+    #[allow(unused_variables)]
+    fn enter_scope(&mut self, flags: ScopeFlags) {}
     fn leave_scope(&mut self) {}
 
     fn alloc<T>(&self, t: &T) -> &'a T {

--- a/crates/oxc_ast/src/visit/visit_mut.rs
+++ b/crates/oxc_ast/src/visit/visit_mut.rs
@@ -10,10 +10,13 @@ use self::walk_mut::*;
 
 /// Syntax tree traversal to mutate an exclusive borrow of a syntax tree in place.
 pub trait VisitMut<'a>: Sized {
-    fn enter_node(&mut self, _kind: AstType) {}
-    fn leave_node(&mut self, _kind: AstType) {}
+    #[allow(unused_variables)]
+    fn enter_node(&mut self, kind: AstType) {}
+    #[allow(unused_variables)]
+    fn leave_node(&mut self, kind: AstType) {}
 
-    fn enter_scope(&mut self, _flags: ScopeFlags) {}
+    #[allow(unused_variables)]
+    fn enter_scope(&mut self, flags: ScopeFlags) {}
     fn leave_scope(&mut self) {}
 
     fn visit_program(&mut self, program: &mut Program<'a>) {


### PR DESCRIPTION
Rename function params from `_kind` to `kind`. This has no practical effect but makes Rust Analyser give nicer param name hints when using these APIs.