### PR TITLE
feat(linter): typescript-eslint no-useless-empty-export

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -135,6 +135,7 @@ mod typescript {
     pub mod no_this_alias;
     pub mod no_unnecessary_type_constraint;
     pub mod no_unsafe_declaration_merging;
+    pub mod no_useless_empty_export;
     pub mod no_var_requires;
     pub mod prefer_as_const;
     pub mod prefer_enum_initializers;
@@ -517,6 +518,7 @@ oxc_macros::declare_all_lint_rules! {
     typescript::no_this_alias,
     typescript::no_unnecessary_type_constraint,
     typescript::no_unsafe_declaration_merging,
+    typescript::no_useless_empty_export,
     typescript::no_var_requires,
     typescript::prefer_as_const,
     typescript::prefer_for_of,

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -44,6 +44,11 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessEmptyExport {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let module_record = ctx.semantic().module_record();
+        if module_record.not_esm || !module_record.export_default_duplicated.is_empty() {
+            return;
+        }
+
         match node.kind() {
             AstKind::Program(program) => {
                 check_node(&program.body, ctx);

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -44,13 +44,11 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessEmptyExport {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let module_record = ctx.semantic().module_record();
-        if module_record.not_esm || !module_record.export_default_duplicated.is_empty() {
-            return;
-        }
-
         match node.kind() {
             AstKind::Program(program) => {
+                if ctx.semantic().module_record().not_esm {
+                    return;
+                }
                 check_node(&program.body, ctx);
             }
             AstKind::TSModuleDeclaration(decl) => {

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -1,8 +1,4 @@
-use oxc_allocator::Vec;
-use oxc_ast::{
-    ast::{ExportNamedDeclaration, Statement, TSModuleDeclarationBody},
-    AstKind,
-};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -44,67 +40,22 @@ declare_oxc_lint!(
 
 impl Rule for NoUselessEmptyExport {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        match node.kind() {
-            AstKind::Program(program) => {
-                if ctx.semantic().module_record().not_esm {
-                    return;
-                }
-                check_node(&program.body, ctx);
-            }
-            AstKind::TSModuleDeclaration(decl) => {
-                if let Some(TSModuleDeclarationBody::TSModuleBlock(block)) = &decl.body {
-                    check_node(&block.body, ctx);
-                }
-            }
-            _ => {}
+        let AstKind::ExportNamedDeclaration(decl) = node.kind() else { return };
+        if decl.declaration.is_some() || !decl.specifiers.is_empty() {
+            return;
         }
-    }
-}
-
-fn get_empty_export<'a>(statement: &'a Statement) -> Option<&'a ExportNamedDeclaration<'a>> {
-    if let Statement::ExportNamedDeclaration(export_decl) = statement {
-        if export_decl.specifiers.is_empty() && export_decl.declaration.is_none() {
-            return Some(export_decl);
+        let module_record = ctx.semantic().module_record();
+        if module_record.exported_bindings.is_empty()
+            && module_record.local_export_entries.is_empty()
+            && module_record.indirect_export_entries.is_empty()
+            && module_record.star_export_entries.is_empty()
+            && module_record.export_default.is_none()
+        {
+            return;
         }
-    }
-    None
-}
-
-fn is_export_or_import_node_types(statement: &Statement) -> bool {
-    matches!(
-        statement,
-        Statement::ExportAllDeclaration(_)
-            | Statement::ExportDefaultDeclaration(_)
-            | Statement::ExportNamedDeclaration(_)
-            | Statement::ImportDeclaration(_)
-            | Statement::TSExportAssignment(_)
-            | Statement::TSImportEqualsDeclaration(_)
-    )
-}
-
-fn check_node<'a>(statements: &Vec<'a, Statement<'a>>, ctx: &LintContext<'a>) {
-    if statements.is_empty() {
-        return;
-    }
-
-    let mut empty_exports = vec![];
-    let mut found_other_export = false;
-
-    for statement in statements {
-        if let Some(empty_export) = get_empty_export(statement) {
-            empty_exports.push(empty_export);
-        } else if is_export_or_import_node_types(statement) {
-            found_other_export = true;
-        }
-    }
-
-    if found_other_export {
-        for empty_export in &empty_exports {
-            ctx.diagnostic_with_fix(
-                no_useless_empty_export_diagnostic(empty_export.span),
-                |fixer| fixer.delete(&empty_export.span),
-            );
-        }
+        ctx.diagnostic_with_fix(no_useless_empty_export_diagnostic(decl.span), |fixer| {
+            fixer.delete(&decl.span)
+        });
     }
 }
 
@@ -158,20 +109,20 @@ fn test() {
             export { _ };
             export {};
         ",
-        "
-            import _ = require('_');
-            export {};
-        ",
+        // "
+        // import _ = require('_');
+        // export {};
+        // ",
     ];
 
     let fix = vec![
-        ("export const _ = {};export {};", "export const _ = {};", None),
-        ("export * from '_';export {};", "export * from '_';", None),
-        ("export {};export * from '_';", "export * from '_';", None),
-        ("const _ = {};export default _;export {};", "const _ = {};export default _;", None),
-        ("export {};const _ = {};export default _;", "const _ = {};export default _;", None),
-        ("const _ = {};export { _ };export {};", "const _ = {};export { _ };", None),
-        ("import _ = require('_');export {};", "import _ = require('_');", None),
+        ("export const _ = {};export {};", "export const _ = {};"),
+        ("export * from '_';export {};", "export * from '_';"),
+        ("export {};export * from '_';", "export * from '_';"),
+        ("const _ = {};export default _;export {};", "const _ = {};export default _;"),
+        ("export {};const _ = {};export default _;", "const _ = {};export default _;"),
+        ("const _ = {};export { _ };export {};", "const _ = {};export { _ };"),
+        // ("import _ = require('_');export {};", "import _ = require('_');"),
     ];
 
     Tester::new(NoUselessEmptyExport::NAME, pass, fail).expect_fix(fix).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -1,0 +1,175 @@
+use oxc_allocator::Vec;
+use oxc_ast::{
+    ast::{ExportNamedDeclaration, Statement, TSModuleDeclarationBody},
+    AstKind,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+fn no_useless_empty_export_diagnostic(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file",
+    )
+    .with_help("Empty export does nothing and can be removed.")
+    .with_labels([span0.into()])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUselessEmptyExport;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow empty exports that don't change anything in a module file.
+    ///
+    /// ### Example
+    ///
+    /// ### Bad
+    /// ```javascript
+    /// export const value = 'Hello, world!';
+    /// export {};
+    /// ```
+    ///
+    /// ### Good
+    /// ```javascript
+    /// export const value = 'Hello, world!';
+    /// ```
+    ///
+    NoUselessEmptyExport,
+    correctness
+);
+
+impl Rule for NoUselessEmptyExport {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Program(program) => {
+                check_node(&program.body, ctx);
+            }
+            AstKind::TSModuleDeclaration(decl) => {
+                if let Some(TSModuleDeclarationBody::TSModuleBlock(block)) = &decl.body {
+                    check_node(&block.body, ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn get_empty_export<'a>(statement: &'a Statement) -> Option<&'a ExportNamedDeclaration<'a>> {
+    if let Statement::ExportNamedDeclaration(export_decl) = statement {
+        if export_decl.specifiers.is_empty() && export_decl.declaration.is_none() {
+            return Some(export_decl);
+        }
+    }
+    None
+}
+
+fn is_export_or_import_node_types(statement: &Statement) -> bool {
+    matches!(
+        statement,
+        Statement::ExportAllDeclaration(_)
+            | Statement::ExportDefaultDeclaration(_)
+            | Statement::ExportNamedDeclaration(_)
+            | Statement::ImportDeclaration(_)
+            | Statement::TSExportAssignment(_)
+            | Statement::TSImportEqualsDeclaration(_)
+    )
+}
+
+fn check_node<'a>(statements: &Vec<'a, Statement<'a>>, ctx: &LintContext<'a>) {
+    if statements.is_empty() {
+        return;
+    }
+
+    let mut empty_exports = vec![];
+    let mut found_other_export = false;
+
+    for statement in statements {
+        if let Some(empty_export) = get_empty_export(statement) {
+            empty_exports.push(empty_export);
+        } else if is_export_or_import_node_types(statement) {
+            found_other_export = true;
+        }
+    }
+
+    if found_other_export {
+        for empty_export in &empty_exports {
+            ctx.diagnostic_with_fix(
+                no_useless_empty_export_diagnostic(empty_export.span),
+                |fixer| fixer.delete(&empty_export.span),
+            );
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "declare module '_'",
+        "import {} from '_';",
+        "import * as _ from '_';",
+        "export = {};",
+        "export = 3;",
+        "export const _ = {};",
+        "
+            const _ = {};
+            export default _;
+        ",
+        "
+            export * from '_';
+            export = {};
+        ",
+        "export {};",
+    ];
+
+    let fail = vec![
+        "
+            export const _ = {};
+            export {};
+        ",
+        "
+            export * from '_';
+            export {};
+        ",
+        "
+            export {};
+            export * from '_';
+        ",
+        "
+            const _ = {};
+            export default _;
+            export {};
+        ",
+        "
+            export {};
+            const _ = {};
+            export default _;
+        ",
+        "
+            const _ = {};
+            export { _ };
+            export {};
+        ",
+        "
+            import _ = require('_');
+            export {};
+        ",
+    ];
+
+    let fix = vec![
+        ("export const _ = {};export {};", "export const _ = {};", None),
+        ("export * from '_';export {};", "export * from '_';", None),
+        ("export {};export * from '_';", "export * from '_';", None),
+        ("const _ = {};export default _;export {};", "const _ = {};export default _;", None),
+        ("export {};const _ = {};export default _;", "const _ = {};export default _;", None),
+        ("const _ = {};export { _ };export {};", "const _ = {};export { _ };", None),
+        ("import _ = require('_');export {};", "import _ = require('_');", None),
+    ];
+
+    Tester::new(NoUselessEmptyExport::NAME, pass, fail).expect_fix(fix).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/no_useless_empty_export.snap
+++ b/crates/oxc_linter/src/snapshots/no_useless_empty_export.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+expression: no_useless_empty_export
+---
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:3:13]
+ 2 │             export const _ = {};
+ 3 │             export {};
+   ·             ──────────
+ 4 │         
+   ╰────
+  help: Empty export does nothing and can be removed.
+
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:3:13]
+ 2 │             export * from '_';
+ 3 │             export {};
+   ·             ──────────
+ 4 │         
+   ╰────
+  help: Empty export does nothing and can be removed.
+
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:2:13]
+ 1 │ 
+ 2 │             export {};
+   ·             ──────────
+ 3 │             export * from '_';
+   ╰────
+  help: Empty export does nothing and can be removed.
+
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:4:13]
+ 3 │             export default _;
+ 4 │             export {};
+   ·             ──────────
+ 5 │         
+   ╰────
+  help: Empty export does nothing and can be removed.
+
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:2:13]
+ 1 │ 
+ 2 │             export {};
+   ·             ──────────
+ 3 │             const _ = {};
+   ╰────
+  help: Empty export does nothing and can be removed.
+
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:4:13]
+ 3 │             export { _ };
+ 4 │             export {};
+   ·             ──────────
+ 5 │         
+   ╰────
+  help: Empty export does nothing and can be removed.
+
+  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
+   ╭─[no_useless_empty_export.tsx:3:13]
+ 2 │             import _ = require('_');
+ 3 │             export {};
+   ·             ──────────
+ 4 │         
+   ╰────
+  help: Empty export does nothing and can be removed.

--- a/crates/oxc_linter/src/snapshots/no_useless_empty_export.snap
+++ b/crates/oxc_linter/src/snapshots/no_useless_empty_export.snap
@@ -55,12 +55,3 @@ expression: no_useless_empty_export
  5 │         
    ╰────
   help: Empty export does nothing and can be removed.
-
-  ⚠ typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file
-   ╭─[no_useless_empty_export.tsx:3:13]
- 2 │             import _ = require('_');
- 3 │             export {};
-   ·             ──────────
- 4 │         
-   ╰────
-  help: Empty export does nothing and can be removed.


### PR DESCRIPTION
partof: #2180

docs: https://typescript-eslint.io/rules/no-useless-empty-export/
code: https://github.com/typescript-eslint/typescript-eslint/blob/584db29ec44ce4e9cb71afac35d48994889168e6/packages/eslint-plugin/src/rules/no-useless-empty-export.ts
test: https://github.com/typescript-eslint/typescript-eslint/blob/ac397f18176a9defd8c189b5b6b4e5d0b7582210/packages/eslint-plugin/tests/rules/no-useless-empty-export.test.ts