### PR TITLE
fix(parser): trailing comma is not allowed in ParenthesizedExpression

### DIFF
--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -215,8 +215,27 @@ impl<'a> SeparatedList<'a> for SequenceExpressionList<'a> {
     // read everything as expression and map to it to either
     // ParenthesizedExpression or ArrowFormalParameters later
     fn parse_element(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
-        let element = p.parse_assignment_expression_or_higher()?;
-        self.elements.push(element);
+        let element = p.parse_assignment_expression_or_higher();
+        self.elements.push(element?);
+        Ok(())
+    }
+
+    fn parse_list(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
+        p.expect(self.open())?;
+
+        let mut first = true;
+
+        while !p.at(self.close()) && !p.at(Kind::Eof) {
+            if first {
+                first = false;
+            } else {
+                p.expect(self.separator())?;
+            }
+
+            self.parse_element(p)?;
+        }
+
+        p.expect(self.close())?;
         Ok(())
     }
 }

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 12619ffe
 parser_babel Summary:
 AST Parsed     : 2095/2101 (99.71%)
 Positive Passed: 2087/2101 (99.33%)
-Negative Passed: 1364/1501 (90.87%)
+Negative Passed: 1365/1501 (90.94%)
 Expect Syntax Error: "annex-b/disabled/1.1-html-comments-close/input.js"
 Expect Syntax Error: "annex-b/disabled/3.1-sloppy-labeled-functions/input.js"
 Expect Syntax Error: "annex-b/disabled/3.1-sloppy-labeled-functions-if-body/input.js"
@@ -27,7 +27,6 @@ Expect Syntax Error: "es2015/uncategorised/297/input.js"
 Expect Syntax Error: "es2015/uncategorised/335/input.js"
 Expect Syntax Error: "es2017/async-functions/async-await-as-arrow-binding-identifier/input.js"
 Expect Syntax Error: "es2017/async-functions/await-binding-inside-arrow-params-inside-async-arrow-params/input.js"
-Expect Syntax Error: "es2017/trailing-function-commas/7/input.js"
 Expect Syntax Error: "es2018/object-rest-spread/24/input.js"
 Expect Syntax Error: "es2018/object-rest-spread/comma-after-rest/input.js"
 Expect Syntax Error: "es2018/object-rest-spread/comma-after-spread-for-in/input.js"
@@ -5152,6 +5151,12 @@ Expect to Parse: "typescript/types/const-type-parameters-babel-7/input.ts"
    ╭─[es2017/trailing-function-commas/6/input.js:1:14]
  1 │ function log(,) { }
    ·              ─
+   ╰────
+
+  × Unexpected token
+   ╭─[es2017/trailing-function-commas/7/input.js:1:8]
+ 1 │ ('foo',)
+   ·        ─
    ╰────
 
   × Expected `(` but found `await`

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -15431,11 +15431,11 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╰────
 
   × Unexpected token
-    ╭─[conformance/expressions/commaOperator/commaOperatorWithoutOperand.ts:16:2]
- 15 │ // Missing the first operand
- 16 │ (, ANY);
-    ·  ─
- 17 │ (, BOOLEAN);
+    ╭─[conformance/expressions/commaOperator/commaOperatorWithoutOperand.ts:9:7]
+  8 │ // Missing the second operand
+  9 │ (ANY, );
+    ·       ─
+ 10 │ (BOOLEAN, );
     ╰────
 
   × 'with' statements are not allowed
@@ -15952,13 +15952,12 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ·                      ─
    ╰────
 
-  × Expected `>` but found `,`
-   ╭─[conformance/externalModules/topLevelAwaitErrors.1.ts:5:14]
+  × Unexpected token
+   ╭─[conformance/externalModules/topLevelAwaitErrors.1.ts:4:10]
+ 3 │ // reparse call as invalid await should error
  4 │ await (1,);
+   ·          ─
  5 │ await <number, string>(1);
-   ·              ┬
-   ·              ╰── `>` expected
- 6 │ 
    ╰────
 
   × Cannot use `await` as an identifier in an async context


### PR DESCRIPTION
close: #3878

The implementation is copied from `SeparatedList`'s `print_list`.
```diff
    fn parse_list(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
        p.expect(self.open())?;

        let mut first = true;

        while !p.at(self.close()) && !p.at(Kind::Eof) {
            if first {
                first = false;
            } else {
                p.expect(self.separator())?;
-                if p.at(self.close()) {
-                    break;
-               }
            }

            self.parse_element(p)?;
        }

        p.expect(self.close())?;
        Ok(())
    }
```