### PR TITLE
refactor(ast)!: remove `ExportDefaultDeclarationKind::TSEnumDeclaration`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -3315,7 +3315,6 @@ pub enum ExportDefaultDeclarationKind<'a> {
     ClassDeclaration(Box<'a, Class<'a>>) = 65,
 
     TSInterfaceDeclaration(Box<'a, TSInterfaceDeclaration<'a>>) = 66,
-    TSEnumDeclaration(Box<'a, TSEnumDeclaration<'a>>) = 67,
 
     // `Expression` variants added here by `inherit_variants!` macro
     @inherit Expression
@@ -3328,7 +3327,7 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
         match self {
             Self::FunctionDeclaration(func) => func.is_typescript_syntax(),
             Self::ClassDeclaration(class) => class.is_typescript_syntax(),
-            Self::TSInterfaceDeclaration(_) | Self::TSEnumDeclaration(_) => true,
+            Self::TSInterfaceDeclaration(_) => true,
             _ => false,
         }
     }

--- a/crates/oxc_ast/src/span.rs
+++ b/crates/oxc_ast/src/span.rs
@@ -565,7 +565,6 @@ impl<'a> GetSpan for ExportDefaultDeclarationKind<'a> {
         match self {
             Self::ClassDeclaration(x) => x.span,
             Self::FunctionDeclaration(x) => x.span,
-            Self::TSEnumDeclaration(x) => x.span,
             Self::TSInterfaceDeclaration(x) => x.span,
             // `Expression`
             Self::BooleanLiteral(e) => e.span,

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -991,7 +991,6 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for ExportDefaultDeclarationKind<'a> {
                 p.print_soft_newline();
             }
             Self::TSInterfaceDeclaration(interface) => interface.gen(p, ctx),
-            Self::TSEnumDeclaration(enum_decl) => enum_decl.gen(p, ctx),
         }
     }
 }

--- a/crates/oxc_prettier/src/format/mod.rs
+++ b/crates/oxc_prettier/src/format/mod.rs
@@ -1233,7 +1233,6 @@ impl<'a> Format<'a> for ExportDefaultDeclarationKind<'a> {
             Self::FunctionDeclaration(decl) => decl.format(p),
             Self::ClassDeclaration(decl) => decl.format(p),
             Self::TSInterfaceDeclaration(decl) => decl.format(p),
-            Self::TSEnumDeclaration(decl) => decl.format(p),
         }
     }
 }

--- a/crates/oxc_prettier/src/format/module.rs
+++ b/crates/oxc_prettier/src/format/module.rs
@@ -60,8 +60,7 @@ fn print_semicolon_after_export_declaration<'a>(
             match_expression!(ExportDefaultDeclarationKind) => Some(ss!(";")),
             ExportDefaultDeclarationKind::FunctionDeclaration(_)
             | ExportDefaultDeclarationKind::ClassDeclaration(_)
-            | ExportDefaultDeclarationKind::TSInterfaceDeclaration(_)
-            | ExportDefaultDeclarationKind::TSEnumDeclaration(_) => None,
+            | ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => None,
         },
         ModuleDeclaration::ExportAllDeclaration(_)
         | ModuleDeclaration::ExportNamedDeclaration(_)

--- a/crates/oxc_semantic/src/module_record/builder.rs
+++ b/crates/oxc_semantic/src/module_record/builder.rs
@@ -249,8 +249,7 @@ impl ModuleRecordBuilder {
             match_expression!(ExportDefaultDeclarationKind) => None,
             ExportDefaultDeclarationKind::FunctionDeclaration(func) => func.id.as_ref(),
             ExportDefaultDeclarationKind::ClassDeclaration(class) => class.id.as_ref(),
-            ExportDefaultDeclarationKind::TSInterfaceDeclaration(_)
-            | ExportDefaultDeclarationKind::TSEnumDeclaration(_) => return,
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => return,
         };
         let export_entry = ExportEntry {
             export_name: ExportExportName::Default(exported_name.span()),

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -3054,9 +3054,6 @@ pub(crate) unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
         ExportDefaultDeclarationKind::TSInterfaceDeclaration(node) => {
             walk_ts_interface_declaration(traverser, (&mut **node) as *mut _, ctx)
         }
-        ExportDefaultDeclarationKind::TSEnumDeclaration(node) => {
-            walk_ts_enum_declaration(traverser, (&mut **node) as *mut _, ctx)
-        }
         ExportDefaultDeclarationKind::BooleanLiteral(_)
         | ExportDefaultDeclarationKind::NullLiteral(_)
         | ExportDefaultDeclarationKind::NumericLiteral(_)


### PR DESCRIPTION
TypeScript doesn't support `export default enum id {}`

https://www.typescriptlang.org/play/?target=2&isolatedDeclarations=true&emitDeclarationOnly=true&isolatedModules=false&ts=5.5.1-rc#code/KYDwDg9gTgLgBAE2AMwIYFcA29gDt0C2cAlgnAN4C+QA

https://github.com/microsoft/TypeScript/issues/3320