### PR TITLE
refactor(transformer): remove outdated comment

### DIFF
--- a/crates/oxc_transformer/src/react/jsx_self.rs
+++ b/crates/oxc_transformer/src/react/jsx_self.rs
@@ -15,10 +15,6 @@ const SELF: &str = "__self";
 ///
 /// In: `<sometag />`
 /// Out: `<sometag __self={this} />`
-///
-/// TODO:
-/// *. Omit adding `this` in some conditions
-///    <https://github.com/babel/babel/blob/9cd048b5ad45eafd157c4f9968343e36170a66c1/packages/babel-plugin-transform-react-jsx-self/src/index.ts#L78>
 pub struct ReactJsxSelf<'a> {
     ctx: Ctx<'a>,
 }


### PR DESCRIPTION
Remove a TODO comment where the do is done.

This was covered by #3258 and #3287.