### PR TITLE
refactor(transformer): move `BoundIdentifier` into helpers

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -462,6 +462,15 @@ impl<'a> IdentifierReference<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
         Self { span, name, reference_id: Cell::default(), reference_flag: ReferenceFlag::default() }
     }
+
+    pub fn new_read(span: Span, name: Atom<'a>, reference_id: Option<ReferenceId>) -> Self {
+        Self {
+            span,
+            name,
+            reference_id: Cell::new(reference_id),
+            reference_flag: ReferenceFlag::Read,
+        }
+    }
 }
 
 /// Binding Identifier

--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -1,0 +1,24 @@
+use oxc_ast::ast::IdentifierReference;
+use oxc_span::{Atom, SPAN};
+use oxc_syntax::{reference::ReferenceFlag, symbol::SymbolId};
+use oxc_traverse::TraverseCtx;
+
+/// Store for a created binding identifier
+#[derive(Clone)]
+pub struct BoundIdentifier<'a> {
+    pub name: Atom<'a>,
+    pub symbol_id: SymbolId,
+}
+
+impl<'a> BoundIdentifier<'a> {
+    /// Create `IdentifierReference` referencing this binding which is read from
+    /// in current scope
+    pub fn create_read_reference(&self, ctx: &mut TraverseCtx) -> IdentifierReference<'a> {
+        let reference_id = ctx.create_bound_reference(
+            self.name.to_compact_str(),
+            self.symbol_id,
+            ReferenceFlag::Read,
+        );
+        IdentifierReference::new_read(SPAN, self.name.clone(), Some(reference_id))
+    }
+}

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -19,6 +19,7 @@ mod react;
 mod typescript;
 
 mod helpers {
+    pub mod bindings;
     pub mod module_imports;
 }
 


### PR DESCRIPTION
Pure refactor. Move `BoundIdentifier` into helpers module so it can be reused by other transforms.