### PR TITLE
fix(transformer): arrow func transform maintain scope ID

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -6,6 +6,7 @@ pub use options::ES2015Options;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
+use oxc_traverse::TraverseCtx;
 use std::rc::Rc;
 
 use crate::context::Ctx;
@@ -61,9 +62,13 @@ impl<'a> ES2015<'a> {
         }
     }
 
-    pub fn transform_expression_on_exit(&mut self, expr: &mut Expression<'a>) {
+    pub fn transform_expression_on_exit(
+        &mut self,
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         if self.options.arrow_function.is_some() {
-            self.arrow_functions.transform_expression_on_exit(expr);
+            self.arrow_functions.transform_expression_on_exit(expr, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -154,8 +154,8 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x3_es2015.transform_expression(expr);
     }
 
-    fn exit_expression(&mut self, expr: &mut Expression<'a>, _ctx: &mut TraverseCtx<'a>) {
-        self.x3_es2015.transform_expression_on_exit(expr);
+    fn exit_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.x3_es2015.transform_expression_on_exit(expr, ctx);
     }
 
     fn enter_simple_assignment_target(


### PR DESCRIPTION
In arrow function transform, set `scope_id` of new `function () {}` to `scope_id` of arrow function it replaces, and alter scope flags.