### PR TITLE
fix(transformer): output empty file for TS definition files

### DIFF
--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -69,7 +69,14 @@ impl<'a> TypeScript<'a> {
 // Transforms
 impl<'a> TypeScript<'a> {
     pub fn transform_program(&self, program: &mut Program<'a>, ctx: &mut TraverseCtx) {
-        self.transform_program_for_namespace(program, ctx);
+        if self.ctx.source_type.is_typescript_definition() {
+            // Output empty file for TS definitions
+            program.directives.clear();
+            program.hashbang = None;
+            program.body.clear();
+        } else {
+            self.transform_program_for_namespace(program, ctx);
+        }
     }
 
     pub fn transform_program_on_exit(&self, program: &mut Program<'a>) {

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 4bd1b2c2
 
-Passed: 2/2
+Passed: 3/3
 
 # All Passed:
 * babel-plugin-transform-typescript

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-declaration-empty-output/input.d.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-declaration-empty-output/input.d.ts
@@ -1,0 +1,14 @@
+export interface Things<P, T> {
+    p: P;
+    t: T;
+}
+
+export interface Props {
+}
+
+export default class MyComponent {
+    props: Props;
+}
+export namespace Something {
+    export const foo = 123;
+}


### PR DESCRIPTION
As discussed in https://github.com/oxc-project/oxc/pull/3489#issuecomment-2143482458, transformer should output an empty file for TS definition files.