### PR TITLE
chore(ci): now we mark both ts alias and eslint rules.

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -39,12 +39,11 @@ const readAllImplementedRuleNames = async () => {
       if (prefixedName.startsWith("eslint/")) {
         const ruleName = prefixedName.replace('eslint/', '');
 
-        // there is no alias
-        if (!pluginTypeScriptRulesNames.includes(ruleName)) {
+        // there is an alias, so we add it with this in mind.
+        if (pluginTypeScriptRulesNames.includes(ruleName)) {
+          rules.add(`typescript/${ruleName}`);
           continue;
         }
-
-        rules.add(`typescript/${ruleName}`);
       }
 
       rules.add(prefixedName);


### PR DESCRIPTION
Fixes the unmarked implemented rules in #479.