### PR TITLE
perf(lexer): move padding to the end of `Token` struct

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -13,6 +13,11 @@ pub struct Token {
     /// End offset in source
     pub end: u32,
 
+    // Padding to fill to 16 bytes.
+    // This makes copying a `Token` 1 x xmmword load & store, rather than 1 x dword + 1 x qword
+    // and `Token::default()` is 1 x xmmword store, rather than 1 x dword + 1 x qword.
+    _padding: u16,
+
     /// Token Kind
     pub kind: Kind,
 
@@ -33,11 +38,6 @@ pub struct Token {
     /// standard and include [`Kind::Decimal`], [`Kind::Binary`],
     /// [`Kind::Octal`], [`Kind::Hex`], etc.
     has_separator: bool,
-
-    // Padding to fill to 16 bytes.
-    // This makes copying a `Token` 1 x xmmword load & store, rather than 1 x dword + 1 x qword
-    // and `Token::default()` is 1 x xmmword store, rather than 1 x dword + 1 x qword.
-    _padding2: u32,
 }
 
 #[cfg(all(test, target_pointer_width = "64"))]

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -5,18 +5,12 @@ use oxc_span::Span;
 use super::kind::Kind;
 
 #[derive(Debug, Clone, Copy, Default)]
-#[repr(C, align(4))]
 pub struct Token {
     /// Start offset in source
     pub start: u32,
 
     /// End offset in source
     pub end: u32,
-
-    // Padding to fill to 16 bytes.
-    // This makes copying a `Token` 1 x xmmword load & store, rather than 1 x dword + 1 x qword
-    // and `Token::default()` is 1 x xmmword store, rather than 1 x dword + 1 x qword.
-    _padding: u16,
 
     /// Token Kind
     pub kind: Kind,
@@ -38,6 +32,11 @@ pub struct Token {
     /// standard and include [`Kind::Decimal`], [`Kind::Binary`],
     /// [`Kind::Octal`], [`Kind::Hex`], etc.
     has_separator: bool,
+
+    // Padding to fill to 16 bytes.
+    // This makes copying a `Token` 1 x xmmword load & store, rather than 1 x dword + 1 x qword
+    // and `Token::default()` is 1 x xmmword store, rather than 1 x dword + 1 x qword.
+    _padding: u8,
 }
 
 #[cfg(all(test, target_pointer_width = "64"))]

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -5,15 +5,16 @@ use oxc_span::Span;
 use super::kind::Kind;
 
 #[derive(Debug, Clone, Copy, Default)]
+#[repr(C, align(4))]
 pub struct Token {
-    /// Token Kind
-    pub kind: Kind,
-
     /// Start offset in source
     pub start: u32,
 
     /// End offset in source
     pub end: u32,
+
+    /// Token Kind
+    pub kind: Kind,
 
     /// Indicates the token is on a newline
     pub is_on_new_line: bool,


### PR DESCRIPTION
Experiment; follows up on #3289.

Before:
![image](https://github.com/oxc-project/oxc/assets/22823424/09525321-64d5-47c8-aed5-06c6329059fb)

After:
![image](https://github.com/oxc-project/oxc/assets/22823424/36cbe8e1-1367-409e-ba2a-f0496d229096)

Maybe this will prevent a shift instruction when accessing `kind`?