### PR TITLE
feat(linter): default config path for linter

### DIFF
--- a/apps/oxlint/fixtures/default_path/test.js
+++ b/apps/oxlint/fixtures/default_path/test.js
@@ -1,0 +1,2 @@
+var x;
+delete x;

--- a/apps/oxlint/oxlintrc.json
+++ b/apps/oxlint/oxlintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "no-delete-var": "error"
+    }
+}

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -89,10 +89,21 @@ impl Runner for LintRunner {
 
         let number_of_files = paths.len();
 
+        let config_path = if let Ok(mut path) = env::current_dir() {
+            path.push("oxlintrc.json");
+            if path.exists() {
+                Some(path)
+            } else {
+                basic_options.config
+            }
+        } else {
+            basic_options.config
+        };
+
         let cwd = std::env::current_dir().unwrap().into_boxed_path();
         let lint_options = LintOptions::default()
             .with_filter(filter)
-            .with_config_path(basic_options.config)
+            .with_config_path(config_path)
             .with_fix(fix_options.fix)
             .with_react_plugin(enable_plugins.react_plugin)
             .with_unicorn_plugin(enable_plugins.unicorn_plugin)

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -89,20 +89,12 @@ impl Runner for LintRunner {
 
         let number_of_files = paths.len();
 
-        let config_path = match basic_options.config {
-            None => match env::current_dir() {
-                Ok(mut path) => {
-                    path.push("oxlintrc.json");
-                    if path.exists() {
-                        Some(path)
-                    } else {
-                        basic_options.config
-                    }
-                }
-                _ => basic_options.config,
-            },
-            _ => basic_options.config,
-        };
+        let config_path = basic_options.config.or_else(|| {
+            env::current_dir().ok().and_then(|mut path| {
+                path.push("oxlintrc.json");
+                path.exists().then(|| path)
+            })
+        });
 
         let cwd = std::env::current_dir().unwrap().into_boxed_path();
         let lint_options = LintOptions::default()

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -222,7 +222,16 @@ mod test {
         let result = test(args);
         assert!(result.number_of_rules > 0);
         assert!(result.number_of_warnings > 0);
-        assert_eq!(result.number_of_errors, 0);
+        assert_eq!(result.number_of_errors, 1);
+    }
+
+    #[test]
+    fn default_path() {
+        let args = &["fixtures/default_path/test.js"];
+        let result = test(args);
+        assert!(result.number_of_rules > 0);
+        assert_eq!(result.number_of_warnings, 0);
+        assert_eq!(result.number_of_errors, 1);
     }
 
     #[test]

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -92,7 +92,11 @@ impl Runner for LintRunner {
         let config_path = basic_options.config.or_else(|| {
             env::current_dir().ok().and_then(|mut path| {
                 path.push("oxlintrc.json");
-                path.exists().then(|| path)
+                if path.exists() {
+                    Some(path)
+                } else {
+                    None
+                }
             })
         });
 

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -90,20 +90,18 @@ impl Runner for LintRunner {
         let number_of_files = paths.len();
 
         let config_path = match basic_options.config {
-            None => {
-                match env::current_dir() {
-                    Ok(mut path) => {
-                        path.push("oxlintrc.json");
-                        if path.exists() {
-                            Some(path)
-                        } else {
-                            basic_options.config
-                        }
+            None => match env::current_dir() {
+                Ok(mut path) => {
+                    path.push("oxlintrc.json");
+                    if path.exists() {
+                        Some(path)
+                    } else {
+                        basic_options.config
                     }
-                    _ => basic_options.config
                 }
-            }
-            _ => basic_options.config
+                _ => basic_options.config,
+            },
+            _ => basic_options.config,
         };
 
         let cwd = std::env::current_dir().unwrap().into_boxed_path();

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -89,15 +89,21 @@ impl Runner for LintRunner {
 
         let number_of_files = paths.len();
 
-        let config_path = if let Ok(mut path) = env::current_dir() {
-            path.push("oxlintrc.json");
-            if path.exists() {
-                Some(path)
-            } else {
-                basic_options.config
+        let config_path = match basic_options.config {
+            None => {
+                match env::current_dir() {
+                    Ok(mut path) => {
+                        path.push("oxlintrc.json");
+                        if path.exists() {
+                            Some(path)
+                        } else {
+                            basic_options.config
+                        }
+                    }
+                    _ => basic_options.config
+                }
             }
-        } else {
-            basic_options.config
+            _ => basic_options.config
         };
 
         let cwd = std::env::current_dir().unwrap().into_boxed_path();


### PR DESCRIPTION
Implemented read default configuration from the root folder when config is not passed via the parameter.  

https://github.com/oxc-project/oxc/issues/3398