### PR TITLE
fix(ast): correct `visited_node` attr for strict mode of arrow fns

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2523,7 +2523,10 @@ impl<'a> FunctionBody<'a> {
 }
 
 /// Arrow Function Definitions
-#[visited_node(scope(ScopeFlags::Function | ScopeFlags::Arrow))]
+#[visited_node(
+    scope(ScopeFlags::Function | ScopeFlags::Arrow),
+    strict_if(self.body.has_use_strict_directive())
+)]
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]


### PR DESCRIPTION
Correct the `#[visited_node]` attr on `ArrowFunctionExpression` to recognise strict mode functions.

This change has no effect at present as `Traverse` codegen currently ignores `strict_if`. But useful for it to be correct for if we codegen `Visit` / `VisitMut` later on (#3392).