### PR TITLE
feat(linter): add `use_cfg` attribute.

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -288,6 +288,7 @@ impl IsolatedLintHandler {
             let program = allocator.alloc(ret.program);
             let semantic_ret = SemanticBuilder::new(javascript_source_text, source_type)
                 .with_trivias(ret.trivias)
+                .with_cfg(true)
                 .with_check_syntax_error(true)
                 .build(program);
 

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -1,5 +1,6 @@
 use std::{cell::RefCell, path::Path, rc::Rc, sync::Arc};
 
+use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_semantic::{AstNodes, JSDocFinder, ScopeTree, Semantic, SymbolTable};
 use oxc_span::{SourceType, Span};
@@ -76,6 +77,16 @@ impl<'a> LintContext<'a> {
 
     pub fn semantic(&self) -> &Rc<Semantic<'a>> {
         &self.semantic
+    }
+
+    /// # Panics
+    /// If rule doesn't have `#[use_cfg]` in it's declaration it would panic.
+    pub fn cfg(&self) -> &ControlFlowGraph {
+        if let Some(cfg) = self.semantic().cfg() {
+            cfg
+        } else {
+            unreachable!("for creating a control flow aware rule you have to add `#[use_cfg]` attribute to its `declare_oxc_lint` declaration");
+        }
     }
 
     pub fn disable_directives(&self) -> &DisableDirectives<'a> {

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -29,6 +29,8 @@ pub trait RuleMeta {
 
     const CATEGORY: RuleCategory;
 
+    const USE_CFG: bool;
+
     fn documentation() -> Option<&'static str> {
         None
     }

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -48,14 +48,14 @@ declare_oxc_lint!(
     ///     }
     /// }
     /// ```
+    #[use_cfg]
     GetterReturn,
-    nursery
+    nursery,
 );
 
 impl Rule for GetterReturn {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // control flow dependant
-        let Some(cfg) = ctx.semantic().cfg() else { return };
+        let cfg = ctx.cfg();
 
         // https://eslint.org/docs/latest/rules/getter-return#handled_by_typescript
         if ctx.source_type().is_typescript() {

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
     /// ```
     #[use_cfg]
     GetterReturn,
-    nursery,
+    nursery
 );
 
 impl Rule for GetterReturn {

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -73,6 +73,7 @@ declare_oxc_lint!(
     ///
     /// Disallow fallthrough of `case` statements
     ///
+    #[use_cfg]
     NoFallthrough,
     correctness
 );
@@ -89,8 +90,7 @@ impl Rule for NoFallthrough {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // control flow dependant
-        let Some(cfg) = ctx.semantic().cfg() else { return };
+        let cfg = ctx.cfg();
 
         let AstKind::SwitchStatement(switch) = node.kind() else { return };
 

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     ///     }
     /// }
     /// ```
+    #[use_cfg]
     NoThisBeforeSuper,
     correctness
 );
@@ -56,9 +57,8 @@ enum DefinitelyCallsThisBeforeSuper {
 
 impl Rule for NoThisBeforeSuper {
     fn run_once(&self, ctx: &LintContext) {
+        let cfg = ctx.cfg();
         let semantic = ctx.semantic();
-        // control flow dependant
-        let Some(cfg) = ctx.semantic().cfg() else { return };
 
         // first pass -> find super calls and local violations
         let mut wanted_nodes = Vec::new();

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -25,14 +25,14 @@ declare_oxc_lint!(
     ///
     /// Disallow unreachable code after `return`, `throw`, `continue`, and `break` statements
     ///
+    #[use_cfg]
     NoUnreachable,
     nursery
 );
 
 impl Rule for NoUnreachable {
     fn run_once(&self, ctx: &LintContext) {
-        // control flow dependant
-        let Some(cfg) = ctx.semantic().cfg() else { return };
+        let cfg = ctx.cfg();
 
         let nodes = ctx.nodes();
         let Some(root) = nodes.root_node() else { return };

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -44,14 +44,14 @@ declare_oxc_lint!(
     ///   }
     /// }
     /// ```
+    #[use_cfg]
     RequireRenderReturn,
     nursery
 );
 
 impl Rule for RequireRenderReturn {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // control flow dependant
-        let Some(cfg) = ctx.semantic().cfg() else { return };
+        let cfg = ctx.cfg();
 
         if !matches!(node.kind(), AstKind::ArrowFunctionExpression(_) | AstKind::Function(_)) {
             return;

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -101,14 +101,14 @@ declare_oxc_lint!(
     ///
     /// <https://reactjs.org/docs/hooks-rules.html>
     ///
+    #[use_cfg]
     RulesOfHooks,
     nursery
 );
 
 impl Rule for RulesOfHooks {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // control flow dependant
-        let Some(cfg) = ctx.semantic().cfg() else { return };
+        let cfg = ctx.cfg();
 
         let AstKind::CallExpression(call) = node.kind() else { return };
 

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -81,6 +81,12 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
+            pub fn use_cfg(&self) -> bool {
+                match self {
+                    #(Self::#struct_names(_) => #struct_names::USE_CFG),*
+                }
+            }
+
             pub fn documentation(&self) -> Option<&'static str> {
                 match self {
                     #(Self::#struct_names(_) => #struct_names::documentation()),*

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -181,7 +181,6 @@ impl Oxc {
 
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
             .with_trivias(ret.trivias.clone())
-            .with_cfg(true)
             .with_check_syntax_error(true)
             .build(program);
 

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -181,6 +181,7 @@ impl Oxc {
 
         let semantic_ret = SemanticBuilder::new(source_text, source_type)
             .with_trivias(ret.trivias.clone())
+            .with_cfg(true)
             .with_check_syntax_error(true)
             .build(program);
 


### PR DESCRIPTION
related to this conversation https://github.com/oxc-project/oxc/pull/3737#discussion_r1644768638

Adds a `use_cfg` attribute to use with `declare_oxc_lint` macro. When this attribute is used it would set the rule's `RuleMeta::USE_CFG` constant to true.

Since with this information, we can figure out whether a set of rules uses control flow or not we can use this information to provide a `LintContext::cfg` method that would panic if called and cfg doesn't exist.
Basically in the context of a rule, the linter should make sure the rule which requests control flow generation always gets it.