### PR TITLE
refactor(minifier): make `Prepass` `Copy`

### DIFF
--- a/crates/oxc_minifier/src/compressor/prepass.rs
+++ b/crates/oxc_minifier/src/compressor/prepass.rs
@@ -4,6 +4,7 @@ use oxc_ast::visit::walk_mut::{walk_expression_mut, walk_statements_mut};
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::{ast::*, AstBuilder, VisitMut};
 
+#[derive(Clone, Copy)]
 pub struct Prepass<'a> {
     ast: AstBuilder<'a>,
 }
@@ -17,7 +18,7 @@ impl<'a> Prepass<'a> {
         self.visit_program(program);
     }
 
-    fn strip_parenthesized_expression(&self, expr: &mut Expression<'a>) {
+    fn strip_parenthesized_expression(self, expr: &mut Expression<'a>) {
         if let Expression::ParenthesizedExpression(paren_expr) = expr {
             *expr = self.ast.move_expression(&mut paren_expr.expression);
             self.strip_parenthesized_expression(expr);


### PR DESCRIPTION
Similar to #3602. `Prepass<'a>` only contains `AstBuilder<'a>`, which only contains shared ref `&'a Allocator`. So make `Prepass` `Copy` and pass around `Prepass<'a>` instead of `&Prepass<'a>` (so avoiding extra indirection).