### PR TITLE
fix(isolated-declarations): `declare global {}` should be kept even if it is not exported

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -824,6 +824,12 @@ pub enum TSModuleDeclarationKind {
     Namespace,
 }
 
+impl TSModuleDeclarationKind {
+    pub fn is_global(self) -> bool {
+        matches!(self, TSModuleDeclarationKind::Global)
+    }
+}
+
 #[visited_node]
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -142,6 +142,11 @@ impl<'a> IsolatedDeclarations<'a> {
                             );
                             variable_transformed_indexes.push_back(Vec::default());
                         }
+                        Declaration::TSModuleDeclaration(decl) => {
+                            if decl.kind.is_global() {
+                                transformed_indexes.push(new_stmts.len());
+                            }
+                        }
                         _ => {}
                     }
                     new_stmts.push(stmt);

--- a/crates/oxc_isolated_declarations/tests/fixtures/declare-global.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/declare-global.ts
@@ -1,0 +1,4 @@
+declare global {
+}
+
+export {}

--- a/crates/oxc_isolated_declarations/tests/snapshots/declare-global.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/declare-global.snap
@@ -1,0 +1,8 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/declare-global.ts
+---
+==================== .D.TS ====================
+
+declare module global {}
+export {};


### PR DESCRIPTION
close: #3952
