### PR TITLE
refactor(ast): make `AstBuilder` `Copy`

### DIFF
--- a/crates/oxc_transformer/src/react/jsx/mod.rs
+++ b/crates/oxc_transformer/src/react/jsx/mod.rs
@@ -412,8 +412,8 @@ impl<'a> ReactJsx<'a> {
         self.ctx.source_type.is_script()
     }
 
-    fn ast(&self) -> &AstBuilder<'a> {
-        &self.ctx.ast
+    fn ast(&self) -> AstBuilder<'a> {
+        self.ctx.ast
     }
 }
 

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -63,7 +63,7 @@ impl<'a> TypeScriptAnnotations<'a> {
 
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, name: &Atom<'a>) -> Statement<'a> {
-        let ast = &self.ctx.ast;
+        let ast = self.ctx.ast;
 
         ast.expression_statement(
             SPAN,


### PR DESCRIPTION
`AstBuilder` only contains a shared ref `&Allocator`. So make it `Copy` and pass around `AstBuilder<'a>` instead of `&AstBuilder<'a>` - 1 less level of indirection.

Hopefully this will have little effect on benchmarks as all `AstBuilder`'s methods are marked `#[inline]`, but this change will minimize impact if compiler decides not to inline for some reason.