### PR TITLE
chore(linter): promote `no-unreachable` to correctness.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     /// Disallow unreachable code after `return`, `throw`, `continue`, and `break` statements
     ///
     NoUnreachable,
-    nursery
+    correctness
 );
 
 impl Rule for NoUnreachable {


### PR DESCRIPTION
Since now there are no known false positives, We might want to promote this rule to correctness for the next release so we can find out about its possible false negatives/positives if any.

Feel free to close this PR if you find it too soon for this.