### PR TITLE
fix(transformer): fix TS annotation transform scopes

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -208,9 +208,9 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn enter_method_definition(
         &mut self,
         def: &mut MethodDefinition<'a>,
-        _ctx: &mut TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.transform_method_definition(def);
+        self.x0_typescript.transform_method_definition(def, ctx);
     }
 
     fn exit_method_definition(

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -127,8 +127,12 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_jsx_opening_element(elem);
     }
 
-    pub fn transform_method_definition(&mut self, def: &mut MethodDefinition<'a>) {
-        self.annotations.transform_method_definition(def);
+    pub fn transform_method_definition(
+        &mut self,
+        def: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.annotations.transform_method_definition(def, ctx);
     }
 
     pub fn transform_method_definition_on_exit(&mut self, def: &mut MethodDefinition<'a>) {


### PR DESCRIPTION
Create symbol references for `IdentifierReferences` created in TS annotations transform.