### PR TITLE
refactor(ast): reduce allocations in AST builder

### DIFF
--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -280,7 +280,7 @@ impl<'a> AstBuilder<'a> {
 
     #[inline]
     pub fn block_statement(self, block: Box<'a, BlockStatement<'a>>) -> Statement<'a> {
-        Statement::BlockStatement(self.block(block.span, block.unbox().body))
+        Statement::BlockStatement(block)
     }
 
     #[inline]


### PR DESCRIPTION
No need to unbox and then box again.