### PR TITLE
refactor(transformer): simplify TS export assignment transform

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -284,11 +284,11 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x0_typescript.transform_for_statement(stmt);
     }
 
-    fn enter_module_declaration(
+    fn enter_ts_export_assignment(
         &mut self,
-        decl: &mut ModuleDeclaration<'a>,
+        export_assignment: &mut TSExportAssignment<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.transform_module_declaration(decl);
+        self.x0_typescript.transform_ts_export_assignment(export_assignment);
     }
 }

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -189,12 +189,6 @@ impl<'a> TypeScript<'a> {
         }
     }
 
-    pub fn transform_module_declaration(&mut self, module_decl: &mut ModuleDeclaration<'a>) {
-        if let ModuleDeclaration::TSExportAssignment(ts_export_assignment) = &mut *module_decl {
-            self.transform_ts_export_assignment(ts_export_assignment);
-        }
-    }
-
     pub fn transform_jsx_element(&mut self, elem: &mut JSXElement<'a>) {
         self.annotations.transform_jsx_element(elem);
     }


### PR DESCRIPTION
Remove unnecessary jump through a `ModuleDeclaration` visitor, and visit as `TSExportAssignment` directly.