### PR TITLE
fix(transformer): do not rename accessible identifier references

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -535,6 +535,16 @@ impl<'a, 'b> VisitMut<'a> for IdentifierReferenceRename<'a, 'b> {
                 None
             }
             Expression::Identifier(ident) => {
+                // If the identifier is binding in current/parent scopes,
+                // and it is not a member of the enum,
+                // we don't need to rename it.
+                // `var c = 1; enum A { a = c }` -> `var c = 1; enum A { a = c }
+                if !self.previous_enum_members.contains_key(&ident.name)
+                    && self.ctx.scopes().has_binding(self.ctx.current_scope_id(), &ident.name)
+                {
+                    return;
+                }
+
                 // TODO: shadowed case, e.g. let ident = 1; ident; // ident is not an enum
                 // enum_name.identifier
                 let ident_reference = IdentifierReference::new(SPAN, self.enum_name.clone());

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 4bd1b2c2
 
-Passed: 3/3
+Passed: 4/4
 
 # All Passed:
 * babel-plugin-transform-typescript

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-member-reference/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-member-reference/input.ts
@@ -1,0 +1,7 @@
+var x = 10;
+
+enum Foo {
+    a = 10,
+    b = a,
+    c = b + x,
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-member-reference/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-member-reference/output.js
@@ -1,0 +1,7 @@
+var x = 10;
+var Foo = function(Foo) {
+       Foo[Foo['a'] = 10] = 'a';
+       Foo[Foo['b'] = 10] = 'b';
+       Foo[Foo['c'] = Foo.b + x] = 'c';
+       return Foo;
+}(Foo || {});


### PR DESCRIPTION
close: #3620

In `Babel`, the expected output is:

```ts
var x = 10;
var Foo = function(Foo) {
       Foo[Foo['a'] = 10] = 'a';
       Foo[Foo['b'] = 10] = 'b';
       Foo[Foo['c'] = 30] = 'c';
       return Foo;
}(Foo || {});
```

IMO, `Foo.b + x` is enough, because `x` is not a const variable. The output same as with `typescript`