### PR TITLE
fix(semantic): Add Eq to CtxFlags

### DIFF
--- a/crates/oxc_semantic/src/control_flow/builder/context.rs
+++ b/crates/oxc_semantic/src/control_flow/builder/context.rs
@@ -3,7 +3,7 @@ use crate::{BasicBlockId, EdgeType};
 use super::ControlFlowGraphBuilder;
 
 bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct CtxFlags: u8 {
         /// Anything above a `FUNCTION` is unreachable.
         const FUNCTION = 1;


### PR DESCRIPTION
I've just created example using `oxc_semantic`. 

> https://gist.github.com/leaysgur/bcb748daa665d1615eabda6967366d05

But it could not be compiled due to:

```
error: to use a constant of type `CtxFlags` in a pattern, `CtxFlags` must be annotated with `#[derive(PartialEq, Eq)]`
```

- 0.14.0: 🆖 
- ...
- 0.13.0: 🆖 
- 0.12.5: 🆗 

This change seems to fix this.