### PR TITLE
feat(linter): add `CFGLintContext` for rules with `#[use_cfg]`.

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -13,7 +13,7 @@ use oxc_linter::{
         AstroPartialLoader, JavaScriptSource, SveltePartialLoader, VuePartialLoader,
         LINT_PARTIAL_LOADER_EXT,
     },
-    LintContext, Linter,
+    LintContext, LintCtx, Linter,
 };
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -14,7 +14,7 @@ pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
 
-use crate::context::LintContext;
+use crate::context::{LintContext, LintCtx};
 
 /// Test if an AST node is a boolean value that never changes. Specifically we
 /// test for:

--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -88,11 +88,6 @@ impl<'a> LintContext<'a> {
 pub struct CFGLintContext<'a>(LintContextData<'a>);
 
 impl<'a> CFGLintContext<'a> {
-    #[allow(dead_code)]
-    pub(super) fn into_data(self) -> LintContextData<'a> {
-        self.0
-    }
-
     /// # Panics
     /// If rule doesn't have `#[use_cfg]` in it's declaration it would panic.
     pub fn cfg(&self) -> &ControlFlowGraph {
@@ -114,7 +109,7 @@ impl<'a, 'b> From<&'b LintContextData<'a>> for &'b LintContext<'a> {
     fn from(data: &'b LintContextData<'a>) -> Self {
         #![allow(unsafe_code)]
         // SAFETY: `LintContext` is just a thin wrapper around `LintContextData`.
-        unsafe { &*((data as *const LintContextData<'_>).cast::<LintContext<'_>>()) }
+        unsafe { &*((data as *const LintContextData<'a>).cast::<LintContext<'a>>()) }
     }
 }
 
@@ -122,111 +117,7 @@ impl<'a, 'b> From<&'b LintContextData<'a>> for &'b CFGLintContext<'a> {
     fn from(data: &'b LintContextData<'a>) -> Self {
         #![allow(unsafe_code)]
         // SAFETY: `CFGLintContext` is just a thin wrapper around `LintContextData`.
-        unsafe { &*((data as *const LintContextData<'_>).cast::<CFGLintContext<'_>>()) }
-    }
-}
-
-impl<'a> LintCtx<'a> for LintContext<'a> {
-    fn new(file_path: Box<Path>, semantic: Rc<Semantic<'a>>) -> Self {
-        LintContextData::new(file_path, semantic).into()
-    }
-
-    fn with_fix(mut self, fix: bool) -> Self {
-        self.0 = self.0.with_fix(fix);
-        self
-    }
-
-    fn with_eslint_config(mut self, eslint_config: &Arc<OxlintConfig>) -> Self {
-        self.0 = self.0.with_eslint_config(eslint_config);
-        self
-    }
-
-    fn with_rule_name(mut self, name: &'static str) -> Self {
-        self.0 = self.0.with_rule_name(name);
-        self
-    }
-
-    fn with_severity(mut self, severity: AllowWarnDeny) -> Self {
-        self.0 = self.0.with_severity(severity);
-        self
-    }
-
-    fn semantic(&self) -> &Rc<Semantic<'a>> {
-        self.0.semantic()
-    }
-
-    fn disable_directives(&self) -> &DisableDirectives<'a> {
-        self.0.disable_directives()
-    }
-
-    fn source_text(&self) -> &'a str {
-        self.0.source_text()
-    }
-
-    fn source_range(&self, span: Span) -> &'a str {
-        self.0.source_range(span)
-    }
-
-    fn source_type(&self) -> &SourceType {
-        self.0.source_type()
-    }
-
-    fn file_path(&self) -> &Path {
-        self.0.file_path()
-    }
-
-    fn settings(&self) -> &OxlintSettings {
-        self.0.settings()
-    }
-
-    fn globals(&self) -> &OxlintGlobals {
-        self.0.globals()
-    }
-
-    fn env(&self) -> &OxlintEnv {
-        self.0.env()
-    }
-
-    fn env_contains_var(&self, var: &str) -> bool {
-        self.0.env_contains_var(var)
-    }
-
-    /* Diagnostics */
-    fn into_message(self) -> Vec<Message<'a>> {
-        self.0.into_message()
-    }
-
-    fn diagnostic(&self, diagnostic: OxcDiagnostic) {
-        self.0.diagnostic(diagnostic);
-    }
-
-    fn diagnostic_with_fix<F: FnOnce(RuleFixer<'_, 'a>) -> Fix<'a>>(
-        &self,
-        diagnostic: OxcDiagnostic,
-        fix: F,
-    ) {
-        self.0.diagnostic_with_fix(diagnostic, fix);
-    }
-
-    fn nodes(&self) -> &AstNodes<'a> {
-        self.0.nodes()
-    }
-
-    fn scopes(&self) -> &ScopeTree {
-        self.0.scopes()
-    }
-
-    fn symbols(&self) -> &SymbolTable {
-        self.0.symbols()
-    }
-
-    fn module_record(&self) -> &ModuleRecord {
-        self.0.module_record()
-    }
-
-    /* JSDoc */
-    fn jsdoc(&self) -> &JSDocFinder<'a> {
-        self.0.jsdoc()
+        unsafe { &*((data as *const LintContextData<'a>).cast::<CFGLintContext<'a>>()) }
     }
 }
 
@@ -382,106 +273,113 @@ impl<'a> LintCtx<'a> for LintContextData<'a> {
     }
 }
 
-impl<'a> LintCtx<'a> for CFGLintContext<'a> {
-    fn new(file_path: Box<Path>, semantic: Rc<Semantic<'a>>) -> Self {
-        Self(LintContextData::new(file_path, semantic))
-    }
+macro_rules! impl_lint_ctx {
+    ($ty:ty) => {
+        impl<'a> LintCtx<'a> for $ty {
+            fn new(file_path: Box<Path>, semantic: Rc<Semantic<'a>>) -> Self {
+                Self(LintContextData::new(file_path, semantic))
+            }
 
-    fn with_fix(mut self, fix: bool) -> Self {
-        self.0 = self.0.with_fix(fix);
-        self
-    }
+            fn with_fix(mut self, fix: bool) -> Self {
+                self.0 = self.0.with_fix(fix);
+                self
+            }
 
-    fn with_eslint_config(mut self, eslint_config: &Arc<OxlintConfig>) -> Self {
-        self.0 = self.0.with_eslint_config(eslint_config);
-        self
-    }
+            fn with_eslint_config(mut self, eslint_config: &Arc<OxlintConfig>) -> Self {
+                self.0 = self.0.with_eslint_config(eslint_config);
+                self
+            }
 
-    fn with_rule_name(mut self, name: &'static str) -> Self {
-        self.0 = self.0.with_rule_name(name);
-        self
-    }
+            fn with_rule_name(mut self, name: &'static str) -> Self {
+                self.0 = self.0.with_rule_name(name);
+                self
+            }
 
-    fn with_severity(mut self, severity: AllowWarnDeny) -> Self {
-        self.0 = self.0.with_severity(severity);
-        self
-    }
+            fn with_severity(mut self, severity: AllowWarnDeny) -> Self {
+                self.0 = self.0.with_severity(severity);
+                self
+            }
 
-    fn semantic(&self) -> &Rc<Semantic<'a>> {
-        self.0.semantic()
-    }
+            fn semantic(&self) -> &Rc<Semantic<'a>> {
+                self.0.semantic()
+            }
 
-    fn disable_directives(&self) -> &DisableDirectives<'a> {
-        self.0.disable_directives()
-    }
+            fn disable_directives(&self) -> &DisableDirectives<'a> {
+                self.0.disable_directives()
+            }
 
-    fn source_text(&self) -> &'a str {
-        self.0.source_text()
-    }
+            fn source_text(&self) -> &'a str {
+                self.0.source_text()
+            }
 
-    fn source_range(&self, span: Span) -> &'a str {
-        self.0.source_range(span)
-    }
+            fn source_range(&self, span: Span) -> &'a str {
+                self.0.source_range(span)
+            }
 
-    fn source_type(&self) -> &SourceType {
-        self.0.source_type()
-    }
+            fn source_type(&self) -> &SourceType {
+                self.0.source_type()
+            }
 
-    fn file_path(&self) -> &Path {
-        self.0.file_path()
-    }
+            fn file_path(&self) -> &Path {
+                self.0.file_path()
+            }
 
-    fn settings(&self) -> &OxlintSettings {
-        self.0.settings()
-    }
+            fn settings(&self) -> &OxlintSettings {
+                self.0.settings()
+            }
 
-    fn globals(&self) -> &OxlintGlobals {
-        self.0.globals()
-    }
+            fn globals(&self) -> &OxlintGlobals {
+                self.0.globals()
+            }
 
-    fn env(&self) -> &OxlintEnv {
-        self.0.env()
-    }
+            fn env(&self) -> &OxlintEnv {
+                self.0.env()
+            }
 
-    fn env_contains_var(&self, var: &str) -> bool {
-        self.0.env_contains_var(var)
-    }
+            fn env_contains_var(&self, var: &str) -> bool {
+                self.0.env_contains_var(var)
+            }
 
-    /* Diagnostics */
-    fn into_message(self) -> Vec<Message<'a>> {
-        self.0.into_message()
-    }
+            /* Diagnostics */
+            fn into_message(self) -> Vec<Message<'a>> {
+                self.0.into_message()
+            }
 
-    fn diagnostic(&self, diagnostic: OxcDiagnostic) {
-        self.0.diagnostic(diagnostic);
-    }
+            fn diagnostic(&self, diagnostic: OxcDiagnostic) {
+                self.0.diagnostic(diagnostic);
+            }
 
-    fn diagnostic_with_fix<F: FnOnce(RuleFixer<'_, 'a>) -> Fix<'a>>(
-        &self,
-        diagnostic: OxcDiagnostic,
-        fix: F,
-    ) {
-        self.0.diagnostic_with_fix(diagnostic, fix);
-    }
+            fn diagnostic_with_fix<F: FnOnce(RuleFixer<'_, 'a>) -> Fix<'a>>(
+                &self,
+                diagnostic: OxcDiagnostic,
+                fix: F,
+            ) {
+                self.0.diagnostic_with_fix(diagnostic, fix);
+            }
 
-    fn nodes(&self) -> &AstNodes<'a> {
-        self.0.nodes()
-    }
+            fn nodes(&self) -> &AstNodes<'a> {
+                self.0.nodes()
+            }
 
-    fn scopes(&self) -> &ScopeTree {
-        self.0.scopes()
-    }
+            fn scopes(&self) -> &ScopeTree {
+                self.0.scopes()
+            }
 
-    fn symbols(&self) -> &SymbolTable {
-        self.0.symbols()
-    }
+            fn symbols(&self) -> &SymbolTable {
+                self.0.symbols()
+            }
 
-    fn module_record(&self) -> &ModuleRecord {
-        self.0.module_record()
-    }
+            fn module_record(&self) -> &ModuleRecord {
+                self.0.module_record()
+            }
 
-    /* JSDoc */
-    fn jsdoc(&self) -> &JSDocFinder<'a> {
-        self.0.jsdoc()
-    }
+            /* JSDoc */
+            fn jsdoc(&self) -> &JSDocFinder<'a> {
+                self.0.jsdoc()
+            }
+        }
+    };
 }
+
+impl_lint_ctx!(LintContext<'a>);
+impl_lint_ctx!(CFGLintContext<'a>);

--- a/crates/oxc_linter/src/fixer.rs
+++ b/crates/oxc_linter/src/fixer.rs
@@ -4,7 +4,7 @@ use oxc_codegen::Codegen;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 
-use crate::LintContext;
+use crate::{LintContext, LintCtx};
 
 #[derive(Debug, Clone, Default)]
 pub struct Fix<'a> {

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -21,7 +21,6 @@ pub mod table;
 
 use std::{io::Write, rc::Rc, sync::Arc};
 
-use context::CFGLintContext;
 use oxc_diagnostics::Error;
 use oxc_semantic::AstNode;
 
@@ -102,20 +101,17 @@ impl Linter {
         self.rules.len()
     }
 
-    pub fn run<'a, C>(&self, ctx: C) -> Vec<Message<'a>>
-    where
-        C: LintCtx<'a> + Into<CFGLintContext<'a>>,
-    {
+    pub fn run<'a>(&self, ctx: LintContext<'a>) -> Vec<Message<'a>> {
         let semantic = Rc::clone(ctx.semantic());
 
         let ctx = ctx.with_fix(self.options.fix).with_eslint_config(&self.eslint_config);
-        let ctx: &CFGLintContext<'a> = &ctx.into();
+        let ctx_data = &ctx.into_data();
 
         let rules = self
             .rules
             .iter()
             .map(|rule| {
-                (rule, ctx.clone().with_rule_name(rule.name()).with_severity(rule.severity))
+                (rule, ctx_data.clone().with_rule_name(rule.name()).with_severity(rule.severity))
             })
             .collect::<Vec<_>>();
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -21,14 +21,15 @@ pub mod table;
 
 use std::{io::Write, rc::Rc, sync::Arc};
 
+use context::CFGLintContext;
 use oxc_diagnostics::Error;
 use oxc_semantic::AstNode;
 
 pub use crate::{
     config::OxlintConfig,
-    context::LintContext,
+    context::{LintContext, LintCtx},
     options::{AllowWarnDeny, LintOptions},
-    rule::{RuleCategory, RuleMeta, RuleWithSeverity},
+    rule::{RuleCategory, RuleContext, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},
 };
 use crate::{
@@ -101,10 +102,15 @@ impl Linter {
         self.rules.len()
     }
 
-    pub fn run<'a>(&self, ctx: LintContext<'a>) -> Vec<Message<'a>> {
+    pub fn run<'a, C>(&self, ctx: C) -> Vec<Message<'a>>
+    where
+        C: LintCtx<'a> + Into<CFGLintContext<'a>>,
+    {
         let semantic = Rc::clone(ctx.semantic());
 
         let ctx = ctx.with_fix(self.options.fix).with_eslint_config(&self.eslint_config);
+        let ctx: &CFGLintContext<'a> = &ctx.into();
+
         let rules = self
             .rules
             .iter()

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -6,22 +6,22 @@ use std::{
 
 use oxc_semantic::SymbolId;
 
-use crate::{context::LintContext, AllowWarnDeny, AstNode, RuleEnum};
+use crate::{AllowWarnDeny, AstNode, RuleEnum};
 
-pub trait Rule: Sized + Default + fmt::Debug {
+pub trait Rule: RuleContext + Sized + Default + fmt::Debug {
     /// Initialize from eslint json configuration
     fn from_configuration(_value: serde_json::Value) -> Self {
         Self::default()
     }
 
     /// Visit each AST Node
-    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
+    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &Self::Context<'a>) {}
 
     /// Visit each symbol
-    fn run_on_symbol(&self, _symbol_id: SymbolId, _ctx: &LintContext<'_>) {}
+    fn run_on_symbol(&self, _symbol_id: SymbolId, _ctx: &Self::Context<'_>) {}
 
     /// Run only once. Useful for inspecting scopes and trivias etc.
-    fn run_once(&self, _ctx: &LintContext) {}
+    fn run_once(&self, _ctx: &Self::Context<'_>) {}
 }
 
 pub trait RuleMeta {
@@ -34,6 +34,10 @@ pub trait RuleMeta {
     fn documentation() -> Option<&'static str> {
         None
     }
+}
+
+pub trait RuleContext {
+    type Context<'a>;
 }
 
 /// Rule categories defined by rust-clippy

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -13,7 +13,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::CFGLintContext, rule::Rule, AstNode};
 
 fn getter_return_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(getter-return): Expected to always return a value in getter.")
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GetterReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &CFGLintContext<'a>) {
         let cfg = ctx.cfg();
 
         // https://eslint.org/docs/latest/rules/getter-return#handled_by_typescript
@@ -119,7 +119,7 @@ impl GetterReturn {
     }
 
     /// Checks whether it is necessary to check the node
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+    fn is_wanted_node(node: &AstNode, ctx: &CFGLintContext<'_>) -> bool {
         if let Some(parent) = ctx.nodes().parent_node(node.id()) {
             match parent.kind() {
                 AstKind::MethodDefinition(mdef) => {
@@ -183,7 +183,7 @@ impl GetterReturn {
     fn run_diagnostic<'a>(
         &self,
         node: &AstNode<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &CFGLintContext<'a>,
         cfg: &ControlFlowGraph,
         span: Span,
     ) {

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -18,7 +18,7 @@ use oxc_span::{GetSpan, Span};
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::CFGLintContext, rule::Rule, AstNode};
 
 fn no_fallthrough_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("eslint(no-fallthrough): Expected a 'break' statement before 'case'.")
@@ -89,7 +89,7 @@ impl Rule for NoFallthrough {
         Self::new(comment_pattern, allow_empty_case, report_unused_fallthrough_comment)
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &CFGLintContext<'a>) {
         let cfg = ctx.cfg();
 
         let AstKind::SwitchStatement(switch) = node.kind() else { return };
@@ -197,7 +197,7 @@ fn possible_fallthrough_comment_span(case: &SwitchCase) -> (u32, Option<u32>) {
 }
 
 impl NoFallthrough {
-    fn has_blanks_between(ctx: &LintContext, range: Range<u32>) -> bool {
+    fn has_blanks_between(ctx: &CFGLintContext, range: Range<u32>) -> bool {
         let in_between = &ctx.semantic().source_text()[range.start as usize..range.end as usize];
         // check for at least 2 new lines, we allow the first new line for formatting.
         in_between.bytes().filter(|it| *it == b'\n').nth(1).is_some()
@@ -205,7 +205,7 @@ impl NoFallthrough {
 
     fn maybe_allow_fallthrough_trivia(
         &self,
-        ctx: &LintContext,
+        ctx: &CFGLintContext,
         case: &SwitchCase,
         fall: &SwitchCase,
     ) -> Option<Span> {
@@ -261,7 +261,7 @@ impl NoFallthrough {
 // TAKE IT AS A MAGICAL BLACK BOX, NO DOCUMENTATION TO PREVENT REUSE!
 // Issue: <https://github.com/oxc-project/oxc/issues/3662>
 fn get_switch_semantic_cases(
-    ctx: &LintContext,
+    ctx: &CFGLintContext,
     cfg: &ControlFlowGraph,
     node: &AstNode,
     switch: &SwitchStatement,

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -13,7 +13,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNodeId;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{context::CFGLintContext, rule::Rule, AstNode};
 
 fn no_this_before_super_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-this-before-super): Expected to always call super() before this/super property access.")
@@ -56,7 +56,7 @@ enum DefinitelyCallsThisBeforeSuper {
 }
 
 impl Rule for NoThisBeforeSuper {
-    fn run_once(&self, ctx: &LintContext) {
+    fn run_once(&self, ctx: &CFGLintContext) {
         let cfg = ctx.cfg();
         let semantic = ctx.semantic();
 
@@ -132,7 +132,7 @@ impl Rule for NoThisBeforeSuper {
 }
 
 impl NoThisBeforeSuper {
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+    fn is_wanted_node(node: &AstNode, ctx: &CFGLintContext<'_>) -> bool {
         if let Some(parent) = ctx.nodes().parent_node(node.id()) {
             if let AstKind::MethodDefinition(mdef) = parent.kind() {
                 if matches!(mdef.kind, MethodDefinitionKind::Constructor) {

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -10,7 +10,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::CFGLintContext, rule::Rule};
 
 fn no_unreachable_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("eslint(no-unreachable): Unreachable code.").with_labels([span.into()])
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnreachable {
-    fn run_once(&self, ctx: &LintContext) {
+    fn run_once(&self, ctx: &CFGLintContext) {
         let cfg = ctx.cfg();
 
         let nodes = ctx.nodes();

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::CFGLintContext,
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
     AstNode,
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireRenderReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &CFGLintContext<'a>) {
         let cfg = ctx.cfg();
 
         if !matches!(node.kind(), AstKind::ArrowFunctionExpression(_) | AstKind::Function(_)) {
@@ -168,7 +168,7 @@ fn is_render_fn(node: &AstNode) -> bool {
     false
 }
 
-fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b CFGLintContext<'a>) -> bool {
     let Some(ancestors_0) = ctx.nodes().parent_node(node.id()) else { return false };
     if !matches!(ancestors_0.kind(), AstKind::ObjectExpression(_)) {
         return false;
@@ -184,7 +184,7 @@ fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
     is_es5_component(ancestors_2)
 }
 
-fn is_in_es6_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_in_es6_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b CFGLintContext<'a>) -> bool {
     let Some(parent) = ctx.nodes().parent_node(node.id()) else { return false };
     if !matches!(parent.kind(), AstKind::ClassBody(_)) {
         return false;

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -12,7 +12,7 @@ use oxc_span::{Atom, CompactStr};
 use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{
-    context::LintContext,
+    context::CFGLintContext,
     rule::Rule,
     utils::{is_react_component_or_hook_name, is_react_function_call, is_react_hook},
     AstNode,
@@ -107,7 +107,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RulesOfHooks {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &CFGLintContext<'a>) {
         let cfg = ctx.cfg();
 
         let AstKind::CallExpression(call) = node.kind() else { return };

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/listener_map.rs
@@ -27,6 +27,7 @@ use crate::{
         is_function_side_effect_free, is_local_variable_a_whitelisted_module, is_pure_function,
         no_effects, FunctionName, NodeListenerOptions, Value,
     },
+    LintCtx,
 };
 
 pub trait ListenerMap {

--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -19,7 +19,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     partial_loader::{JavaScriptSource, PartialLoader, LINT_PARTIAL_LOADER_EXT},
-    Fixer, LintContext, Linter, Message,
+    Fixer, LintContext, LintCtx, Linter, Message,
 };
 
 pub struct LintServiceOptions {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -11,7 +11,7 @@ use oxc_semantic::{AstNode, ReferenceId};
 use oxc_span::Atom;
 use phf::phf_set;
 
-use crate::LintContext;
+use crate::{LintContext, LintCtx};
 
 mod parse_jest_fn;
 pub use crate::utils::jest::parse_jest_fn::{
@@ -307,7 +307,7 @@ mod test {
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
 
-    use crate::LintContext;
+    use crate::{LintContext, LintCtx};
 
     #[test]
     fn test_is_jest_file() {

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -11,7 +11,7 @@ use oxc_semantic::AstNode;
 use oxc_span::{Atom, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LintCtx},
     utils::jest::{is_pure_string, JestFnKind, JestGeneralFnKind, PossibleJestNode},
 };
 

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -6,7 +6,11 @@ use oxc_semantic::JSDoc;
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
 
-use crate::{config::JSDocPluginSettings, context::LintContext, AstNode};
+use crate::{
+    config::JSDocPluginSettings,
+    context::{LintContext, LintCtx},
+    AstNode,
+};
 
 /// JSDoc is often attached on the parent node of a function.
 ///

--- a/crates/oxc_linter/src/utils/nextjs.rs
+++ b/crates/oxc_linter/src/utils/nextjs.rs
@@ -1,6 +1,6 @@
 use oxc_span::CompactStr;
 
-use crate::LintContext;
+use crate::{LintContext, LintCtx};
 
 pub fn is_in_app_dir(file_path: &str) -> bool {
     file_path.contains("app/") || file_path.contains("app\\")

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 };
 use oxc_semantic::{AstNode, SymbolFlags};
 
-use crate::{LintContext, OxlintSettings};
+use crate::{LintContext, LintCtx, OxlintSettings};
 
 pub fn is_create_element_call(call_expr: &CallExpression) -> bool {
     if let Some(member_expr) = call_expr.callee.get_member_expr() {

--- a/crates/oxc_linter/src/utils/tree_shaking.rs
+++ b/crates/oxc_linter/src/utils/tree_shaking.rs
@@ -10,7 +10,7 @@ use oxc_span::{CompactStr, GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, LogicalOperator, UnaryOperator};
 use rustc_hash::FxHashSet;
 
-use crate::LintContext;
+use crate::{LintContext, LintCtx};
 
 mod pure_functions;
 

--- a/crates/oxc_linter/src/utils/unicorn/boolean.rs
+++ b/crates/oxc_linter/src/utils/unicorn/boolean.rs
@@ -7,7 +7,7 @@ use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
 use super::is_logical_expression;
-use crate::{ast_util::outermost_paren_parent, LintContext};
+use crate::{ast_util::outermost_paren_parent, LintContext, LintCtx};
 pub fn is_logic_not(node: &AstKind) -> bool {
     matches!(node, AstKind::UnaryExpression(unary_expr) if unary_expr.operator == UnaryOperator::LogicalNot)
 }

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use oxc_linter::{RuleCategory, RuleMeta};
+use oxc_linter::{LintContext, RuleCategory, RuleContext, RuleMeta};
 use oxc_macros::declare_oxc_lint_test;
 
 struct TestRule;

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -53,7 +53,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let expanded = quote! {
         #(pub use self::#use_stmts::#struct_names;)*
 
-        use crate::{context::LintContext, rule::{Rule, RuleCategory, RuleMeta}, AstNode};
+        use crate::{context::{CFGLintContext, LintContext}, rule::{Rule, RuleCategory, RuleMeta}, AstNode};
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
@@ -107,21 +107,21 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+            pub fn run<'a>(&self, node: &AstNode<'a>, ctx: &CFGLintContext<'a>) {
                 match self {
-                    #(Self::#struct_names(rule) => rule.run(node, ctx)),*
+                    #(Self::#struct_names(rule) => rule.run(node, ctx.into())),*
                 }
             }
 
-            pub fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContext<'a>) {
+            pub fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &CFGLintContext<'a>) {
                 match self {
-                    #(Self::#struct_names(rule) => rule.run_on_symbol(symbol_id, ctx)),*
+                    #(Self::#struct_names(rule) => rule.run_on_symbol(symbol_id, ctx.into())),*
                 }
             }
 
-            pub fn run_once<'a>(&self, ctx: &LintContext<'a>) {
+            pub fn run_once<'a>(&self, ctx: &CFGLintContext<'a>) {
                 match self {
-                    #(Self::#struct_names(rule) => rule.run_once(ctx)),*
+                    #(Self::#struct_names(rule) => rule.run_once(ctx.into())),*
                 }
             }
         }

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -53,7 +53,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let expanded = quote! {
         #(pub use self::#use_stmts::#struct_names;)*
 
-        use crate::{context::{CFGLintContext, LintContext}, rule::{Rule, RuleCategory, RuleMeta}, AstNode};
+        use crate::{context::LintContextData, rule::{Rule, RuleCategory, RuleMeta}, AstNode};
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
@@ -107,19 +107,19 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub fn run<'a>(&self, node: &AstNode<'a>, ctx: &CFGLintContext<'a>) {
+            pub fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContextData<'a>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run(node, ctx.into())),*
                 }
             }
 
-            pub fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &CFGLintContext<'a>) {
+            pub fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContextData<'a>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run_on_symbol(symbol_id, ctx.into())),*
                 }
             }
 
-            pub fn run_once<'a>(&self, ctx: &CFGLintContext<'a>) {
+            pub fn run_once<'a>(&self, ctx: &LintContextData<'a>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run_once(ctx.into())),*
                 }

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -59,7 +59,13 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
     let import_statement = if used_in_test {
         None
     } else {
-        Some(quote! { use crate::rule::{RuleCategory, RuleMeta}; })
+        Some(quote! { use crate::{context::LintCtx, rule::{RuleCategory, RuleMeta, RuleContext}}; })
+    };
+
+    let context = if use_cfg {
+        quote! { CFGLintContext<'a> }
+    } else {
+        quote! { LintContext<'a> }
     };
 
     let output = quote! {
@@ -75,6 +81,10 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
             fn documentation() -> Option<&'static str> {
                 Some(#documentation)
             }
+        }
+
+        impl RuleContext for #name {
+            type Context<'a> = #context;
         }
     };
 

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -16,7 +16,7 @@ use oxc::{
     span::SourceType,
     transformer::{TransformOptions, Transformer},
 };
-use oxc_linter::{LintContext, Linter};
+use oxc_linter::{LintContext, LintCtx, Linter};
 use oxc_prettier::{Prettier, PrettierOptions};
 use serde::Serialize;
 use tsify::Tsify;

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf, rc::Rc};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, LintContext, LintOptions, Linter};
+use oxc_linter::{AllowWarnDeny, LintContext, LintCtx, LintOptions, Linter};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;


### PR DESCRIPTION
related to this https://github.com/oxc-project/oxc/pull/3744#issuecomment-2176735840

Now only rules declared with the `#[use_cfg]` attribute would get to use `ctx.cfg` method otherwise they have to check for `cfx.semantic().cfg()` to be `Some`.

If this gets merged we should be able to unwrap the control flow unchecked; Since our current linter runner is getting its context from outside we should check for this not being `None` before iterating and panicking early on.