### PR TITLE
fix(transformer): TS transform generate do not copy statements

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -208,17 +208,17 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn enter_method_definition(
         &mut self,
         def: &mut MethodDefinition<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        _ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.transform_method_definition(def, ctx);
+        self.x0_typescript.transform_method_definition(def);
     }
 
     fn exit_method_definition(
         &mut self,
         def: &mut MethodDefinition<'a>,
-        _ctx: &mut TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
-        self.x0_typescript.transform_method_definition_on_exit(def);
+        self.x0_typescript.transform_method_definition_on_exit(def, ctx);
     }
 
     fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, _ctx: &mut TraverseCtx<'a>) {
@@ -238,8 +238,8 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x3_es2015.enter_statements(stmts);
     }
 
-    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, _ctx: &mut TraverseCtx<'a>) {
-        self.x0_typescript.transform_statements_on_exit(stmts);
+    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+        self.x0_typescript.transform_statements_on_exit(stmts, ctx);
         self.x3_es2015.exit_statements(stmts);
     }
 

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -127,16 +127,16 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_jsx_opening_element(elem);
     }
 
-    pub fn transform_method_definition(
+    pub fn transform_method_definition(&mut self, def: &mut MethodDefinition<'a>) {
+        self.annotations.transform_method_definition(def);
+    }
+
+    pub fn transform_method_definition_on_exit(
         &mut self,
         def: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        self.annotations.transform_method_definition(def, ctx);
-    }
-
-    pub fn transform_method_definition_on_exit(&mut self, def: &mut MethodDefinition<'a>) {
-        self.annotations.transform_method_definition_on_exit(def);
+        self.annotations.transform_method_definition_on_exit(def, ctx);
     }
 
     pub fn transform_new_expression(&mut self, expr: &mut NewExpression<'a>) {
@@ -151,8 +151,12 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_statements(stmts);
     }
 
-    pub fn transform_statements_on_exit(&mut self, stmts: &mut Vec<'a, Statement<'a>>) {
-        self.annotations.transform_statements_on_exit(stmts);
+    pub fn transform_statements_on_exit(
+        &mut self,
+        stmts: &mut Vec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.annotations.transform_statements_on_exit(stmts, ctx);
     }
 
     pub fn transform_statement(&mut self, stmt: &mut Statement<'a>, ctx: &TraverseCtx<'a>) {


### PR DESCRIPTION
Remove an unsound usage of `ast.copy` from TS transform. Previously the same statements were inserted into the AST multiple times. Instead generate these statements on demand.

Also use a `std::vec::Vec` for temporary values, rather than allocating them into arena, where they take up space to no purpose.