### PR TITLE
refactor(transformer): comment for unimplemented `spec` option in arrow fns transform

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -25,6 +25,8 @@ pub struct ArrowFunctionsOptions {
 ///
 /// * <https://babeljs.io/docs/babel-plugin-transform-arrow-functions>
 /// * <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-arrow-functions>
+//
+// TODO: The `spec` option is not currently supported. Add support for it.
 pub struct ArrowFunctions<'a> {
     ctx: Ctx<'a>,
     _options: ArrowFunctionsOptions,


### PR DESCRIPTION
Babel's arrow functions transform has a `spec` option which alters the behavior of the the transform significantly.

https://babel.dev/docs/babel-plugin-transform-arrow-functions

We don't yet support that option. Add a TODO comment to that effect.