### PR TITLE
refactor(ast): add comment about alternatives to `AstBuilder::copy`

### DIFF
--- a/crates/oxc_ast/src/ast_builder.rs
+++ b/crates/oxc_ast/src/ast_builder.rs
@@ -71,6 +71,7 @@ impl<'a> AstBuilder<'a> {
     /// # SAFETY
     /// This method is completely unsound and should not be used.
     /// We need to remove all uses of it. Please don't add any more!
+    /// Use `move_expression`, `move_statement`, or one of the other `move_*` methods below instead.
     /// <https://github.com/oxc-project/oxc/issues/3483>
     #[inline]
     pub fn copy<T>(self, src: &T) -> T {


### PR DESCRIPTION
Expand on comment added in #3891.