### PR TITLE
chore: make `println` and `eprintln` opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ empty_docs = { level = "allow", priority = 1 } # from `Tsify`
 dbg_macro     = "warn"
 todo          = "warn"
 unimplemented = "warn"
+print_stdout  = "warn" # must be opt-in
+print_stderr  = "warn" # must be opt-in
 # I like the explicitness of this rule as it removes confusion around `clone`.
 # This increases readability, avoids `clone` mindlessly and heap allocating on accident.
 clone_on_ref_ptr = "warn"

--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -111,9 +111,8 @@ impl Runner for LintRunner {
                 let handler = GraphicalReportHandler::new();
                 let mut err = String::new();
                 handler.render_report(&mut err, diagnostic.as_ref()).unwrap();
-                eprintln!("{err}");
                 return CliRunResult::InvalidOptions {
-                    message: "Failed to parse configuration file.".to_string(),
+                    message: "Failed to parse configuration file.\n{err}".to_string(),
                 };
             }
         };

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -33,6 +33,7 @@ pub struct FormatResult {
 }
 
 impl Termination for CliRunResult {
+    #[allow(clippy::print_stdout)]
     fn report(self) -> ExitCode {
         match self {
             Self::None => ExitCode::from(0),

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_codegen/examples/sourcemap.rs
+++ b/crates/oxc_codegen/examples/sourcemap.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use base64::{prelude::BASE64_STANDARD, Engine};

--- a/crates/oxc_diagnostics/src/reporter/checkstyle.rs
+++ b/crates/oxc_diagnostics/src/reporter/checkstyle.rs
@@ -22,6 +22,7 @@ impl DiagnosticReporter for CheckstyleReporter {
     }
 }
 
+#[allow(clippy::print_stdout)]
 fn format_checkstyle(diagnostics: &[Error]) {
     let infos = diagnostics.iter().map(Info::new).collect::<Vec<_>>();
     let mut grouped: HashMap<String, Vec<Info>> = HashMap::new();

--- a/crates/oxc_diagnostics/src/reporter/json.rs
+++ b/crates/oxc_diagnostics/src/reporter/json.rs
@@ -25,6 +25,7 @@ impl DiagnosticReporter for JsonReporter {
 }
 
 /// <https://github.com/fregante/eslint-formatters/tree/main/packages/eslint-formatter-json>
+#[allow(clippy::print_stdout)]
 fn format_json(diagnostics: &mut Vec<Error>) {
     let handler = JSONReportHandler::new();
     let messages = diagnostics

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 //! The simplest linter
 
 use std::{env, path::Path};

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::print_stdout)]
 #![allow(clippy::self_named_module_files)] // for rules.rs
 
 #[cfg(test)]

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_module_lexer/examples/module_lexer.rs
+++ b/crates/oxc_module_lexer/examples/module_lexer.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_parser/examples/multi-thread.rs
+++ b/crates/oxc_parser/examples/multi-thread.rs
@@ -1,5 +1,5 @@
 //! Parse files in parallel and then `Send` them to the main thread for processing.
-
+#![allow(clippy::print_stdout)]
 #![allow(clippy::future_not_send)] // clippy warns `Allocator` is not `Send`
 #![allow(clippy::redundant_pub_crate)] // comes from  `ouroboros`'s macro
 

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_parser/examples/visitor.rs
+++ b/crates/oxc_parser/examples/visitor.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_prettier/examples/prettier.rs
+++ b/crates/oxc_prettier/examples/prettier.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::path::Path;
 
 use pico_args::Arguments;

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{collections::HashMap, env, path::Path, sync::Arc};
 
 use itertools::Itertools;

--- a/crates/oxc_semantic/examples/simple.rs
+++ b/crates/oxc_semantic/examples/simple.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path, sync::Arc};
 
 use itertools::Itertools;

--- a/crates/oxc_sourcemap/src/sourcemap_visualizer.rs
+++ b/crates/oxc_sourcemap/src/sourcemap_visualizer.rs
@@ -189,7 +189,6 @@ mod test {
         let output = "\n// shared.js\nconst a = 'shared.js';\n\n// index.js\nconst a$1 = 'index.js';\nconsole.log(a$1, a);\n";
         let visualizer = SourcemapVisualizer::new(output, &sourcemap);
         let visualizer_text = visualizer.into_visualizer_text();
-        println!("{visualizer_text}");
         assert_eq!(
             visualizer_text,
             r#"- shared.js

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_transformer_dts/examples/transformer_dts.rs
+++ b/crates/oxc_transformer_dts/examples/transformer_dts.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/tasks/common/src/lib.rs
+++ b/tasks/common/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::path::{Path, PathBuf};
 
 mod diff;

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 // Core
 mod runtime;
 mod suite;

--- a/tasks/javascript_globals/src/main.rs
+++ b/tasks/javascript_globals/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 use lazy_static::lazy_static;
 use oxc_tasks_common::agent;
 use serde::Serialize;

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 use std::{
     fs::File,
     io::{self, Write},

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 mod ignore_list;
 mod spec;
 

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 use std::{
     collections::HashMap,
     fmt::{self, Display, Formatter},

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
 mod constants;
 use std::{
     fs,

--- a/tasks/website/src/lib.rs
+++ b/tasks/website/src/lib.rs
@@ -1,3 +1,3 @@
-#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::missing_panics_doc)]
 
 pub mod linter;

--- a/tasks/website/src/main.rs
+++ b/tasks/website/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 use pico_args::Arguments;
 
 use website::linter;


### PR DESCRIPTION
I noticed accidental `println` can be merged, which isn't really nice.