### PR TITLE
perf(syntax): use `NonZeroU32` for `SymbolId` and `ReferenceId`

### DIFF
--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,10 +1,28 @@
+use std::num::NonZeroU32;
+
 use bitflags::bitflags;
-use oxc_index::define_index_type;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
-define_index_type! {
-    pub struct ReferenceId = u32;
+use oxc_index::Idx;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct ReferenceId(NonZeroU32);
+
+impl Idx for ReferenceId {
+    #[allow(clippy::cast_possible_truncation)]
+    fn from_usize(idx: usize) -> Self {
+        // SAFETY: + 1 is always non-zero.
+        #[allow(unsafe_code)]
+        unsafe {
+            Self(NonZeroU32::new_unchecked(idx as u32 + 1))
+        }
+    }
+
+    fn index(self) -> usize {
+        self.0.get() as usize - 1
+    }
 }
 
 #[cfg(feature = "serialize")]

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -1,10 +1,28 @@
+use std::num::NonZeroU32;
+
 use bitflags::bitflags;
-use oxc_index::define_index_type;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
-define_index_type! {
-    pub struct SymbolId = u32;
+use oxc_index::Idx;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct SymbolId(NonZeroU32);
+
+impl Idx for SymbolId {
+    #[allow(clippy::cast_possible_truncation)]
+    fn from_usize(idx: usize) -> Self {
+        // SAFETY: + 1 is always non-zero.
+        #[allow(unsafe_code)]
+        unsafe {
+            Self(NonZeroU32::new_unchecked(idx as u32 + 1))
+        }
+    }
+
+    fn index(self) -> usize {
+        self.0.get() as usize - 1
+    }
 }
 
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
closes https://github.com/oxc-project/backlog/issues/55
closes https://github.com/oxc-project/oxc/issues/3318