### PR TITLE
refactor(transformer): pass in symbols and scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "oxc_codegen",
  "oxc_diagnostics",
  "oxc_parser",
+ "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
  "oxc_traverse",

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -27,6 +27,7 @@ oxc_allocator   = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_syntax      = { workspace = true, features = ["to_js_string"] }
 oxc_traverse    = { workspace = true }
+oxc_semantic    = { workspace = true }
 
 dashmap          = { workspace = true }
 indexmap         = { workspace = true }

--- a/crates/oxc_transformer/src/context.rs
+++ b/crates/oxc_transformer/src/context.rs
@@ -7,7 +7,7 @@ use std::{
 
 use oxc_allocator::Allocator;
 use oxc_ast::{AstBuilder, Trivias};
-use oxc_diagnostics::{Error, OxcDiagnostic};
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::SourceType;
 
 use crate::{helpers::module_imports::ModuleImports, TransformOptions};
@@ -65,9 +65,8 @@ impl<'a> TransformCtx<'a> {
         }
     }
 
-    pub fn take_errors(&self) -> Vec<Error> {
-        let errors: Vec<OxcDiagnostic> = mem::take(&mut self.errors.borrow_mut());
-        errors.into_iter().map(Error::from).collect()
+    pub fn take_errors(&self) -> Vec<OxcDiagnostic> {
+        mem::take(&mut self.errors.borrow_mut())
     }
 
     /// Add an Error

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -25,10 +25,10 @@ mod helpers {
 
 use std::{path::Path, rc::Rc};
 
-use es2015::ES2015;
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::{ast::*, AstBuilder, Trivias};
-use oxc_diagnostics::Error;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::{ScopeTree, SemanticBuilder, SymbolTable};
 use oxc_span::SourceType;
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
 
@@ -42,9 +42,16 @@ pub use crate::{
 };
 use crate::{
     context::{Ctx, TransformCtx},
+    es2015::ES2015,
     react::React,
     typescript::TypeScript,
 };
+
+pub struct TransformerReturn {
+    pub errors: std::vec::Vec<OxcDiagnostic>,
+    pub symbols: SymbolTable,
+    pub scopes: ScopeTree,
+}
 
 pub struct Transformer<'a> {
     ctx: Ctx<'a>,
@@ -79,20 +86,25 @@ impl<'a> Transformer<'a> {
         }
     }
 
-    /// # Errors
-    ///
-    /// Returns `Vec<Error>` if any errors were collected during the transformation.
-    pub fn build(mut self, program: &mut Program<'a>) -> Result<(), std::vec::Vec<Error>> {
-        let TransformCtx { ast: AstBuilder { allocator }, source_text, source_type, .. } =
-            *self.ctx;
-        traverse_mut(&mut self, program, source_text, source_type, allocator);
+    pub fn build(mut self, program: &mut Program<'a>) -> TransformerReturn {
+        let (symbols, scopes) = SemanticBuilder::new(self.ctx.source_text, self.ctx.source_type)
+            .build(program)
+            .semantic
+            .into_symbol_table_and_scope_tree();
+        let TransformCtx { ast: AstBuilder { allocator }, .. } = *self.ctx;
+        let (symbols, scopes) = traverse_mut(&mut self, allocator, program, symbols, scopes);
+        TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes }
+    }
 
-        let errors = self.ctx.take_errors();
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
+    pub fn build_with_symbols_and_scopes(
+        mut self,
+        symbols: SymbolTable,
+        scopes: ScopeTree,
+        program: &mut Program<'a>,
+    ) -> TransformerReturn {
+        let TransformCtx { ast: AstBuilder { allocator }, .. } = *self.ctx;
+        let (symbols, scopes) = traverse_mut(&mut self, allocator, program, symbols, scopes);
+        TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes }
     }
 }
 

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -30,6 +30,10 @@ pub struct TraverseScoping {
 
 // Public methods
 impl TraverseScoping {
+    pub fn into_symbol_table_and_scope_tree(self) -> (SymbolTable, ScopeTree) {
+        (self.symbols, self.scopes)
+    }
+
     /// Get current scope ID
     #[inline]
     pub fn current_scope_id(&self) -> ScopeId {

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -62,8 +62,7 @@
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
-use oxc_semantic::SemanticBuilder;
-use oxc_span::SourceType;
+use oxc_semantic::{ScopeTree, SymbolTable};
 
 pub mod ancestor;
 pub use ancestor::Ancestor;
@@ -140,16 +139,14 @@ mod walk;
 #[allow(unsafe_code)]
 pub fn traverse_mut<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
-    program: &mut Program<'a>,
-    source_text: &'a str,
-    source_type: SourceType,
     allocator: &'a Allocator,
-) {
-    let semantic = SemanticBuilder::new(source_text, source_type).build(program).semantic;
-    let (symbols, scopes) = semantic.into_symbol_table_and_scope_tree();
-
+    program: &mut Program<'a>,
+    symbols: SymbolTable,
+    scopes: ScopeTree,
+) -> (SymbolTable, ScopeTree) {
     let mut ctx = TraverseCtx::new(scopes, symbols, allocator);
     // SAFETY: Walk functions are constructed to avoid unsoundness
     unsafe { walk::walk_program(traverser, program as *mut Program, &mut ctx) };
     debug_assert!(ctx.ancestors_depth() == 1);
+    ctx.scoping.into_symbol_table_and_scope_tree()
 }

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -244,8 +244,9 @@ impl Oxc {
                 options,
             )
             .build(program);
-            if let Err(errs) = result {
-                self.save_diagnostics(errs);
+            if !result.errors.is_empty() {
+                let errors = result.errors.into_iter().map(Error::from).collect::<Vec<_>>();
+                self.save_diagnostics(errors);
             }
         }
 

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -149,7 +149,7 @@ pub fn transform(
 
     let mut program = parser_ret.program;
     let transform_options = TransformOptions::from(options);
-    if let Err(e) = Transformer::new(
+    let ret = Transformer::new(
         &allocator,
         source_path,
         source_type,
@@ -157,9 +157,10 @@ pub fn transform(
         parser_ret.trivias.clone(),
         transform_options,
     )
-    .build(&mut program)
-    {
-        errors.extend(e.into_iter().map(|error| error.to_string()));
+    .build(&mut program);
+
+    if !ret.errors.is_empty() {
+        errors.extend(ret.errors.into_iter().map(|error| error.to_string()));
     }
 
     let mut codegen = CodeGenerator::new();

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -31,8 +31,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                     trivias,
                     transform_options,
                 )
-                .build(program)
-                .unwrap();
+                .build(program);
                 allocator
             });
         });


### PR DESCRIPTION
This PR adds a new method `build_with_symbols_and_scopes` to make semantic building optional, there may be prior steps that has the semantic data already built.