### PR TITLE
feat(napi/transform): add `crate-type: "lib"`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,13 +1078,12 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.16.6"
+version = "3.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc300228808a0e6aea5a58115c82889240bcf8dab16fc25ad675b33e454b368"
+checksum = "99d38fbf4cbfd7d2785d153f4dcce374d515d3dabd688504dd9093f8135829d0"
 dependencies = [
  "bitflags 2.5.0",
  "ctor",
- "napi-derive",
  "napi-sys",
  "once_cell",
  "tokio",
@@ -1098,9 +1097,9 @@ checksum = "e1c0f5d67ee408a4685b61f5ab7e58605c8ae3f2b4189f0127d804ff13d5560a"
 
 [[package]]
 name = "napi-derive"
-version = "2.16.5"
+version = "3.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e034ddf6155192cf83f267ede763fe6c164dfa9971585436b16173718d94c4"
+checksum = "c230c813bfd4d6c7aafead3c075b37f0cf7fecb38be8f4cf5cfcee0b2c273ad0"
 dependencies = [
  "cfg-if",
  "convert_case",
@@ -1112,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.67"
+version = "2.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff2c00437f3b3266391eb5e6aa25d0029187daf5caf05b8e3271468fb5ae73e"
+checksum = "4370cc24c2e58d0f3393527b282eb00f1158b304248f549e1ec81bd2927db5fe"
 dependencies = [
  "convert_case",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ oxc_linter       = { path = "crates/oxc_linter" }
 oxc_prettier     = { path = "crates/oxc_prettier" }
 oxc_tasks_common = { path = "tasks/common" }
 
-napi        = "2.16.6"
-napi-derive = "2.16.5"
+napi        = "3.0.0-alpha.1"
+napi-derive = "3.0.0-alpha.1"
 napi-build  = "2.1.3"
 
 assert-unchecked    = "0.1.2"

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace   = true
 workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 test       = false
 doctest    = false
 


### PR DESCRIPTION
The pr add a `crate-type: lib` for transform binding, it will be used for rolldown export binding. I tested the binary size 895k -> 944K, it could be acceptable.

Here bump the napi library version due to rolldown napi version is used `3.0.0-alpha`, different napi version make rolldown release build error.

It means the binding library need to publish to crate.io, @Boshen Could you add it to ci pipeline for it? I'm not familiar for it.