### PR TITLE
ci: enable semantic benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,7 +55,7 @@ jobs:
           - lexer
           - parser
           - transformer
-          # - semantic # Too flaky
+          - semantic
           - minifier
           - codegen_sourcemap
           - sourcemap


### PR DESCRIPTION
#3776 does seem to have stabilized the benchmark results. Re-enable semantic benchmarks which we disabled because they were showing wild variance, and see if they still do.