### PR TITLE
fix(transformer): arrow function transform use UIDs for `_this` vars

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -44,9 +44,13 @@ impl<'a> ES2015<'a> {
         }
     }
 
-    pub fn transform_jsx_element_name(&mut self, elem: &mut JSXElementName<'a>) {
+    pub fn transform_jsx_element_name(
+        &mut self,
+        elem: &mut JSXElementName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         if self.options.arrow_function.is_some() {
-            self.arrow_functions.transform_jsx_element_name(elem);
+            self.arrow_functions.transform_jsx_element_name(elem, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -203,12 +203,8 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x1_react.transform_jsx_opening_element(elem, ctx);
     }
 
-    fn enter_jsx_element_name(
-        &mut self,
-        elem: &mut JSXElementName<'a>,
-        _ctx: &mut TraverseCtx<'a>,
-    ) {
-        self.x3_es2015.transform_jsx_element_name(elem);
+    fn enter_jsx_element_name(&mut self, elem: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.x3_es2015.transform_jsx_element_name(elem, ctx);
     }
 
     fn enter_method_definition(


### PR DESCRIPTION
Change arrow function transform to use UIDs for `_this` vars, which can't clash with an existing binding.

I believe there are some problems with our current implementation, but have struggled to fix them due to weird interactions with TS transforms. Have added "TODO" comments, so we can return to this and fix them later on, once scopes in TS transforms are correct.

My failed attempt at fixing is on this branch: https://github.com/oxc-project/oxc/tree/transform-arrow-functions