### PR TITLE
fix(diagnostics): do not print ansi color codes in non-TTYs

### DIFF
--- a/crates/oxc_diagnostics/src/graphical_theme.rs
+++ b/crates/oxc_diagnostics/src/graphical_theme.rs
@@ -64,7 +64,7 @@ impl Default for GraphicalTheme {
     fn default() -> Self {
         match std::env::var("NO_COLOR") {
             _ if !std::io::stdout().is_terminal() || !std::io::stderr().is_terminal() => {
-                Self::ascii()
+                Self::none()
             }
             Ok(string) if string != "0" => Self::unicode_nocolor(),
             _ => Self::unicode(),


### PR DESCRIPTION
closes #3539

upstream issue https://github.com/zkat/miette/issues/380