### PR TITLE
up(linter): add rule fixer

### DIFF
--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -341,7 +341,6 @@ impl<'a> GetSpan for Argument<'a> {
     }
 }
 
-// impl_get_span!(ArrayExpression);
 impl<'a> GetSpan for ArrayExpression<'a> {
     fn span(&self) -> Span {
         self.span

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -2,6 +2,33 @@ use oxc_span::{GetSpan, Span};
 
 use crate::ast::*;
 
+macro_rules! impl_get_span {
+    ($Ty:ident) => {
+        impl<'a> GetSpan for $Ty<'a> {
+            #[inline]
+            fn span(&self) -> Span {
+                self.span
+            }
+        }
+    };
+}
+
+impl_get_span!(Directive);
+impl_get_span!(SpreadElement);
+
+impl_get_span!(IdentifierReference);
+impl_get_span!(LabelIdentifier);
+impl_get_span!(RegExpLiteral);
+
+impl_get_span!(TemplateElement);
+impl_get_span!(CallExpression);
+impl_get_span!(AssignmentExpression);
+impl_get_span!(BinaryExpression);
+
+impl_get_span!(TSTypeLiteral);
+impl_get_span!(TSTypeReference);
+impl_get_span!(TSTypeAliasDeclaration);
+
 impl<'a> GetSpan for Statement<'a> {
     fn span(&self) -> Span {
         match self {
@@ -94,12 +121,6 @@ impl<'a> GetSpan for Expression<'a> {
     }
 }
 
-impl<'a> GetSpan for Directive<'a> {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
 impl<'a> GetSpan for BindingPatternKind<'a> {
     fn span(&self) -> Span {
         match self {
@@ -122,11 +143,7 @@ impl<'a> GetSpan for BindingPattern<'a> {
     }
 }
 
-impl<'a> GetSpan for BindingProperty<'a> {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
+impl_get_span!(BindingProperty);
 
 impl<'a> GetSpan for ClassElement<'a> {
     fn span(&self) -> Span {
@@ -347,11 +364,7 @@ impl<'a> GetSpan for Argument<'a> {
     }
 }
 
-impl<'a> GetSpan for ArrayExpression<'a> {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
+impl_get_span!(ArrayExpression);
 
 impl<'a> GetSpan for ArrayExpressionElement<'a> {
     fn span(&self) -> Span {

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -2,33 +2,6 @@ use oxc_span::{GetSpan, Span};
 
 use crate::ast::*;
 
-macro_rules! impl_get_span {
-    ($Ty:ident) => {
-        impl<'a> GetSpan for $Ty<'a> {
-            #[inline]
-            fn span(&self) -> Span {
-                self.span
-            }
-        }
-    };
-}
-
-impl_get_span!(Directive);
-impl_get_span!(SpreadElement);
-
-impl_get_span!(IdentifierReference);
-impl_get_span!(LabelIdentifier);
-impl_get_span!(RegExpLiteral);
-
-impl_get_span!(TemplateElement);
-impl_get_span!(CallExpression);
-impl_get_span!(AssignmentExpression);
-impl_get_span!(BinaryExpression);
-
-impl_get_span!(TSTypeLiteral);
-impl_get_span!(TSTypeReference);
-impl_get_span!(TSTypeAliasDeclaration);
-
 impl<'a> GetSpan for Statement<'a> {
     fn span(&self) -> Span {
         match self {
@@ -143,7 +116,11 @@ impl<'a> GetSpan for BindingPattern<'a> {
     }
 }
 
-impl_get_span!(BindingProperty);
+impl GetSpan for BindingProperty<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
 
 impl<'a> GetSpan for ClassElement<'a> {
     fn span(&self) -> Span {
@@ -364,7 +341,12 @@ impl<'a> GetSpan for Argument<'a> {
     }
 }
 
-impl_get_span!(ArrayExpression);
+// impl_get_span!(ArrayExpression);
+impl<'a> GetSpan for ArrayExpression<'a> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
 
 impl<'a> GetSpan for ArrayExpressionElement<'a> {
     fn span(&self) -> Span {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -15,7 +15,7 @@ mod gen_ts;
 mod operator;
 mod sourcemap_builder;
 
-use std::ops::Range;
+use std::{borrow::Cow, ops::Range};
 
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
@@ -522,5 +522,22 @@ fn choose_quote(s: &str) -> char {
         '"'
     } else {
         '\''
+    }
+}
+
+impl From<CodegenReturn> for String {
+    fn from(val: CodegenReturn) -> Self {
+        val.source_text
+    }
+}
+
+impl<'a, const MINIFY: bool> From<Codegen<'a, MINIFY>> for String {
+    fn from(mut val: Codegen<'a, MINIFY>) -> Self {
+        val.into_source_text()
+    }
+}
+impl<'a, const MINIFY: bool> From<Codegen<'a, MINIFY>> for Cow<'a, str> {
+    fn from(mut val: Codegen<'a, MINIFY>) -> Self {
+        Cow::Owned(val.into_source_text())
     }
 }

--- a/crates/oxc_linter/src/fixer.rs
+++ b/crates/oxc_linter/src/fixer.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 
+use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
+
+use crate::LintContext;
 
 #[derive(Debug, Clone, Default)]
 pub struct Fix<'a> {
@@ -16,6 +19,52 @@ impl<'a> Fix<'a> {
 
     pub fn new<T: Into<Cow<'a, str>>>(content: T, span: Span) -> Self {
         Self { content: content.into(), span }
+    }
+}
+
+/// Inspired by ESLint's [`RuleFixer`].
+///
+/// [`RuleFixer`]: https://github.com/eslint/eslint/blob/main/lib/linter/rule-fixer.js
+#[derive(Clone, Copy)]
+pub struct RuleFixer<'c, 'a: 'c> {
+    ctx: &'c LintContext<'a>,
+}
+
+impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
+    pub fn new(ctx: &'c LintContext<'a>) -> Self {
+        Self { ctx }
+    }
+
+    pub fn source_range(self, span: Span) -> &'a str {
+        self.ctx.source_range(span)
+    }
+
+    /// Create a [`Fix`] that deletes the text covered by the given [`Span`] or
+    /// AST node.
+    pub fn delete<S: GetSpan>(self, spanned: &S) -> Fix<'a> {
+        self.delete_range(spanned.span())
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn delete_range(self, span: Span) -> Fix<'a> {
+        Fix::delete(span)
+    }
+
+    /// Replace a `target` AST node with the source code of a `replacement` node..
+    pub fn replace_with<T: GetSpan, S: GetSpan>(self, target: &T, replacement: &S) -> Fix<'a> {
+        let replacement_text = self.ctx.source_range(replacement.span());
+        Fix::new(replacement_text, target.span())
+    }
+
+    /// Replace a `target` AST node with a `replacement` string.
+    #[allow(clippy::unused_self)]
+    pub fn replace<S: Into<Cow<'a, str>>>(self, target: Span, replacement: S) -> Fix<'a> {
+        Fix::new(replacement, target)
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn codegen(self) -> Codegen<'a, false> {
+        Codegen::<false>::new("", "", CodegenOptions::default(), None)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn eqeqeq_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(eqeqeq): Expected {x1} and instead saw {x0}"))
@@ -120,10 +120,11 @@ impl Rule for Eqeqeq {
         if is_type_of_binary_bool || are_literals_and_same_type_bool {
             ctx.diagnostic_with_fix(
                 eqeqeq_diagnostic(operator, preferred_operator, operator_span),
-                || {
+                |fixer| {
                     let start = binary_expr.left.span().end;
                     let end = binary_expr.right.span().start;
-                    Fix::new(preferred_operator_with_padding, Span::new(start, end))
+                    let span = Span::new(start, end);
+                    fixer.replace(span, preferred_operator_with_padding)
                 },
             );
         } else {

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_debugger_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-debugger): `debugger` statement is not allowed")
@@ -35,7 +35,9 @@ declare_oxc_lint!(
 impl Rule for NoDebugger {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::DebuggerStatement(stmt) = node.kind() {
-            ctx.diagnostic_with_fix(no_debugger_diagnostic(stmt.span), || Fix::delete(stmt.span));
+            ctx.diagnostic_with_fix(no_debugger_diagnostic(stmt.span), |fixer| {
+                fixer.delete(&stmt.span)
+            });
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_div_regex_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -38,8 +38,9 @@ impl Rule for NoDivRegex {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::RegExpLiteral(lit) = node.kind() {
             if lit.regex.pattern.starts_with('=') {
-                ctx.diagnostic_with_fix(no_div_regex_diagnostic(lit.span), || {
-                    Fix::new("[=]", Span::new(lit.span.start + 1, lit.span.start + 2))
+                ctx.diagnostic_with_fix(no_div_regex_diagnostic(lit.span), |fixer| {
+                    let span = Span::sized(lit.span.start + 1, 1);
+                    fixer.replace(span, "[=]")
                 });
             }
         }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule};
+use crate::{context::LintContext, rule::Rule};
 
 fn no_unused_labels_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-unused-labels): Disallow unused labels")
@@ -51,7 +51,7 @@ impl Rule for NoUnusedLabels {
                 // e.g. A: /* Comment */ function foo(){}
                 ctx.diagnostic_with_fix(
                     no_unused_labels_diagnostic(stmt.label.name.as_str(), stmt.label.span),
-                    || Fix::delete(stmt.label.span),
+                    |fixer| fixer.delete_range(stmt.label.span),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -6,7 +6,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_escape_diagnostic(x0: char, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(no-useless-escape): Unnecessary escape character {x0:?}"))
@@ -84,8 +84,8 @@ fn check(ctx: &LintContext<'_>, node_id: AstNodeId, start: u32, offsets: &[usize
 
         if !is_within_jsx_attribute_item(node_id, ctx) {
             let span = Span::new(offset - 1, offset + len);
-            ctx.diagnostic_with_fix(no_useless_escape_diagnostic(c, span), || {
-                Fix::new(c.to_string(), span)
+            ctx.diagnostic_with_fix(no_useless_escape_diagnostic(c, span), |fixer| {
+                fixer.replace(span, c.to_string())
             });
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -1,8 +1,8 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{Span, SPAN};
 
-use crate::{context::LintContext, rule::Rule, Fix};
+use crate::{context::LintContext, rule::Rule};
 
 fn unexpected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(unicode-bom): Unexpected Unicode BOM (Byte Order Mark)")
@@ -59,14 +59,14 @@ impl Rule for UnicodeBom {
         let has_bomb = source.starts_with('﻿');
 
         if has_bomb && matches!(self.bom_option, BomOptionType::Never) {
-            ctx.diagnostic_with_fix(unexpected_unicode_bom_diagnostic(Span::new(0, 0)), || {
-                return Fix::delete(Span::new(0, 3));
+            ctx.diagnostic_with_fix(unexpected_unicode_bom_diagnostic(SPAN), |fixer| {
+                return fixer.delete_range(Span::new(0, 3));
             });
         }
 
         if !has_bomb && matches!(self.bom_option, BomOptionType::Always) {
-            ctx.diagnostic_with_fix(expected_unicode_bom_diagnostic(Span::new(0, 0)), || {
-                return Fix::new("﻿", Span::new(0, 0));
+            ctx.diagnostic_with_fix(expected_unicode_bom_diagnostic(SPAN), |fixer| {
+                return fixer.replace(SPAN, "﻿");
             });
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn comparison_with_na_n(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
@@ -90,13 +90,13 @@ impl Rule for UseIsnan {
             }
             AstKind::BinaryExpression(expr) if expr.operator.is_equality() => {
                 if is_nan_identifier(&expr.left) {
-                    ctx.diagnostic_with_fix(comparison_with_na_n(expr.left.span()), || {
-                        Fix::new(make_equality_fix(true, expr, ctx), expr.span)
+                    ctx.diagnostic_with_fix(comparison_with_na_n(expr.left.span()), |fixer| {
+                        fixer.replace(expr.span, make_equality_fix(true, expr, ctx))
                     });
                 }
                 if is_nan_identifier(&expr.right) {
-                    ctx.diagnostic_with_fix(comparison_with_na_n(expr.right.span()), || {
-                        Fix::new(make_equality_fix(false, expr, ctx), expr.span)
+                    ctx.diagnostic_with_fix(comparison_with_na_n(expr.right.span()), |fixer| {
+                        fixer.replace(expr.span, make_equality_fix(false, expr, ctx))
                     });
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -5,7 +5,7 @@ use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 use phf::{phf_set, Set};
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn not_string(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
     let mut d = OxcDiagnostic::warn(
@@ -110,7 +110,7 @@ impl Rule for ValidTypeof {
                             sibling.span(),
                         )
                     },
-                    || Fix::new("\"undefined\"", sibling.span()),
+                    |fixer| fixer.replace(sibling.span(), "\"undefined\""),
                 );
                 return;
             }

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -6,7 +6,6 @@ use oxc_span::Span;
 
 use crate::{
     context::LintContext,
-    fixer::Fix,
     rule::Rule,
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
@@ -71,18 +70,18 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
             if let Some(method_name) = BadAliasMethodName::from_str(alias.as_ref()) {
                 let (name, canonical_name) = method_name.name_with_canonical();
 
-                let mut start = matcher.span.start;
-                let mut end = matcher.span.end;
+                let mut span = matcher.span;
                 // expect(a).not['toThrowError']()
                 // matcher is the node of `toThrowError`, we only what to replace the content in the quotes.
                 if matcher.element.is_string_literal() {
-                    start += 1;
-                    end -= 1;
+                    span.start += 1;
+                    span.end -= 1;
                 }
 
                 ctx.diagnostic_with_fix(
                     no_alias_methods_diagnostic(name, canonical_name, matcher.span),
-                    || Fix::new(canonical_name, Span::new(start, end)),
+                    // || Fix::new(canonical_name, Span::new(start, end)),
+                    |fixer| fixer.replace(span, canonical_name),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use phf::{phf_map, Map};
 use std::borrow::Cow;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule};
+use crate::{context::LintContext, rule::Rule};
 
 fn deprecated_function(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -129,7 +129,7 @@ impl Rule for NoDeprecatedFunctions {
             if jest_version_num >= *base_version {
                 ctx.diagnostic_with_fix(
                     deprecated_function(&node_name, replacement, mem_expr.span()),
-                    || Fix::new(*replacement, mem_expr.span()),
+                    |fixer| fixer.replace(mem_expr.span(), *replacement),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, Fix};
+use crate::{context::LintContext, rule::Rule};
 
 fn no_jasmine_globals_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint-plugin-jest(no-jasmine-globals): {x0:?}"))
@@ -87,9 +87,9 @@ fn diagnostic_assign_expr<'a>(expr: &'a AssignmentExpression<'a>, ctx: &LintCont
             if let Expression::NumericLiteral(number_literal) = &expr.right {
                 ctx.diagnostic_with_fix(
                     no_jasmine_globals_diagnostic(COMMON_ERROR_TEXT, COMMON_HELP_TEXT, span),
-                    || {
+                    |fixer| {
                         let content = format!("jest.setTimeout({})", number_literal.value);
-                        Fix::new(content, expr.span)
+                        fixer.replace(expr.span, content)
                     },
                 );
                 return;
@@ -119,7 +119,7 @@ fn diagnostic_call_expr<'a>(expr: &'a CallExpression<'a>, ctx: &LintContext) {
                 if jasmine_property.available_in_jest_expect() {
                     ctx.diagnostic_with_fix(
                         no_jasmine_globals_diagnostic(error, help, span),
-                        || Fix::new("expect", member_expr.object().span()),
+                        |fixer| fixer.replace(member_expr.object().span(), "expect"),
                     );
                 } else {
                     ctx.diagnostic(no_jasmine_globals_diagnostic(error, help, span));

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -6,7 +6,6 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     context::LintContext,
-    fixer::Fix,
     rule::Rule,
     utils::{
         collect_possible_jest_call_node, parse_general_jest_fn_call, JestGeneralFnKind,
@@ -87,8 +86,8 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
 
     let preferred_node_name = get_preferred_node_names(&jest_fn_call);
 
-    ctx.diagnostic_with_fix(no_test_prefixes_diagnostic(&preferred_node_name, span), || {
-        Fix::new(preferred_node_name, span)
+    ctx.diagnostic_with_fix(no_test_prefixes_diagnostic(&preferred_node_name, span), |fixer| {
+        fixer.replace(span, preferred_node_name)
     });
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -1,6 +1,5 @@
 use crate::{
     context::LintContext,
-    fixer::Fix,
     rule::Rule,
     utils::{collect_possible_jest_call_node, PossibleJestNode},
 };
@@ -140,16 +139,14 @@ impl NoUntypedMockFactory {
                     string_literal.value.as_str(),
                     property_span,
                 ),
-                || {
-                    let mut content = ctx.codegen();
+                |fixer| {
+                    let mut content = fixer.codegen();
                     content.print_str(b"<typeof import('");
                     content.print_str(string_literal.value.as_bytes());
                     content.print_str(b"')>(");
+                    let span = Span::sized(string_literal.span.start - 1, 1);
 
-                    Fix::new(
-                        content.into_source_text(),
-                        Span::new(string_literal.span.start - 1, string_literal.span.start),
-                    )
+                    fixer.replace(span, content)
                 },
             );
         } else if let Expression::Identifier(ident) = expr {

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::LintContext,
-    fixer::Fix,
+    fixer::RuleFixer,
     rule::Rule,
     utils::{
         collect_possible_jest_call_node, is_equality_matcher, parse_expect_jest_fn_call,
@@ -113,16 +113,16 @@ impl PreferComparisonMatcher {
             return;
         };
 
-        ctx.diagnostic_with_fix(use_to_be_comparison(prefer_matcher_name, matcher.span), || {
+        ctx.diagnostic_with_fix(use_to_be_comparison(prefer_matcher_name, matcher.span), |fixer| {
             // This is to handle the case can be transform into the following case:
             // expect(value > 1,).toEqual(true,) => expect(value,).toBeGreaterThan(1,)
             //                 ^              ^
             // Therefore the range starting after ',' and before '.' is called as call_span_end,
             // and the same as `arg_span_end`.
-            let call_span_end = Span::new(binary_expr.span.end, parent_call_expr.span.end)
-                .source_text(ctx.source_text());
-            let arg_span_end = Span::new(matcher_arg_value.span.end, call_expr.span.end)
-                .source_text(ctx.source_text());
+            let call_span_end =
+                fixer.source_range(Span::new(binary_expr.span.end, parent_call_expr.span.end));
+            let arg_span_end =
+                fixer.source_range(Span::new(matcher_arg_value.span.end, call_expr.span.end));
             let content = Self::building_code(
                 binary_expr,
                 call_span_end,
@@ -130,9 +130,9 @@ impl PreferComparisonMatcher {
                 parse_expect_jest_fn.local.as_bytes(),
                 &parse_expect_jest_fn.modifiers(),
                 prefer_matcher_name,
-                ctx,
+                fixer,
             );
-            Fix::new(content, call_expr.span)
+            fixer.replace(call_expr.span, content)
         });
     }
 
@@ -171,16 +171,16 @@ impl PreferComparisonMatcher {
         }
     }
 
-    fn building_code(
-        binary_expr: &BinaryExpression,
+    fn building_code<'a>(
+        binary_expr: &BinaryExpression<'a>,
         call_span_end: &str,
         arg_span_end: &str,
         local_name: &[u8],
-        modifiers: &[&KnownMemberExpressionProperty],
+        modifiers: &[&KnownMemberExpressionProperty<'a>],
         prefer_matcher_name: &str,
-        ctx: &LintContext,
+        fixer: RuleFixer<'_, 'a>,
     ) -> String {
-        let mut content = ctx.codegen();
+        let mut content = fixer.codegen();
         content.print_str(local_name);
         content.print(b'(');
         content.print_expression(&binary_expr.left);

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -5,7 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule};
+use crate::{context::LintContext, rule::Rule};
 
 fn ban_tslint_comment_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -48,7 +48,7 @@ impl Rule for BanTslintComment {
 
                 ctx.diagnostic_with_fix(
                     ban_tslint_comment_diagnostic(raw.trim(), comment_span),
-                    || Fix::delete(comment_span),
+                    |fixer| fixer.delete_range(comment_span),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn consistent_type_definitions_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("typescript-eslint(consistent-type-definitions):")
@@ -100,10 +100,10 @@ impl Rule for ConsistentTypeDefinitions {
                                 "type",
                                 Span::new(start, start + 4),
                             ),
-                            || {
-                                Fix::new(
-                                    format!("interface {name} {body}"),
+                            |fixer| {
+                                fixer.replace(
                                     Span::new(start, decl.span.end),
+                                    format!("interface {name} {body}"),
                                 )
                             },
                         );
@@ -157,10 +157,10 @@ impl Rule for ConsistentTypeDefinitions {
                             "interface",
                             Span::new(decl.span.start, decl.span.start + 9),
                         ),
-                        || {
-                            Fix::new(
+                        |fixer| {
+                            fixer.replace(
+                                exp.span,
                                 format!("type {name} = {body}{extends}\nexport default {name}"),
-                                Span::new(exp.span.start, exp.span.end),
                             )
                         },
                     );
@@ -215,10 +215,10 @@ impl Rule for ConsistentTypeDefinitions {
                         "interface",
                         Span::new(start, start + 9),
                     ),
-                    || {
-                        Fix::new(
-                            format!("type {name} = {body}{extends}"),
+                    |fixer| {
+                        fixer.replace(
                             Span::new(start, decl.span.end),
+                            format!("type {name} = {body}{extends}"),
                         )
                     },
                 );

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -1,4 +1,3 @@
-use crate::Fix;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 
@@ -97,8 +96,8 @@ impl Rule for NoExplicitAny {
         }
 
         if self.fix_to_unknown {
-            ctx.diagnostic_with_fix(no_explicit_any_diagnostic(any.span), || {
-                Fix::new("unknown", any.span)
+            ctx.diagnostic_with_fix(no_explicit_any_diagnostic(any.span), |fixer| {
+                fixer.replace(any.span, "unknown")
             });
         } else {
             ctx.diagnostic(no_explicit_any_diagnostic(any.span));

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -5,7 +5,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_as_const_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("typescript-eslint(prefer-as-const): Expected a `const` assertion instead of a literal type annotation.")
@@ -117,10 +117,8 @@ fn check_and_report(
         };
         if let Some(span) = error_span {
             if can_fix {
-                ctx.diagnostic_with_fix(prefer_as_const_diagnostic(span), || {
-                    let start = span.start;
-                    let end = span.end;
-                    Fix::new("const", Span::new(start, end))
+                ctx.diagnostic_with_fix(prefer_as_const_diagnostic(span), |fixer| {
+                    fixer.replace(span, "const")
                 });
             } else {
                 ctx.diagnostic(prefer_as_const_diagnostic(span));

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -4,7 +4,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::fixer::Fix;
 use crate::{context::LintContext, rule::Rule};
 
 fn prefer_ts_expect_error_diagnostic(span0: Span) -> OxcDiagnostic {
@@ -56,18 +55,18 @@ impl Rule for PreferTsExpectError {
 
             if kind.is_single_line() {
                 let comment_span = Span::new(span.start - 2, span.end);
-                ctx.diagnostic_with_fix(prefer_ts_expect_error_diagnostic(comment_span), || {
-                    Fix::new(
-                        format!("//{}", raw.replace("@ts-ignore", "@ts-expect-error")),
+                ctx.diagnostic_with_fix(prefer_ts_expect_error_diagnostic(comment_span), |fixer| {
+                    fixer.replace(
                         comment_span,
+                        format!("//{}", raw.replace("@ts-ignore", "@ts-expect-error")),
                     )
                 });
             } else {
                 let comment_span = Span::new(span.start - 2, span.end + 2);
-                ctx.diagnostic_with_fix(prefer_ts_expect_error_diagnostic(comment_span), || {
-                    Fix::new(
-                        format!("/*{}*/", raw.replace("@ts-ignore", "@ts-expect-error")),
+                ctx.diagnostic_with_fix(prefer_ts_expect_error_diagnostic(comment_span), |fixer| {
+                    fixer.replace(
                         comment_span,
+                        format!("/*{}*/", raw.replace("@ts-ignore", "@ts-expect-error")),
                     )
                 });
             }

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn empty_brace_spaces_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(empty-brace-spaces): No spaces inside empty pair of braces allowed")
@@ -47,7 +47,7 @@ impl Rule for EmptyBraceSpaces {
                 {
                     ctx.diagnostic_with_fix(
                         empty_brace_spaces_diagnostic(static_block.span),
-                        || Fix::new("static {}", static_block.span),
+                        |fixer| fixer.replace(static_block.span, "static {}"),
                     );
                 }
             }
@@ -88,7 +88,9 @@ fn remove_empty_braces_spaces(ctx: &LintContext, is_empty_body: bool, span: Span
 
     if is_empty_body && end - start > 2 && !ctx.semantic().trivias().has_comments_between(span) {
         // length of "{}"
-        ctx.diagnostic_with_fix(empty_brace_spaces_diagnostic(span), || Fix::new("{}", span));
+        ctx.diagnostic_with_fix(empty_brace_spaces_diagnostic(span), |fixer| {
+            fixer.replace(span, "{}")
+        });
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn escape_case_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(escape-case): Use uppercase characters for the value of the escape sequence.").with_labels([span0.into()])
@@ -125,8 +125,8 @@ impl Rule for EscapeCase {
             AstKind::StringLiteral(StringLiteral { span, .. }) => {
                 let text = span.source_text(ctx.source_text());
                 if let Some(fixed) = check_case(text, false) {
-                    ctx.diagnostic_with_fix(escape_case_diagnostic(*span), || {
-                        Fix::new(fixed, *span)
+                    ctx.diagnostic_with_fix(escape_case_diagnostic(*span), |fixer| {
+                        fixer.replace(*span, fixed)
                     });
                 }
             }
@@ -135,8 +135,8 @@ impl Rule for EscapeCase {
                     if let Some(fixed) =
                         check_case(quasi.span.source_text(ctx.source_text()), false)
                     {
-                        ctx.diagnostic_with_fix(escape_case_diagnostic(quasi.span), || {
-                            Fix::new(fixed, quasi.span)
+                        ctx.diagnostic_with_fix(escape_case_diagnostic(quasi.span), |fixer| {
+                            fixer.replace(quasi.span, fixed)
                         });
                     }
                 });
@@ -144,8 +144,8 @@ impl Rule for EscapeCase {
             AstKind::RegExpLiteral(regex) => {
                 let text = regex.span.source_text(ctx.source_text());
                 if let Some(fixed) = check_case(text, true) {
-                    ctx.diagnostic_with_fix(escape_case_diagnostic(regex.span), || {
-                        Fix::new(fixed, regex.span)
+                    ctx.diagnostic_with_fix(escape_case_diagnostic(regex.span), |fixer| {
+                        fixer.replace(regex.span, fixed)
                     });
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -6,7 +6,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_instanceof_array_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(no-instanceof-array): Use `Array.isArray()` instead of `instanceof Array`.")
@@ -44,15 +44,15 @@ impl Rule for NoInstanceofArray {
 
         match &expr.right.without_parenthesized() {
             Expression::Identifier(identifier) if identifier.name == "Array" => {
-                ctx.diagnostic_with_fix(no_instanceof_array_diagnostic(expr.span), || {
+                ctx.diagnostic_with_fix(no_instanceof_array_diagnostic(expr.span), |fixer| {
                     let modified_code = {
                         let mut codegen = String::new();
                         codegen.push_str("Array.isArray(");
-                        codegen.push_str(expr.left.span().source_text(ctx.source_text()));
+                        codegen.push_str(fixer.source_range(expr.left.span()));
                         codegen.push(')');
                         codegen
                     };
-                    Fix::new(modified_code, expr.span)
+                    fixer.replace(expr.span, modified_code)
                 });
             }
             _ => {}

--- a/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn unparenthesized_nested_ternary(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(no-nested-ternary): Unexpected nested ternary expression without parentheses.")
@@ -86,17 +86,14 @@ impl Rule for NoNestedTernary {
                 if let AstKind::ParenthesizedExpression(_) = parent_node.kind() {
                     return;
                 }
-                ctx.diagnostic_with_fix(unparenthesized_nested_ternary(cond_expr.span), || {
-                    Fix::new(
-                        format!("({})", cond_expr.span.source_text(ctx.source_text())),
-                        cond_expr.span,
-                    )
+                ctx.diagnostic_with_fix(unparenthesized_nested_ternary(cond_expr.span), |fixer| {
+                    let content = format!("({})", fixer.source_range(cond_expr.span));
+                    fixer.replace(cond_expr.span, content)
                 });
             }
-            2 => {
+            _ => {
                 ctx.diagnostic(deeply_nested_ternary(cond_expr.span));
             }
-            _ => unreachable!(),
         }
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unnecessary_await_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -66,11 +66,7 @@ impl Rule for NoUnnecessaryAwait {
                         expr.span.start,
                         expr.span.start + 5,
                     )),
-                    || {
-                        let mut codegen = String::new();
-                        codegen.push_str(expr.argument.span().source_text(ctx.source_text()));
-                        Fix::new(codegen, expr.span)
-                    },
+                    |fixer| fixer.replace(expr.span, fixer.source_range(expr.argument.span())),
                 );
             };
         }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -5,9 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::LogicalOperator;
 
-use crate::{
-    ast_util::outermost_paren_parent, context::LintContext, fixer::Fix, rule::Rule, AstNode,
-};
+use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_fallback_in_spread_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals")
@@ -80,9 +78,9 @@ impl Rule for NoUselessFallbackInSpread {
         let diagnostic = no_useless_fallback_in_spread_diagnostic(spread_element.span);
 
         if can_fix(&logical_expression.left) {
-            ctx.diagnostic_with_fix(diagnostic, || {
-                let left_text = ctx.source_range(logical_expression.left.span());
-                Fix::new(format!("...{left_text}"), spread_element.span)
+            ctx.diagnostic_with_fix(diagnostic, |fixer| {
+                let left_text = fixer.source_range(logical_expression.left.span());
+                fixer.replace(spread_element.span, format!("...{left_text}"))
             });
         } else {
             ctx.diagnostic(diagnostic);

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread.rs
@@ -15,7 +15,7 @@ use crate::{
         get_new_expr_ident_name, is_method_call, is_new_expression, outermost_paren_parent,
     },
     context::LintContext,
-    fixer::Fix,
+    fixer::{Fix, RuleFixer},
     rule::Rule,
     AstNode,
 };
@@ -167,8 +167,8 @@ fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
                 AstKind::ArrayExpressionElement(_) => {
                     let diagnostic = spread_in_list(span, "array");
                     if let Some(outer_array) = ctx.nodes().parent_kind(parent_parent.id()) {
-                        ctx.diagnostic_with_fix(diagnostic, || {
-                            fix_replace(ctx, &outer_array, array_expr)
+                        ctx.diagnostic_with_fix(diagnostic, |fixer| {
+                            fix_replace(fixer, &outer_array, array_expr)
                         });
                     } else {
                         ctx.diagnostic(diagnostic);
@@ -176,8 +176,8 @@ fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
                 }
                 // foo(...[ ])
                 AstKind::Argument(_) => {
-                    ctx.diagnostic_with_fix(spread_in_arguments(span), || {
-                        fix_by_removing_spread(ctx, array_expr, spread_elem)
+                    ctx.diagnostic_with_fix(spread_in_arguments(span), |fixer| {
+                        fix_by_removing_spread(fixer, array_expr, spread_elem)
                     });
                 }
                 _ => {}
@@ -260,7 +260,7 @@ fn check_useless_iterable_to_array<'a>(
             }
             ctx.diagnostic_with_fix(
                 iterable_to_array(span, get_new_expr_ident_name(new_expr).unwrap_or("unknown")),
-                || fix_by_removing_spread(ctx, &new_expr.arguments[0], spread_elem),
+                |fixer| fix_by_removing_spread(fixer, &new_expr.arguments[0], spread_elem),
             );
         }
         AstKind::CallExpression(call_expr) => {
@@ -305,7 +305,7 @@ fn check_useless_iterable_to_array<'a>(
                     span,
                     &get_method_name(call_expr).unwrap_or_else(|| "unknown".into()),
                 ),
-                || fix_by_removing_spread(ctx, array_expr, spread_elem),
+                |fixer| fix_by_removing_spread(fixer, array_expr, spread_elem),
             );
         }
         _ => {}
@@ -363,8 +363,8 @@ fn check_useless_array_clone<'a>(array_expr: &ArrayExpression<'a>, ctx: &LintCon
             },
         );
 
-        ctx.diagnostic_with_fix(clone_array(span, &method), || {
-            fix_by_removing_spread(ctx, array_expr, spread_elem)
+        ctx.diagnostic_with_fix(clone_array(span, &method), |fixer| {
+            fix_by_removing_spread(fixer, array_expr, spread_elem)
         });
     }
 
@@ -382,29 +382,30 @@ fn check_useless_array_clone<'a>(array_expr: &ArrayExpression<'a>, ctx: &LintCon
             let method_name =
                 call_expr.callee.get_member_expr().unwrap().static_property_name().unwrap();
 
-            ctx.diagnostic_with_fix(clone_array(span, &format!("Promise.{method_name}")), || {
-                fix_by_removing_spread(ctx, array_expr, spread_elem)
-            });
+            ctx.diagnostic_with_fix(
+                clone_array(span, &format!("Promise.{method_name}")),
+                |fixer| fix_by_removing_spread(fixer, array_expr, spread_elem),
+            );
         }
     }
 }
 
 fn fix_replace<'a, T: GetSpan, U: GetSpan>(
-    ctx: &LintContext<'a>,
+    fixer: RuleFixer<'_, 'a>,
     target: &T,
     replacement: &U,
 ) -> Fix<'a> {
-    let replacement = ctx.source_range(replacement.span());
-    Fix::new(replacement, target.span())
+    let replacement = fixer.source_range(replacement.span());
+    fixer.replace(target.span(), replacement)
 }
 
 /// Creates a fix that replaces `[...spread]` with `spread`
 fn fix_by_removing_spread<'a, S: GetSpan>(
-    ctx: &LintContext<'a>,
+    fixer: RuleFixer<'_, 'a>,
     iterable: &S,
     spread: &SpreadElement<'a>,
 ) -> Fix<'a> {
-    Fix::new(ctx.source_range(spread.argument.span()), iterable.span())
+    fixer.replace(iterable.span(), fixer.source_range(spread.argument.span()))
 }
 
 /// Checks if `node` is `[...(expr)]`

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn zero_fraction(span0: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -69,7 +69,7 @@ impl Rule for NoZeroFractions {
             } else {
                 zero_fraction(number_literal.span, &fmt)
             },
-            || Fix::new(fmt, number_literal.span),
+            |fixer| fixer.replace(number_literal.span, fmt),
         );
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn uppercase_prefix(span0: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(number-literal-case): Unexpected number literal prefix in uppercase.")
@@ -83,7 +83,7 @@ impl Rule for NumberLiteralCase {
         };
 
         if let Some((diagnostic, fixed_literal)) = check_number_literal(raw_literal, raw_span) {
-            ctx.diagnostic_with_fix(diagnostic, || Fix::new(fixed_literal, raw_span));
+            ctx.diagnostic_with_fix(diagnostic, |fixer| fixer.replace(raw_span, fixed_literal));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -9,7 +9,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn numeric_separators_style_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -98,7 +98,7 @@ impl Rule for NumericSeparatorsStyle {
                 if formatted != number.raw {
                     ctx.diagnostic_with_fix(
                         numeric_separators_style_diagnostic(number.span),
-                        || Fix::new(formatted, number.span),
+                        |fixer| fixer.replace(number.span, formatted),
                     );
                 }
             }
@@ -114,7 +114,7 @@ impl Rule for NumericSeparatorsStyle {
                 if formatted.len() != number.span.size() as usize {
                     ctx.diagnostic_with_fix(
                         numeric_separators_style_diagnostic(number.span),
-                        || Fix::new(formatted, number.span),
+                        |fixer| fixer.replace(number.span, formatted),
                     );
                 }
             }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_dom_node_text_content_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-text-content): Prefer `.textContent` over `.innerText`.")
@@ -44,9 +44,10 @@ impl Rule for PreferDomNodeTextContent {
         if let AstKind::MemberExpression(member_expr) = node.kind() {
             if let Some((span, name)) = member_expr.static_property_info() {
                 if name == "innerText" && !member_expr.is_computed() {
-                    ctx.diagnostic_with_fix(prefer_dom_node_text_content_diagnostic(span), || {
-                        Fix::new("textContent", span)
-                    });
+                    ctx.diagnostic_with_fix(
+                        prefer_dom_node_text_content_diagnostic(span),
+                        |fixer| fixer.replace(span, "textContent"),
+                    );
                 }
             }
         }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -8,7 +8,7 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{is_empty_array_expression, is_empty_object_expression},
-    AstNode, Fix,
+    AstNode,
 };
 
 fn known_method(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
@@ -109,17 +109,17 @@ impl Rule for PreferPrototypeMethods {
                 || unknown_method(method_expr.span(), constructor_name),
                 |method_name| known_method(method_expr.span(), constructor_name, method_name),
             ),
-            || {
+            |fixer| {
                 let span = object_expr.span();
                 let need_padding = span.start >= 1
                     && ctx.source_text().as_bytes()[span.start as usize - 1].is_ascii_alphabetic();
-                Fix::new(
+                fixer.replace(
+                    span,
                     format!(
                         "{}{}.prototype",
                         if need_padding { " " } else { "" },
                         constructor_name
                     ),
-                    span,
                 )
             },
         );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -88,8 +88,8 @@ impl Rule for PreferQuerySelector {
             );
 
             if argument_expr.is_null() {
-                return ctx.diagnostic_with_fix(diagnostic, || {
-                    return Fix::new(*preferred_selector, property_span);
+                return ctx.diagnostic_with_fix(diagnostic, |fixer| {
+                    fixer.replace(property_span, *preferred_selector)
                 });
             }
 
@@ -106,15 +106,18 @@ impl Rule for PreferQuerySelector {
             };
 
             if let Some(literal_value) = literal_value {
-                return ctx.diagnostic_with_fix(diagnostic, || {
+                return ctx.diagnostic_with_fix(diagnostic, |fixer| {
                     if literal_value.is_empty() {
                         return Fix::new(*preferred_selector, property_span);
                     }
 
-                    let source_text = argument_expr.span().source_text(ctx.source_text());
+                    // let source_text =
+                    // argument_expr.span().source_text(ctx.source_text());
+                    let source_text = fixer.source_range(argument_expr.span());
                     let quotes_symbol = source_text.chars().next().unwrap();
                     let sharp = if cur_property_name.eq(&"getElementById") { "#" } else { "" };
-                    return Fix::new(format!("{preferred_selector}({quotes_symbol}{sharp}{literal_value}{quotes_symbol}"), property_span.merge(&argument_expr.span()));
+                    let span = property_span.merge(&argument_expr.span());
+                    return fixer.replace(span, format!("{preferred_selector}({quotes_symbol}{sharp}{literal_value}{quotes_symbol}"));
                 });
             }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use phf::phf_set;
 
-use crate::{context::LintContext, rule::Rule, AstNode, Fix};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_spread_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -161,11 +161,11 @@ impl Rule for PreferSpread {
 
                 ctx.diagnostic_with_fix(
                     prefer_spread_diagnostic(call_expr.span, "string.split()"),
-                    || {
+                    |fixer| {
                         let callee_obj = member_expr.object().without_parenthesized();
-                        Fix::new(
-                            format!("[...{}]", callee_obj.span().source_text(ctx.source_text())),
+                        fixer.replace(
                             call_expr.span,
+                            format!("[...{}]", callee_obj.span().source_text(ctx.source_text())),
                         )
                     },
                 );

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -4,7 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn require_number_to_fixed_digits_argument_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint-plugin-unicorn(require-number-to-fixed-digits-argument): Number method .toFixed() should have an argument")
@@ -61,15 +61,15 @@ impl Rule for RequireNumberToFixedDigitsArgument {
 
                     ctx.diagnostic_with_fix(
                         require_number_to_fixed_digits_argument_diagnostic(parenthesis_span),
-                        || {
+                        |fixer| {
                             let modified_code = {
-                                let mut formatter = ctx.codegen();
+                                let mut formatter = fixer.codegen();
 
                                 let mut parenthesis_span_without_right_one = parenthesis_span;
                                 parenthesis_span_without_right_one.end -= 1;
 
-                                let span_source_code = parenthesis_span_without_right_one
-                                    .source_text(ctx.source_text());
+                                let span_source_code =
+                                    fixer.source_range(parenthesis_span_without_right_one);
 
                                 formatter.print_str(span_source_code.as_bytes());
                                 formatter.print_str(b"0)");
@@ -77,7 +77,7 @@ impl Rule for RequireNumberToFixedDigitsArgument {
                                 formatter.into_source_text()
                             };
 
-                            Fix::new(modified_code, parenthesis_span)
+                            fixer.replace(parenthesis_span, modified_code)
                         },
                     );
                 }

--- a/crates/oxc_linter/src/snapshots/no_console_spaces.snap
+++ b/crates/oxc_linter/src/snapshots/no_console_spaces.snap
@@ -3,30 +3,30 @@ source: crates/oxc_linter/src/tester.rs
 expression: no_console_spaces
 ---
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:13]
+   ╭─[no_console_spaces.tsx:1:14]
  1 │ console.log("abc ", "def");
-   ·             ──────
+   ·              ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:20]
+   ╭─[no_console_spaces.tsx:1:21]
  1 │ console.log("abc", " def");
-   ·                    ──────
+   ·                     ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:13]
+   ╭─[no_console_spaces.tsx:1:14]
  1 │ console.log(" abc ", "def");
-   ·             ───────
+   ·              ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.debug` parameters
-   ╭─[no_console_spaces.tsx:1:15]
+   ╭─[no_console_spaces.tsx:1:16]
  1 │ console.debug("abc ", "def");
-   ·               ──────
+   ·                ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
@@ -38,58 +38,58 @@ expression: no_console_spaces
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.info` parameters
-   ╭─[no_console_spaces.tsx:1:14]
+   ╭─[no_console_spaces.tsx:1:15]
  1 │ console.info("abc ", "def");
-   ·              ──────
+   ·               ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.warn` parameters
-   ╭─[no_console_spaces.tsx:1:14]
+   ╭─[no_console_spaces.tsx:1:15]
  1 │ console.warn("abc ", "def");
-   ·              ──────
+   ·               ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:15]
+   ╭─[no_console_spaces.tsx:1:16]
  1 │ console.error("abc ", "def");
-   ·               ──────
+   ·                ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:20]
+   ╭─[no_console_spaces.tsx:1:21]
  1 │ console.log("abc", " def ", "ghi");
-   ·                    ───────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.log("abc", " def ", "ghi");
-   ·                    ───────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:13]
- 1 │ console.log("abc ", "def ", "ghi");
-   ·             ──────
+   ·                     ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
    ╭─[no_console_spaces.tsx:1:21]
- 1 │ console.log("abc ", "def ", "ghi");
-   ·                     ──────
+ 1 │ console.log("abc", " def ", "ghi");
+   ·                     ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:13]
+   ╭─[no_console_spaces.tsx:1:14]
+ 1 │ console.log("abc ", "def ", "ghi");
+   ·              ────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
+   ╭─[no_console_spaces.tsx:1:22]
+ 1 │ console.log("abc ", "def ", "ghi");
+   ·                      ────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
+   ╭─[no_console_spaces.tsx:1:14]
  1 │ console.log('abc ', "def");
-   ·             ──────
+   ·              ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
@@ -101,9 +101,9 @@ expression: no_console_spaces
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:15]
+   ╭─[no_console_spaces.tsx:1:16]
  1 │ console.error('abc ', "def");
-   ·               ──────
+   ·                ────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
@@ -122,225 +122,225 @@ expression: no_console_spaces
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:20]
+   ╭─[no_console_spaces.tsx:1:21]
  1 │ console.log("abc", " def ", "ghi");
-   ·                    ───────
+   ·                     ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:20]
+   ╭─[no_console_spaces.tsx:1:21]
  1 │ console.log("abc", " def ", "ghi");
-   ·                    ───────
+   ·                     ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:18]
+   ╭─[no_console_spaces.tsx:1:19]
  1 │ console.log("_", " leading", "_")
-   ·                  ──────────
+   ·                   ────────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:18]
+   ╭─[no_console_spaces.tsx:1:19]
  1 │ console.log("_", "trailing ", "_")
-   ·                  ───────────
+   ·                   ─────────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:18]
+   ╭─[no_console_spaces.tsx:1:19]
  1 │ console.log("_", " leading and trailing ", "_")
-   ·                  ────────────────────────
+   ·                   ──────────────────────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:18]
+   ╭─[no_console_spaces.tsx:1:19]
  1 │ console.log("_", " leading and trailing ", "_")
-   ·                  ────────────────────────
+   ·                   ──────────────────────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:22]
- 1 │ console.error("abc", " def ", "ghi");
-   ·                      ───────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:22]
- 1 │ console.error("abc", " def ", "ghi");
-   ·                      ───────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.error("_", " leading", "_")
-   ·                    ──────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.error("_", "trailing ", "_")
-   ·                    ───────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.error("_", " leading and trailing ", "_")
-   ·                    ────────────────────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.error("_", " leading and trailing ", "_")
-   ·                    ────────────────────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:18]
- 1 │ console.log("_", " log ", "_")
-   ·                  ───────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:18]
- 1 │ console.log("_", " log ", "_")
-   ·                  ───────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.debug` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.debug("_", " debug ", "_")
-   ·                    ─────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.debug` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.debug("_", " debug ", "_")
-   ·                    ─────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.info` parameters
-   ╭─[no_console_spaces.tsx:1:19]
- 1 │ console.info("_", " info ", "_")
-   ·                   ────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.info` parameters
-   ╭─[no_console_spaces.tsx:1:19]
- 1 │ console.info("_", " info ", "_")
-   ·                   ────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.warn` parameters
-   ╭─[no_console_spaces.tsx:1:19]
- 1 │ console.warn("_", " warn ", "_")
-   ·                   ────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.warn` parameters
-   ╭─[no_console_spaces.tsx:1:19]
- 1 │ console.warn("_", " warn ", "_")
-   ·                   ────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.error("_", " error ", "_")
-   ·                    ─────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:20]
- 1 │ console.error("_", " error ", "_")
-   ·                    ─────────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
-   ╭─[no_console_spaces.tsx:1:16]
- 1 │ console["log"](" a ", " b ");
-   ·                ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
    ╭─[no_console_spaces.tsx:1:23]
- 1 │ console["log"](" a ", " b ");
+ 1 │ console.error("abc", " def ", "ghi");
    ·                       ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.debug` parameters
-   ╭─[no_console_spaces.tsx:1:18]
- 1 │ console["debug"](" a ", " b ");
-   ·                  ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.debug` parameters
-   ╭─[no_console_spaces.tsx:1:25]
- 1 │ console["debug"](" a ", " b ");
-   ·                         ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.info` parameters
-   ╭─[no_console_spaces.tsx:1:17]
- 1 │ console["info"](" a ", " b ");
-   ·                 ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.info` parameters
-   ╭─[no_console_spaces.tsx:1:24]
- 1 │ console["info"](" a ", " b ");
-   ·                        ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.warn` parameters
-   ╭─[no_console_spaces.tsx:1:17]
- 1 │ console["warn"](" a ", " b ");
-   ·                 ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
-  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.warn` parameters
-   ╭─[no_console_spaces.tsx:1:24]
- 1 │ console["warn"](" a ", " b ");
-   ·                        ─────
-   ╰────
-  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
-
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
-   ╭─[no_console_spaces.tsx:1:18]
- 1 │ console["error"](" a ", " b ");
-   ·                  ─────
+   ╭─[no_console_spaces.tsx:1:23]
+ 1 │ console.error("abc", " def ", "ghi");
+   ·                       ─────
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
 
   ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.error("_", " leading", "_")
+   ·                     ────────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.error("_", "trailing ", "_")
+   ·                     ─────────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.error("_", " leading and trailing ", "_")
+   ·                     ──────────────────────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.error("_", " leading and trailing ", "_")
+   ·                     ──────────────────────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
+   ╭─[no_console_spaces.tsx:1:19]
+ 1 │ console.log("_", " log ", "_")
+   ·                   ─────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
+   ╭─[no_console_spaces.tsx:1:19]
+ 1 │ console.log("_", " log ", "_")
+   ·                   ─────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.debug` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.debug("_", " debug ", "_")
+   ·                     ───────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.debug` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.debug("_", " debug ", "_")
+   ·                     ───────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.info` parameters
+   ╭─[no_console_spaces.tsx:1:20]
+ 1 │ console.info("_", " info ", "_")
+   ·                    ──────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.info` parameters
+   ╭─[no_console_spaces.tsx:1:20]
+ 1 │ console.info("_", " info ", "_")
+   ·                    ──────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.warn` parameters
+   ╭─[no_console_spaces.tsx:1:20]
+ 1 │ console.warn("_", " warn ", "_")
+   ·                    ──────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.warn` parameters
+   ╭─[no_console_spaces.tsx:1:20]
+ 1 │ console.warn("_", " warn ", "_")
+   ·                    ──────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.error("_", " error ", "_")
+   ·                     ───────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:21]
+ 1 │ console.error("_", " error ", "_")
+   ·                     ───────
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.log` parameters
+   ╭─[no_console_spaces.tsx:1:17]
+ 1 │ console["log"](" a ", " b ");
+   ·                 ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.log` parameters
+   ╭─[no_console_spaces.tsx:1:24]
+ 1 │ console["log"](" a ", " b ");
+   ·                        ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.debug` parameters
+   ╭─[no_console_spaces.tsx:1:19]
+ 1 │ console["debug"](" a ", " b ");
+   ·                   ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.debug` parameters
+   ╭─[no_console_spaces.tsx:1:26]
+ 1 │ console["debug"](" a ", " b ");
+   ·                          ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.info` parameters
+   ╭─[no_console_spaces.tsx:1:18]
+ 1 │ console["info"](" a ", " b ");
+   ·                  ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.info` parameters
    ╭─[no_console_spaces.tsx:1:25]
+ 1 │ console["info"](" a ", " b ");
+   ·                         ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.warn` parameters
+   ╭─[no_console_spaces.tsx:1:18]
+ 1 │ console["warn"](" a ", " b ");
+   ·                  ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.warn` parameters
+   ╭─[no_console_spaces.tsx:1:25]
+ 1 │ console["warn"](" a ", " b ");
+   ·                         ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use trailing spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:19]
  1 │ console["error"](" a ", " b ");
-   ·                         ─────
+   ·                   ───
+   ╰────
+  help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.
+
+  ⚠ eslint-plugin-unicorn(no-console-spaces): Do not use leading spaces with `console.error` parameters
+   ╭─[no_console_spaces.tsx:1:26]
+ 1 │ console["error"](" a ", " b ");
+   ·                          ───
    ╰────
   help: The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.

--- a/crates/oxc_linter/src/snapshots/prefer_todo.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_todo.snap
@@ -3,21 +3,21 @@ source: crates/oxc_linter/src/tester.rs
 expression: prefer_todo
 ---
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
-   ╭─[prefer_todo.tsx:1:5]
+   ╭─[prefer_todo.tsx:1:1]
  1 │ test('i need to write this test');
-   ·     ▲
+   · ────
    ╰────
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
-   ╭─[prefer_todo.tsx:1:5]
+   ╭─[prefer_todo.tsx:1:1]
  1 │ test('i need to write this test',);
-   ·     ▲
+   · ────
    ╰────
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.
-   ╭─[prefer_todo.tsx:1:5]
+   ╭─[prefer_todo.tsx:1:1]
  1 │ test(`i need to write this test`);
-   ·     ▲
+   · ────
    ╰────
 
   ⚠ eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.


### PR DESCRIPTION
Adds a new `RuleFixer` struct that gets passed to `ctx.diagnostic_with_fix`.

This PR is half proposal and half implementation. I'd love thoughts and feedback on its design (including whether or not it adds enough benefit to make it worth merging this PR).