### PR TITLE
fix(semantic): set program scope_id for TS definition files

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -140,7 +140,8 @@ impl<'a> SemanticBuilder<'a> {
 
     pub fn build(mut self, program: &Program<'a>) -> SemanticBuilderReturn<'a> {
         if self.source_type.is_typescript_definition() {
-            self.scope.add_scope(None, ScopeFlags::Top);
+            let scope_id = self.scope.add_scope(None, ScopeFlags::Top);
+            program.scope_id.set(Some(scope_id));
         } else {
             self.visit_program(program);
 


### PR DESCRIPTION
Semantic does not visit the AST for TS definition files, but it does create a root scope. Record this scope ID in `Program`'s `scope_id` field.