### PR TITLE
fix(docs): detect typescript alias rules and mark them as supported

### DIFF
--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -263,3 +263,7 @@ exports.loadTargetPluginRules = (linter) => {
   loadPluginReactPerfRules(linter);
   loadPluginNextRules(linter);
 };
+
+// some typescript rules are some extension of the basic eslint rules
+// we need them later to map them for both
+exports.pluginTypeScriptRulesNames = Object.keys(pluginTypeScriptAllRules);

--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -1,5 +1,6 @@
 const { resolve } = require("node:path");
 const { readFile } = require("node:fs/promises");
+const { pluginTypeScriptRulesNames } = require("./eslint-rules.cjs");
 
 const readAllImplementedRuleNames = async () => {
   const rulesFile = await readFile(
@@ -33,6 +34,18 @@ const readAllImplementedRuleNames = async () => {
 
       // Ignore no reference rules
       if (prefixedName.startsWith("oxc/")) continue;
+
+      // some tyescript rules are extensions of eslint core rules
+      if (prefixedName.startsWith("eslint/")) {
+        const ruleName = prefixedName.replace('eslint/', '');
+
+        // there is no alias
+        if (!pluginTypeScriptRulesNames.includes(ruleName)) {
+          continue;
+        }
+
+        rules.add(`typescript/${ruleName}`);
+      }
 
       rules.add(prefixedName);
     }


### PR DESCRIPTION
Some tpyescript rules are extensions of the core eslint rules.  

Now we mark them as supported :) 

Maybe add a info for the user about this behavior?

Some discord discussion:
https://discord.com/channels/1079625926024900739/1080712072012238858/1226407188650659845

## Current State

Found Aliases:
- default-param-last
- max-params
- no-array-constructor
- require-await
- no-dupe-class-members
- no-empty-function
- no-loss-of-precision
- no-redeclare
- no-useless-constructor

Todo: why im getting following output:
```
👀 typescript/require-await is implemented but not found in their rules
👀 tree-shaking/no-side-effects-in-initialization is implemented but not found in their rules
```