### PR TITLE
refactor(eslint): convert with_labels to with_label where applicable

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -22,7 +22,7 @@ fn expect_return(x0: &str, span1: Span) -> OxcDiagnostic {
         "eslint(array-callback-return): Missing return on some path for array method {x0:?}"
     ))
     .with_help(format!("Array method {x0:?} needs to have valid return on all code paths"))
-    .with_labels([span1.into()])
+    .with_label(span1)
 }
 
 fn expect_no_return(x0: &str, span1: Span) -> OxcDiagnostic {
@@ -30,7 +30,7 @@ fn expect_no_return(x0: &str, span1: Span) -> OxcDiagnostic {
         "eslint(array-callback-return): Unexpected return for array method {x0:?}"
     ))
     .with_help(format!("Array method {x0:?} expects no useless return from the function"))
-    .with_labels([span1.into()])
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -9,7 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn default_case_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(default-case): Require default cases in switch statements.")
         .with_help("Add a default case.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn default_param_last_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(default-param-last): Default parameters should be last")
         .with_help("Enforce default parameters to be last.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn eqeqeq_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(eqeqeq): Expected {x1} and instead saw {x0}"))
         .with_help(format!("Prefer {x1} operator"))
-        .with_labels([span2.into()])
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -21,7 +21,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn getter_return_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(getter-return): Expected to always return a value in getter.")
         .with_help("Return a value from all code paths in getter.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
+++ b/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn guard_for_in_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(guard-for-in): Require `for-in` loops to include an `if` statement")
         .with_help("The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -12,7 +12,7 @@ fn max_classes_per_file_diagnostic(total: usize, max: usize, span1: Span) -> Oxc
         "eslint(max-classes-per-file): File has too many classes ({total}). Maximum allowed is {max}",
     ))
     .with_help("Reduce the number of classes in this file")
-    .with_labels([span1.into()])
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule};
 fn max_lines_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(max-lines): {x0:?}"))
         .with_help("Reduce the number of lines in this file")
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -11,7 +11,7 @@ fn max_params_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
         .with_help(
             "This rule enforces a maximum number of parameters allowed in function definitions.",
         )
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_array_constructor_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-array-constructor): Disallow `Array` constructors")
         .with_help("Use array literal instead")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -12,7 +12,7 @@ fn no_async_promise_executor_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "eslint(no-async-promise-executor): Promise executor functions should not be `async`.",
     )
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -10,7 +10,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_await_in_loop_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-await-in-loop): Unexpected `await` inside a loop.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -9,7 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_bitwise_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(no-bitwise): Unexpected use of {x0:?}"))
         .with_help("bitwise operators are not allowed, maybe you mistyped `&&` or `||`")
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_caller_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-caller): Disallow the use of arguments.caller or arguments.callee")
         .with_help("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -12,7 +12,7 @@ fn no_case_declarations_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "eslint(no-case-declarations): Unexpected lexical declaration in case block.",
     )
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -11,7 +11,7 @@ fn no_compare_neg_zero_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
         "eslint(no-compare-neg-zero): Do not use the {x0} operator to compare against -0."
     ))
     .with_help("Use Object.is(x, -0) to test equality with -0 and use 0 for other cases")
-    .with_labels([span1.into()])
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -13,7 +13,7 @@ fn no_cond_assign_diagnostic(span0: Span) -> OxcDiagnostic {
         "eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment",
     )
     .with_help("Consider wrapping the assignment in additional parentheses")
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_console_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-console): Unexpected console statement.")
-        .with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-console): Unexpected console statement.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 fn constant_short_circuit(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(no-constant-binary-expression): Unexpected constant {x0:?} on the left-hand side of a {x1:?} expression"))
         .with_help("This expression always evaluates to the constant on the left-hand side")
-        .with_labels([span2.into()])
+        .with_label(span2)
 }
 
 fn constant_binary_operand(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
@@ -59,7 +59,7 @@ fn constant_binary_operand(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
         "eslint(no-constant-binary-expression): Unexpected constant binary expression",
     )
     .with_help(format!("This compares constantly with the {x0}-hand side of the {x1}"))
-    .with_labels([span2.into()])
+    .with_label(span2)
 }
 
 fn constant_always_new(span0: Span) -> OxcDiagnostic {
@@ -67,11 +67,11 @@ fn constant_always_new(span0: Span) -> OxcDiagnostic {
         "eslint(no-constant-binary-expression): Unexpected comparison to newly constructed object",
     )
     .with_help("These two values can never be equal")
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 fn constant_both_always_new(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-constant-binary-expression): Unexpected comparison of two newly constructed objects").with_help("These two values can never be equal").with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-constant-binary-expression): Unexpected comparison of two newly constructed objects").with_help("These two values can never be equal").with_label(span0)
 }
 
 impl Rule for NoConstantBinaryExpression {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -8,7 +8,7 @@ use crate::{ast_util::IsConstant, context::LintContext, rule::Rule, AstNode};
 fn no_constant_condition_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-constant-condition): Unexpected constant condition")
         .with_help("Constant expression as a test condition is not allowed")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -13,7 +13,7 @@ fn no_constructor_return_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "eslint(no-constructor-return): Unexpected return statement in constructor.",
     )
-    .with_labels([span.into()])
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_continue_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-continue): Unexpected use of `continue` statement.")
         .with_help("Do not use the `continue` statement.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -13,7 +13,7 @@ use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, Ast
 fn no_control_regex_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-control-regex): Unexpected control character(s)")
         .with_help(format!("Unexpected control character(s) in regular expression: \"{x0}\""))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -7,7 +7,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_debugger_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-debugger): `debugger` statement is not allowed")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -7,8 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_delete_var_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-delete-var): variables should not be deleted")
-        .with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-delete-var): variables should not be deleted").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -10,7 +10,7 @@ fn no_div_regex_diagnostic(span0: Span) -> OxcDiagnostic {
         "eslint(no-div-regex): A regular expression literal can be confused with '/='.",
     )
     .with_help("Rewrite `/=` into `/[=]`")
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_empty_character_class_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-empty-character-class): Empty character class")
         .with_help("Try to remove empty character class `[]` in regexp literal")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_empty_function_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-empty-function): Disallow empty functions")
         .with_help("Unexpected empty function block")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_empty_static_block_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-empty-static-block): Disallow empty static blocks")
         .with_help("Unexpected empty static block.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_eq_null_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-eq-null): Use '===' to compare with null")
         .with_help("Disallow `null` comparisons without type-checking operators.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -8,7 +8,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_eval_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-eval): eval can be harmful.").with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-eval): eval can be harmful.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_ex_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-ex-assign): Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-ex-assign): Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -10,13 +10,13 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_extra_double_negation_cast_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-extra-boolean-cast): Redundant double negation")
         .with_help("Remove the double negation as it will already be coerced to a boolean")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn no_extra_boolean_cast_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-extra-boolean-cast): Redundant Boolean call")
         .with_help("Remove the Boolean call as it will already be coerced to a boolean")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -22,17 +22,17 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_fallthrough_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("eslint(no-fallthrough): Expected a 'break' statement before 'case'.")
-        .with_labels([span.into()])
+        .with_label(span)
 }
 
 fn no_fallthrough_default_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("eslint(no-fallthrough): Expected a 'break' statement before 'default'.")
-        .with_labels([span.into()])
+        .with_label(span)
 }
 
 fn no_unused_fallthrough_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("eslint(no-fallthrough): Found a comment that would permit fallthrough, but case cannot fall through.")
-        .with_labels([span.into()])
+        .with_label(span)
 }
 
 const DEFAULT_FALLTHROUGH_COMMENT_PATTERN: &str = r"falls?\s?through";

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule};
 fn no_import_assign_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-import-assign): do not assign to imported bindings")
         .with_help("imported bindings are readonly")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_inner_declarations_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks")
         .with_help(format!("Move {x0} declaration to {x1} root"))
-        .with_labels([span2.into()])
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -7,7 +7,7 @@ use crate::{context::LintContext, rule::Rule};
 fn no_irregular_whitespace_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-irregular-whitespace): Unexpected irregular whitespace")
         .with_help("Try to remove the irregular whitespace")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_iterator_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-iterator): Reserved name '__iterator__'")
         .with_help("Disallow the use of the `__iterator__` property.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -11,7 +11,7 @@ fn no_loss_of_precision_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "eslint(no-loss-of-precision): This number literal will lose precision at runtime.",
     )
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -6,8 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-new): Do not use 'new' for side effects.")
-        .with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-new): Do not use 'new' for side effects.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -9,7 +9,7 @@ fn no_new_native_nonconstructor_diagnostic(x0: &str, span1: Span) -> OxcDiagnost
     OxcDiagnostic::warn(format!(
         "eslint(no-new-native-nonconstructor): `{x0}` cannot be called as a constructor."
     ))
-    .with_labels([span1.into()])
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_new_wrappers_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects")
         .with_help(format!("do not use {x0} as a constructor, consider removing the new operator."))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -12,7 +12,7 @@ fn replacement(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
         "eslint(no-nonoctal-decimal-escape): Don't use '{x0}' escape sequence."
     ))
     .with_help(format!("Replace '{x0}' with '{x1}'. This maintains the current functionality."))
-    .with_labels([span2.into()])
+    .with_label(span2)
 }
 
 fn escape_backslash(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
@@ -20,7 +20,7 @@ fn escape_backslash(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
         "eslint(no-nonoctal-decimal-escape): Don't use '{x0}' escape sequence."
     ))
     .with_help(format!("Replace '{x0}' with '{x1}' to include the actual backslash character."))
-    .with_labels([span2.into()])
+    .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -15,7 +15,7 @@ const NON_CALLABLE_GLOBALS: [&str; 5] = ["Atomics", "Intl", "JSON", "Math", "Ref
 fn no_obj_calls_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-obj-calls): Disallow calling some global objects as functions")
         .with_help(format!("{x0} is not a function."))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_proto_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-proto): The '__proto__' property is deprecated")
         .with_help("Disallow the use of the `__proto__` property.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_prototype_builtins_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(no-prototype-builtins): do not access Object.prototype method {x0:?} from target object"))
         .with_help(format!("to avoid prototype pollution, use `Object.prototype.{x0}.call` instead"))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_regex_spaces_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-regex-spaces): Spaces are hard to count.")
         .with_help("Use a quantifier, e.g. {2}")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -14,7 +14,7 @@ fn no_restricted_globals(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
         format!("eslint(no-restricted-globals): Unexpected use of '{x0}'. {x1}")
     };
 
-    OxcDiagnostic::warn(warn_text).with_labels([span2.into()])
+    OxcDiagnostic::warn(warn_text).with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_script_url_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-script-url): Script URL is a form of eval")
         .with_help("Disallow `javascript:` urls")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -15,7 +15,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_self_assign_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-self-assign): this expression is assigned to itself")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_setter_return_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-setter-return): Setter cannot return a value")
-        .with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(no-setter-return): Setter cannot return a value").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, globals::PRE_DEFINE_VAR, rule::Rule};
 fn no_shadow_restricted_names_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.")
         .with_help(format!("Shadowing of global properties '{x0}'."))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -10,7 +10,7 @@ fn no_template_curly_in_string_diagnostic(span0: Span) -> OxcDiagnostic {
         "eslint(no-template-curly-in-string): Unexpected template string expression",
     )
     .with_help("Disallow template literal placeholder syntax in regular strings")
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_ternary_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-ternary): Unexpected use of ternary expression")
         .with_help("Do not use the ternary expression.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -18,7 +18,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_this_before_super_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-this-before-super): Expected to always call super() before this/super property access.")
         .with_help("Call super() before this/super property access.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -9,7 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_undef_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-undef): Disallow the use of undeclared variables.")
         .with_help(format!("'{x0}' is not defined."))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -13,7 +13,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unreachable_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("eslint(no-unreachable): Unreachable code.").with_labels([span.into()])
+    OxcDiagnostic::error("eslint(no-unreachable): Unreachable code.").with_label(span)
 }
 
 /// <https://github.com/eslint/eslint/blob/069aa680c78b8516b9a1b568519f1d01e74fb2a2/lib/rules/no-unreachable.js#L196>

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_unsafe_finally_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-unsafe-finally): Unsafe finally block")
         .with_help("Control flow inside try or catch blocks will be overwritten by this statement")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -12,7 +12,7 @@ use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, AstNode};
 fn no_unsafe_negation_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unexpected logical not in the left hand side of '{x0}' operator"))
         .with_help(format!("use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '{x0}'"))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_unsafe_optional_chaining_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining")
         .with_help("If this short-circuits with 'undefined' the evaluation will throw TypeError")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn no_unsafe_arithmetic_diagnostic(span0: Span) -> OxcDiagnostic {
@@ -20,7 +20,7 @@ fn no_unsafe_arithmetic_diagnostic(span0: Span) -> OxcDiagnostic {
         "eslint(no-unsafe-optional-chaining): Unsafe arithmetic operation on optional chaining",
     )
     .with_help("This can result in NaN.")
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule};
 fn no_unused_labels_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-unused-labels): Disallow unused labels")
         .with_help(format!("'{x0}:' is defined but never used."))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -12,7 +12,7 @@ fn no_unused_private_class_members_diagnostic(x0: &str, span1: Span) -> OxcDiagn
     OxcDiagnostic::warn(format!(
         "eslint(no-unused-private-class-members): '{x0}' is defined but never used."
     ))
-    .with_labels([span1.into()])
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -15,7 +15,7 @@ pub struct NoUselessConcat;
 fn no_useless_concat_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-useless-concat): Unexpected string concatenation of literals.")
         .with_help("Rewrite into one string literal")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -13,13 +13,12 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_constructor(constructor_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-useless-constructor): Empty constructors are unnecessary")
-        .with_labels([constructor_span.into()])
+        .with_label(constructor_span)
         .with_help("Remove the constructor or add code to it.")
 }
 fn no_redundant_super_call(constructor_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-useless-constructor): Redundant super call in constructor")
-        .with_labels([constructor_span.into()])
-        .with_help("Constructors of subclasses invoke super() automatically if they are empty. Remove this constructor or add code to it.")
+        .with_label(constructor_span).with_help("Constructors of subclasses invoke super() automatically if they are empty. Remove this constructor or add code to it.")
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -9,7 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_escape_diagnostic(x0: char, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(no-useless-escape): Unnecessary escape character {x0:?}"))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -11,7 +11,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_useless_rename_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name")
         .with_help("Either remove the renaming or rename the variable.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_var_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-var): Unexpected var, use let or const instead.")
         .with_help("Replace var with let or const")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -9,7 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_void_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-void): Disallow `void` operators")
         .with_help("Expected 'undefined' and instead saw 'void'.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -8,7 +8,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn no_with_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(no-with): Unexpected use of `with` statement.")
         .with_help("Do not use the `with` statement.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -15,7 +15,7 @@ fn prefer_exponentian_operator_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.",
     )
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -9,22 +9,22 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn missing_parameters(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(radix): Missing parameters.").with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(radix): Missing parameters.").with_label(span0)
 }
 
 fn missing_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(radix): Missing radix parameter.").with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(radix): Missing radix parameter.").with_label(span0)
 }
 
 fn redundant_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(radix): Redundant radix parameter.").with_labels([span0.into()])
+    OxcDiagnostic::warn("eslint(radix): Redundant radix parameter.").with_label(span0)
 }
 
 fn invalid_radix(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.",
     )
-    .with_labels([span0.into()])
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -15,7 +15,7 @@ pub struct RequireAwait;
 
 fn require_await_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(require-await): Async function has no 'await' expression.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -7,7 +7,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn require_yield_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(require-yield): This generator function does not have 'yield'")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -22,17 +22,17 @@ fn unexpected_syntax_order_diagnostic(
     OxcDiagnostic::warn(format!(
         "eslint(sort-imports): Expected '{x0}' syntax before '{x1}' syntax."
     ))
-    .with_labels([span2.into()])
+    .with_label(span2)
 }
 
 fn sort_imports_alphabetically_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(sort-imports): Imports should be sorted alphabetically.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn sort_members_alphabetically_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("eslint(sort-imports): Member '{x0}' of the import declaration should be sorted alphabetically."))
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -10,7 +10,7 @@ pub struct SymbolDescription;
 
 fn symbol_description_diagnostic(span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(symbol-description): Expected Symbol to have a description.")
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -7,13 +7,13 @@ use crate::{context::LintContext, rule::Rule};
 fn unexpected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(unicode-bom): Unexpected Unicode BOM (Byte Order Mark)")
         .with_help("File must not begin with the Unicode BOM")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn expected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(unicode-bom): Expected Unicode BOM (Byte Order Mark)")
         .with_help("File must begin with the Unicode BOM")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -12,7 +12,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 fn comparison_with_na_n(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
         .with_help("Use the isNaN function to compare with NaN.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn switch_na_n(span0: Span) -> OxcDiagnostic {
@@ -20,19 +20,19 @@ fn switch_na_n(span0: Span) -> OxcDiagnostic {
         .with_help(
             "'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.",
         )
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn case_na_n(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
         .with_help("'case NaN' can never match. Use Number.isNaN before the switch.")
-        .with_labels([span0.into()])
+        .with_label(span0)
 }
 
 fn index_of_na_n(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
         .with_help(format!("Array prototype method '{x0}' cannot find NaN."))
-        .with_labels([span1.into()])
+        .with_label(span1)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -11,7 +11,7 @@ fn not_string(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
     let mut d = OxcDiagnostic::warn(
         "eslint(valid-typeof): Typeof comparisons should be to string literals.",
     )
-    .with_labels([span1.into()]);
+    .with_label(span1);
     if let Some(x) = x0 {
         d = d.with_help(x);
     }
@@ -20,7 +20,7 @@ fn not_string(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
 
 fn invalid_value(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
     let mut d = OxcDiagnostic::warn("eslint(valid-typeof): Invalid typeof comparison value.")
-        .with_labels([span1.into()]);
+        .with_label(span1);
     if let Some(x) = x0 {
         d = d.with_help(x);
     }


### PR DESCRIPTION
Following earlier work in d6437fec0bf453ff89e prefer `with_label` over `with_labels`. Automatically converted using CoccinelleForRust.

---

I noticed some conversions of `with_labels` to `with_label` for a single span in https://github.com/oxc-project/oxc/pull/3854 and in my recent pull requests. The Linux kernel uses Coccinelle to automatically converted helper functions, so I was wondering if there was something similar for Rust as Coccinelle only does C. It turns out that there is a [Coccinelle for Rust](https://gitlab.inria.fr/coccinelle/coccinelleforrust), so I wrote a small Coccinelle rule to automatically convert all rules. (This PR only touches eslint, I am happy to run it for the whole rules directory, this is more a test if the project is willing to accept such massive automatic refactors).

To convert this automatically build the tool, and save the snippet below as `with_labels.cocci` and run:

```
~/code/coccinelleforrust/target/debug/cfr --apply --coccifile with_labels.cocci  crates/oxc_linter/src/rules/eslint
```

with_labels.cocci:
```
@@
expression E, OxcDiagnostic;
@@

OxcDiagnostic.
- with_labels([E.into()])
+ with_label(E)
```
