### PR TITLE
feat(isolated-declarations): shrink span for arrow function that needs an explicit return type

### DIFF
--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -4,7 +4,7 @@ use oxc_ast::ast::{
     TSTypeOperatorOperator,
 };
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{GetSpan, SPAN};
+use oxc_span::{GetSpan, Span, SPAN};
 
 use crate::{
     diagnostics::{
@@ -41,7 +41,10 @@ impl<'a> IsolatedDeclarations<'a> {
         let return_type = self.infer_arrow_function_return_type(func);
 
         if return_type.is_none() {
-            self.error(function_must_have_explicit_return_type(func.span));
+            self.error(function_must_have_explicit_return_type(Span::new(
+                func.params.span.start,
+                func.body.span.start + 1,
+            )));
         }
 
         let params = self.transform_formal_parameters(&func.params);

--- a/crates/oxc_isolated_declarations/tests/fixtures/arrow-function-return-type.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/arrow-function-return-type.ts
@@ -1,0 +1,9 @@
+function A() {
+  return () => {
+    return C;
+  }
+}
+
+const B = () => { return B };
+
+const C = function () {}

--- a/crates/oxc_isolated_declarations/tests/snapshots/arrow-function-return-type.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/arrow-function-return-type.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/arrow-function-return-type.ts
+---
+==================== .D.TS ====================
+
+declare function A(): unknown;
+declare const B: unknown;
+declare const C: unknown;
+
+
+==================== Errors ====================
+
+  x Function must have an explicit return type annotation with
+  | --isolatedDeclarations.
+   ,-[2:10]
+ 1 | function A() {
+ 2 |   return () => {
+   :          ^^^^^^^
+ 3 |     return C;
+   `----
+
+  x Function must have an explicit return type annotation with
+  | --isolatedDeclarations.
+   ,-[7:11]
+ 6 | 
+ 7 | const B = () => { return B };
+   :           ^^^^^^^
+ 8 | 
+   `----
+
+  x Function must have an explicit return type annotation with
+  | --isolatedDeclarations.
+   ,-[9:20]
+ 8 | 
+ 9 | const C = function () {}
+   :                    ^
+   `----


### PR DESCRIPTION
Current `span` we can't be consistent with typescript.

We report the following
```ts
(a, b) =>
^^^^^^^^^
{ }
^
```

TypeScript reports the following
```ts
(a, b) => 
^^^^^^^^^
{}
```

The TypeScript only reports the first line, if we want it to be exactly the same we need to find the first newline position