### PR TITLE
refactor(traverse): `generate_uid` return `SymbolId`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -250,9 +250,10 @@ impl<'a> SemanticBuilder<'a> {
         }
 
         let includes = includes | self.current_symbol_flags;
-        let symbol_id = self.symbols.create_symbol(span, name, includes, scope_id);
+        let name = CompactStr::new(name);
+        let symbol_id = self.symbols.create_symbol(span, name.clone(), includes, scope_id);
         self.symbols.add_declaration(self.current_node_id);
-        self.scope.add_binding(scope_id, CompactStr::from(name), symbol_id);
+        self.scope.add_binding(scope_id, name, symbol_id);
         symbol_id
     }
 
@@ -310,9 +311,11 @@ impl<'a> SemanticBuilder<'a> {
         includes: SymbolFlags,
     ) -> SymbolId {
         let includes = includes | self.current_symbol_flags;
-        let symbol_id = self.symbols.create_symbol(span, name, includes, self.current_scope_id);
+        let name = CompactStr::new(name);
+        let symbol_id =
+            self.symbols.create_symbol(span, name.clone(), includes, self.current_scope_id);
         self.symbols.add_declaration(self.current_node_id);
-        self.scope.get_bindings_mut(scope_id).insert(CompactStr::from(name), symbol_id);
+        self.scope.get_bindings_mut(scope_id).insert(name, symbol_id);
         symbol_id
     }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -117,12 +117,12 @@ impl SymbolTable {
     pub fn create_symbol(
         &mut self,
         span: Span,
-        name: &str,
+        name: CompactStr,
         flag: SymbolFlags,
         scope_id: ScopeId,
     ) -> SymbolId {
         _ = self.spans.push(span);
-        _ = self.names.push(CompactStr::from(name));
+        _ = self.names.push(name);
         _ = self.flags.push(flag);
         _ = self.scope_ids.push(scope_id);
         _ = self.resolved_references.push(vec![]);

--- a/crates/oxc_transformer/src/react/jsx/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx/mod.rs
@@ -251,11 +251,12 @@ impl<'a> ReactJsx<'a> {
         ctx: &mut TraverseCtx,
     ) -> CompactStr {
         let root_scope_id = ctx.scopes().root_scope_id();
-        let local = ctx.generate_uid(name, root_scope_id, SymbolFlags::FunctionScopedVariable);
+        let symbol_id = ctx.generate_uid(name, root_scope_id, SymbolFlags::FunctionScopedVariable);
+        let local = &ctx.symbols().names[symbol_id];
 
         let import = NamedImport::new(name.into(), Some(local.clone()));
         self.ctx.module_imports.add_import(source, import);
-        local
+        local.clone()
     }
 
     fn add_require_statement(
@@ -266,12 +267,13 @@ impl<'a> ReactJsx<'a> {
         ctx: &mut TraverseCtx,
     ) -> CompactStr {
         let root_scope_id = ctx.scopes().root_scope_id();
-        let variable_name =
+        let symbol_id =
             ctx.generate_uid(variable_name, root_scope_id, SymbolFlags::FunctionScopedVariable);
+        let variable_name = &ctx.symbols().names[symbol_id];
 
         let import = NamedImport::new(variable_name.clone(), None);
         self.ctx.module_imports.add_require(source, import, front);
-        variable_name
+        variable_name.clone()
     }
 }
 

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -139,11 +139,8 @@ impl<'a> TypeScript<'a> {
 
         // Reuse `TSModuleDeclaration`'s scope in transformed function
         let scope_id = decl.scope_id.get().unwrap();
-        let name = self.ctx.ast.new_atom(&ctx.generate_uid(
-            &real_name,
-            scope_id,
-            SymbolFlags::FunctionScopedVariable,
-        ));
+        let symbol_id = ctx.generate_uid(&real_name, scope_id, SymbolFlags::FunctionScopedVariable);
+        let name = self.ctx.ast.new_atom(ctx.symbols().get_name(symbol_id));
 
         let namespace_top_level = match body {
             TSModuleDeclarationBody::TSModuleBlock(block) => block.unbox().body,

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -1,10 +1,9 @@
 use oxc_allocator::{Allocator, Box};
 use oxc_ast::AstBuilder;
 use oxc_semantic::{ScopeTree, SymbolTable};
-use oxc_span::CompactStr;
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
-    symbol::SymbolFlags,
+    symbol::{SymbolFlags, SymbolId},
 };
 
 use crate::ancestor::{Ancestor, AncestorType};
@@ -277,19 +276,14 @@ impl<'a> TraverseCtx<'a> {
     /// Generate UID.
     ///
     /// This is a shortcut for `ctx.scoping.generate_uid`.
-    pub fn generate_uid(
-        &mut self,
-        name: &str,
-        scope_id: ScopeId,
-        flags: SymbolFlags,
-    ) -> CompactStr {
+    pub fn generate_uid(&mut self, name: &str, scope_id: ScopeId, flags: SymbolFlags) -> SymbolId {
         self.scoping.generate_uid(name, scope_id, flags)
     }
 
     /// Generate UID in current scope.
     ///
     /// This is a shortcut for `ctx.scoping.generate_uid_in_current_scope`.
-    pub fn generate_uid_in_current_scope(&mut self, name: &str, flags: SymbolFlags) -> CompactStr {
+    pub fn generate_uid_in_current_scope(&mut self, name: &str, flags: SymbolFlags) -> SymbolId {
         self.scoping.generate_uid_in_current_scope(name, flags)
     }
 }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -6,7 +6,7 @@ use oxc_semantic::{ScopeTree, SymbolTable};
 use oxc_span::{CompactStr, SPAN};
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
-    symbol::SymbolFlags,
+    symbol::{SymbolFlags, SymbolId},
 };
 
 use super::FinderRet;
@@ -169,24 +169,18 @@ impl TraverseScoping {
     ///
     /// This is a slightly different method from Babel, but hopefully close enough that output will
     /// match Babel for most (or maybe all) test cases.
-    pub fn generate_uid(
-        &mut self,
-        name: &str,
-        scope_id: ScopeId,
-        flags: SymbolFlags,
-    ) -> CompactStr {
+    pub fn generate_uid(&mut self, name: &str, scope_id: ScopeId, flags: SymbolFlags) -> SymbolId {
         // Get name for UID
         let name = CompactStr::new(&self.find_uid_name(name));
 
         // Add binding to scope
-        let symbol_id = self.symbols.create_symbol(SPAN, name.as_str(), flags, scope_id);
-        self.scopes.add_binding(scope_id, name.clone(), symbol_id);
-
-        name
+        let symbol_id = self.symbols.create_symbol(SPAN, name.clone(), flags, scope_id);
+        self.scopes.add_binding(scope_id, name, symbol_id);
+        symbol_id
     }
 
     /// Generate UID in current scope.
-    pub fn generate_uid_in_current_scope(&mut self, name: &str, flags: SymbolFlags) -> CompactStr {
+    pub fn generate_uid_in_current_scope(&mut self, name: &str, flags: SymbolFlags) -> SymbolId {
         self.generate_uid(name, self.current_scope_id, flags)
     }
 }


### PR DESCRIPTION
Preparatory step for setting correct `SymbolId` for identifiers added to AST in transformer.