### PR TITLE
refactor(semantic)!: Do not expose `CompactStr` from `Reference`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -66,7 +66,7 @@ impl Rule for NoGlobalAssign {
                 let reference = symbol_table.get_reference(reference_id);
                 if reference.is_write() {
                     let name = reference.name();
-                    if !self.excludes.contains(name) && ctx.env_contains_var(name) {
+                    if !self.excludes.iter().any(|ex| ex == name) && ctx.env_contains_var(name) {
                         ctx.diagnostic(no_global_assign_diagnostic(name, reference.span()));
                     }
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -58,7 +58,7 @@ impl Rule for NoUndef {
                     continue;
                 }
 
-                if ctx.globals().is_enabled(name.as_str()) {
+                if ctx.globals().is_enabled(name) {
                     continue;
                 }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -319,7 +319,7 @@ impl<'a> SemanticBuilder<'a> {
         reference: Reference,
         add_unresolved_reference: bool,
     ) -> ReferenceId {
-        let reference_name = reference.name().clone();
+        let reference_name = reference.name().into();
         let reference_id = self.symbols.create_reference(reference);
         if add_unresolved_reference {
             self.scope.add_unresolved_reference(
@@ -328,7 +328,7 @@ impl<'a> SemanticBuilder<'a> {
                 reference_id,
             );
         } else {
-            self.resolve_reference_ids(reference_name.clone(), vec![reference_id]);
+            self.resolve_reference_ids(reference_name, vec![reference_id]);
         }
         reference_id
     }

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -43,7 +43,7 @@ impl Reference {
         self.span
     }
 
-    pub fn name(&self) -> &CompactStr {
+    pub fn name(&self) -> &str {
         &self.name
     }
 

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -98,7 +98,7 @@ impl<'a> Borrow<str> for Atom<'a> {
     }
 }
 
-impl<'a, T: AsRef<str>> PartialEq<T> for Atom<'a> {
+impl<'a, T: AsRef<str> + ?Sized> PartialEq<T> for Atom<'a> {
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }
@@ -107,12 +107,6 @@ impl<'a, T: AsRef<str>> PartialEq<T> for Atom<'a> {
 impl<'a> PartialEq<Atom<'a>> for &str {
     fn eq(&self, other: &Atom<'a>) -> bool {
         *self == other.as_str()
-    }
-}
-
-impl<'a> PartialEq<str> for Atom<'a> {
-    fn eq(&self, other: &str) -> bool {
-        self.as_str() == other
     }
 }
 
@@ -254,7 +248,7 @@ impl Borrow<str> for CompactStr {
     }
 }
 
-impl<T: AsRef<str>> PartialEq<T> for CompactStr {
+impl<T: AsRef<str> + ?Sized> PartialEq<T> for CompactStr {
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -459,7 +459,7 @@ impl TraverseScoping {
                 // which already checked above
                 false
             } else {
-                reference.name().as_str() == name
+                reference.name() == name
             }
         })
     }


### PR DESCRIPTION
Changes `Reference::name()` to return a `&str` instead of a `&CompactStr`. As such, it is technically a breaking change. I scanned through Rolldown to see how they use `Reference`s, and I do not think this PR will break anything.

Doing this will give us flexibility to change the representation of a reference name in the future. I'm thinking of making this an `Rc<CompactStr>` or something similar to reduce allocations within semantic.