### PR TITLE
fix(span): correct doc comments

### DIFF
--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -74,7 +74,7 @@ impl Span {
         Self { start: at, end: at }
     }
 
-    /// Create a new [`Span`] starting at `start` and covering `size` characters.
+    /// Create a new [`Span`] starting at `start` and covering `size` bytes.
     ///
     /// # Example
     /// ```
@@ -88,7 +88,7 @@ impl Span {
         Self::new(start, start + size)
     }
 
-    /// Get the number of characters covered by the [`Span`].
+    /// Get the number of bytes covered by the [`Span`].
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
Fix doc comments for `Span` methods. `Span` offsets are in bytes, not characters.