### PR TITLE
improve(transformer): create `Atom` for react import source lazily

### DIFF
--- a/crates/oxc_transformer/src/options/transformer.rs
+++ b/crates/oxc_transformer/src/options/transformer.rs
@@ -86,8 +86,8 @@ impl TransformOptions {
                             ReactOptions::default()
                         })
                 };
-            react_options.development = options.has_plugin("transform-react-jsx-development");
-            react_options.jsx_plugin = has_jsx_plugin || has_jsx_development_plugin;
+            react_options.development = has_jsx_development_plugin;
+            react_options.jsx_plugin = has_jsx_plugin;
             react_options.display_name_plugin = options.has_plugin("transform-react-display-name");
             react_options.jsx_self_plugin = options.has_plugin("transform-react-jsx-self");
             react_options.jsx_source_plugin = options.has_plugin("transform-react-jsx-source");

--- a/crates/oxc_transformer/src/react/jsx/diagnostics.rs
+++ b/crates/oxc_transformer/src/react/jsx/diagnostics.rs
@@ -17,7 +17,7 @@ pub fn import_source_cannot_be_set() -> OxcDiagnostic {
 }
 
 pub fn invalid_import_source() -> OxcDiagnostic {
-    OxcDiagnostic::warn("import_source cannot be an empty string")
+    OxcDiagnostic::warn("importSource cannot be an empty string or longer than u32::MAX bytes")
         .with_help("Fix `importSource` option.")
 }
 

--- a/crates/oxc_transformer/src/react/jsx/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx/mod.rs
@@ -36,7 +36,7 @@ pub use super::{
 /// * <https://babeljs.io/docs/babel-plugin-transform-react-jsx>
 /// * <https://github.com/babel/babel/tree/main/packages/babel-helper-builder-react-jsx>
 pub struct ReactJsx<'a> {
-    options: Rc<ReactOptions>,
+    options: ReactOptions,
 
     ctx: Ctx<'a>,
 
@@ -310,7 +310,7 @@ impl<'a> Pragma<'a> {
 
 // Transforms
 impl<'a> ReactJsx<'a> {
-    pub fn new(options: Rc<ReactOptions>, ctx: Ctx<'a>) -> Self {
+    pub fn new(options: ReactOptions, ctx: Ctx<'a>) -> Self {
         let bindings = match options.runtime {
             ReactJsxRuntime::Classic => {
                 if options.import_source.is_some() {
@@ -612,9 +612,7 @@ impl<'a> ReactJsx<'a> {
 
         // React.createElement's second argument
         if !is_fragment && is_classic {
-            if self.options.is_jsx_self_plugin_enabled()
-                && self.jsx_self.can_add_self_attribute(ctx)
-            {
+            if self.options.jsx_self_plugin && self.jsx_self.can_add_self_attribute(ctx) {
                 if let Some(span) = self_attr_span {
                     self.jsx_self.report_error(span);
                 } else {
@@ -622,7 +620,7 @@ impl<'a> ReactJsx<'a> {
                 }
             }
 
-            if self.options.is_jsx_source_plugin_enabled() {
+            if self.options.jsx_source_plugin {
                 if let Some(span) = source_attr_span {
                     self.jsx_source.report_error(span);
                 } else {
@@ -678,7 +676,7 @@ impl<'a> ReactJsx<'a> {
             // Fragment doesn't have source and self
             if !is_fragment {
                 // { __source: { fileName, lineNumber, columnNumber } }
-                if self.options.is_jsx_source_plugin_enabled() {
+                if self.options.jsx_source_plugin {
                     if let Some(span) = source_attr_span {
                         self.jsx_source.report_error(span);
                     } else {
@@ -690,9 +688,7 @@ impl<'a> ReactJsx<'a> {
                 }
 
                 // this
-                if self.options.is_jsx_self_plugin_enabled()
-                    && self.jsx_self.can_add_self_attribute(ctx)
-                {
+                if self.options.jsx_self_plugin && self.jsx_self.can_add_self_attribute(ctx) {
                     if let Some(span) = self_attr_span {
                         self.jsx_self.report_error(span);
                     } else {

--- a/crates/oxc_transformer/src/react/options.rs
+++ b/crates/oxc_transformer/src/react/options.rs
@@ -127,16 +127,12 @@ impl Default for ReactOptions {
 }
 
 impl ReactOptions {
-    pub fn is_jsx_plugin_enabled(&self) -> bool {
-        self.jsx_plugin || self.development
-    }
-
-    pub fn is_jsx_self_plugin_enabled(&self) -> bool {
-        self.jsx_self_plugin || self.development
-    }
-
-    pub fn is_jsx_source_plugin_enabled(&self) -> bool {
-        self.jsx_source_plugin || self.development
+    pub fn conform(&mut self) {
+        if self.development {
+            self.jsx_plugin = true;
+            self.jsx_self_plugin = true;
+            self.jsx_source_plugin = true;
+        }
     }
 
     /// Scan through all comments and find the following pragmas


### PR DESCRIPTION
In JSX transform:

* Don't generate an `Atom` for react importer unless it's needed.
* Re-use the same string slice as `jsx_runtime_importer`.
* Reduce size of `Bindings`.
