### PR TITLE
feat(parser): display jsx mismatch error, e.g. `<Foo></Bar>`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -402,3 +402,9 @@ pub fn static_constructor(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("TS1089: `static` modifier cannot appear on a constructor declaration.")
         .with_labels([span0.into()])
 }
+
+#[cold]
+pub fn jsx_element_no_match(span0: Span, span1: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Expected corresponding JSX closing tag for '{name}'."))
+        .with_labels([span0.into(), span1.into()])
+}

--- a/tasks/coverage/misc/fail/oxc-3528.jsx
+++ b/tasks/coverage/misc/fail/oxc-3528.jsx
@@ -1,0 +1,5 @@
+let a = <Apple></Banana>;
+
+let b = <Apple:Orange></Banana>;
+
+let c = <Apple.Orange></Banana>;

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 18/18 (100.00%)
 Positive Passed: 18/18 (100.00%)
-Negative Passed: 9/9 (100.00%)
+Negative Passed: 10/10 (100.00%)
 
   × Unexpected token
    ╭─[fail/oxc-169.js:2:1]
@@ -103,6 +103,28 @@ Negative Passed: 9/9 (100.00%)
    ╭─[fail/oxc-3320.tsx:1:8]
  1 │ m< $<{3[   $<{3[  $<{3[ m< m$<{3[ m< mm< $<{3[   $<{3[  $<{3[ m< m$<{3[ m< m$<{3[  $<{3[ m< m$<{3[
    ·        ─
+   ╰────
+
+  × Expected corresponding JSX closing tag for 'Apple'.
+   ╭─[fail/oxc-3528.jsx:1:10]
+ 1 │ let a = <Apple></Banana>;
+   ·          ─────   ──────
+ 2 │ 
+   ╰────
+
+  × Expected corresponding JSX closing tag for 'Apple:Orange'.
+   ╭─[fail/oxc-3528.jsx:3:10]
+ 2 │ 
+ 3 │ let b = <Apple:Orange></Banana>;
+   ·          ────────────   ──────
+ 4 │ 
+   ╰────
+
+  × Expected corresponding JSX closing tag for 'Apple.Orange'.
+   ╭─[fail/oxc-3528.jsx:5:10]
+ 4 │ 
+ 5 │ let c = <Apple.Orange></Banana>;
+   ·          ────────────   ──────
    ╰────
 
   × The keyword 'let' is reserved

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: d8086f14
 parser_typescript Summary:
 AST Parsed     : 5280/5283 (99.94%)
 Positive Passed: 5273/5283 (99.81%)
-Negative Passed: 1052/4875 (21.58%)
+Negative Passed: 1053/4875 (21.60%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
 Expect Syntax Error: "compiler/ClassDeclaration13.ts"
@@ -3026,7 +3026,6 @@ Expect Syntax Error: "conformance/jsx/tsxUnionElementType3.tsx"
 Expect Syntax Error: "conformance/jsx/tsxUnionElementType4.tsx"
 Expect Syntax Error: "conformance/jsx/tsxUnionElementType6.tsx"
 Expect Syntax Error: "conformance/jsx/tsxUnionTypeComponent2.tsx"
-Expect Syntax Error: "conformance/jsx/unicodeEscapesInJsxtags.tsx"
 Expect Syntax Error: "conformance/override/override1.ts"
 Expect Syntax Error: "conformance/override/override11.ts"
 Expect Syntax Error: "conformance/override/override13.ts"
@@ -16204,6 +16203,54 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ·                ┬
     ·                ╰── `,` expected
  42 │ }
+    ╰────
+
+  × Expected corresponding JSX closing tag for '\u0061'.
+    ╭─[conformance/jsx/unicodeEscapesInJsxtags.tsx:15:4]
+ 14 │ // tag name:
+ 15 │ ; <\u0061></a>
+    ·    ──────   ─
+ 16 │ ; <\u0061-b></a-b>
+    ╰────
+
+  × Expected corresponding JSX closing tag for '\u0061-b'.
+    ╭─[conformance/jsx/unicodeEscapesInJsxtags.tsx:16:4]
+ 15 │ ; <\u0061></a>
+ 16 │ ; <\u0061-b></a-b>
+    ·    ────────   ───
+ 17 │ ; <a-\u0063></a-c>
+    ╰────
+
+  × Expected corresponding JSX closing tag for 'a-'.
+    ╭─[conformance/jsx/unicodeEscapesInJsxtags.tsx:17:4]
+ 16 │ ; <\u0061-b></a-b>
+ 17 │ ; <a-\u0063></a-c>
+    ·    ──         ───
+ 18 │ ; <Comp\u0061 x={12} />
+    ╰────
+
+  × Expected corresponding JSX closing tag for '\u{0061}'.
+    ╭─[conformance/jsx/unicodeEscapesInJsxtags.tsx:20:4]
+ 19 │ ; <x.\u0076ideo />
+ 20 │ ; <\u{0061}></a>
+    ·    ────────   ─
+ 21 │ ; <\u{0061}-b></a-b>
+    ╰────
+
+  × Expected corresponding JSX closing tag for '\u{0061}-b'.
+    ╭─[conformance/jsx/unicodeEscapesInJsxtags.tsx:21:4]
+ 20 │ ; <\u{0061}></a>
+ 21 │ ; <\u{0061}-b></a-b>
+    ·    ──────────   ───
+ 22 │ ; <a-\u{0063}></a-c>
+    ╰────
+
+  × Expected corresponding JSX closing tag for 'a-'.
+    ╭─[conformance/jsx/unicodeEscapesInJsxtags.tsx:22:4]
+ 21 │ ; <\u{0061}-b></a-b>
+ 22 │ ; <a-\u{0063}></a-c>
+    ·    ──           ───
+ 23 │ ; <Comp\u{0061} x={12} />
     ╰────
 
   × Expected `(` but found `Identifier`


### PR DESCRIPTION
relates #3548 

I'll remove the closing name in a follow up PR.

The snapshot is incorrect, so I created a follow up issue: https://github.com/oxc-project/oxc/issues/3697