### PR TITLE
fix(transformer): arrow functions transform find all functions

### DIFF
--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -183,12 +183,8 @@ impl<'a> ArrowFunctions<'a> {
     }
 
     pub fn transform_expression(&mut self, expr: &mut Expression<'a>) {
-        match expr {
-            Expression::ArrowFunctionExpression(_) => {
-                self.stacks.push(true);
-            }
-            Expression::FunctionExpression(_) => self.stacks.push(false),
-            _ => {}
+        if matches!(expr, Expression::ArrowFunctionExpression(_)) {
+            self.stacks.push(true);
         }
     }
 
@@ -209,23 +205,16 @@ impl<'a> ArrowFunctions<'a> {
                 *expr = self.transform_arrow_function_expression(arrow_function_expr);
                 self.stacks.pop();
             }
-            Expression::FunctionExpression(_) => {
-                self.stacks.pop();
-            }
             _ => {}
         }
     }
 
-    pub fn transform_declaration(&mut self, decl: &mut Declaration<'a>) {
-        if let Declaration::FunctionDeclaration(_) = decl {
-            self.stacks.push(false);
-        }
+    pub fn transform_function(&mut self, _func: &mut Function<'a>) {
+        self.stacks.push(false);
     }
 
-    pub fn transform_declaration_on_exit(&mut self, decl: &mut Declaration<'a>) {
-        if let Declaration::FunctionDeclaration(_) = decl {
-            self.stacks.pop();
-        }
+    pub fn transform_function_on_exit(&mut self, _func: &mut Function<'a>) {
+        self.stacks.pop();
     }
 
     pub fn transform_class(&mut self, _class: &mut Class<'a>) {

--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -49,12 +49,6 @@ impl<'a> ES2015<'a> {
         }
     }
 
-    pub fn transform_declaration(&mut self, decl: &mut Declaration<'a>) {
-        if self.options.arrow_function.is_some() {
-            self.arrow_functions.transform_declaration(decl);
-        }
-    }
-
     pub fn transform_expression(&mut self, expr: &mut Expression<'a>) {
         if self.options.arrow_function.is_some() {
             self.arrow_functions.transform_expression(expr);
@@ -67,9 +61,15 @@ impl<'a> ES2015<'a> {
         }
     }
 
-    pub fn transform_declaration_on_exit(&mut self, decl: &mut Declaration<'a>) {
+    pub fn transform_function(&mut self, func: &mut Function<'a>) {
         if self.options.arrow_function.is_some() {
-            self.arrow_functions.transform_declaration_on_exit(decl);
+            self.arrow_functions.transform_function(func);
+        }
+    }
+
+    pub fn transform_function_on_exit(&mut self, func: &mut Function<'a>) {
+        if self.options.arrow_function.is_some() {
+            self.arrow_functions.transform_function_on_exit(func);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -183,6 +183,11 @@ impl<'a> Traverse<'a> for Transformer<'a> {
 
     fn enter_function(&mut self, func: &mut Function<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_function(func);
+        self.x3_es2015.transform_function(func);
+    }
+
+    fn exit_function(&mut self, func: &mut Function<'a>, _ctx: &mut TraverseCtx<'a>) {
+        self.x3_es2015.transform_function_on_exit(func);
     }
 
     fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, _ctx: &mut TraverseCtx<'a>) {
@@ -254,11 +259,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
 
     fn enter_declaration(&mut self, decl: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_declaration(decl, ctx);
-        self.x3_es2015.transform_declaration(decl);
-    }
-
-    fn exit_declaration(&mut self, decl: &mut Declaration<'a>, _ctx: &mut TraverseCtx<'a>) {
-        self.x3_es2015.transform_declaration_on_exit(decl);
     }
 
     fn enter_if_statement(&mut self, stmt: &mut IfStatement<'a>, _ctx: &mut TraverseCtx<'a>) {


### PR DESCRIPTION
Arrow functions transform fails to identify "full" functions above an arrow function in many cases. e.g. `foo` in these cases:

```js
function foo() {
  return () => this;
}

class C {
  foo() {
    return () => this;
  }
};
```

i.e. `Statement::FunctionDeclaration` and `MethodDefinition`s.

This PR fixes that. Rather than visiting `Expression`, `Declaration` etc, just visit `Function`.