### PR TITLE
fix(transformer): do not add `__source` for generated nodes

### DIFF
--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -118,6 +118,21 @@ impl Span {
         self.start == self.end
     }
 
+    /// Returns `true` if `self` is not a real span.
+    /// i.e. `SPAN` which is used for generated nodes which are not in source code.
+    ///
+    /// # Example
+    /// ```
+    /// use oxc_span::{Span, SPAN};
+    ///
+    /// assert!(SPAN.is_unspanned());
+    /// assert!(!Span::new(0, 5).is_unspanned());
+    /// assert!(!Span::new(5, 5).is_unspanned());
+    /// ```
+    pub const fn is_unspanned(&self) -> bool {
+        self.start == SPAN.start && self.end == SPAN.end
+    }
+
     /// Create a [`Span`] covering the maximum range of two [`Span`]s.
     ///
     /// # Example

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -65,6 +65,11 @@ impl<'a> ReactJsxSource<'a> {
         elem: &mut JSXOpeningElement<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        // Don't add `__source` if this node was generated
+        if elem.span.is_unspanned() {
+            return;
+        }
+
         // Check if `__source` attribute already exists
         for item in &elem.attributes {
             if let JSXAttributeItem::Attribute(attribute) = item {


### PR DESCRIPTION
JSX transform don't add `__source` to nodes which were generated (not present in source).

Following:
https://github.com/babel/babel/blob/8e39f35eb94898c58a6f21e5320a48a709082f8d/packages/babel-plugin-transform-react-jsx-source/src/index.ts#L57-L64