### PR TITLE
feat(traverse): disable syntax check and disable build module record

### DIFF
--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -60,8 +60,6 @@
 //! scheme could very easily be derailed entirely by a single mistake, so in my opinion, it's unwise
 //! to edit by hand.
 
-use std::path::PathBuf;
-
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
 use oxc_semantic::SemanticBuilder;
@@ -147,11 +145,7 @@ pub fn traverse_mut<'a, Tr: Traverse<'a>>(
     source_type: SourceType,
     allocator: &'a Allocator,
 ) {
-    let semantic = SemanticBuilder::new(source_text, source_type)
-        .with_check_syntax_error(true)
-        .build_module_record(PathBuf::default(), program)
-        .build(program)
-        .semantic;
+    let semantic = SemanticBuilder::new(source_text, source_type).build(program).semantic;
     let (symbols, scopes) = semantic.into_symbol_table_and_scope_tree();
 
     let mut ctx = TraverseCtx::new(scopes, symbols, allocator);

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 473/927
+Passed: 472/927
 
 # All Passed:
 * babel-preset-react
@@ -445,10 +445,11 @@ Passed: 473/927
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (129/151)
+# babel-plugin-transform-typescript (128/151)
 * enum/mix-references/input.ts
 * enum/ts5.0-const-foldable/input.ts
 * exports/declared-types/input.ts
+* exports/imported-types/input.ts
 * exports/interface/input.ts
 * imports/elide-no-import-specifiers/input.ts
 * imports/elision-locations/input.ts


### PR DESCRIPTION
These can be skipped because :
 * semantic errors are not passed to the caller
 * module record is not used