### PR TITLE
fix(ast): fix JSON serialization of `BindingPattern`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1326,7 +1326,7 @@ pub struct DebuggerStatement {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(rename_all = "camelCase"))]
 pub struct BindingPattern<'a> {
-    #[cfg_attr(feature = "serialize", serde(flatten))]
+    #[cfg_attr(feature = "serialize", serde(skip))]
     pub span: Span,
     // serde(flatten) the attributes because estree has no `BindingPattern`
     #[cfg_attr(feature = "serialize", serde(flatten))]


### PR DESCRIPTION
#3855 added a `span` field to `BindingPattern` but it's duplicate information from `BindingPatternKind`. `BindingPatternKind`'s `span` is already included in JS AST, so serde can skip the duplicate in `BindingPattern`.