### PR TITLE
perf(transformer): avoid fragment update where possible

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -24,6 +24,13 @@ pub const MAX_INLINE_LEN: usize = 16;
 #[cfg_attr(feature = "serialize", serde(transparent))]
 pub struct Atom<'a>(&'a str);
 
+impl Atom<'static> {
+    #[inline]
+    pub const fn empty() -> Self {
+        Atom("")
+    }
+}
+
 impl<'a> Atom<'a> {
     #[inline]
     pub fn as_str(&self) -> &'a str {


### PR DESCRIPTION
Due to needing to align output with Babel, React JSX transform has to perform imports for fragments after dealing with the fragments' children.

Transform generates a dummy identifier initially, and then generates a UID later on and replaces the dummy.

The PR avoids that process 2-stage process unless we have to. If the UID was already generated for a previous fragment, we can just use it straight away.