### PR TITLE
fix(semantic/cfg): discrete finalization path after `NewFunction`s.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -273,6 +273,24 @@ fn test() {
         // allows `this`/`super` after `super()`.
         ("class A extends B { }", None),
         ("class A extends B { constructor() { super(); } }", None),
+        (
+        "
+        function f() {
+            try {
+                return a();
+            }
+            catch (err) {
+                throw new class CustomError extends Error {
+                    constructor() {
+                        super(err);
+                    }
+                };
+            }
+            finally {
+                this.b();
+            }
+        }
+        ", None),
         ("class A extends B { constructor() { super(); this.c = this.d; } }", None),
         ("class A extends B { constructor() { super(); this.c(); } }", None),
         ("class A extends B { constructor() { super(); super.c(); } }", None),

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1367,6 +1367,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         let before_function_graph_ix = self.cfg.current_node_ix;
+        self.cfg.push_finalization_stack();
         let error_harness = self.cfg.attach_error_harness(ErrorEdgeKind::Implicit);
         let function_graph_ix = self.cfg.new_basic_block_function();
         self.cfg.ctx(None).new_function();
@@ -1391,6 +1392,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         /* cfg */
         self.cfg.ctx(None).resolve_expect(CtxFlags::FUNCTION);
         self.cfg.release_error_harness(error_harness);
+        self.cfg.pop_finalization_stack();
         let after_function_graph_ix = self.cfg.new_basic_block_normal();
         self.cfg.add_edge(before_function_graph_ix, after_function_graph_ix, EdgeType::Normal);
         /* cfg */
@@ -1463,6 +1465,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         let current_node_ix = self.cfg.current_node_ix;
+        self.cfg.push_finalization_stack();
         let error_harness = self.cfg.attach_error_harness(ErrorEdgeKind::Implicit);
         let function_graph_ix = self.cfg.new_basic_block_function();
         self.cfg.ctx(None).new_function();
@@ -1483,6 +1486,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         /* cfg */
         self.cfg.ctx(None).resolve_expect(CtxFlags::FUNCTION);
         self.cfg.release_error_harness(error_harness);
+        self.cfg.pop_finalization_stack();
         self.cfg.current_node_ix = current_node_ix;
         /* cfg */
         if let Some(parameters) = &expr.type_parameters {


### PR DESCRIPTION
closes #3668 

[oxlint-ecosystem-ci](https://github.com/rzvxa/oxlint-ecosystem-ci/actions/runs/9512489987/job/26220576138)

For this code:

```js
function f() {
    try {
        return a();
    }
    catch (err) {
        throw new class CustomError extends Error {
            constructor() {
                super(err);
            }
        };
    }
    finally {
        this.b();
    }
}

```

We went from this:
![image](https://github.com/oxc-project/oxc/assets/3788964/bcb751aa-50cf-4c0a-8975-e01697ff78b2)

To this:
![Screenshot 2024-06-14 110805](https://github.com/oxc-project/oxc/assets/3788964/03a03525-5326-47b1-8d6c-69720f7f3149)

