### PR TITLE
feat(transformer/typescript): remove typescript ast nodes

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -353,7 +353,7 @@ impl<'a> Expression<'a> {
         matches!(self, Expression::Identifier(_))
     }
 
-    pub fn get_identifier_reference(&self) -> Option<&IdentifierReference> {
+    pub fn get_identifier_reference(&self) -> Option<&IdentifierReference<'a>> {
         match self.get_inner_expression() {
             Expression::Identifier(ident) => Some(ident),
             _ => None,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -157,6 +157,14 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x3_es2015.transform_expression_on_exit(expr);
     }
 
+    fn enter_simple_assignment_target(
+        &mut self,
+        node: &mut SimpleAssignmentTarget<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x0_typescript.transform_simple_assignment_target(node);
+    }
+
     fn enter_formal_parameter(
         &mut self,
         param: &mut FormalParameter<'a>,

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -109,6 +109,10 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_expression(expr);
     }
 
+    pub fn transform_simple_assignment_target(&mut self, target: &mut SimpleAssignmentTarget<'a>) {
+        self.annotations.transform_simple_assignment_target(target);
+    }
+
     pub fn transform_formal_parameter(&mut self, param: &mut FormalParameter<'a>) {
         self.annotations.transform_formal_parameter(param);
     }

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 4bd1b2c2
 
-Passed: 469/926
+Passed: 477/926
 
 # All Passed:
 * babel-preset-react
@@ -445,20 +445,12 @@ Passed: 469/926
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (125/150)
-* cast/multiple-assert-and-assign/input.ts
-* class/accessor-allowDeclareFields-false/input.ts
-* class/accessor-allowDeclareFields-true/input.ts
-* class/methods/input.ts
-* class/private-method-override/input.ts
+# babel-plugin-transform-typescript (133/150)
 * enum/mix-references/input.ts
 * enum/ts5.0-const-foldable/input.ts
 * exports/declared-types/input.ts
-* exports/default-function/input.ts
 * exports/interface/input.ts
 * imports/type-only-export-specifier-2/input.ts
-* lvalues/as-expression/input.ts
-* lvalues/type-assertion/input.ts
 * optimize-const-enums/custom-values/input.ts
 * optimize-const-enums/custom-values-exported/input.ts
 * optimize-const-enums/declare/input.ts


### PR DESCRIPTION
According to Babel tests feedback, remove some known ts AST nodes. 
There are still many TS AST nodes that need to be deleted