### PR TITLE
up(parser): gracefully handle illegal list separators

### DIFF
--- a/crates/oxc_parser/src/list.rs
+++ b/crates/oxc_parser/src/list.rs
@@ -65,7 +65,7 @@ pub trait SeparatedList<'a>: Sized {
                     let Some(illegal_sep) = self.illegal_separator() else { return Err(e) };
                     match p.expect(illegal_sep) {
                         Err(_) => return Err(e),
-                        Ok(_) => {
+                        Ok(()) => {
                             // report illegal separator, but continue parsing
                             p.error(e);
                         }

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -28942,6 +28942,15 @@ Expect Syntax Error: "language/import/import-attributes/json-named-bindings.js"
  22 │ //
     ╰────
 
+  × Expected `,` but found `+=`
+    ╭─[language/statements/for/S12.6.3_A8_T3.js:21:20]
+ 20 │ //CHECK#1
+ 21 │ for({index=0; index+=1;} index++<=10; index*2;) {   arr.add(""+index);};
+    ·                    ─┬
+    ·                     ╰── `,` expected
+ 22 │ //
+    ╰────
+
   × Async functions can only be declared at the top level or inside a block
     ╭─[language/statements/for/decl-async-fun.js:20:18]
  19 │ 

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -8145,12 +8145,28 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╰────
 
   × Expected `,` but found `;`
+   ╭─[compiler/objectLiteralWithSemicolons1.ts:1:15]
+ 1 │ var v = { a; b; c }
+   ·               ┬
+   ·               ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `;`
    ╭─[compiler/objectLiteralWithSemicolons2.ts:2:4]
  1 │ var v = {
  2 │   a;
    ·    ┬
    ·    ╰── `,` expected
  3 │   b;
+   ╰────
+
+  × Expected `,` but found `;`
+   ╭─[compiler/objectLiteralWithSemicolons2.ts:3:4]
+ 2 │   a;
+ 3 │   b;
+   ·    ┬
+   ·    ╰── `,` expected
+ 4 │   c
    ╰────
 
   × Expected `,` but found `;`
@@ -8163,6 +8179,24 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    ╰────
 
   × Expected `,` but found `;`
+   ╭─[compiler/objectLiteralWithSemicolons3.ts:3:4]
+ 2 │   a;
+ 3 │   b;
+   ·    ┬
+   ·    ╰── `,` expected
+ 4 │   c;
+   ╰────
+
+  × Expected `,` but found `;`
+   ╭─[compiler/objectLiteralWithSemicolons3.ts:4:4]
+ 3 │   b;
+ 4 │   c;
+   ·    ┬
+   ·    ╰── `,` expected
+ 5 │ }
+   ╰────
+
+  × Expected `,` but found `;`
    ╭─[compiler/objectLiteralWithSemicolons4.ts:3:1]
  2 │   a
  3 │ ;
@@ -8170,11 +8204,31 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
    · ╰── `,` expected
    ╰────
 
+  × Unexpected token
+   ╭─[compiler/objectLiteralWithSemicolons4.ts:3:2]
+ 2 │   a
+ 3 │ ;
+   ╰────
+
   × Expected `,` but found `;`
    ╭─[compiler/objectLiteralWithSemicolons5.ts:1:20]
  1 │ var v = { foo() { }; a: b; get baz() { }; }
    ·                    ┬
    ·                    ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `;`
+   ╭─[compiler/objectLiteralWithSemicolons5.ts:1:26]
+ 1 │ var v = { foo() { }; a: b; get baz() { }; }
+   ·                          ┬
+   ·                          ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `;`
+   ╭─[compiler/objectLiteralWithSemicolons5.ts:1:41]
+ 1 │ var v = { foo() { }; a: b; get baz() { }; }
+   ·                                         ┬
+   ·                                         ╰── `,` expected
    ╰────
 
   × Expected `,` but found `?`
@@ -12425,6 +12479,15 @@ Expect to Parse: "conformance/salsa/plainJSRedeclare3.ts"
     ·                  ┬
     ·                  ╰── `,` expected
  49 │     postColonValueComma: 2,
+    ╰────
+
+  × Expected `,` but found `:`
+    ╭─[conformance/enums/enumErrors.ts:49:24]
+ 48 │     postSemicolon;
+ 49 │     postColonValueComma: 2,
+    ·                        ┬
+    ·                        ╰── `,` expected
+ 50 │     postColonValueSemicolon: 3;
     ╰────
 
   × Bad escape sequence in untagged template literal


### PR DESCRIPTION
Continue parsing when an illegal list separator is found when parsing a `SeparatedList`. Illegal but handle-able separators are specified via `illegal_separator()`. This defaults to `;`, but can be changed or disabled by returning `None`.

For example:
```ts
const x = {
  a: 1;
  b: 2
}
```

instead of panicking, the parser will produce a valid AST and still report the illegal `;` in the object literal expression.
