### PR TITLE
fix(transformer): fix spans and scopes in TS enum transform

### DIFF
--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -37,7 +37,7 @@ impl<'a> BoundIdentifier<'a> {
 
     /// Create `IdentifierReference` referencing this binding which is read from
     /// in current scope
-    pub fn create_read_reference(&self, ctx: &mut TraverseCtx) -> IdentifierReference<'a> {
+    pub fn create_read_reference(&self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
         self.create_spanned_read_reference(SPAN, ctx)
     }
 
@@ -46,14 +46,9 @@ impl<'a> BoundIdentifier<'a> {
     pub fn create_spanned_read_reference(
         &self,
         span: Span,
-        ctx: &mut TraverseCtx,
+        ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        let reference_id = ctx.create_bound_reference(
-            self.name.to_compact_str(),
-            self.symbol_id,
-            ReferenceFlag::Read,
-        );
-        IdentifierReference::new_read(span, self.name.clone(), Some(reference_id))
+        ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, ReferenceFlag::Read)
     }
 
     /// Create `BindingIdentifier` for this binding

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -167,7 +167,7 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_statements_on_exit(stmts, ctx);
     }
 
-    pub fn transform_statement(&mut self, stmt: &mut Statement<'a>, ctx: &TraverseCtx<'a>) {
+    pub fn transform_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         self.r#enum.transform_statement(stmt, ctx);
     }
 

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -1,10 +1,10 @@
 use oxc_allocator::{Allocator, Box};
 use oxc_ast::{
-    ast::{Expression, Statement},
+    ast::{Expression, IdentifierReference, Statement},
     AstBuilder,
 };
 use oxc_semantic::{ScopeTree, SymbolTable};
-use oxc_span::CompactStr;
+use oxc_span::{Atom, CompactStr, Span};
 use oxc_syntax::{
     reference::{ReferenceFlag, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -358,6 +358,19 @@ impl<'a> TraverseCtx<'a> {
         self.scoping.create_bound_reference(name, symbol_id, flag)
     }
 
+    /// Create an `IdentifierReference` bound to a `SymbolId`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_bound_reference_id`.
+    pub fn create_bound_reference_id(
+        &mut self,
+        span: Span,
+        name: Atom<'a>,
+        symbol_id: SymbolId,
+        flag: ReferenceFlag,
+    ) -> IdentifierReference<'a> {
+        self.scoping.create_bound_reference_id(span, name, symbol_id, flag)
+    }
+
     /// Create an unbound reference.
     ///
     /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
@@ -367,6 +380,18 @@ impl<'a> TraverseCtx<'a> {
         flag: ReferenceFlag,
     ) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flag)
+    }
+
+    /// Create an unbound `IdentifierReference`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_unbound_reference_id`.
+    pub fn create_unbound_reference_id(
+        &mut self,
+        span: Span,
+        name: Atom<'a>,
+        flag: ReferenceFlag,
+    ) -> IdentifierReference<'a> {
+        self.scoping.create_unbound_reference_id(span, name, flag)
     }
 
     /// Create a reference optionally bound to a `SymbolId`.
@@ -382,6 +407,22 @@ impl<'a> TraverseCtx<'a> {
         flag: ReferenceFlag,
     ) -> ReferenceId {
         self.scoping.create_reference(name, symbol_id, flag)
+    }
+
+    /// Create an `IdentifierReference` optionally bound to a `SymbolId`.
+    ///
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_reference_id`
+    /// or `TraverseCtx::create_unbound_reference_id`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_reference_id`.
+    pub fn create_reference_id(
+        &mut self,
+        span: Span,
+        name: Atom<'a>,
+        symbol_id: Option<SymbolId>,
+        flag: ReferenceFlag,
+    ) -> IdentifierReference<'a> {
+        self.scoping.create_reference_id(span, name, symbol_id, flag)
     }
 
     /// Create reference in current scope, looking up binding for `name`,


### PR DESCRIPTION
Fix scope and spans in TS `enum` transform.

Incomplete - not yet fixed either scopes or spans for the interior of the function which TS `enum` is transformed into, only what's outside the function.