### PR TITLE
test(linter): add linter to coverage task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,7 @@ dependencies = [
  "oxc_ast",
  "oxc_codegen",
  "oxc_diagnostics",
+ "oxc_linter",
  "oxc_minifier",
  "oxc_parser",
  "oxc_prettier",

--- a/crates/oxc_linter/src/fixer.rs
+++ b/crates/oxc_linter/src/fixer.rs
@@ -25,7 +25,7 @@ pub struct FixResult<'a> {
     pub messages: Vec<Message<'a>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Message<'a> {
     pub error: OxcDiagnostic,
     pub start: u32,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -28,6 +28,7 @@ use oxc_semantic::AstNode;
 pub use crate::{
     config::OxlintConfig,
     context::LintContext,
+    fixer::{Fixer, Message},
     options::{AllowWarnDeny, LintOptions},
     rule::{RuleCategory, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},
@@ -35,7 +36,6 @@ pub use crate::{
 use crate::{
     config::{OxlintEnv, OxlintGlobals, OxlintSettings},
     fixer::Fix,
-    fixer::{Fixer, Message},
     rules::RuleEnum,
     table::RuleTable,
 };

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -135,16 +135,10 @@ fn is_argument_only_used_in_recursion<'a>(
     has_references && is_used_only_in_recursion
 }
 
-fn is_function_maybe_reassigned<'a>(
-    function_id: SymbolId,
-    ctx: &'a LintContext<'_>,
-) -> bool {
+fn is_function_maybe_reassigned(function_id: SymbolId, ctx: &LintContext<'_>) -> bool {
     let mut is_maybe_reassigned = false;
 
-    for reference in ctx
-        .semantic()
-        .symbol_references(function_id)
-    {
+    for reference in ctx.semantic().symbol_references(function_id) {
         if let Some(AstKind::SimpleAssignmentTarget(_)) =
             ctx.nodes().parent_kind(reference.node_id())
         {

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -22,16 +22,17 @@ test = false
 
 [dependencies]
 oxc_allocator    = { workspace = true }
-oxc_parser       = { workspace = true }
 oxc_ast          = { workspace = true, features = ["serialize"] }
 oxc_codegen      = { workspace = true }
 oxc_diagnostics  = { workspace = true }
-oxc_semantic     = { workspace = true }
+oxc_linter       = { workspace = true }
 oxc_minifier     = { workspace = true }
+oxc_parser       = { workspace = true }
 oxc_prettier     = { workspace = true }
+oxc_semantic     = { workspace = true }
+oxc_sourcemap    = { workspace = true }
 oxc_span         = { workspace = true }
 oxc_tasks_common = { workspace = true }
-oxc_sourcemap    = { workspace = true }
 oxc_transformer  = { workspace = true }
 
 serde          = { workspace = true, features = ["derive"] }

--- a/tasks/coverage/linter_babel.snap
+++ b/tasks/coverage/linter_babel.snap
@@ -1,0 +1,28 @@
+commit: 4bd1b2c2
+
+linter_babel Summary:
+AST Parsed     : 2079/2099 (99.05%)
+Positive Passed: 2077/2099 (98.95%)
+Expect to Parse: "annex-b/enabled/3.1-sloppy-labeled-functions/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "annex-b/enabled/3.1-sloppy-labeled-functions-multiple-labels/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "core/categorized/label-kind-switch/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "core/categorized/labeled-block-statement-regex/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "core/uncategorised/257/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "core/uncategorised/258/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "core/uncategorised/319/input.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "core/uncategorised/323/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "core/uncategorised/327/input.js"
+Parser panicked on second pass: TS1108: A 'return' statement can only be used within a function bodyExpect to Parse: "core/uncategorised/328/input.js"
+Parser panicked on second pass: TS1108: A 'return' statement can only be used within a function bodyExpect to Parse: "es2015/let/let-block-with-newline/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "es2015/statements/label-valid-func-non-strict/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "es2015/statements/label-valid-var/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "es2015/uncategorised/34/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "esprima/es2015-arrow-function/migrated_0006/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "esprima/statement-labelled/migrated_0002/input.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "typescript/arrow-function/generic-tsx-babel-7/input.ts"
+Parser panicked on first pass: Expected `<` but found `EOF`Expect to Parse: "typescript/interface/get-set-properties/input.ts"
+Parser panicked on first pass: Expected `(` but found `:`Expect to Parse: "typescript/regression/nested-extends-in-arrow-type-param/input.ts"
+Parser panicked on first pass: Expected `,` but found `extends`Expect to Parse: "typescript/regression/nested-extends-in-arrow-type-param-babel-7/input.ts"
+Parser panicked on first pass: Expected `,` but found `extends`Expect to Parse: "typescript/types/const-type-parameters/input.ts"
+Parser panicked on first pass: Unexpected tokenExpect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
+Parser panicked on first pass: Unexpected token

--- a/tasks/coverage/linter_misc.snap
+++ b/tasks/coverage/linter_misc.snap
@@ -1,0 +1,3 @@
+linter_misc Summary:
+AST Parsed     : 18/18 (100.00%)
+Positive Passed: 18/18 (100.00%)

--- a/tasks/coverage/linter_test262.snap
+++ b/tasks/coverage/linter_test262.snap
@@ -1,0 +1,160 @@
+commit: 17ba9aea
+
+linter_test262 Summary:
+AST Parsed     : 45176/45289 (99.75%)
+Positive Passed: 45161/45289 (99.72%)
+Expect to Parse: "annexB/language/statements/labeled/function-declaration.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-default-radix.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-1.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-10.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-11.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-12.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-13.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-14.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-15.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-16.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-17.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-18.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-19.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-2.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-20.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-21.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-22.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-23.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-24.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-25.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-26.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-27.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-28.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-29.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-3.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-30.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-31.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-32.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-33.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-34.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-35.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-36.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-37.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-4.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-5.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-6.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-7.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-8.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-9.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/Number/prototype/toString/numeric-literal-tostring-radix-poisoned.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "built-ins/encodeURI/S15.1.3.3_A2.2_T1.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/asi/S7.9_A1.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/asi/S7.9_A10_T10.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/asi/S7.9_A10_T11.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/asi/S7.9_A10_T12.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/asi/S7.9_A2.js"
+Parser panicked on second pass: Unexpected tokenExpect to run correctly: "language/expressions/delete/non-reference-return-true.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-eval-rqstd-abrupt-typeerror.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-eval-rqstd-abrupt-urierror.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-eval-script-code-target.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-file-does-not-exist.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-ambiguous-import.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-circular.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/catch/nested-block-labeled-specifier-tostring-abrupt-rejects.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-empty-str-is-valid-assign-expr.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-assertions-trailing-comma-first.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-assertions-trailing-comma-second.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-attributes-trailing-comma-first.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-attributes-trailing-comma-second.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-nested-imports.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/syntax/valid/nested-block-labeled-script-code-valid.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-gtbndng-indirect-update-dflt.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-gtbndng-indirect-update.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-script-code-host-resolves-module-code.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/usage/syntax-nested-block-labeled-is-call-expression-square-brackets.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/usage/syntax-nested-block-labeled-returns-thenable.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/dynamic-import/usage/syntax-nested-block-labeled-specifier-tostring.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/expressions/property-accessors/S11.2.1_A3_T2.js"
+Parser panicked on second pass: Invalid characters after numberExpect to run correctly: "language/literals/numeric/S7.8.3_A2.2_T1.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A2.2_T2.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A2.2_T7.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A2.2_T8.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.3_T1.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.3_T2.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.3_T7.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.3_T8.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.4_T1.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.4_T2.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.4_T7.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to run correctly: "language/literals/numeric/S7.8.3_A3.4_T8.js"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to Parse: "language/literals/string/S7.8.4_A6.3_T1.js"
+Parser panicked on second pass: Invalid Character ``Expect to Parse: "language/module-code/import-assertions/eval-gtbndng-indirect-faux-assertion.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-block-with-labels.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-array-literal-with-item.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-array-literal.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-arrow-function-assignment-expr.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-arrow-function-functionbody.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-block-with-labels.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-block.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-expr-arrow-function-boolean-literal.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-let-declaration.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-regexp-literal-flags.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/block-with-statment-regexp-literal.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/class-block-with-labels.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statementList/fn-block-with-labels.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/S12.8_A3.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/S12.8_A4_T1.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/S12.8_A4_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/S12.8_A4_T3.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/S12.8_A7.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/S12.8_A9_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/break/line-terminators.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/continue/S12.7_A7.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/continue/S12.7_A9_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/continue/line-terminators.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/debugger/statement.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/do-while/S12.6.1_A4_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/do-while/S12.6.1_A4_T3.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/do-while/S12.6.1_A4_T4.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/for/S12.6.3_A11.1_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/for/S12.6.3_A11_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/for/S12.6.3_A12.1_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/for/S12.6.3_A12_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/let-block-with-newline.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/let-identifier-with-newline.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/tco.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/value-await-non-module-escaped.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/value-await-non-module.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/value-yield-non-strict-escaped.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/labeled/value-yield-non-strict.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/let/dstr/obj-init-null.js"
+Parser panicked on second pass: Missing initializer in destructuring declarationExpect to Parse: "language/statements/variable/dstr/obj-init-null.js"
+Parser panicked on second pass: Missing initializer in destructuring declarationExpect to Parse: "language/statements/while/S12.6.2_A4_T2.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/while/S12.6.2_A4_T3.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/statements/while/S12.6.2_A4_T4.js"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "language/types/reference/get-value-prop-base-primitive.js"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "language/types/reference/put-value-prop-base-primitive.js"
+Parser panicked on second pass: Invalid characters after number

--- a/tasks/coverage/linter_typescript.snap
+++ b/tasks/coverage/linter_typescript.snap
@@ -1,0 +1,45 @@
+commit: 64d2eeea
+
+linter_typescript Summary:
+AST Parsed     : 5217/5243 (99.50%)
+Positive Passed: 5211/5243 (99.39%)
+Expect to Parse: "compiler/bom-utf16be.ts"
+Parser panicked on first pass: Invalid Character `￾`Expect to Parse: "compiler/breakTarget3.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/breakTarget4.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/commentsAtEndOfFile1.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/continueTarget3.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/continueTarget4.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/duplicateLabel3.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/duplicateLabel4.ts"
+Parser panicked on second pass: Unexpected tokenExpect to run correctly: "compiler/inheritedOverloadedSpecializedSignatures.ts"
+But got a runtime error: 3 more semantic errors occurred after fixing lint errors than before (3 vs 0)
+
+Expect to Parse: "compiler/sourceMapValidationLabeled.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "compiler/toStringOnPrimitives.ts"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts"
+Parser panicked on second pass: Classes may not have a static property named prototypeExpect to Parse: "conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts"
+Parser panicked on second pass: Invalid characters after numberExpect to Parse: "conformance/externalModules/topLevelAwait.2.ts"
+Parser panicked on second pass: Cannot use `await` as an identifier in an async contextExpect to run correctly: "conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts"
+But got a runtime error: 1 more semantic errors occurred after fixing lint errors than before (1 vs 0)
+
+Expect to Parse: "conformance/parser/ecmascript5/Fuzz/parser768531.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget3.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget4.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget3.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget4.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/parser/ecmascript5/Statements/LabeledStatements/parser_duplicateLabel3.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/parser/ecmascript5/Statements/LabeledStatements/parser_duplicateLabel4.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/breakStatements/doWhileBreakStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/breakStatements/forBreakStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/breakStatements/forInBreakStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/breakStatements/whileBreakStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/continueStatements/doWhileContinueStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/continueStatements/forContinueStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/continueStatements/forInContinueStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to Parse: "conformance/statements/continueStatements/whileContinueStatements.ts"
+Parser panicked on second pass: Unexpected tokenExpect to run correctly: "conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType3.ts"
+But got a runtime error: 2 more semantic errors occurred after fixing lint errors than before (2 vs 0)
+
+Expect to run correctly: "conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures3.ts"
+But got a runtime error: 2 more semantic errors occurred after fixing lint errors than before (2 vs 0)
+

--- a/tasks/coverage/src/codegen.rs
+++ b/tasks/coverage/src/codegen.rs
@@ -43,7 +43,7 @@ fn write_failure(
     parser_result2: &str,
     source_text2: &str,
 ) {
-    let base_path = Path::new(&format!("./tasks/coverage/failures/{case_name}"))
+    let base_path = Path::new(&format!("./tasks/coverage/failures/codegen/{case_name}"))
         .join(file_name)
         .join(result_type);
     let _ = std::fs::create_dir_all(&base_path);

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -9,6 +9,7 @@ mod test262_meta;
 mod typescript;
 // Tools
 mod codegen;
+mod linter;
 mod minifier;
 mod prettier;
 mod sourcemap;
@@ -16,6 +17,7 @@ mod transformer;
 
 use std::{fs, path::PathBuf, process::Command, time::Duration};
 
+use linter::{LinterBabelCase, LinterMiscCase, LinterTest262Case, LinterTypeScriptCase};
 use oxc_tasks_common::agent;
 use runtime::{CodegenRuntimeTest262Case, V8_TEST_262_FAILED_TESTS_PATH};
 use similar::DiffableStr;
@@ -62,6 +64,7 @@ impl AppArgs {
         self.run_transformer();
         // self.run_codegen_runtime();
         self.run_minifier();
+        self.run_linter();
     }
 
     pub fn run_parser(&self) {
@@ -91,6 +94,13 @@ impl AppArgs {
         BabelSuite::<TransformerBabelCase>::new().run("transformer_babel", self);
         TypeScriptSuite::<TransformerTypeScriptCase>::new().run("transformer_typescript", self);
         MiscSuite::<TransformerMiscCase>::new().run("transformer_misc", self);
+    }
+
+    pub fn run_linter(&self) {
+        Test262Suite::<LinterTest262Case>::new().run("linter_test262", self);
+        BabelSuite::<LinterBabelCase>::new().run("linter_babel", self);
+        TypeScriptSuite::<LinterTypeScriptCase>::new().run("linter_typescript", self);
+        MiscSuite::<LinterMiscCase>::new().run("linter_misc", self);
     }
 
     /// # Panics

--- a/tasks/coverage/src/linter.rs
+++ b/tasks/coverage/src/linter.rs
@@ -65,10 +65,8 @@ fn get_result(
         Parser::new(&allocator, source_text, source_type).parse();
 
     if panicked {
-        let error_string = errors
-            .get(0)
-            .map(ToString::to_string)
-            .unwrap_or_else(|| "(No error diagnostic)".to_string());
+        let error_string =
+            errors.first().map_or_else(|| "(No error diagnostic)".to_string(), ToString::to_string);
         let msg = format!("Parser panicked on first pass: {error_string}");
         do_write_failure(true, vec![], vec![], "(Not fixed)", false, vec![]);
         return TestResult::ParseError(msg, panicked);
@@ -113,10 +111,8 @@ fn get_result(
         Parser::new(&allocator, &fixes.fixed_code, source_type).parse();
 
     if !errors.is_empty() {
-        let error_string = errors
-            .get(0)
-            .map(ToString::to_string)
-            .unwrap_or_else(|| "(No error diagnostic)".to_string());
+        let error_string =
+            errors.first().map_or_else(|| "(No error diagnostic)".to_string(), ToString::to_string);
         let msg = format!("Parser panicked on second pass: {error_string}");
         do_write_failure(
             false,
@@ -162,6 +158,7 @@ fn get_result(
     TestResult::Passed
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_failure(
     case_name: &str,
     file_name: &Path,
@@ -184,9 +181,9 @@ fn write_failure(
         (false, false) => ".ts",
     };
 
-    fs::write(dir.join(format!("original{}", ext)), source_text)
+    fs::write(dir.join(format!("original{ext}")), source_text)
         .expect("Error writing original source file");
-    fs::write(dir.join(format!("fixed_source{}", ext)), source_after_fixes)
+    fs::write(dir.join(format!("fixed_source{ext}")), source_after_fixes)
         .expect("Error writing fixed source file");
 
     let file =
@@ -208,7 +205,7 @@ fn write_failure(
             if $list.is_empty() {
                 writeln!(w, "None")?;
             } else {
-                for el in &$list {
+                for el in $list {
                     writeln!(w, "{:#?}", el)?;
                 }
             }
@@ -220,12 +217,12 @@ fn write_failure(
     writeln!(w, "file name: {}", file_name.display())?;
     writeln!(w, "source type:\n{source_type:#?}\n")?;
     writeln!(w, "fixes applied: {}", fixes.len())?;
-    writeln!(w, "parser panicked before: {}", parser_panicked_before)?;
+    writeln!(w, "parser panicked before: {parser_panicked_before}")?;
     writeln!(w, "semantic errors before: {}", semantic_errors_before.len())?;
-    writeln!(w, "parser panicked after: {}", parser_panicked_after)?;
+    writeln!(w, "parser panicked after: {parser_panicked_after}")?;
     writeln!(w, "semantic errors after: {}", semantic_errors_after.len())?;
     print_header_sep!()?;
-    w.write(b"\n")?;
+    writeln!(w)?;
 
     writeln!(w, "fixes applied:")?;
     print_list!(fixes);

--- a/tasks/coverage/src/linter.rs
+++ b/tasks/coverage/src/linter.rs
@@ -1,0 +1,297 @@
+use crate::{
+    babel::BabelCase,
+    misc::MiscCase,
+    suite::{Case, TestResult},
+    test262::Test262Case,
+    typescript::TypeScriptCase,
+};
+use oxc_allocator::Allocator;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_linter::{AllowWarnDeny, Fixer, LintContext, LintOptions, Linter, Message};
+use oxc_parser::{Parser, ParserReturn};
+use oxc_semantic::{SemanticBuilder, SemanticBuilderReturn};
+use oxc_span::SourceType;
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+/// # What this test does:
+///
+/// 1. First round of parsing + semantic analysis.
+///     - Aborts if parser panics.
+/// 2. Runs the linter with autofix on and all plugins and rules enabled.
+/// 3. Applies fixes to the source code.
+/// 4. Second round of parsing + semantic analysis, this time on the fixed code.
+///     - Aborts if parser panics.
+/// 5. Compares the number of semantic errors before and after fixing lint errors.
+///     - If there are more errors after fixing lint errors, the test fails.
+fn get_result(
+    case_name: &str,
+    file_name: &Path,
+    source_text: &str,
+    source_type: SourceType,
+) -> TestResult {
+    let allocator = Allocator::default();
+    let pathbuf = file_name.to_path_buf();
+    let boxed_path = pathbuf.clone().into_boxed_path();
+
+    let do_write_failure = |parser_panicked_before: bool,
+                            semantic_errors_before: Vec<OxcDiagnostic>,
+                            fixes: Vec<Message>,
+                            source_after_fixes: &str,
+                            parser_panicked_after: bool,
+                            semantic_errors_after: Vec<OxcDiagnostic>| {
+        write_failure(
+            case_name,
+            file_name,
+            source_text,
+            source_type,
+            parser_panicked_before,
+            semantic_errors_before,
+            fixes,
+            source_after_fixes,
+            parser_panicked_after,
+            semantic_errors_after,
+        )
+        .expect("Failed to write linter conformance failure info");
+    };
+
+    // 1. First round of parsing + semantic analysis.
+
+    let ParserReturn { program, trivias, panicked, errors } =
+        Parser::new(&allocator, source_text, source_type).parse();
+
+    if panicked {
+        let error_string = errors
+            .get(0)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "(No error diagnostic)".to_string());
+        let msg = format!("Parser panicked on first pass: {error_string}");
+        do_write_failure(true, vec![], vec![], "(Not fixed)", false, vec![]);
+        return TestResult::ParseError(msg, panicked);
+    }
+
+    let program = allocator.alloc(program);
+
+    let SemanticBuilderReturn { semantic, errors: semantic_errors } =
+        SemanticBuilder::new(source_text, source_type)
+            .with_trivias(trivias)
+            .with_check_syntax_error(true)
+            .build_module_record(pathbuf.clone(), program)
+            .build(program);
+
+    // 2. Run the linter with autofix on and all plugins and rules enabled.
+
+    let options = LintOptions::default()
+        .with_fix(true)
+        .with_filter(vec![(AllowWarnDeny::Warn, String::from("all"))])
+        .with_react_plugin(true)
+        .with_unicorn_plugin(true)
+        .with_typescript_plugin(true)
+        .with_oxc_plugin(true)
+        .with_import_plugin(true)
+        .with_jsdoc_plugin(true)
+        .with_jest_plugin(true)
+        .with_jsx_a11y_plugin(true)
+        .with_nextjs_plugin(true)
+        .with_react_perf_plugin(true);
+    let linter = Linter::from_options(options).unwrap();
+    let semantic = Rc::new(semantic);
+    let ctx = LintContext::new(boxed_path, semantic);
+    let messages = linter.run(ctx.clone());
+
+    // 3. Apply fixes to the source code.
+    let fixes = Fixer::new(source_text, messages).fix();
+
+    // 4. Second round of parsing + semantic analysis, this time on the fixed
+    //    code.
+
+    let ParserReturn { program: fixed_program, trivias, panicked, errors } =
+        Parser::new(&allocator, &fixes.fixed_code, source_type).parse();
+
+    if !errors.is_empty() {
+        let error_string = errors
+            .get(0)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "(No error diagnostic)".to_string());
+        let msg = format!("Parser panicked on second pass: {error_string}");
+        do_write_failure(
+            false,
+            semantic_errors,
+            fixes.messages,
+            &fixes.fixed_code,
+            panicked,
+            vec![],
+        );
+        return TestResult::ParseError(msg, panicked);
+    }
+
+    let program = allocator.alloc(fixed_program);
+    let SemanticBuilderReturn { errors: fixed_semantic_errors, .. } =
+        SemanticBuilder::new(&fixes.fixed_code, source_type)
+            .with_trivias(trivias)
+            .with_check_syntax_error(true)
+            .build_module_record(pathbuf, program)
+            .build(program);
+
+    // 5. Compare the number of semantic errors before and after fixing lint
+
+    let semantic_error_count = semantic_errors.len();
+    let fixed_semantic_error_count = fixed_semantic_errors.len();
+    #[allow(clippy::cast_possible_wrap)]
+    let additional_errors = (fixed_semantic_error_count as isize) - (semantic_error_count as isize);
+
+    if additional_errors > 0 {
+        do_write_failure(
+            false,
+            semantic_errors,
+            fixes.messages,
+            &fixes.fixed_code,
+            panicked,
+            fixed_semantic_errors,
+        );
+        return TestResult::RuntimeError(format!(
+            "{additional_errors} more semantic errors occurred after fixing lint errors than before ({fixed_semantic_error_count} vs {semantic_error_count})"
+        ));
+    }
+
+    // If we reach this point, the test passed.
+    TestResult::Passed
+}
+
+fn write_failure(
+    case_name: &str,
+    file_name: &Path,
+    source_text: &str,
+    source_type: SourceType,
+    parser_panicked_before: bool,
+    semantic_errors_before: Vec<OxcDiagnostic>,
+    fixes: Vec<Message>,
+    source_after_fixes: &str,
+    parser_panicked_after: bool,
+    semantic_errors_after: Vec<OxcDiagnostic>,
+) -> io::Result<()> {
+    let dir = Path::new("./tasks/coverage/failures/linter").join(case_name).join(file_name);
+    fs::create_dir_all(&dir).expect("Error creating failure directory for linter coverage");
+
+    let ext = match (source_type.is_jsx(), source_type.is_javascript()) {
+        (true, true) => ".jsx",
+        (false, true) => ".js",
+        (true, false) => ".tsx",
+        (false, false) => ".ts",
+    };
+
+    fs::write(dir.join(format!("original{}", ext)), source_text)
+        .expect("Error writing original source file");
+    fs::write(dir.join(format!("fixed_source{}", ext)), source_after_fixes)
+        .expect("Error writing fixed source file");
+
+    let file =
+        fs::File::create(dir.join("failure_info.txt")).expect("Error creating failure info file");
+    let mut w = io::BufWriter::new(file);
+
+    macro_rules! print_header_sep {
+        () => {
+            writeln!(w, "{}", "=".repeat(80))
+        };
+    }
+    macro_rules! print_section_sep {
+        () => {
+            writeln!(w, "\n{}", "-".repeat(80))
+        };
+    }
+    macro_rules! print_list {
+        ($list:expr) => {
+            if $list.is_empty() {
+                writeln!(w, "None")?;
+            } else {
+                for el in &$list {
+                    writeln!(w, "{:#?}", el)?;
+                }
+            }
+        };
+    }
+
+    // print_header_sep(&mut w)?;
+    print_header_sep!()?;
+    writeln!(w, "file name: {}", file_name.display())?;
+    writeln!(w, "source type:\n{source_type:#?}\n")?;
+    writeln!(w, "fixes applied: {}", fixes.len())?;
+    writeln!(w, "parser panicked before: {}", parser_panicked_before)?;
+    writeln!(w, "semantic errors before: {}", semantic_errors_before.len())?;
+    writeln!(w, "parser panicked after: {}", parser_panicked_after)?;
+    writeln!(w, "semantic errors after: {}", semantic_errors_after.len())?;
+    print_header_sep!()?;
+    w.write(b"\n")?;
+
+    writeln!(w, "fixes applied:")?;
+    print_list!(fixes);
+
+    print_section_sep!()?;
+    writeln!(w, "semantic errors before:")?;
+    print_list!(semantic_errors_before);
+
+    print_section_sep!()?;
+    writeln!(w, "semantic errors after:")?;
+    print_list!(semantic_errors_after);
+
+    w.flush()
+}
+
+// TODO: use concat_idents! macro when it's stable
+macro_rules! impl_case {
+    ($Ty:ident, $Inner:ident, $name:tt) => {
+        impl Case for $Ty {
+            fn new(path: PathBuf, code: String) -> Self {
+                Self { base: $Inner::new(path, code) }
+            }
+
+            fn code(&self) -> &str {
+                self.base.code()
+            }
+
+            fn path(&self) -> &Path {
+                self.base.path()
+            }
+
+            fn test_result(&self) -> &TestResult {
+                self.base.test_result()
+            }
+
+            fn skip_test_case(&self) -> bool {
+                self.base.skip_test_case() || self.base.should_fail()
+            }
+
+            fn run(&mut self) {
+                let source_text = self.base.code();
+                let source_type = self.base.source_type();
+                let result = get_result($name, self.base.path(), source_text, source_type);
+                self.base.set_result(result);
+            }
+        }
+    };
+}
+
+pub struct LinterTest262Case {
+    base: Test262Case,
+}
+
+impl_case!(LinterTest262Case, Test262Case, "test262");
+
+pub struct LinterBabelCase {
+    base: BabelCase,
+}
+impl_case!(LinterBabelCase, BabelCase, "babel");
+
+pub struct LinterTypeScriptCase {
+    base: TypeScriptCase,
+}
+impl_case!(LinterTypeScriptCase, TypeScriptCase, "typescript");
+
+pub struct LinterMiscCase {
+    base: MiscCase,
+}
+impl_case!(LinterMiscCase, MiscCase, "misc");

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
         "prettier" => args.run_prettier(),
         "transformer" => args.run_transformer(),
         "minifier" => args.run_minifier(),
+        "linter" => args.run_linter(),
         "v8_test262_status" => args.run_sync_v8_test262_status(),
         _ => args.run_all(),
     };

--- a/tasks/coverage/src/test262.rs
+++ b/tasks/coverage/src/test262.rs
@@ -76,6 +76,16 @@ impl Test262Case {
     fn compute_should_fail(meta: &MetaData) -> bool {
         meta.negative.as_ref().filter(|n| n.phase == Phase::Parse).is_some()
     }
+
+    pub fn source_type(&self) -> SourceType {
+        SourceType::default().with_module(self.has_flag(TestFlag::Module)).with_always_strict(
+            self.has_flag(TestFlag::OnlyStrict)
+                || !(self.has_flag(TestFlag::NoStrict) || self.has_flag(TestFlag::Raw)),
+        )
+    }
+    fn has_flag(&self, flag: TestFlag) -> bool {
+        self.meta.flags.contains(&flag)
+    }
 }
 
 impl Case for Test262Case {


### PR DESCRIPTION
Makes `cargo coverage` run the linter. It can be run in isolation with `cargo coverage linter`.


The linter is run with fixes and all rules enabled (except nursery rules) in an identical fashion to `oxlint -W all --fix`. The fixed code is then re-parsed and checked for errors. Tests will fail if parsing fails or if semantic analysis produces more errors the second time around than when the original source code is analyzed.

I've already found several problems with fixes, including 2 panics. One of them was fixed in #3590, and the other is fixed in this PR.