### PR TITLE
fix(transformer): TS namespace transform do not track var decl names

### DIFF
--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 4bd1b2c2
 
-Passed: 480/928
+Passed: 478/926
 
 # All Passed:
 * babel-preset-react
@@ -445,7 +445,7 @@ Passed: 480/928
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (136/152)
+# babel-plugin-transform-typescript (134/150)
 * enum/mix-references/input.ts
 * enum/ts5.0-const-foldable/input.ts
 * exports/declared-types/input.ts

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -91,5 +91,7 @@ pub(crate) const SKIP_TESTS: &[&str] = &[
     "typescript/test/fixtures/namespace/nested-shorthand-export/input.ts",
     "react-jsx-development/test/fixtures/cross-platform/self-inside-arrow/input.mjs",
     // Babel outputs is not correct
+    "typescript/test/fixtures/namespace/clobber-import/input.ts",
+    "typescript/test/fixtures/namespace/namespace-nested-module/input.ts",
     "typescript/test/fixtures/namespace/nested-destructuring/input.ts",
 ];


### PR DESCRIPTION
Don't track variable declaration or import binding names in TS namespace transform.

Babel does, but it appears to be wrong. It's illegal to have a `var`/`let`/`const` declaration or import in same scope as a TS namespace declaration with same binding.

https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAQTgMyhEcDkUCmBDAYxkwG4AoAOzxBwGcxCdE4BvAXzLIIgtvgCE4AXjgBGclRr1GcQSzJxFcADY54AD3Icyq+AGFhYidToMCTA-KUq1cTWW0A3PFDgARQ+Monp596wUlXTstMiA