### PR TITLE
refactor(ast): shorten code in AST builder

### DIFF
--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -575,7 +575,7 @@ impl<'a> AstBuilder<'a> {
         self,
         expr: MemberExpression<'a>,
     ) -> AssignmentTarget<'a> {
-        AssignmentTarget::from(SimpleAssignmentTarget::from(expr))
+        AssignmentTarget::from(expr)
     }
 
     #[inline]


### PR DESCRIPTION
Shorten code in AST builder. `MemberExpression` can be converted directly to `AssignmentTarget`.