### PR TITLE
refactor(parser): use function instead of trait to parse normal lists

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -334,4 +334,30 @@ impl<'a> ParserImpl<'a> {
         let decorators = std::mem::take(&mut self.state.decorators);
         self.ast.new_vec_from_iter(decorators)
     }
+
+    pub(crate) fn parse_normal_list<F, T>(
+        &mut self,
+        open: Kind,
+        close: Kind,
+        f: F,
+    ) -> Result<oxc_allocator::Vec<'a, T>>
+    where
+        F: Fn(&mut Self) -> Result<Option<T>>,
+    {
+        let mut list = self.ast.new_vec();
+        self.expect(open)?;
+        loop {
+            let kind = self.cur_kind();
+            if kind == close || kind == Kind::Eof {
+                break;
+            }
+            if let Some(e) = f(self)? {
+                list.push(e);
+            } else {
+                break;
+            }
+        }
+        self.expect(close)?;
+        Ok(list)
+    }
 }

--- a/crates/oxc_parser/src/js/list.rs
+++ b/crates/oxc_parser/src/js/list.rs
@@ -4,13 +4,7 @@ use oxc_diagnostics::Result;
 use oxc_span::{Atom, GetSpan, Span};
 use rustc_hash::FxHashMap;
 
-use crate::{
-    diagnostics,
-    lexer::Kind,
-    list::{NormalList, SeparatedList},
-    modifiers::ModifierFlags,
-    ParserImpl,
-};
+use crate::{diagnostics, lexer::Kind, list::SeparatedList, modifiers::ModifierFlags, ParserImpl};
 
 /// ObjectExpression.properties
 pub struct ObjectExpressionProperties<'a> {
@@ -397,66 +391,6 @@ impl<'a> SeparatedList<'a> for ExportNamedSpecifiers<'a> {
         let exported = if p.eat(Kind::As) { p.parse_module_export_name()? } else { local.clone() };
         let element =
             ExportSpecifier { span: p.end_span(specifier_span), local, exported, export_kind };
-        self.elements.push(element);
-        Ok(())
-    }
-}
-
-pub struct ClassElements<'a> {
-    pub elements: Vec<'a, ClassElement<'a>>,
-}
-
-impl<'a> ClassElements<'a> {
-    pub(crate) fn new(p: &ParserImpl<'a>) -> Self {
-        Self { elements: p.ast.new_vec() }
-    }
-}
-
-impl<'a> NormalList<'a> for ClassElements<'a> {
-    fn open(&self) -> Kind {
-        Kind::LCurly
-    }
-
-    fn close(&self) -> Kind {
-        Kind::RCurly
-    }
-
-    fn parse_element(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
-        // skip empty class element `;`
-        while p.at(Kind::Semicolon) {
-            p.bump_any();
-        }
-        if p.at(self.close()) {
-            return Ok(());
-        }
-        let element = p.parse_class_element()?;
-
-        self.elements.push(element);
-        Ok(())
-    }
-}
-
-pub struct SwitchCases<'a> {
-    pub elements: Vec<'a, SwitchCase<'a>>,
-}
-
-impl<'a> SwitchCases<'a> {
-    pub(crate) fn new(p: &ParserImpl<'a>) -> Self {
-        Self { elements: p.ast.new_vec() }
-    }
-}
-
-impl<'a> NormalList<'a> for SwitchCases<'a> {
-    fn open(&self) -> Kind {
-        Kind::LCurly
-    }
-
-    fn close(&self) -> Kind {
-        Kind::RCurly
-    }
-
-    fn parse_element(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
-        let element = p.parse_switch_case()?;
         self.elements.push(element);
         Ok(())
     }

--- a/crates/oxc_parser/src/list.rs
+++ b/crates/oxc_parser/src/list.rs
@@ -2,26 +2,6 @@ use oxc_diagnostics::Result;
 
 use crate::{lexer::Kind, ParserImpl};
 
-pub trait NormalList<'a> {
-    /// Open element, e.g.. `{` `[` `(`
-    fn open(&self) -> Kind;
-
-    /// Close element, e.g.. `}` `]` `)`
-    fn close(&self) -> Kind;
-
-    fn parse_element(&mut self, p: &mut ParserImpl<'a>) -> Result<()>;
-
-    /// Main entry point, parse the list
-    fn parse(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
-        p.expect(self.open())?;
-        while !p.at(self.close()) && !p.at(Kind::Eof) {
-            self.parse_element(p)?;
-        }
-        p.expect(self.close())?;
-        Ok(())
-    }
-}
-
 pub trait SeparatedList<'a>: Sized {
     fn new(p: &ParserImpl<'a>) -> Self;
 

--- a/crates/oxc_parser/src/ts/list.rs
+++ b/crates/oxc_parser/src/ts/list.rs
@@ -2,11 +2,7 @@ use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_diagnostics::Result;
 
-use crate::{
-    lexer::Kind,
-    list::{NormalList, SeparatedList},
-    ParserImpl,
-};
+use crate::{lexer::Kind, list::SeparatedList, ParserImpl};
 
 pub struct TSEnumMemberList<'a> {
     pub members: Vec<'a, TSEnumMember<'a>>,
@@ -76,32 +72,6 @@ impl<'a> SeparatedList<'a> for TSTypeParameterList<'a> {
     fn parse_element(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
         let param = p.parse_ts_type_parameter()?;
         self.params.push(param);
-        Ok(())
-    }
-}
-
-pub struct TSInterfaceOrObjectBodyList<'a> {
-    pub body: Vec<'a, TSSignature<'a>>,
-}
-
-impl<'a> TSInterfaceOrObjectBodyList<'a> {
-    pub(crate) fn new(p: &ParserImpl<'a>) -> Self {
-        Self { body: p.ast.new_vec() }
-    }
-}
-
-impl<'a> NormalList<'a> for TSInterfaceOrObjectBodyList<'a> {
-    fn open(&self) -> Kind {
-        Kind::LCurly
-    }
-
-    fn close(&self) -> Kind {
-        Kind::RCurly
-    }
-
-    fn parse_element(&mut self, p: &mut ParserImpl<'a>) -> Result<()> {
-        let property = p.parse_ts_type_signature()?;
-        self.body.push(property);
         Ok(())
     }
 }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -4,13 +4,11 @@ use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
-use super::list::{
-    TSInterfaceOrObjectBodyList, TSTupleElementList, TSTypeArgumentList, TSTypeParameterList,
-};
+use super::list::{TSTupleElementList, TSTypeArgumentList, TSTypeParameterList};
 use crate::{
     diagnostics,
     lexer::Kind,
-    list::{NormalList, SeparatedList},
+    list::SeparatedList,
     modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
     ts::list::TSImportAttributeList,
     Context, ParserImpl,
@@ -618,9 +616,9 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_type_literal(&mut self) -> Result<TSType<'a>> {
         let span = self.start_span();
-        let mut member_list = TSInterfaceOrObjectBodyList::new(self);
-        member_list.parse(self)?;
-        Ok(self.ast.ts_type_literal(self.end_span(span), member_list.body))
+        let member_list =
+            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature)?;
+        Ok(self.ast.ts_type_literal(self.end_span(span), member_list))
     }
 
     fn parse_type_query(&mut self) -> Result<TSType<'a>> {


### PR DESCRIPTION
To reduce boilerplate and code noise.

relates #3887