### PR TITLE
refactor(transformer): replace `&’a Trivias` with `Rc<Trivias>`

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -287,7 +287,7 @@ impl IsolatedLintHandler {
 
             let program = allocator.alloc(ret.program);
             let semantic_ret = SemanticBuilder::new(javascript_source_text, source_type)
-                .with_trivias(ret.trivias)
+                .with_trivias(Rc::new(ret.trivias))
                 .with_check_syntax_error(true)
                 .build(program);
 

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -1,6 +1,6 @@
 //! The simplest linter
 
-use std::{env, path::Path};
+use std::{env, path::Path, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_ast::AstKind;
@@ -29,8 +29,9 @@ fn main() -> std::io::Result<()> {
     }
 
     let program = allocator.alloc(ret.program);
-    let semantic_ret =
-        SemanticBuilder::new(&source_text, source_type).with_trivias(ret.trivias).build(program);
+    let semantic_ret = SemanticBuilder::new(&source_text, source_type)
+        .with_trivias(Rc::new(ret.trivias))
+        .build(program);
 
     let mut errors: Vec<OxcDiagnostic> = vec![];
 

--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -264,10 +264,12 @@ impl Runtime {
 
         let program = allocator.alloc(ret.program);
 
+        let trivias = Rc::new(ret.trivias);
+
         // Build the module record to unblock other threads from waiting for too long.
         // The semantic model is not built at this stage.
         let semantic_builder = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(ret.trivias)
+            .with_trivias(trivias)
             .with_check_syntax_error(check_syntax_errors)
             .build_module_record(path.to_path_buf(), program);
         let module_record = semantic_builder.module_record();

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, path::Path, sync::Arc};
+use std::{collections::HashMap, env, path::Path, rc::Rc, sync::Arc};
 
 use itertools::Itertools;
 use oxc_allocator::Allocator;
@@ -38,7 +38,7 @@ fn main() -> std::io::Result<()> {
 
     let semantic = SemanticBuilder::new(&source_text, source_type)
         .with_check_syntax_error(true)
-        .with_trivias(ret.trivias)
+        .with_trivias(Rc::new(ret.trivias))
         .build(program);
 
     if !semantic.errors.is_empty() {

--- a/crates/oxc_semantic/examples/simple.rs
+++ b/crates/oxc_semantic/examples/simple.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path, sync::Arc};
+use std::{env, path::Path, rc::Rc, sync::Arc};
 
 use itertools::Itertools;
 use oxc_allocator::Allocator;
@@ -23,7 +23,7 @@ fn main() -> std::io::Result<()> {
 
     let semantic = SemanticBuilder::new(&source_text, source_type)
         .with_check_syntax_error(true)
-        .with_trivias(ret.trivias)
+        .with_trivias(Rc::new(ret.trivias))
         .build(program);
 
     if !semantic.errors.is_empty() {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -108,10 +108,9 @@ impl<'a> SemanticBuilder<'a> {
     }
 
     #[must_use]
-    pub fn with_trivias(mut self, trivias: Trivias) -> Self {
-        let trivias = Rc::new(trivias);
-        self.trivias = Rc::clone(&trivias);
-        self.jsdoc = JSDocBuilder::new(self.source_text, trivias);
+    pub fn with_trivias(mut self, trivias: Rc<Trivias>) -> Self {
+        self.trivias = trivias;
+        self.jsdoc = JSDocBuilder::new(self.source_text, Rc::clone(&self.trivias));
         self
     }
 

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -230,6 +230,8 @@ fn should_attach_jsdoc(kind: &AstKind) -> bool {
 
 #[cfg(test)]
 mod test {
+    use std::rc::Rc;
+
     use oxc_allocator::Allocator;
     use oxc_parser::Parser;
     use oxc_span::{SourceType, Span};
@@ -246,7 +248,7 @@ mod test {
         let ret = Parser::new(allocator, source_text, source_type).parse();
         let program = allocator.alloc(ret.program);
         let semantic = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(ret.trivias)
+            .with_trivias(Rc::new(ret.trivias))
             .build(program)
             .semantic;
         semantic

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -36,6 +36,8 @@ impl<'a> JSDoc<'a> {
 
 #[cfg(test)]
 mod test {
+    use std::rc::Rc;
+
     use crate::{Semantic, SemanticBuilder};
     use oxc_allocator::Allocator;
     use oxc_parser::Parser;
@@ -46,7 +48,7 @@ mod test {
         let ret = Parser::new(allocator, source_text, source_type).parse();
         let program = allocator.alloc(ret.program);
         let semantic = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(ret.trivias)
+            .with_trivias(Rc::new(ret.trivias))
             .build(program)
             .semantic;
         semantic

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -182,6 +182,8 @@ impl<'a> JSDocTag<'a> {
 
 #[cfg(test)]
 mod test {
+    use std::rc::Rc;
+
     use crate::{Semantic, SemanticBuilder};
     use oxc_allocator::Allocator;
     use oxc_parser::Parser;
@@ -192,7 +194,7 @@ mod test {
         let ret = Parser::new(allocator, source_text, source_type).parse();
         let program = allocator.alloc(ret.program);
         let semantic = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(ret.trivias)
+            .with_trivias(Rc::new(ret.trivias))
             .build(program)
             .semantic;
         semantic

--- a/crates/oxc_semantic/src/module_record/mod.rs
+++ b/crates/oxc_semantic/src/module_record/mod.rs
@@ -9,7 +9,7 @@ mod module_record_tests {
     use oxc_span::{SourceType, Span};
     #[allow(clippy::wildcard_imports)]
     use oxc_syntax::module_record::*;
-    use std::{path::PathBuf, sync::Arc};
+    use std::{path::PathBuf, rc::Rc, sync::Arc};
 
     use crate::SemanticBuilder;
 
@@ -19,7 +19,7 @@ mod module_record_tests {
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let program = allocator.alloc(ret.program);
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(ret.trivias)
+            .with_trivias(Rc::new(ret.trivias))
             .build_module_record(PathBuf::new(), program)
             .build(program);
         Arc::clone(&semantic_ret.semantic.module_record)

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -1,7 +1,7 @@
 mod class_tester;
 mod expect;
 mod symbol_tester;
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, rc::Rc, sync::Arc};
 
 use itertools::Itertools;
 use oxc_allocator::Allocator;
@@ -80,7 +80,7 @@ impl<'a> SemanticTester<'a> {
         let program = self.allocator.alloc(parse.program);
         let semantic_ret = SemanticBuilder::new(self.source_text, self.source_type)
             .with_check_syntax_error(true)
-            .with_trivias(parse.trivias)
+            .with_trivias(Rc::new(parse.trivias))
             .build_module_record(PathBuf::new(), program)
             .build(program);
 

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path};
+use std::{env, path::Path, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
@@ -22,6 +22,7 @@ fn main() {
     let source_type = SourceType::from_path(path).unwrap();
 
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
+    let trivias = Rc::new(ret.trivias);
 
     if !ret.errors.is_empty() {
         for error in ret.errors {
@@ -46,7 +47,7 @@ fn main() {
         },
         ..Default::default()
     };
-    Transformer::new(&allocator, path, source_type, &source_text, &ret.trivias, transform_options)
+    Transformer::new(&allocator, path, source_type, &source_text, trivias, transform_options)
         .build(&mut program)
         .unwrap();
 

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -17,7 +17,7 @@ pub type Ctx<'a> = Rc<TransformCtx<'a>>;
 pub struct TransformCtx<'a> {
     errors: RefCell<Vec<OxcDiagnostic>>,
 
-    pub trivias: &'a Trivias,
+    pub trivias: Rc<Trivias>,
 
     pub ast: AstBuilder<'a>,
 
@@ -42,7 +42,7 @@ impl<'a> TransformCtx<'a> {
         source_path: &Path,
         source_type: SourceType,
         source_text: &'a str,
-        trivias: &'a Trivias,
+        trivias: Rc<Trivias>,
         options: &TransformOptions,
     ) -> Self {
         let filename = source_path

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -61,7 +61,7 @@ impl<'a> Transformer<'a> {
         source_path: &Path,
         source_type: SourceType,
         source_text: &'a str,
-        trivias: &'a Trivias,
+        trivias: Rc<Trivias>,
         options: TransformOptions,
     ) -> Self {
         let ctx = Rc::new(TransformCtx::new(

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -29,7 +29,7 @@ fn bench_linter(criterion: &mut Criterion) {
                 let ret = Parser::new(&allocator, source_text, source_type).parse();
                 let program = allocator.alloc(ret.program);
                 let semantic_ret = SemanticBuilder::new(source_text, source_type)
-                    .with_trivias(ret.trivias)
+                    .with_trivias(Rc::new(ret.trivias))
                     .build_module_record(PathBuf::new(), program)
                     .build(program);
                 let filter = vec![

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -28,7 +28,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                     Path::new(&file.file_name),
                     source_type,
                     source_text,
-                    &trivias,
+                    Rc::new(trivias),
                     transform_options,
                 )
                 .build(program)

--- a/tasks/coverage/src/suite.rs
+++ b/tasks/coverage/src/suite.rs
@@ -5,6 +5,7 @@ use std::{
     panic::UnwindSafe,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    rc::Rc,
 };
 
 use console::Style;
@@ -327,7 +328,7 @@ pub trait Case: Sized + Sync + Send + UnwindSafe {
 
         let program = allocator.alloc(parser_ret.program);
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
-            .with_trivias(parser_ret.trivias)
+            .with_trivias(Rc::new(parser_ret.trivias))
             .with_check_syntax_error(true)
             .build_module_record(PathBuf::new(), program)
             .build(program);

--- a/tasks/coverage/src/transformer.rs
+++ b/tasks/coverage/src/transformer.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
@@ -48,7 +51,7 @@ fn get_result(
         source_path,
         source_type,
         source_text,
-        &parse_result1.trivias,
+        Rc::new(parse_result1.trivias),
         options.clone(),
     )
     .build(&mut program);
@@ -79,7 +82,7 @@ fn get_result(
         source_path,
         source_type,
         &source_text1,
-        &parse_result2.trivias,
+        Rc::new(parse_result2.trivias),
         options,
     )
     .build(&mut program);

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    rc::Rc,
 };
 
 use oxc_allocator::Allocator;
@@ -176,7 +177,7 @@ pub trait TestCase {
             path,
             source_type,
             &source_text,
-            &ret.trivias,
+            Rc::new(ret.trivias),
             transform_options.clone(),
         )
         .build(&mut program);
@@ -270,7 +271,7 @@ impl TestCase for ConformanceTestCase {
                         &self.path,
                         source_type,
                         &input,
-                        &ret.trivias,
+                        Rc::new(ret.trivias),
                         transform_options.clone(),
                     );
                     let result = transformer.build(&mut program);


### PR DESCRIPTION
`Transformer` needs to borrow `Trivias`. https://github.com/rolldown/rolldown/pull/1364/files/8be1cc80520e1a466cd7b2d3fb8b637db9e529a9#r1630711060