### PR TITLE
refactor(traverse): `generate_uid_in_root_scope` method

### DIFF
--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -75,6 +75,7 @@ impl ScopeTree {
         self.parent_ids.iter_enumerated().map(|(scope_id, _)| scope_id)
     }
 
+    #[inline]
     pub fn root_scope_id(&self) -> ScopeId {
         ScopeId::new(0)
     }

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -118,9 +118,8 @@ impl<'a> AutomaticScriptBindings<'a> {
         front: bool,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
-        let root_scope_id = ctx.scopes().root_scope_id();
         let symbol_id =
-            ctx.generate_uid(variable_name, root_scope_id, SymbolFlags::FunctionScopedVariable);
+            ctx.generate_uid_in_root_scope(variable_name, SymbolFlags::FunctionScopedVariable);
         let variable_name = ctx.ast.new_atom(&ctx.symbols().names[symbol_id]);
 
         let import = NamedImport::new(variable_name.clone(), None, symbol_id);
@@ -220,8 +219,7 @@ impl<'a> AutomaticModuleBindings<'a> {
         source: Atom<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
-        let root_scope_id = ctx.scopes().root_scope_id();
-        let symbol_id = ctx.generate_uid(name, root_scope_id, SymbolFlags::FunctionScopedVariable);
+        let symbol_id = ctx.generate_uid_in_root_scope(name, SymbolFlags::FunctionScopedVariable);
         let local = ctx.ast.new_atom(&ctx.symbols().names[symbol_id]);
 
         let import = NamedImport::new(Atom::from(name), Some(local.clone()), symbol_id);

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -289,6 +289,13 @@ impl<'a> TraverseCtx<'a> {
         self.scoping.generate_uid_in_current_scope(name, flags)
     }
 
+    /// Generate UID in root scope.
+    ///
+    /// This is a shortcut for `ctx.scoping.generate_uid_in_root_scope`.
+    pub fn generate_uid_in_root_scope(&mut self, name: &str, flags: SymbolFlags) -> SymbolId {
+        self.scoping.generate_uid_in_root_scope(name, flags)
+    }
+
     /// Create a reference bound to a `SymbolId`.
     ///
     /// This is a shortcut for `ctx.scoping.create_bound_reference`.

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -185,6 +185,11 @@ impl TraverseScoping {
         self.generate_uid(name, self.current_scope_id, flags)
     }
 
+    /// Generate UID in root scope.
+    pub fn generate_uid_in_root_scope(&mut self, name: &str, flags: SymbolFlags) -> SymbolId {
+        self.generate_uid(name, self.scopes.root_scope_id(), flags)
+    }
+
     /// Create a reference bound to a `SymbolId`
     pub fn create_bound_reference(
         &mut self,


### PR DESCRIPTION
Add method on `TraverseCtx` for common case of creating a UID binding in root scope.