### PR TITLE
improvement(ast_codegen): better output formatting.

### DIFF
--- a/tasks/ast_codegen/src/generators/mod.rs
+++ b/tasks/ast_codegen/src/generators/mod.rs
@@ -15,7 +15,8 @@ macro_rules! endl {
 /// Wraps the result of the given expression in `insert!({value here});` and outputs it as `TokenStream`.
 macro_rules! insert {
     ($txt:expr) => {{
-        format!(r#"insert!("{}");"#, $txt.as_str()).parse::<proc_macro2::TokenStream>().unwrap()
+        let txt: &str = &*$txt;
+        format!(r#"insert!("{}");"#, txt).parse::<proc_macro2::TokenStream>().unwrap()
     }};
 }
 

--- a/tasks/ast_codegen/src/main.rs
+++ b/tasks/ast_codegen/src/main.rs
@@ -1,9 +1,9 @@
 // TODO: remove me please!
 #![allow(dead_code, unused_imports)]
 mod defs;
+mod fmt;
 mod generators;
 mod linker;
-mod pprint;
 mod schema;
 
 use std::{
@@ -16,8 +16,8 @@ use std::{
     rc::Rc,
 };
 
+use fmt::{cargo_fmt, pprint};
 use itertools::Itertools;
-use pprint::pprint;
 use proc_macro2::TokenStream;
 use syn::parse_file;
 
@@ -218,41 +218,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         file.write_all(span_content.as_bytes())?;
     }
 
-    // NOTE: Print AstKind
-    // println!(
-    //     "{}",
-    //     outputs
-    //         .into_iter()
-    //         .find(|it| it.0 == AstKindGenerator.name())
-    //         .map(|(_, output)| {
-    //             let GeneratorOutput::One(result) = output else { unreachable!() };
-    //             prettyplease::unparse(&parse_file(result.to_string().as_str()).unwrap())
-    //         })
-    //         .unwrap()
-    // );
-
-    // NOTE: Print AST
-    // println!(
-    //     "{}",
-    //     outputs
-    //         .into_iter()
-    //         .find(|it| it.0 == AstGenerator.name())
-    //         .map(|(_, output)| {
-    //             let GeneratorOutput::Many(results) = output else { unreachable!() };
-    //
-    //             results
-    //                 .into_iter()
-    //                 .map(|(k, v)| {
-    //                     format!(
-    //                         "file \"{}\":\n{}",
-    //                         k,
-    //                         prettyplease::unparse(&parse_file(v.to_string().as_str()).unwrap())
-    //                     )
-    //                 })
-    //                 .join("\n //-nextfile")
-    //         })
-    //         .unwrap()
-    // );
+    cargo_fmt(".")?;
 
     // let schema = serde_json::to_string_pretty(&schema).map_err(|e| e.to_string())?;
     // println!("{schema}");


### PR DESCRIPTION
We use prettyplease for formatting our generated code, Which has a lot of advantages over rustfmt, But sometimes it conflicts with our cargo fmt config,
Since it isn't configurable I just added a `cargo fmt` step after the generation process to prevent conflicts.
We might be able to not rely on prettyplease at all, But We have to test that one after we have most of our generated code, rustfmt usually bails on nested calls and macros so it might not work as our only solution. In contrast to that prettyplease is used in both bindgen and cargo-expand and is created for this exact reason(formatting generated code).