### PR TITLE
feat(linter): change `no-import-assign` to correctness

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
     /// Object.assign(mod_ns, { foo: "foo" }) // ERROR: The members of 'mod_ns' are readonly.
     /// ```
     NoImportAssign,
-    nursery
+    correctness
 );
 
 const OBJECT_MUTATION_METHODS: phf::Set<&'static str> =


### PR DESCRIPTION
closes #3733