### PR TITLE
Revert "perf(semantic): use `Atom<'a>` for `Reference`s"

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -66,9 +66,7 @@ impl Rule for NoGlobalAssign {
                 let reference = symbol_table.get_reference(reference_id);
                 if reference.is_write() {
                     let name = reference.name();
-                    // Vec::contains isn't working here, but this has the same
-                    // effect and time complexity.
-                    if !self.excludes.iter().any(|e| e == name) && ctx.env_contains_var(name) {
+                    if !self.excludes.contains(name) && ctx.env_contains_var(name) {
                         ctx.diagnostic(no_global_assign_diagnostic(name, reference.span()));
                     }
                 }

--- a/crates/oxc_minifier/src/mangler/mod.rs
+++ b/crates/oxc_minifier/src/mangler/mod.rs
@@ -7,11 +7,11 @@ use oxc_span::CompactStr;
 type Slot = usize;
 
 #[derive(Debug)]
-pub struct Mangler<'a> {
-    symbol_table: SymbolTable<'a>,
+pub struct Mangler {
+    symbol_table: SymbolTable,
 }
 
-impl<'a> Mangler<'a> {
+impl Mangler {
     pub fn get_symbol_name(&self, symbol_id: SymbolId) -> &str {
         self.symbol_table.get_name(symbol_id)
     }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -42,9 +42,9 @@ pub struct Semantic<'a> {
 
     nodes: AstNodes<'a>,
 
-    scopes: ScopeTree<'a>,
+    scopes: ScopeTree,
 
-    symbols: SymbolTable<'a>,
+    symbols: SymbolTable,
 
     classes: ClassTable,
 
@@ -60,7 +60,7 @@ pub struct Semantic<'a> {
 }
 
 impl<'a> Semantic<'a> {
-    pub fn into_symbol_table_and_scope_tree(self) -> (SymbolTable<'a>, ScopeTree<'a>) {
+    pub fn into_symbol_table_and_scope_tree(self) -> (SymbolTable, ScopeTree) {
         (self.symbols, self.scopes)
     }
 
@@ -84,7 +84,7 @@ impl<'a> Semantic<'a> {
         &self.classes
     }
 
-    pub fn scopes_mut(&mut self) -> &mut ScopeTree<'a> {
+    pub fn scopes_mut(&mut self) -> &mut ScopeTree {
         &mut self.scopes
     }
 

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,7 +1,7 @@
 // Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
 #![allow(non_snake_case)]
 
-use oxc_span::{Atom, Span};
+use oxc_span::{CompactStr, Span};
 pub use oxc_syntax::reference::{ReferenceFlag, ReferenceId};
 #[cfg(feature = "serialize")]
 use serde::Serialize;
@@ -13,10 +13,10 @@ use crate::{symbol::SymbolId, AstNodeId};
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(rename_all = "camelCase"))]
-pub struct Reference<'a> {
+pub struct Reference {
     span: Span,
     /// The name of the identifier that was referred to
-    name: Atom<'a>,
+    name: CompactStr,
     node_id: AstNodeId,
     symbol_id: Option<SymbolId>,
     /// Describes how this referenced is used by other AST nodes. References can
@@ -24,14 +24,14 @@ pub struct Reference<'a> {
     flag: ReferenceFlag,
 }
 
-impl<'a> Reference<'a> {
-    pub fn new(span: Span, name: Atom<'a>, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
+impl Reference {
+    pub fn new(span: Span, name: CompactStr, node_id: AstNodeId, flag: ReferenceFlag) -> Self {
         Self { span, name, node_id, symbol_id: None, flag }
     }
 
     pub fn new_with_symbol_id(
         span: Span,
-        name: Atom<'a>,
+        name: CompactStr,
         node_id: AstNodeId,
         symbol_id: SymbolId,
         flag: ReferenceFlag,
@@ -43,7 +43,7 @@ impl<'a> Reference<'a> {
         self.span
     }
 
-    pub fn name(&self) -> &Atom<'a> {
+    pub fn name(&self) -> &CompactStr {
         &self.name
     }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -28,7 +28,7 @@ export type IndexVec<I, T> = Array<T>;
 /// `SoA` (Struct of Arrays) for memory efficiency.
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify), serde(rename_all = "camelCase"))]
-pub struct SymbolTable<'a> {
+pub struct SymbolTable {
     pub spans: IndexVec<SymbolId, Span>,
     pub names: IndexVec<SymbolId, CompactStr>,
     pub flags: IndexVec<SymbolId, SymbolFlags>,
@@ -36,11 +36,11 @@ pub struct SymbolTable<'a> {
     /// Pointer to the AST Node where this symbol is declared
     pub declarations: IndexVec<SymbolId, AstNodeId>,
     pub resolved_references: IndexVec<SymbolId, Vec<ReferenceId>>,
-    pub references: IndexVec<ReferenceId, Reference<'a>>,
+    pub references: IndexVec<ReferenceId, Reference>,
     pub redeclare_variables: IndexVec<SymbolId, Vec<Span>>,
 }
 
-impl<'a> SymbolTable<'a> {
+impl SymbolTable {
     pub fn len(&self) -> usize {
         self.spans.len()
     }
@@ -136,15 +136,15 @@ impl<'a> SymbolTable<'a> {
         self.redeclare_variables[symbol_id].push(span);
     }
 
-    pub fn create_reference(&mut self, reference: Reference<'a>) -> ReferenceId {
+    pub fn create_reference(&mut self, reference: Reference) -> ReferenceId {
         self.references.push(reference)
     }
 
-    pub fn get_reference(&self, reference_id: ReferenceId) -> &Reference<'a> {
+    pub fn get_reference(&self, reference_id: ReferenceId) -> &Reference {
         &self.references[reference_id]
     }
 
-    pub fn get_reference_mut(&mut self, reference_id: ReferenceId) -> &mut Reference<'a> {
+    pub fn get_reference_mut(&mut self, reference_id: ReferenceId) -> &mut Reference {
         &mut self.references[reference_id]
     }
 

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -110,24 +110,18 @@ impl<'a> SymbolTester<'a> {
         self
     }
 
-    // Note: can't use `Reference::is_read()` due to error warning about overly
-    // generic FnMut impl.
-
     #[must_use]
     pub fn has_number_of_reads(self, ref_count: usize) -> Self {
-        #[allow(clippy::redundant_closure_for_method_calls)]
-        self.has_number_of_references_where(ref_count, |r| r.is_read())
+        self.has_number_of_references_where(ref_count, Reference::is_read)
     }
 
     #[must_use]
     pub fn has_number_of_writes(self, ref_count: usize) -> Self {
-        #[allow(clippy::redundant_closure_for_method_calls)]
-        self.has_number_of_references_where(ref_count, |r| r.is_write())
+        self.has_number_of_references_where(ref_count, Reference::is_write)
     }
 
     #[must_use]
     pub fn has_number_of_references(self, ref_count: usize) -> Self {
-        #[allow(clippy::redundant_closure_for_method_calls)]
         self.has_number_of_references_where(ref_count, |_| true)
     }
 

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -986,7 +986,8 @@ fn get_read_identifier_reference<'a>(
     name: Atom<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> IdentifierReference<'a> {
-    let reference_id = ctx.create_reference_in_current_scope(name.clone(), ReferenceFlag::Read);
+    let reference_id =
+        ctx.create_reference_in_current_scope(name.to_compact_str(), ReferenceFlag::Read);
     IdentifierReference::new_read(span, name, Some(reference_id))
 }
 

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -540,8 +540,11 @@ struct Assignment<'a> {
 impl<'a> Assignment<'a> {
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
-        let reference_id =
-            ctx.create_bound_reference(self.name.clone(), self.symbol_id, ReferenceFlag::Read);
+        let reference_id = ctx.create_bound_reference(
+            self.name.to_compact_str(),
+            self.symbol_id,
+            ReferenceFlag::Read,
+        );
         let id = IdentifierReference::new_read(self.span, self.name.clone(), Some(reference_id));
 
         ctx.ast.expression_statement(

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
     AstBuilder,
 };
 use oxc_semantic::{ScopeTree, SymbolTable};
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, CompactStr, Span};
 use oxc_syntax::{
     reference::{ReferenceFlag, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -106,7 +106,7 @@ pub use scoping::TraverseScoping;
 /// [`alloc`]: `TraverseCtx::alloc`
 pub struct TraverseCtx<'a> {
     pub ancestry: TraverseAncestry<'a>,
-    pub scoping: TraverseScoping<'a>,
+    pub scoping: TraverseScoping,
     pub ast: AstBuilder<'a>,
 }
 
@@ -120,11 +120,7 @@ pub enum FinderRet<T> {
 // Public methods
 impl<'a> TraverseCtx<'a> {
     /// Create new traversal context.
-    pub(crate) fn new(
-        scopes: ScopeTree<'a>,
-        symbols: SymbolTable<'a>,
-        allocator: &'a Allocator,
-    ) -> Self {
+    pub(crate) fn new(scopes: ScopeTree, symbols: SymbolTable, allocator: &'a Allocator) -> Self {
         let ancestry = TraverseAncestry::new();
         let scoping = TraverseScoping::new(scopes, symbols);
         let ast = AstBuilder::new(allocator);
@@ -228,7 +224,7 @@ impl<'a> TraverseCtx<'a> {
     ///
     /// Shortcut for `ctx.scoping.scopes`.
     #[inline]
-    pub fn scopes(&self) -> &ScopeTree<'a> {
+    pub fn scopes(&self) -> &ScopeTree {
         self.scoping.scopes()
     }
 
@@ -236,7 +232,7 @@ impl<'a> TraverseCtx<'a> {
     ///
     /// Shortcut for `ctx.scoping.scopes_mut`.
     #[inline]
-    pub fn scopes_mut(&mut self) -> &mut ScopeTree<'a> {
+    pub fn scopes_mut(&mut self) -> &mut ScopeTree {
         self.scoping.scopes_mut()
     }
 
@@ -244,7 +240,7 @@ impl<'a> TraverseCtx<'a> {
     ///
     /// Shortcut for `ctx.scoping.symbols`.
     #[inline]
-    pub fn symbols(&self) -> &SymbolTable<'a> {
+    pub fn symbols(&self) -> &SymbolTable {
         self.scoping.symbols()
     }
 
@@ -252,7 +248,7 @@ impl<'a> TraverseCtx<'a> {
     ///
     /// Shortcut for `ctx.scoping.symbols_mut`.
     #[inline]
-    pub fn symbols_mut(&mut self) -> &mut SymbolTable<'a> {
+    pub fn symbols_mut(&mut self) -> &mut SymbolTable {
         self.scoping.symbols_mut()
     }
 
@@ -355,7 +351,7 @@ impl<'a> TraverseCtx<'a> {
     /// This is a shortcut for `ctx.scoping.create_bound_reference`.
     pub fn create_bound_reference(
         &mut self,
-        name: Atom<'a>,
+        name: CompactStr,
         symbol_id: SymbolId,
         flag: ReferenceFlag,
     ) -> ReferenceId {
@@ -378,7 +374,11 @@ impl<'a> TraverseCtx<'a> {
     /// Create an unbound reference.
     ///
     /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
-    pub fn create_unbound_reference(&mut self, name: Atom<'a>, flag: ReferenceFlag) -> ReferenceId {
+    pub fn create_unbound_reference(
+        &mut self,
+        name: CompactStr,
+        flag: ReferenceFlag,
+    ) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flag)
     }
 
@@ -402,7 +402,7 @@ impl<'a> TraverseCtx<'a> {
     /// This is a shortcut for `ctx.scoping.create_reference`.
     pub fn create_reference(
         &mut self,
-        name: Atom<'a>,
+        name: CompactStr,
         symbol_id: Option<SymbolId>,
         flag: ReferenceFlag,
     ) -> ReferenceId {
@@ -430,7 +430,7 @@ impl<'a> TraverseCtx<'a> {
     /// This is a shortcut for `ctx.scoping.create_reference_in_current_scope`.
     pub fn create_reference_in_current_scope(
         &mut self,
-        name: Atom<'a>,
+        name: CompactStr,
         flag: ReferenceFlag,
     ) -> ReferenceId {
         self.scoping.create_reference_in_current_scope(name, flag)


### PR DESCRIPTION
Reverts oxc-project/oxc#3972

@DonIsaac As it turns out we can't have lifetimes on these structures because semantic data is exposed to downstream users to use freely, detached from the ast and allocator.