### PR TITLE
fix(napi/parser): typescript types for `Comment` is out of order

### DIFF
--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -99,8 +99,8 @@ export interface ParseResult {
   errors: Array<string>
 }
 export interface Comment {
-  type: string
-  value: 'Line' | 'Block'
+  type: 'Line' | 'Block'
+  value: string
   start: number
   end: number
 }

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -41,8 +41,8 @@ pub struct ParseResult {
 
 #[napi(object)]
 pub struct Comment {
-    pub r#type: &'static str,
     #[napi(ts_type = "'Line' | 'Block'")]
+    pub r#type: &'static str,
     pub value: String,
     pub start: u32,
     pub end: u32,


### PR DESCRIPTION
Fix `oxc-parser` Typescript type definition for `Comment` type where the `type` and `value` have reversed types in place.