### PR TITLE
feat(isolated-declarations): infer undefined as any type

### DIFF
--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -17,7 +17,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub fn infer_type_from_expression(&self, expr: &Expression<'a>) -> Option<TSType<'a>> {
         match expr {
             Expression::BooleanLiteral(_) => Some(self.ast.ts_boolean_keyword(SPAN)),
-            Expression::NullLiteral(_) => Some(self.ast.ts_null_keyword(SPAN)),
+            Expression::NullLiteral(lit) => Some(self.ast.ts_any_keyword(lit.span)),
             Expression::NumericLiteral(_) | Expression::BigintLiteral(_) => {
                 Some(self.ast.ts_number_keyword(SPAN))
             }
@@ -30,7 +30,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
             Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" => Some(self.ast.ts_undefined_keyword(SPAN)),
+                "undefined" => Some(self.ast.ts_any_keyword(ident.span)),
                 _ => None,
             },
             Expression::FunctionExpression(func) => {

--- a/crates/oxc_isolated_declarations/tests/fixtures/infer-null.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/infer-null.ts
@@ -1,0 +1,3 @@
+const a = null;
+using d = null;
+function c(p = null): void {}

--- a/crates/oxc_isolated_declarations/tests/fixtures/infer-undefined.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/infer-undefined.ts
@@ -1,0 +1,3 @@
+const a = undefined;
+using d = undefined;
+function c(p = undefined): void {}

--- a/crates/oxc_isolated_declarations/tests/snapshots/infer-null.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/infer-null.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/infer-null.ts
+---
+==================== .D.TS ====================
+
+declare const a: any;
+declare const d: any;
+declare function c(p?: any): void;

--- a/crates/oxc_isolated_declarations/tests/snapshots/infer-undefined.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/infer-undefined.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/infer-undefined.ts
+---
+==================== .D.TS ====================
+
+declare const a: any;
+declare const d: any;
+declare function c(p?: any): void;


### PR DESCRIPTION
In the TypeScript Playground, it is inferred as the `undefined` type, but in `transpileDeclaration`, it is inferred as the `any` type. We should make sure that the output is the same as transpileDeclaration's. See: https://github.com/microsoft/TypeScript/pull/58912#issuecomment-2177327619
