### PR TITLE
fix(semantic): resolve reference incorrectly when a parameter references a parameter that hasn't been defined yet

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1048,6 +1048,9 @@ impl<'a> FormalParameters<'a> {
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
+    pub fn has_parameter(&self) -> bool {
+        !self.is_empty() || self.rest.is_some()
+    }
 }
 
 impl<'a> FunctionBody<'a> {

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -108,17 +108,19 @@ fn test_switch_case() {
 
 #[test]
 fn test_function_parameters() {
-    SemanticTester::js(
+    let tester = SemanticTester::js(
         "
             const foo = 2;
-            function func(a = foo, b = a) {
+            const c = 0;
+            function func(a = foo, b = c, c = 0) {
                 const foo = 0;
             }
         ",
-    )
-    .has_root_symbol("foo")
-    .has_number_of_references(1)
-    .test();
+    );
+
+    tester.has_root_symbol("foo").has_number_of_references(1).test();
+    // b = c should reference the third parameter, so root symbol `c`` should have 0 reference
+    tester.has_root_symbol("c").has_number_of_references(0).test();
 }
 
 #[test]

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -30,7 +30,6 @@ bitflags! {
         const JSDoc     = 1 << 0; // If the Node has a JSDoc comment attached
         const Class     = 1 << 1; // If Node is inside a class
         const HasYield  = 1 << 2; // If function has yield statement
-        const Parameter = 1 << 3; // If Node is inside a parameter
     }
 }
 
@@ -48,10 +47,5 @@ impl NodeFlags {
     #[inline]
     pub fn has_yield(&self) -> bool {
         self.contains(Self::HasYield)
-    }
-
-    #[inline]
-    pub fn has_parameter(&self) -> bool {
-        self.contains(Self::Parameter)
     }
 }


### PR DESCRIPTION
close: #3682

The TypeScript code that handles this is [here](https://github.com/Dunqing/TypeScript/blob/d8086f14b6b97c0df34a0cc2f56d4b5926a0c299/src/compiler/utilities.ts#L11515-L11577). It looks complicated.