### PR TITLE
feat(coverage/transformer): handle @jsx option

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::{
     es2015::{ArrowFunctionsOptions, ES2015Options},
     options::BabelOptions,
     options::TransformOptions,
-    react::ReactOptions,
+    react::{ReactJsxRuntime, ReactOptions},
     typescript::TypeScriptOptions,
 };
 

--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -12,7 +12,11 @@ use oxc_traverse::TraverseCtx;
 
 use crate::context::Ctx;
 
-pub use self::{display_name::ReactDisplayName, jsx::ReactJsx, options::ReactOptions};
+pub use self::{
+    display_name::ReactDisplayName,
+    jsx::ReactJsx,
+    options::{ReactJsxRuntime, ReactOptions},
+};
 
 /// [Preset React](https://babel.dev/docs/babel-preset-react)
 ///

--- a/tasks/coverage/src/typescript.rs
+++ b/tasks/coverage/src/typescript.rs
@@ -81,6 +81,10 @@ impl TypeScriptCase {
     pub fn set_result(&mut self, result: TestResult) {
         self.result = result;
     }
+
+    pub fn meta(&self) -> &TypeScriptTestMeta {
+        &self.meta
+    }
 }
 
 impl Case for TypeScriptCase {
@@ -133,8 +137,8 @@ impl Case for TypeScriptCase {
     }
 }
 
-struct TypeScriptTestMeta {
-    pub tests: Vec<TestUnitData>,
+pub struct TypeScriptTestMeta {
+    pub(self) tests: Vec<TestUnitData>,
     pub options: CompilerOptions,
     error_files: Vec<String>,
 }
@@ -224,7 +228,7 @@ struct TestUnitData {
 
 #[derive(Debug)]
 #[allow(unused)]
-struct CompilerOptions {
+pub struct CompilerOptions {
     pub modules: Vec<String>,
     pub targets: Vec<String>,
     pub strict: bool,

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,7 +2,5 @@ commit: 64d2eeea
 
 transformer_typescript Summary:
 AST Parsed     : 5243/5243 (100.00%)
-Positive Passed: 5240/5243 (99.94%)
+Positive Passed: 5242/5243 (99.98%)
 Mismatch: "compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts"
-Mismatch: "compiler/jsxComplexSignatureHasApplicabilityError.tsx"
-Mismatch: "compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx"


### PR DESCRIPTION
if has`@jsx: react`, configure transformer options to match `@jsx: react` behavior