### PR TITLE
perf(diagnostics): optimize string-buffer reallocations

### DIFF
--- a/crates/oxc_diagnostics/src/graphic_reporter.rs
+++ b/crates/oxc_diagnostics/src/graphic_reporter.rs
@@ -1122,9 +1122,9 @@ impl GraphicalReportHandler {
         let mut column = context_data.column();
         let mut offset = context_data.span().offset();
         let mut line_offset = offset;
+        let mut line_str = String::with_capacity(context.len());
+        let mut lines = Vec::with_capacity(1);
         let mut iter = context.chars().peekable();
-        let mut line_str = String::new();
-        let mut lines = Vec::new();
         while let Some(char) = iter.next() {
             offset += char.len_utf8();
             let mut at_end_of_file = false;


### PR DESCRIPTION
This improves `GraphicalReportHandler` logic by using a string-buffer with a capacity hint. That avoids growing the buffer from zero each time, saving a bunch of reallocations.