### PR TITLE
fix(transformer): TS transform handle when type exports first

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -138,12 +138,28 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x0_typescript.transform_class_body(body);
     }
 
+    fn enter_import_declaration(
+        &mut self,
+        decl: &mut ImportDeclaration<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x0_typescript.transform_import_declaration(decl);
+    }
+
     fn enter_export_named_declaration(
         &mut self,
         decl: &mut ExportNamedDeclaration<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
         self.x0_typescript.transform_export_named_declaration(decl);
+    }
+
+    fn enter_ts_module_declaration(
+        &mut self,
+        decl: &mut TSModuleDeclaration<'a>,
+        _ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x0_typescript.transform_ts_module_declaration(decl);
     }
 
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -99,8 +99,16 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_class_body(body);
     }
 
+    pub fn transform_import_declaration(&mut self, decl: &mut ImportDeclaration<'a>) {
+        self.annotations.transform_import_declaration(decl);
+    }
+
     pub fn transform_export_named_declaration(&mut self, decl: &mut ExportNamedDeclaration<'a>) {
         self.annotations.transform_export_named_declaration(decl);
+    }
+
+    pub fn transform_ts_module_declaration(&mut self, decl: &mut TSModuleDeclaration<'a>) {
+        self.annotations.transform_ts_module_declaration(decl);
     }
 
     pub fn transform_expression(&mut self, expr: &mut Expression<'a>) {


### PR DESCRIPTION
Fix 2 bugs in TS transform:

1. Handle where export declaration precedes its import/definition. e.g. `export { X }; import { type X } from "x";`
2. Don't insert `export {}` statement if any other `export` statements remain.

Also refactor to simplify logic for removing imports/exports.