### PR TITLE
chore(codegen): print typescript code for typescript files

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -49,6 +49,17 @@ pub struct CodegenOptions {
     pub preserve_annotate_comments: bool,
 }
 
+impl CodegenOptions {
+    #[must_use]
+    pub fn with_typescript(mut self, yes: bool) -> Self {
+        if yes {
+            self.enable_typescript = true;
+        }
+
+        self
+    }
+}
+
 pub struct CodegenReturn {
     pub source_text: String,
     pub source_map: Option<oxc_sourcemap::SourceMap>,

--- a/tasks/coverage/codegen_typescript.snap
+++ b/tasks/coverage/codegen_typescript.snap
@@ -2,12 +2,9 @@ commit: 64d2eeea
 
 codegen_typescript Summary:
 AST Parsed     : 5243/5243 (100.00%)
-Positive Passed: 5235/5243 (99.85%)
-Typescript failed: "compiler/castExpressionParentheses.ts"
-Default failed: "compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts"
-Typescript failed: "compiler/genericTypeAssertions3.ts"
+Positive Passed: 5238/5243 (99.90%)
+Default failed: "compiler/castExpressionParentheses.ts"
+Default failed: "compiler/genericTypeAssertions3.ts"
 Default failed: "compiler/jsxMultilineAttributeStringValues.tsx"
 Default failed: "compiler/jsxMultilineAttributeValuesReact.tsx"
-Default failed: "compiler/typeAliasDeclarationEmit3.ts"
-Default failed: "conformance/constEnums/constEnum4.ts"
 Default failed: "conformance/jsx/tsxReactEmitEntities.tsx"


### PR DESCRIPTION
We should not print typescript code as javascript code. Forcing to print as JavaScript code may result in syntax errors. If we truly want javascript code, we can use the `oxc_transformer`.