### PR TITLE
refactor(transformer): reduce cloning and referencing `Rc`s

### DIFF
--- a/crates/oxc_transformer/src/react/jsx/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx/mod.rs
@@ -13,7 +13,10 @@ use oxc_syntax::{
 };
 use oxc_traverse::TraverseCtx;
 
-use crate::{context::Ctx, helpers::module_imports::NamedImport};
+use crate::{
+    context::{Ctx, TransformCtx},
+    helpers::module_imports::NamedImport,
+};
 
 use super::utils::get_line_column;
 pub use super::{
@@ -256,7 +259,11 @@ impl<'a> Pragma<'a> {
     /// Parse `options.pragma` or `options.pragma_frag`.
     ///
     /// If provided option is invalid, raise an error and use default.
-    fn parse(pragma: Option<&String>, default_property_name: &'static str, ctx: &Ctx<'a>) -> Self {
+    fn parse(
+        pragma: Option<&String>,
+        default_property_name: &'static str,
+        ctx: &TransformCtx<'a>,
+    ) -> Self {
         if let Some(pragma) = pragma {
             let mut parts = pragma.split('.');
 
@@ -282,7 +289,7 @@ impl<'a> Pragma<'a> {
         }
     }
 
-    fn invalid(default_property_name: &'static str, ctx: &Ctx<'a>) -> Self {
+    fn invalid(default_property_name: &'static str, ctx: &TransformCtx<'a>) -> Self {
         ctx.error(diagnostics::invalid_pragma());
         Self::default(default_property_name)
     }

--- a/crates/oxc_transformer/src/react/options.rs
+++ b/crates/oxc_transformer/src/react/options.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::Ctx;
+use crate::TransformCtx;
 
 #[inline]
 fn default_as_true() -> bool {
@@ -147,7 +147,7 @@ impl ReactOptions {
     /// otherwise `JSDoc` could be used instead.
     ///
     /// This behavior is aligned with babel.
-    pub(crate) fn update_with_comments(&mut self, ctx: &Ctx) {
+    pub(crate) fn update_with_comments(&mut self, ctx: &TransformCtx) {
         for (_, span) in ctx.trivias.comments() {
             let mut comment = span.source_text(ctx.source_text).trim_start();
             // strip leading jsdoc comment `*` and then whitespaces

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -28,7 +28,7 @@ pub struct TypeScriptAnnotations<'a> {
 }
 
 impl<'a> TypeScriptAnnotations<'a> {
-    pub fn new(options: &Rc<TypeScriptOptions>, ctx: Ctx<'a>) -> Self {
+    pub fn new(options: Rc<TypeScriptOptions>, ctx: Ctx<'a>) -> Self {
         let jsx_element_import_name = if options.jsx_pragma.contains('.') {
             options.jsx_pragma.split('.').next().map(String::from).unwrap()
         } else {
@@ -44,7 +44,7 @@ impl<'a> TypeScriptAnnotations<'a> {
         Self {
             has_super_call: false,
             assignments: ctx.ast.new_vec(),
-            options: Rc::clone(options),
+            options,
             ctx,
             has_jsx_element: false,
             has_jsx_fragment: false,

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -52,7 +52,7 @@ impl<'a> TypeScript<'a> {
         let options = Rc::new(options.update_with_comments(&ctx));
 
         Self {
-            annotations: TypeScriptAnnotations::new(&options, Rc::clone(&ctx)),
+            annotations: TypeScriptAnnotations::new(Rc::clone(&options), Rc::clone(&ctx)),
             r#enum: TypeScriptEnum::new(Rc::clone(&ctx)),
             options,
             ctx,

--- a/crates/oxc_transformer/src/typescript/options.rs
+++ b/crates/oxc_transformer/src/typescript/options.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::Deserialize;
 
-use crate::context::Ctx;
+use crate::context::TransformCtx;
 
 fn default_for_jsx_pragma() -> Cow<'static, str> {
     Cow::Borrowed("React.createElement")
@@ -54,7 +54,7 @@ impl TypeScriptOptions {
     /// otherwise `JSDoc` could be used instead.
     ///
     /// This behavior is aligned with babel.
-    pub(crate) fn update_with_comments(mut self, ctx: &Ctx) -> Self {
+    pub(crate) fn update_with_comments(mut self, ctx: &TransformCtx) -> Self {
         for (_, span) in ctx.trivias.comments() {
             let mut comment = span.source_text(ctx.source_text).trim_start();
             // strip leading jsdoc comment `*` and then whitespaces


### PR DESCRIPTION
Similar to #3550. Avoid cloning an `Rc` in one place and pass `Rc`s as values not references in others.