### PR TITLE
fix(oxlint): gate custom allocators by feature flag

### DIFF
--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -1,11 +1,11 @@
 #![cfg(not(miri))] // Miri does not support custom allocators
 
-#[cfg(not(debug_assertions))]
+#[cfg(feature = "allocator")]
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[cfg(not(debug_assertions))]
+#[cfg(feature = "allocator")]
 #[cfg(target_os = "windows")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;


### PR DESCRIPTION
This tweaks the conditional compilation of custom allocators by wiring the dedicated Cargo feature flag `allocator` to the source code. It ensures that allocator gating is directly checking the relevant feature instead of trying to infer it from the build profile.