### PR TITLE
improve(transformer): avoid reallocating strings

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -570,7 +570,7 @@ impl<'a, 'b> VisitMut<'a> for IdentifierReferenceRename<'a, 'b> {
                 // enum_name.identifier
                 let ident_reference = IdentifierReference::new(SPAN, self.enum_name.clone());
                 let object = self.ctx.ast.identifier_reference_expression(ident_reference);
-                let property = self.ctx.ast.identifier_name(SPAN, &ident.name);
+                let property = IdentifierName::new(SPAN, ident.name.clone());
                 Some(self.ctx.ast.static_member_expression(SPAN, object, property, false))
             }
             _ => None,

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -421,12 +421,12 @@ impl<'a> TypeScript<'a> {
 
     // name.item_name = item_name
     fn create_assignment_statement(&self, name: &Atom<'a>, item_name: &Atom<'a>) -> Expression<'a> {
-        let ident = self.ctx.ast.identifier_reference(SPAN, name.as_str());
+        let ident = IdentifierReference::new(SPAN, name.clone());
         let object = self.ctx.ast.identifier_reference_expression(ident);
         let property = IdentifierName::new(SPAN, item_name.clone());
         let left = self.ctx.ast.static_member(SPAN, object, property, false);
         let left = AssignmentTarget::from(left);
-        let ident = self.ctx.ast.identifier_reference(SPAN, item_name.as_str());
+        let ident = IdentifierReference::new(SPAN, item_name.clone());
         let right = self.ctx.ast.identifier_reference_expression(ident);
         let op = AssignmentOperator::Assign;
         self.ctx.ast.assignment_expression(SPAN, op, left, right)


### PR DESCRIPTION
Re-use existing `Atom`s rather than allocating duplicate strings in TS transforms.