### PR TITLE
chore(coverage, transformer_conformance): print all AST whether or not they are Typecript AST

### DIFF
--- a/tasks/coverage/src/transformer.rs
+++ b/tasks/coverage/src/transformer.rs
@@ -53,10 +53,14 @@ fn get_result(
     )
     .build(&mut program);
 
-    let source_text1 =
-        Codegen::<false>::new(&filename, source_text, CodegenOptions::default(), None)
-            .build(&program)
-            .source_text;
+    let source_text1 = Codegen::<false>::new(
+        &filename,
+        source_text,
+        CodegenOptions::default().with_typescript(true),
+        None,
+    )
+    .build(&program)
+    .source_text;
 
     let parse_result2 = Parser::new(&allocator, &source_text1, source_type).parse();
     let mut program = parse_result2.program;
@@ -71,11 +75,16 @@ fn get_result(
     )
     .build(&mut program);
 
-    let source_text2 =
-        Codegen::<false>::new(&filename, &source_text1, CodegenOptions::default(), None)
-            .build(&program)
-            .source_text;
+    let source_text2 = Codegen::<false>::new(
+        &filename,
+        &source_text1,
+        CodegenOptions::default().with_typescript(true),
+        None,
+    )
+    .build(&program)
+    .source_text;
 
+    // println!("\n\n{:?}\n{:?}\n\n", source_text1, source_text2);
     let result = source_text1 == source_text2;
 
     if result {

--- a/tasks/coverage/src/transformer.rs
+++ b/tasks/coverage/src/transformer.rs
@@ -84,7 +84,6 @@ fn get_result(
     .build(&program)
     .source_text;
 
-    // println!("\n\n{:?}\n{:?}\n\n", source_text1, source_text2);
     let result = source_text1 == source_text2;
 
     if result {

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 4bd1b2c2
 
-Passed: 478/926
+Passed: 469/926
 
 # All Passed:
 * babel-preset-react
@@ -445,11 +445,20 @@ Passed: 478/926
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (134/150)
+# babel-plugin-transform-typescript (125/150)
+* cast/multiple-assert-and-assign/input.ts
+* class/accessor-allowDeclareFields-false/input.ts
+* class/accessor-allowDeclareFields-true/input.ts
+* class/methods/input.ts
+* class/private-method-override/input.ts
 * enum/mix-references/input.ts
 * enum/ts5.0-const-foldable/input.ts
 * exports/declared-types/input.ts
+* exports/default-function/input.ts
+* exports/interface/input.ts
 * imports/type-only-export-specifier-2/input.ts
+* lvalues/as-expression/input.ts
+* lvalues/type-assertion/input.ts
 * optimize-const-enums/custom-values/input.ts
 * optimize-const-enums/custom-values-exported/input.ts
 * optimize-const-enums/declare/input.ts

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -182,9 +182,14 @@ pub trait TestCase {
         .build(&mut program);
 
         result.map(|()| {
-            Codegen::<false>::new("", &source_text, CodegenOptions::default(), None)
-                .build(&program)
-                .source_text
+            Codegen::<false>::new(
+                "",
+                &source_text,
+                CodegenOptions::default().with_typescript(true),
+                None,
+            )
+            .build(&program)
+            .source_text
         })
     }
 }
@@ -251,7 +256,7 @@ impl TestCase for ConformanceTestCase {
             println!("output_path: {output_path:?}");
         }
 
-        let codegen_options = CodegenOptions::default();
+        let codegen_options = CodegenOptions::default().with_typescript(true);
         let mut transformed_code = String::new();
         let mut actual_errors = String::new();
 
@@ -382,9 +387,14 @@ impl ExecTestCase {
         let source_type = SourceType::from_path(&target_path).unwrap();
         let transformed_program =
             Parser::new(&allocator, &source_text, source_type).parse().program;
-        let result = Codegen::<false>::new("", &source_text, CodegenOptions::default(), None)
-            .build(&transformed_program)
-            .source_text;
+        let result = Codegen::<false>::new(
+            "",
+            &source_text,
+            CodegenOptions::default().with_typescript(true),
+            None,
+        )
+        .build(&transformed_program)
+        .source_text;
 
         fs::write(&target_path, result).unwrap();
 


### PR DESCRIPTION
We have a conclusion that codegen will print whatever is in the AST, instead of having an option to enable printing TypeScript syntax. I plan to remove codegen's `enable_typescript` option after we strip out all typescript AST in the transformer typescript plugin.