### PR TITLE
fix(ast): correct JSON serialization of `TSModuleBlock`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -832,13 +832,15 @@ pub enum TSModuleDeclarationBody<'a> {
     TSModuleBlock(Box<'a, TSModuleBlock<'a>>),
 }
 
+// See serializer in serialize.rs
 #[visited_node]
 #[derive(Debug, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
+#[cfg_attr(feature = "serialize", derive(Tsify))]
 #[cfg_attr(feature = "serialize", serde(tag = "type", rename_all = "camelCase"))]
 pub struct TSModuleBlock<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
+    #[cfg_attr(feature = "serialize", serde(skip))]
     pub directives: Vec<'a, Directive<'a>>,
     pub body: Vec<'a, Statement<'a>>,
 }


### PR DESCRIPTION
Fix #3848.

#3830 added a `directives` field to `TSModuleBlock`. ESTree AST treats directives in module blocks as `StringLiteral`s. Add a custom `Serialize` impl to combine any directives back into `body` in JS AST.

NB: `#[serde(skip)]` attr on `directives` field is for benefit of `Tsify` derive macro, so TS defs match the actual JSON AST.