### PR TITLE
fix(transformer): JSX set `reference_id` on refs to imports

### DIFF
--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -30,6 +30,16 @@ impl Reference {
         Self { span, name, node_id, symbol_id: None, flag }
     }
 
+    pub fn new_with_symbol_id(
+        span: Span,
+        name: CompactStr,
+        node_id: AstNodeId,
+        symbol_id: SymbolId,
+        flag: ReferenceFlag,
+    ) -> Self {
+        Self { span, name, node_id, symbol_id: Some(symbol_id), flag }
+    }
+
     pub fn span(&self) -> Span {
         self.span
     }

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -104,12 +104,25 @@ impl ScopeTree {
         self.get_binding(self.root_scope_id(), name)
     }
 
+    pub fn add_root_unresolved_reference(&mut self, name: CompactStr, reference_id: ReferenceId) {
+        self.add_unresolved_reference(self.root_scope_id(), name, reference_id);
+    }
+
     pub fn has_binding(&self, scope_id: ScopeId, name: &str) -> bool {
         self.bindings[scope_id].get(name).is_some()
     }
 
     pub fn get_binding(&self, scope_id: ScopeId, name: &str) -> Option<SymbolId> {
         self.bindings[scope_id].get(name).copied()
+    }
+
+    pub fn find_binding(&self, scope_id: ScopeId, name: &str) -> Option<SymbolId> {
+        for scope_id in self.ancestors(scope_id) {
+            if let Some(symbol_id) = self.bindings[scope_id].get(name) {
+                return Some(*symbol_id);
+            }
+        }
+        None
     }
 
     pub fn get_bindings(&self, scope_id: ScopeId) -> &Bindings {

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -5,6 +5,13 @@ define_index_type! {
     pub struct AstNodeId = usize;
 }
 
+impl AstNodeId {
+    #[inline]
+    pub fn dummy() -> Self {
+        Self::new(0)
+    }
+}
+
 #[cfg(feature = "serialize")]
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -1,7 +1,9 @@
 use oxc_allocator::{Allocator, Box};
 use oxc_ast::AstBuilder;
 use oxc_semantic::{ScopeTree, SymbolTable};
+use oxc_span::CompactStr;
 use oxc_syntax::{
+    reference::{ReferenceFlag, ReferenceId},
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
@@ -285,6 +287,55 @@ impl<'a> TraverseCtx<'a> {
     /// This is a shortcut for `ctx.scoping.generate_uid_in_current_scope`.
     pub fn generate_uid_in_current_scope(&mut self, name: &str, flags: SymbolFlags) -> SymbolId {
         self.scoping.generate_uid_in_current_scope(name, flags)
+    }
+
+    /// Create a reference bound to a `SymbolId`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_bound_reference`.
+    pub fn create_bound_reference(
+        &mut self,
+        name: CompactStr,
+        symbol_id: SymbolId,
+        flag: ReferenceFlag,
+    ) -> ReferenceId {
+        self.scoping.create_bound_reference(name, symbol_id, flag)
+    }
+
+    /// Create an unbound reference.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
+    pub fn create_unbound_reference(
+        &mut self,
+        name: CompactStr,
+        flag: ReferenceFlag,
+    ) -> ReferenceId {
+        self.scoping.create_unbound_reference(name, flag)
+    }
+
+    /// Create a reference optionally bound to a `SymbolId`.
+    ///
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_reference`
+    /// or `TraverseCtx::create_unbound_reference`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_reference`.
+    pub fn create_reference(
+        &mut self,
+        name: CompactStr,
+        symbol_id: Option<SymbolId>,
+        flag: ReferenceFlag,
+    ) -> ReferenceId {
+        self.scoping.create_reference(name, symbol_id, flag)
+    }
+
+    /// Create reference in current scope, looking up binding for `name`,
+    ///
+    /// This is a shortcut for `ctx.scoping.create_reference_in_current_scope`.
+    pub fn create_reference_in_current_scope(
+        &mut self,
+        name: CompactStr,
+        flag: ReferenceFlag,
+    ) -> ReferenceId {
+        self.scoping.create_reference_in_current_scope(name, flag)
     }
 }
 


### PR DESCRIPTION
Set `reference_id` for references to new imported bindings. e.g. `_jsx` in `_jsx(Foo, {})` where JSX transform has inserted `import {jsx as _jsx} from "react/jsx-runtime";`.