### PR TITLE
feat(linter): add `parserOptions.emitDecoratorMetadata` and `parserOptions.experimentalDecorators` for config file

### DIFF
--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -1,5 +1,6 @@
 mod env;
 mod globals;
+mod parser_options;
 mod rules;
 mod settings;
 
@@ -13,7 +14,7 @@ use serde::Deserialize;
 use crate::{rules::RuleEnum, AllowWarnDeny, RuleWithSeverity};
 
 pub use self::{
-    env::OxlintEnv, globals::OxlintGlobals, rules::OxlintRules,
+    env::OxlintEnv, globals::OxlintGlobals, parser_options::OxlintParseOptions, rules::OxlintRules,
     settings::jsdoc::JSDocPluginSettings, settings::OxlintSettings,
 };
 
@@ -56,6 +57,9 @@ pub struct OxlintConfig {
     pub(crate) settings: OxlintSettings,
     pub(crate) env: OxlintEnv,
     pub(crate) globals: OxlintGlobals,
+
+    #[serde(rename = "parserOptions")]
+    pub(crate) parser_options: OxlintParseOptions,
 }
 
 impl OxlintConfig {
@@ -208,14 +212,20 @@ mod test {
                 },
             },
             "env": { "browser": true, },
-            "globals": { "foo": "readonly", }
+            "globals": { "foo": "readonly", },
+            "parserOptions": {
+                "emitDecoratorMetadata": true,
+                "experimentalDecorators": true
+            }
         }));
         assert!(config.is_ok());
 
-        let OxlintConfig { rules, settings, env, globals } = config.unwrap();
+        let OxlintConfig { rules, settings, env, globals, parser_options } = config.unwrap();
         assert!(!rules.is_empty());
         assert_eq!(settings.jsx_a11y.polymorphic_prop_name, Some("role".to_string()));
         assert_eq!(env.iter().count(), 1);
         assert!(globals.is_enabled("foo"));
+        assert!(parser_options.emit_decorator_metadata);
+        assert!(parser_options.experimental_decorators);
     }
 }

--- a/crates/oxc_linter/src/config/parser_options.rs
+++ b/crates/oxc_linter/src/config/parser_options.rs
@@ -1,0 +1,49 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+// <https://typescript-eslint.io/packages/parser/#configuration>
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct OxlintParseOptions {
+    /// This option allow you to tell parser to act as if `emitDecoratorMetadata: true` is set in `tsconfig.json`.
+    #[serde(rename = "emitDecoratorMetadata")]
+    pub emit_decorator_metadata: bool,
+
+    /// This option allow you to tell parser to act as if `experimentalDecorators: true` is set in `tsconfig.json`.
+    #[serde(rename = "experimentalDecorators")]
+    pub experimental_decorators: bool,
+}
+
+#[cfg(test)]
+mod test {
+    use super::OxlintParseOptions;
+    use serde::Deserialize;
+
+    #[test]
+    fn test_parse_options() {
+        let options = OxlintParseOptions::deserialize(&serde_json::json!({
+            "emitDecoratorMetadata": true,
+            "experimentalDecorators": true
+        }))
+        .unwrap();
+        assert!(options.emit_decorator_metadata);
+        assert!(options.experimental_decorators);
+    }
+
+    #[test]
+    fn test_parse_options_default() {
+        let options = OxlintParseOptions::default();
+        assert!(!options.emit_decorator_metadata);
+        assert!(!options.experimental_decorators);
+    }
+
+    #[test]
+    fn test_one_lack_field() {
+        let options = OxlintParseOptions::deserialize(&serde_json::json!({
+            "emitDecoratorMetadata": true
+        }))
+        .unwrap();
+        assert!(options.emit_decorator_metadata);
+        assert!(!options.experimental_decorators);
+    }
+}

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -14,6 +14,9 @@ expression: json
     "globals": {
       "$ref": "#/definitions/OxlintGlobals"
     },
+    "parserOptions": {
+      "$ref": "#/definitions/OxlintParseOptions"
+    },
     "rules": {
       "description": "See [Oxlint Rules](./rules)",
       "allOf": [
@@ -188,6 +191,21 @@ expression: json
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/GlobalValue"
+      }
+    },
+    "OxlintParseOptions": {
+      "type": "object",
+      "properties": {
+        "emitDecoratorMetadata": {
+          "description": "This option allow you to tell parser to act as if `emitDecoratorMetadata: true` is set in `tsconfig.json`.",
+          "default": false,
+          "type": "boolean"
+        },
+        "experimentalDecorators": {
+          "description": "This option allow you to tell parser to act as if `experimentalDecorators: true` is set in `tsconfig.json`.",
+          "default": false,
+          "type": "boolean"
+        }
       }
     },
     "OxlintRules": {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10,6 +10,9 @@
     "globals": {
       "$ref": "#/definitions/OxlintGlobals"
     },
+    "parserOptions": {
+      "$ref": "#/definitions/OxlintParseOptions"
+    },
     "rules": {
       "description": "See [Oxlint Rules](./rules)",
       "allOf": [
@@ -184,6 +187,21 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/GlobalValue"
+      }
+    },
+    "OxlintParseOptions": {
+      "type": "object",
+      "properties": {
+        "emitDecoratorMetadata": {
+          "description": "This option allow you to tell parser to act as if `emitDecoratorMetadata: true` is set in `tsconfig.json`.",
+          "default": false,
+          "type": "boolean"
+        },
+        "experimentalDecorators": {
+          "description": "This option allow you to tell parser to act as if `experimentalDecorators: true` is set in `tsconfig.json`.",
+          "default": false,
+          "type": "boolean"
+        }
       }
     },
     "OxlintRules": {

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -50,6 +50,30 @@ Add or remove global variables.
 
 
 
+## parserOptions
+
+type: `object`
+
+
+
+
+### parserOptions.emitDecoratorMetadata
+
+type: `boolean`
+
+This option allow you to tell parser to act as if `emitDecoratorMetadata: true` is set in `tsconfig.json`.
+
+
+
+### parserOptions.experimentalDecorators
+
+type: `boolean`
+
+This option allow you to tell parser to act as if `experimentalDecorators: true` is set in `tsconfig.json`.
+
+
+
+
 ## rules
 
 


### PR DESCRIPTION
 These two options are needed in [`consistent-type-import`](https://typescript-eslint.io/rules/consistent-type-imports/#caveat-decorators--experimentaldecorators-true--emitdecoratormetadata-true).

At first, I think `parserOptions` is not useful for us, and want to hard-code `experimentalDecorators` and `emitDecoratorMetadata` to `false` directly. But I changed the thought after reading:

1. https://typescript-eslint.io/blog/changes-to-consistent-type-imports-with-decorators
2. https://github.com/typescript-eslint/typescript-eslint/pull/8335 

We don't have type-aware linting for now, and require these two options to decide how we perform: if we have both `experimentalDecorators: true` and `emitDecoratorMetadata: true`, then it will not report any errors within any files that contain decorators.

https://github.com/typescript-eslint/typescript-eslint/blob/e408b93e48e5199d83a8d99d1e27126d2dd8bc8f/packages/eslint-plugin/src/rules/consistent-type-imports.ts#L303-L336

