### PR TITLE
feat(coverage): add `--debug` option for finding crash scene

### DIFF
--- a/tasks/coverage/README.md
+++ b/tasks/coverage/README.md
@@ -1,13 +1,11 @@
 # Coverage
 
-The parser is tested against [test262], [babel] and TypeScript for conformance.
+Tools are tested against [test262], [babel] and [TypeScript] for conformance.
 
-Note: tests against regexp are disabled for now.
-
-Clone the test files beforehand:
+Clone the test repositories beforehand:
 
 ```bash
-git submodule update --init
+just submodules
 ```
 
 ## Development
@@ -24,8 +22,12 @@ cargo watch -x 'coverage js'
 
 # filter for a file path
 cargo watch -x 'coverage js --filter filter-file-path'
+
+# find crash scene by turning off rayon and print out the test cases in serial
+cargo coverage -- --debug
 ```
 
 <!-- Links -->
 [test262]: https://github.com/tc39/test262
 [babel]: https://github.com/babel/babel
+[TypeScript]: https://github.com/microsoft/TypeScript

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -44,6 +44,7 @@ pub fn project_root() -> PathBuf {
 
 #[derive(Debug, Default)]
 pub struct AppArgs {
+    pub debug: bool,
     pub filter: Option<String>,
     pub detail: bool,
     /// Print mismatch diff

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -1,18 +1,24 @@
-use oxc_coverage::AppArgs;
 use pico_args::Arguments;
+use rayon::ThreadPoolBuilder;
+
+use oxc_coverage::AppArgs;
 
 fn main() {
     let mut args = Arguments::from_env();
     let command = args.subcommand().expect("subcommands");
 
     let args = AppArgs {
+        debug: args.contains("--debug"),
         filter: args.opt_value_from_str("--filter").unwrap(),
         detail: args.contains("--detail"),
         diff: args.contains("--diff"),
     };
 
-    let task = command.as_deref().unwrap_or("default");
+    if args.debug {
+        ThreadPoolBuilder::new().num_threads(1).build_global().unwrap();
+    }
 
+    let task = command.as_deref().unwrap_or("default");
     match task {
         "parser" => args.run_parser(),
         "codegen" => args.run_codegen(),

--- a/tasks/coverage/src/suite.rs
+++ b/tasks/coverage/src/suite.rs
@@ -56,7 +56,12 @@ pub struct CoverageReport<'a, T> {
 pub trait Suite<T: Case> {
     fn run(&mut self, name: &str, args: &AppArgs) {
         self.read_test_cases(name, args);
-        self.get_test_cases_mut().par_iter_mut().for_each(Case::run);
+        self.get_test_cases_mut().par_iter_mut().for_each(|case| {
+            if args.debug {
+                println!("{:?}", case.path());
+            }
+            case.run();
+        });
         self.run_coverage(name, args);
     }
 


### PR DESCRIPTION
The `--debug` options turns off rayon and prints the paths so we can
find the crashing file by looking at the last printed out file.

closes #3497