### PR TITLE
refactor(traverse): use camel case props internally

### DIFF
--- a/crates/oxc_traverse/scripts/lib/parse.mjs
+++ b/crates/oxc_traverse/scripts/lib/parse.mjs
@@ -2,7 +2,7 @@ import {readFile} from 'fs/promises';
 import {join as pathJoin} from 'path';
 import {fileURLToPath} from 'url';
 import assert from 'assert';
-import {typeAndWrappers} from './utils.mjs';
+import {typeAndWrappers, snakeToCamel} from './utils.mjs';
 
 const FILENAMES = ['js.rs', 'jsx.rs', 'literal.rs', 'ts.rs'];
 
@@ -145,7 +145,8 @@ function parseScopeArgs(argsStr, filename, lineIndex) {
             }
             assert(bracketCount === 0);
 
-            args[key] = argsStr.slice(0, index).trim();
+            const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+            args[camelKey] = argsStr.slice(0, index).trim();
             argsStr = argsStr.slice(index + 1);
             if (argsStr === '') break;
 

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -61,7 +61,7 @@ function generateWalkForStruct(type, types) {
     let scopeEnterField, enterScopeCode = '', exitScopeCode = '';
     if (scopeArgs && scopeIdField) {
         // Get field to enter scope before
-        const enterFieldName = scopeArgs.enter_scope_before;
+        const enterFieldName = scopeArgs.enterScopeBefore;
         if (enterFieldName) {
             scopeEnterField = visitedFields.find(field => field.name === enterFieldName);
             assert(


### PR DESCRIPTION
Small change to internals of `oxc_traverse` codegen. Use camel-case property names.