### PR TITLE
fix(ast): incorrect visit order in function

### DIFF
--- a/crates/oxc_ast/src/visit/visit.rs
+++ b/crates/oxc_ast/src/visit/visit.rs
@@ -1247,12 +1247,12 @@ pub mod walk {
         if let Some(ident) = &func.id {
             visitor.visit_binding_identifier(ident);
         }
+        if let Some(parameters) = &func.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(parameters);
+        }
         visitor.visit_formal_parameters(&func.params);
         if let Some(body) = &func.body {
             visitor.visit_function_body(body);
-        }
-        if let Some(parameters) = &func.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(parameters);
         }
         if let Some(annotation) = &func.return_type {
             visitor.visit_ts_type_annotation(annotation);


### PR DESCRIPTION
```ts
function hello<T>(a: T): T {
  return 0 as T
}
```

The `T` is a type parameter. It can be used in `FormalParameters`, `ReturnType`, and `FunctionBody`. Therefore we need to visit `type_parameters` before visiting `FormalParameters`, `ReturnType`, and `FunctionBody`