### PR TITLE
fix(transformer): arrow function transform alter `</this>`

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -43,9 +43,9 @@ impl<'a> ES2015<'a> {
         }
     }
 
-    pub fn transform_jsx_opening_element(&mut self, elem: &mut JSXOpeningElement<'a>) {
+    pub fn transform_jsx_element_name(&mut self, elem: &mut JSXElementName<'a>) {
         if self.options.arrow_function.is_some() {
-            self.arrow_functions.transform_jsx_opening_element(elem);
+            self.arrow_functions.transform_jsx_element_name(elem);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -201,7 +201,14 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     ) {
         self.x0_typescript.transform_jsx_opening_element(elem);
         self.x1_react.transform_jsx_opening_element(elem, ctx);
-        self.x3_es2015.transform_jsx_opening_element(elem);
+    }
+
+    fn enter_jsx_element_name(
+        &mut self,
+        elem: &mut JSXElementName<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x3_es2015.transform_jsx_element_name(elem);
     }
 
     fn enter_method_definition(


### PR DESCRIPTION
Arrow function transform transforms `this` in `<this>` (JSX opening element), but was missing out transforming `</this>` (JSX closing element).