### PR TITLE
refactor(transformer): pass `Rc`s by value

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_span::{Atom, SPAN};
@@ -39,9 +37,9 @@ pub struct ArrowFunctions<'a> {
 }
 
 impl<'a> ArrowFunctions<'a> {
-    pub fn new(options: ArrowFunctionsOptions, ctx: &Ctx<'a>) -> Self {
+    pub fn new(options: ArrowFunctionsOptions, ctx: Ctx<'a>) -> Self {
         Self {
-            ctx: Rc::clone(ctx),
+            ctx,
             _options: options,
             uid: 0,
             has_this: false,

--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -20,13 +20,13 @@ pub struct ES2015<'a> {
 }
 
 impl<'a> ES2015<'a> {
-    pub fn new(options: ES2015Options, ctx: &Ctx<'a>) -> Self {
+    pub fn new(options: ES2015Options, ctx: Ctx<'a>) -> Self {
         Self {
             arrow_functions: ArrowFunctions::new(
                 options.arrow_function.clone().unwrap_or_default(),
-                ctx,
+                Rc::clone(&ctx),
             ),
-            ctx: Rc::clone(ctx),
+            ctx,
             options,
         }
     }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -74,9 +74,9 @@ impl<'a> Transformer<'a> {
         ));
         Self {
             ctx: Rc::clone(&ctx),
-            x0_typescript: TypeScript::new(options.typescript, &ctx),
-            x1_react: React::new(options.react, &ctx),
-            x3_es2015: ES2015::new(options.es2015, &ctx),
+            x0_typescript: TypeScript::new(options.typescript, Rc::clone(&ctx)),
+            x1_react: React::new(options.react, Rc::clone(&ctx)),
+            x3_es2015: ES2015::new(options.es2015, ctx),
         }
     }
 

--- a/crates/oxc_transformer/src/react/display_name/mod.rs
+++ b/crates/oxc_transformer/src/react/display_name/mod.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
 use oxc_span::{Atom, SPAN};
@@ -20,8 +18,8 @@ pub struct ReactDisplayName<'a> {
 }
 
 impl<'a> ReactDisplayName<'a> {
-    pub fn new(ctx: &Ctx<'a>) -> Self {
-        Self { ctx: Rc::clone(ctx) }
+    pub fn new(ctx: Ctx<'a>) -> Self {
+        Self { ctx }
     }
 }
 

--- a/crates/oxc_transformer/src/react/jsx/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx/mod.rs
@@ -299,14 +299,14 @@ impl<'a> Pragma<'a> {
 
 // Transforms
 impl<'a> ReactJsx<'a> {
-    pub fn new(options: &Rc<ReactOptions>, ctx: &Ctx<'a>) -> Self {
+    pub fn new(options: Rc<ReactOptions>, ctx: Ctx<'a>) -> Self {
         let bindings = match options.runtime {
             ReactJsxRuntime::Classic => {
                 if options.import_source.is_some() {
                     ctx.error(diagnostics::import_source_cannot_be_set());
                 }
-                let pragma = Pragma::parse(options.pragma.as_ref(), "createElement", ctx);
-                let pragma_frag = Pragma::parse(options.pragma_frag.as_ref(), "Fragment", ctx);
+                let pragma = Pragma::parse(options.pragma.as_ref(), "createElement", &ctx);
+                let pragma_frag = Pragma::parse(options.pragma_frag.as_ref(), "Fragment", &ctx);
                 Bindings::Classic(ClassicBindings { pragma, pragma_frag })
             }
             ReactJsxRuntime::Automatic => {
@@ -338,14 +338,14 @@ impl<'a> ReactJsx<'a> {
 
                 if ctx.source_type.is_script() {
                     Bindings::AutomaticScript(AutomaticScriptBindings::new(
-                        Rc::clone(ctx),
-                        Rc::clone(options),
+                        Rc::clone(&ctx),
+                        Rc::clone(&options),
                         jsx_runtime_importer,
                     ))
                 } else {
                     Bindings::AutomaticModule(AutomaticModuleBindings::new(
-                        Rc::clone(ctx),
-                        Rc::clone(options),
+                        Rc::clone(&ctx),
+                        Rc::clone(&options),
                         jsx_runtime_importer,
                     ))
                 }
@@ -353,9 +353,9 @@ impl<'a> ReactJsx<'a> {
         };
 
         Self {
-            options: Rc::clone(options),
-            ctx: Rc::clone(ctx),
-            jsx_self: ReactJsxSelf::new(ctx),
+            options,
+            ctx: Rc::clone(&ctx),
+            jsx_self: ReactJsxSelf::new(Rc::clone(&ctx)),
             jsx_source: ReactJsxSource::new(ctx),
             bindings,
             can_add_filename_statement: false,

--- a/crates/oxc_transformer/src/react/jsx_self/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx_self/mod.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Span, SPAN};
@@ -26,8 +24,8 @@ pub struct ReactJsxSelf<'a> {
 }
 
 impl<'a> ReactJsxSelf<'a> {
-    pub fn new(ctx: &Ctx<'a>) -> Self {
-        Self { ctx: Rc::clone(ctx) }
+    pub fn new(ctx: Ctx<'a>) -> Self {
+        Self { ctx }
     }
 
     pub fn transform_jsx_opening_element(&self, elem: &mut JSXOpeningElement<'a>) {

--- a/crates/oxc_transformer/src/react/jsx_source/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx_source/mod.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{Span, SPAN};
@@ -25,8 +23,8 @@ pub struct ReactJsxSource<'a> {
 }
 
 impl<'a> ReactJsxSource<'a> {
-    pub fn new(ctx: &Ctx<'a>) -> Self {
-        Self { ctx: Rc::clone(ctx) }
+    pub fn new(ctx: Ctx<'a>) -> Self {
+        Self { ctx }
     }
 
     pub fn transform_jsx_opening_element(&mut self, elem: &mut JSXOpeningElement<'a>) {

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -30,15 +30,15 @@ pub struct React<'a> {
 
 // Constructors
 impl<'a> React<'a> {
-    pub fn new(options: ReactOptions, ctx: &Ctx<'a>) -> Self {
+    pub fn new(options: ReactOptions, ctx: Ctx<'a>) -> Self {
         let mut options = options;
         if options.is_jsx_plugin_enabled() {
-            options.update_with_comments(ctx);
+            options.update_with_comments(&ctx);
         }
         let options = Rc::new(options);
         Self {
             options: Rc::clone(&options),
-            jsx: ReactJsx::new(&options, ctx),
+            jsx: ReactJsx::new(options, Rc::clone(&ctx)),
             display_name: ReactDisplayName::new(ctx),
         }
     }

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -28,7 +28,7 @@ pub struct TypeScriptAnnotations<'a> {
 }
 
 impl<'a> TypeScriptAnnotations<'a> {
-    pub fn new(options: &Rc<TypeScriptOptions>, ctx: &Ctx<'a>) -> Self {
+    pub fn new(options: &Rc<TypeScriptOptions>, ctx: Ctx<'a>) -> Self {
         let jsx_element_import_name = if options.jsx_pragma.contains('.') {
             options.jsx_pragma.split('.').next().map(String::from).unwrap()
         } else {
@@ -45,7 +45,7 @@ impl<'a> TypeScriptAnnotations<'a> {
             has_super_call: false,
             assignments: ctx.ast.new_vec(),
             options: Rc::clone(options),
-            ctx: Rc::clone(ctx),
+            ctx,
             has_jsx_element: false,
             has_jsx_fragment: false,
             jsx_element_import_name,

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -18,8 +18,8 @@ pub struct TypeScriptEnum<'a> {
 }
 
 impl<'a> TypeScriptEnum<'a> {
-    pub fn new(ctx: &Ctx<'a>) -> Self {
-        Self { ctx: Rc::clone(ctx), enums: FxHashMap::default() }
+    pub fn new(ctx: Ctx<'a>) -> Self {
+        Self { ctx, enums: FxHashMap::default() }
     }
     /// ```TypeScript
     /// enum Foo {

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -48,14 +48,14 @@ pub struct TypeScript<'a> {
 }
 
 impl<'a> TypeScript<'a> {
-    pub fn new(options: TypeScriptOptions, ctx: &Ctx<'a>) -> Self {
-        let options = Rc::new(options.update_with_comments(ctx));
+    pub fn new(options: TypeScriptOptions, ctx: Ctx<'a>) -> Self {
+        let options = Rc::new(options.update_with_comments(&ctx));
 
         Self {
-            annotations: TypeScriptAnnotations::new(&options, ctx),
-            r#enum: TypeScriptEnum::new(ctx),
+            annotations: TypeScriptAnnotations::new(&options, Rc::clone(&ctx)),
+            r#enum: TypeScriptEnum::new(Rc::clone(&ctx)),
             options,
-            ctx: Rc::clone(ctx),
+            ctx,
         }
     }
 }


### PR DESCRIPTION
`Rc<T>` is already a pointer, so passing `&Rc<T>` to functions adds unnecessary indirection (reference to a reference).