### PR TITLE
feat(linter): implement @typescript-eslint/prefer-namespace-keyword

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -148,6 +148,7 @@ mod typescript {
     pub mod prefer_for_of;
     pub mod prefer_function_type;
     pub mod prefer_literal_enum_member;
+    pub mod prefer_namespace_keyword;
     pub mod prefer_ts_expect_error;
     pub mod triple_slash_reference;
 }
@@ -542,6 +543,7 @@ oxc_macros::declare_all_lint_rules! {
     typescript::prefer_literal_enum_member,
     typescript::explicit_function_return_type,
     typescript::no_non_null_assertion,
+    typescript::prefer_namespace_keyword,
     jest::expect_expect,
     jest::max_expects,
     jest::max_nested_describe,

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -1,0 +1,95 @@
+use oxc_ast::{
+    ast::{TSModuleDeclarationKind, TSModuleDeclarationName},
+    AstKind,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, AstNode};
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferNamespaceKeyword;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Require using namespace keyword over module keyword to declare custom TypeScript modules.
+    ///
+    /// ### Why is this bad?
+    /// TypeScript historically allowed a form of code organization called "custom modules" (module Example {}), later renamed to "namespaces" (namespace Example).
+    ///
+    /// Namespaces are an outdated way to organize TypeScript code. ES2015 module syntax is now preferred (import/export).
+    ///
+    /// For projects still using custom modules / namespaces, it's preferred to refer to them as namespaces. This rule reports when the module keyword is used instead of namespace.
+    ///
+    /// ### Example
+    /// ```javascript
+    /// module foo {}
+    /// declare module foo {}
+    /// ```
+    PreferNamespaceKeyword,
+    restriction,
+);
+
+fn prefer_namespace_keyword_diagnostic(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("typescript-eslint(prefer-namespace-keyword): Use 'namespace' instead of 'module' to declare custom TypeScript modules.")
+        .with_help("'Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules")
+        .with_labels([span0.into()])
+}
+
+impl Rule for PreferNamespaceKeyword {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSModuleDeclaration(decl) = node.kind() else { return };
+        if decl.kind != TSModuleDeclarationKind::Module {
+            return;
+        }
+        let TSModuleDeclarationName::Identifier(id) = &decl.id else { return };
+
+        ctx.diagnostic_with_fix(prefer_namespace_keyword_diagnostic(decl.span), |fixer| {
+            // replace `module` with `namespace`
+            fixer.replace(Span::new(id.span.start - 7, id.span.start - 1), "namespace")
+        });
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "declare module 'foo';",
+        "declare module 'foo' {}",
+        "namespace foo {}",
+        "declare namespace foo {}",
+        "declare global {}",
+    ];
+
+    let fail = vec![
+        "module foo {}",
+        "declare module foo {}",
+        "
+        	declare module foo {
+        	  declare module bar {}
+        	}
+        	      ",
+    ];
+
+    let fix = vec![
+        ("module foo {}", "namespace foo {}", None),
+        ("declare module foo {}", "declare namespace foo {}", None),
+        (
+            "
+        	declare module foo {
+        	  declare module bar {}
+        	}
+        	      ",
+            "
+        	declare namespace foo {
+        	  declare namespace bar {}
+        	}
+        	      ",
+            None,
+        ),
+    ];
+    Tester::new(PreferNamespaceKeyword::NAME, pass, fail).expect_fix(fix).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/prefer_namespace_keyword.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_namespace_keyword.snap
@@ -1,0 +1,35 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ typescript-eslint(prefer-namespace-keyword): Use 'namespace' instead of 'module' to declare custom TypeScript modules.
+   ╭─[prefer_namespace_keyword.tsx:1:1]
+ 1 │ module foo {}
+   · ─────────────
+   ╰────
+  help: 'Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules
+
+  ⚠ typescript-eslint(prefer-namespace-keyword): Use 'namespace' instead of 'module' to declare custom TypeScript modules.
+   ╭─[prefer_namespace_keyword.tsx:1:1]
+ 1 │ declare module foo {}
+   · ─────────────────────
+   ╰────
+  help: 'Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules
+
+  ⚠ typescript-eslint(prefer-namespace-keyword): Use 'namespace' instead of 'module' to declare custom TypeScript modules.
+   ╭─[prefer_namespace_keyword.tsx:2:10]
+ 1 │     
+ 2 │ ╭─▶             declare module foo {
+ 3 │ │                 declare module bar {}
+ 4 │ ╰─▶             }
+ 5 │                       
+   ╰────
+  help: 'Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules
+
+  ⚠ typescript-eslint(prefer-namespace-keyword): Use 'namespace' instead of 'module' to declare custom TypeScript modules.
+   ╭─[prefer_namespace_keyword.tsx:3:12]
+ 2 │             declare module foo {
+ 3 │               declare module bar {}
+   ·               ─────────────────────
+ 4 │             }
+   ╰────
+  help: 'Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules


### PR DESCRIPTION
Related issue: https://github.com/oxc-project/oxc/issues/2180

original implementation

- code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/prefer-namespace-keyword.ts
- test: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/prefer-namespace-keyword.test.ts
- doc: https://typescript-eslint.io/rules/prefer-namespace-keyword/
