### PR TITLE
pref(ast): inline visit walks with small bodies.

### DIFF
--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -31,6 +31,7 @@ pub trait Visit<'a>: Sized {
     fn enter_scope(&mut self, flags: ScopeFlags) {}
     fn leave_scope(&mut self) {}
 
+    #[inline]
     fn alloc<T>(&self, t: &T) -> &'a T {
         // SAFETY:
         // This should be safe as long as `src` is an reference from the allocator.
@@ -1347,6 +1348,7 @@ pub trait Visit<'a>: Sized {
 pub mod walk {
     use super::*;
 
+    #[inline]
     pub fn walk_program<'a, V: Visit<'a>>(visitor: &mut V, it: &Program<'a>) {
         visitor.enter_scope({
             let mut flags = ScopeFlags::Top;
@@ -1366,12 +1368,14 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Directive<'a>>) {
         for el in it.iter() {
             visitor.visit_directive(el);
         }
     }
 
+    #[inline]
     pub fn walk_directive<'a, V: Visit<'a>>(visitor: &mut V, it: &Directive<'a>) {
         let kind = AstKind::Directive(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1379,18 +1383,21 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_string_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &StringLiteral<'a>) {
         let kind = AstKind::StringLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_hashbang<'a, V: Visit<'a>>(visitor: &mut V, it: &Hashbang<'a>) {
         let kind = AstKind::Hashbang(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_statements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Statement<'a>>) {
         for el in it.iter() {
             visitor.visit_statement(el);
@@ -1424,6 +1431,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_block_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
         visitor.enter_scope(ScopeFlags::empty());
         let kind = AstKind::BlockStatement(visitor.alloc(it));
@@ -1433,6 +1441,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_break_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BreakStatement<'a>) {
         let kind = AstKind::BreakStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1442,12 +1451,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_label_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &LabelIdentifier<'a>) {
         let kind = AstKind::LabelIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_continue_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ContinueStatement<'a>) {
         let kind = AstKind::ContinueStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1457,12 +1468,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_debugger_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DebuggerStatement) {
         let kind = AstKind::DebuggerStatement(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_do_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DoWhileStatement<'a>) {
         let kind = AstKind::DoWhileStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1525,36 +1538,42 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_boolean_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BooleanLiteral) {
         let kind = AstKind::BooleanLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_null_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NullLiteral) {
         let kind = AstKind::NullLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_numeric_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NumericLiteral<'a>) {
         let kind = AstKind::NumericLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_big_int_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BigIntLiteral<'a>) {
         let kind = AstKind::BigIntLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_reg_exp_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &RegExpLiteral<'a>) {
         let kind = AstKind::RegExpLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_template_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateLiteral<'a>) {
         let kind = AstKind::TemplateLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1563,6 +1582,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_template_elements<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TemplateElement<'a>>,
@@ -1572,16 +1592,19 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_template_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateElement<'a>) {
         // NOTE: AstKind doesn't exists!
     }
 
+    #[inline]
     pub fn walk_expressions<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Expression<'a>>) {
         for el in it.iter() {
             visitor.visit_expression(el);
         }
     }
 
+    #[inline]
     pub fn walk_identifier_reference<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &IdentifierReference<'a>,
@@ -1591,6 +1614,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_meta_property<'a, V: Visit<'a>>(visitor: &mut V, it: &MetaProperty<'a>) {
         let kind = AstKind::MetaProperty(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1599,18 +1623,21 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_identifier_name<'a, V: Visit<'a>>(visitor: &mut V, it: &IdentifierName<'a>) {
         let kind = AstKind::IdentifierName(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_super<'a, V: Visit<'a>>(visitor: &mut V, it: &Super) {
         let kind = AstKind::Super(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_array_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayExpression<'a>) {
         let kind = AstKind::ArrayExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1618,6 +1645,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_array_expression_elements<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, ArrayExpressionElement<'a>>,
@@ -1627,6 +1655,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_array_expression_element<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ArrayExpressionElement<'a>,
@@ -1643,6 +1672,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_spread_element<'a, V: Visit<'a>>(visitor: &mut V, it: &SpreadElement<'a>) {
         let kind = AstKind::SpreadElement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1650,6 +1680,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_elision<'a, V: Visit<'a>>(visitor: &mut V, it: &Elision) {
         let kind = AstKind::Elision(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1713,6 +1744,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_arrow_function_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ArrowFunctionExpression<'a>,
@@ -1738,6 +1770,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_formal_parameters<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameters<'a>) {
         let kind = AstKind::FormalParameters(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1748,6 +1781,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_formal_parameter_list<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, FormalParameter<'a>>,
@@ -1757,6 +1791,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_formal_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameter<'a>) {
         let kind = AstKind::FormalParameter(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1765,6 +1800,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binding_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingPattern<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_binding_pattern_kind(&it.kind);
@@ -1773,6 +1809,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_binding_pattern_kind<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &BindingPatternKind<'a>,
@@ -1785,12 +1822,14 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_binding_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingIdentifier<'a>) {
         let kind = AstKind::BindingIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
         let kind = AstKind::ObjectPattern(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1801,6 +1840,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binding_properties<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, BindingProperty<'a>>,
@@ -1810,12 +1850,14 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_binding_property<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingProperty<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_property_key(&it.key);
         visitor.visit_binding_pattern(&it.value);
     }
 
+    #[inline]
     pub fn walk_property_key<'a, V: Visit<'a>>(visitor: &mut V, it: &PropertyKey<'a>) {
         let kind = AstKind::PropertyKey(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1827,12 +1869,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_private_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &PrivateIdentifier<'a>) {
         let kind = AstKind::PrivateIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binding_rest_element<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &BindingRestElement<'a>,
@@ -1843,6 +1887,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
         let kind = AstKind::ArrayPattern(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1855,6 +1900,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentPattern<'a>) {
         let kind = AstKind::AssignmentPattern(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1863,6 +1909,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_annotation<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAnnotation<'a>) {
         let kind = AstKind::TSTypeAnnotation(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1913,89 +1960,104 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_any_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAnyKeyword) {
         let kind = AstKind::TSAnyKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_big_int_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBigIntKeyword) {
         let kind = AstKind::TSBigIntKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_boolean_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBooleanKeyword) {
         let kind = AstKind::TSBooleanKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_intrinsic_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIntrinsicKeyword) {
         let kind = AstKind::TSIntrinsicKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_never_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNeverKeyword) {
         let kind = AstKind::TSNeverKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_null_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNullKeyword) {
         let kind = AstKind::TSNullKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_number_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNumberKeyword) {
         let kind = AstKind::TSNumberKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_object_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSObjectKeyword) {
         let kind = AstKind::TSObjectKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_string_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSStringKeyword) {
         let kind = AstKind::TSStringKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_symbol_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSymbolKeyword) {
         let kind = AstKind::TSSymbolKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_undefined_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUndefinedKeyword) {
         let kind = AstKind::TSUndefinedKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_unknown_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnknownKeyword) {
         let kind = AstKind::TSUnknownKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_void_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSVoidKeyword) {
         let kind = AstKind::TSVoidKeyword(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_array_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSArrayType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type(&it.element_type);
     }
 
+    #[inline]
     pub fn walk_ts_conditional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConditionalType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type(&it.check_type);
@@ -2004,6 +2066,7 @@ pub mod walk {
         visitor.visit_ts_type(&it.false_type);
     }
 
+    #[inline]
     pub fn walk_ts_constructor_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConstructorType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_formal_parameters(&it.params);
@@ -2013,6 +2076,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_parameter_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSTypeParameterDeclaration<'a>,
@@ -2023,6 +2087,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_parameters<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSTypeParameter<'a>>,
@@ -2032,6 +2097,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeParameter<'a>) {
         visitor.enter_scope(ScopeFlags::empty());
         let kind = AstKind::TSTypeParameter(visitor.alloc(it));
@@ -2047,6 +2113,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_ts_function_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSFunctionType<'a>) {
         // NOTE: AstKind doesn't exists!
         if let Some(this_param) = &it.this_param {
@@ -2059,6 +2126,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_this_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisParameter<'a>) {
         let kind = AstKind::TSThisParameter(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2069,6 +2137,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_import_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportType<'a>) {
         let kind = AstKind::TSImportType(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2085,6 +2154,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeName<'a>) {
         let kind = AstKind::TSTypeName(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2095,6 +2165,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_qualified_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSQualifiedName<'a>) {
         let kind = AstKind::TSQualifiedName(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2103,6 +2174,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_import_attributes<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSImportAttributes<'a>,
@@ -2111,6 +2183,7 @@ pub mod walk {
         visitor.visit_ts_import_attribute_list(&it.elements);
     }
 
+    #[inline]
     pub fn walk_ts_import_attribute_list<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSImportAttribute<'a>>,
@@ -2120,12 +2193,14 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportAttribute<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_import_attribute_name(&it.name);
         visitor.visit_expression(&it.value);
     }
 
+    #[inline]
     pub fn walk_ts_import_attribute_name<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSImportAttributeName<'a>,
@@ -2136,6 +2211,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_parameter_instantiation<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSTypeParameterInstantiation<'a>,
@@ -2146,12 +2222,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_types<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSType<'a>>) {
         for el in it.iter() {
             visitor.visit_ts_type(el);
         }
     }
 
+    #[inline]
     pub fn walk_ts_indexed_access_type<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSIndexedAccessType<'a>,
@@ -2163,6 +2241,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_infer_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInferType<'a>) {
         let kind = AstKind::TSInferType(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2170,6 +2249,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_intersection_type<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSIntersectionType<'a>,
@@ -2180,6 +2260,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_literal_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteralType<'a>) {
         let kind = AstKind::TSLiteralType(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2200,6 +2281,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_unary_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &UnaryExpression<'a>) {
         let kind = AstKind::UnaryExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2207,6 +2289,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_mapped_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMappedType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type_parameter(&it.type_parameter);
@@ -2218,6 +2301,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_named_tuple_member<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSNamedTupleMember<'a>,
@@ -2229,6 +2313,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_tuple_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleElement<'a>) {
         match it {
             TSTupleElement::TSOptionalType(it) => visitor.visit_ts_optional_type(it),
@@ -2237,16 +2322,19 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_optional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSOptionalType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_rest_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSRestType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_template_literal_type<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSTemplateLiteralType<'a>,
@@ -2258,17 +2346,20 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_this_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisType) {
         let kind = AstKind::TSThisType(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_tuple_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleType<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_tuple_elements(&it.element_types);
     }
 
+    #[inline]
     pub fn walk_ts_tuple_elements<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSTupleElement<'a>>,
@@ -2278,6 +2369,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeLiteral<'a>) {
         let kind = AstKind::TSTypeLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2285,12 +2377,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_signatures<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSSignature<'a>>) {
         for el in it.iter() {
             visitor.visit_ts_signature(el);
         }
     }
 
+    #[inline]
     pub fn walk_ts_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSignature<'a>) {
         match it {
             TSSignature::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
@@ -2305,12 +2399,14 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_index_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIndexSignature<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_index_signature_names(&it.parameters);
         visitor.visit_ts_type_annotation(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_index_signature_names<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSIndexSignatureName<'a>>,
@@ -2320,6 +2416,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_index_signature_name<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSIndexSignatureName<'a>,
@@ -2328,6 +2425,7 @@ pub mod walk {
         visitor.visit_ts_type_annotation(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_property_signature<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSPropertySignature<'a>,
@@ -2341,6 +2439,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_call_signature_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSCallSignatureDeclaration<'a>,
@@ -2358,6 +2457,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_construct_signature_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSConstructSignatureDeclaration<'a>,
@@ -2372,6 +2472,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_method_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMethodSignature<'a>) {
         let kind = AstKind::TSMethodSignature(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2389,11 +2490,13 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_operator<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeOperator<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_type_predicate<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypePredicate<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_type_predicate_name(&it.parameter_name);
@@ -2402,6 +2505,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_predicate_name<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSTypePredicateName<'a>,
@@ -2412,6 +2516,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_query<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeQuery<'a>) {
         let kind = AstKind::TSTypeQuery(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2422,6 +2527,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_query_expr_name<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSTypeQueryExprName<'a>,
@@ -2434,6 +2540,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_reference<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeReference<'a>) {
         let kind = AstKind::TSTypeReference(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2444,6 +2551,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_union_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnionType<'a>) {
         let kind = AstKind::TSUnionType(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2451,6 +2559,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_parenthesized_type<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSParenthesizedType<'a>,
@@ -2461,6 +2570,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_js_doc_nullable_type<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &JSDocNullableType<'a>,
@@ -2469,6 +2579,7 @@ pub mod walk {
         visitor.visit_ts_type(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_js_doc_non_nullable_type<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &JSDocNonNullableType<'a>,
@@ -2477,16 +2588,19 @@ pub mod walk {
         visitor.visit_ts_type(&it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_js_doc_unknown_type<'a, V: Visit<'a>>(visitor: &mut V, it: &JSDocUnknownType) {
         // NOTE: AstKind doesn't exists!
     }
 
+    #[inline]
     pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
         for el in it.iter() {
             visitor.visit_decorator(el);
         }
     }
 
+    #[inline]
     pub fn walk_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
         let kind = AstKind::Decorator(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2494,6 +2608,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_function_body<'a, V: Visit<'a>>(visitor: &mut V, it: &FunctionBody<'a>) {
         let kind = AstKind::FunctionBody(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2502,6 +2617,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentExpression<'a>,
@@ -2513,6 +2629,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_target<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentTarget<'a>) {
         let kind = AstKind::AssignmentTarget(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2555,6 +2672,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_as_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAsExpression<'a>) {
         let kind = AstKind::TSAsExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2563,6 +2681,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_satisfies_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSSatisfiesExpression<'a>,
@@ -2574,6 +2693,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_non_null_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSNonNullExpression<'a>,
@@ -2584,6 +2704,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_assertion<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAssertion<'a>) {
         let kind = AstKind::TSTypeAssertion(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2592,6 +2713,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_instantiation_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSInstantiationExpression<'a>,
@@ -2603,6 +2725,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_member_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &MemberExpression<'a>) {
         let kind = AstKind::MemberExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2620,6 +2743,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_computed_member_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ComputedMemberExpression<'a>,
@@ -2629,6 +2753,7 @@ pub mod walk {
         visitor.visit_expression(&it.expression);
     }
 
+    #[inline]
     pub fn walk_static_member_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &StaticMemberExpression<'a>,
@@ -2638,6 +2763,7 @@ pub mod walk {
         visitor.visit_identifier_name(&it.property);
     }
 
+    #[inline]
     pub fn walk_private_field_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &PrivateFieldExpression<'a>,
@@ -2647,6 +2773,7 @@ pub mod walk {
         visitor.visit_private_identifier(&it.field);
     }
 
+    #[inline]
     pub fn walk_assignment_target_pattern<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetPattern<'a>,
@@ -2661,6 +2788,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_array_assignment_target<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ArrayAssignmentTarget<'a>,
@@ -2674,6 +2802,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_maybe_default<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetMaybeDefault<'a>,
@@ -2688,6 +2817,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_with_default<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetWithDefault<'a>,
@@ -2699,6 +2829,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_target_rest<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetRest<'a>,
@@ -2707,6 +2838,7 @@ pub mod walk {
         visitor.visit_assignment_target(&it.target);
     }
 
+    #[inline]
     pub fn walk_object_assignment_target<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ObjectAssignmentTarget<'a>,
@@ -2718,6 +2850,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_properties<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, AssignmentTargetProperty<'a>>,
@@ -2727,6 +2860,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_property<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetProperty<'a>,
@@ -2741,6 +2875,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_property_identifier<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetPropertyIdentifier<'a>,
@@ -2752,6 +2887,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_property_property<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetPropertyProperty<'a>,
@@ -2761,6 +2897,7 @@ pub mod walk {
         visitor.visit_assignment_target_maybe_default(&it.binding);
     }
 
+    #[inline]
     pub fn walk_await_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &AwaitExpression<'a>) {
         let kind = AstKind::AwaitExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2768,6 +2905,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binary_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &BinaryExpression<'a>) {
         let kind = AstKind::BinaryExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2776,6 +2914,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_call_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &CallExpression<'a>) {
         let kind = AstKind::CallExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2787,12 +2926,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_arguments<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Argument<'a>>) {
         for el in it.iter() {
             visitor.visit_argument(el);
         }
     }
 
+    #[inline]
     pub fn walk_argument<'a, V: Visit<'a>>(visitor: &mut V, it: &Argument<'a>) {
         let kind = AstKind::Argument(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2803,6 +2944,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_chain_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ChainExpression<'a>) {
         let kind = AstKind::ChainExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2810,6 +2952,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_chain_element<'a, V: Visit<'a>>(visitor: &mut V, it: &ChainElement<'a>) {
         match it {
             ChainElement::CallExpression(it) => visitor.visit_call_expression(it),
@@ -2901,6 +3044,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_conditional_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ConditionalExpression<'a>,
@@ -2947,6 +3091,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_import_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportExpression<'a>) {
         let kind = AstKind::ImportExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2955,6 +3100,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_logical_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &LogicalExpression<'a>) {
         let kind = AstKind::LogicalExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2963,6 +3109,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_new_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &NewExpression<'a>) {
         let kind = AstKind::NewExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2974,6 +3121,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_object_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectExpression<'a>) {
         let kind = AstKind::ObjectExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -2981,6 +3129,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_object_property_kinds<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, ObjectPropertyKind<'a>>,
@@ -2990,6 +3139,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_object_property_kind<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ObjectPropertyKind<'a>,
@@ -3000,6 +3150,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_object_property<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectProperty<'a>) {
         let kind = AstKind::ObjectProperty(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3011,6 +3162,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_parenthesized_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ParenthesizedExpression<'a>,
@@ -3021,6 +3173,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_sequence_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &SequenceExpression<'a>,
@@ -3031,6 +3184,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_tagged_template_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TaggedTemplateExpression<'a>,
@@ -3045,12 +3199,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_this_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ThisExpression) {
         let kind = AstKind::ThisExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_update_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &UpdateExpression<'a>) {
         let kind = AstKind::UpdateExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3058,6 +3214,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_yield_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &YieldExpression<'a>) {
         let kind = AstKind::YieldExpression(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3067,6 +3224,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_private_in_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &PrivateInExpression<'a>,
@@ -3078,6 +3236,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElement<'a>) {
         let kind = AstKind::JSXElement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3089,6 +3248,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_opening_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXOpeningElement<'a>) {
         let kind = AstKind::JSXOpeningElement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3100,6 +3260,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_element_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElementName<'a>) {
         let kind = AstKind::JSXElementName(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3111,12 +3272,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXIdentifier<'a>) {
         let kind = AstKind::JSXIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_namespaced_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXNamespacedName<'a>) {
         let kind = AstKind::JSXNamespacedName(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3125,6 +3288,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_member_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &JSXMemberExpression<'a>,
@@ -3136,6 +3300,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_member_expression_object<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &JSXMemberExpressionObject<'a>,
@@ -3151,6 +3316,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_items<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, JSXAttributeItem<'a>>,
@@ -3160,6 +3326,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_item<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeItem<'a>) {
         let kind = AstKind::JSXAttributeItem(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3170,6 +3337,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttribute<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_jsx_attribute_name(&it.name);
@@ -3178,6 +3346,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeName<'a>) {
         match it {
             JSXAttributeName::Identifier(it) => visitor.visit_jsx_identifier(it),
@@ -3185,6 +3354,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_value<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeValue<'a>) {
         match it {
             JSXAttributeValue::StringLiteral(it) => visitor.visit_string_literal(it),
@@ -3196,6 +3366,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_expression_container<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &JSXExpressionContainer<'a>,
@@ -3206,6 +3377,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXExpression<'a>) {
         match it {
             JSXExpression::EmptyExpression(it) => visitor.visit_jsx_empty_expression(it),
@@ -3213,10 +3385,12 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_empty_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXEmptyExpression) {
         // NOTE: AstKind doesn't exists!
     }
 
+    #[inline]
     pub fn walk_jsx_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXFragment<'a>) {
         let kind = AstKind::JSXFragment(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3224,12 +3398,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_children<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, JSXChild<'a>>) {
         for el in it.iter() {
             visitor.visit_jsx_child(el);
         }
     }
 
+    #[inline]
     pub fn walk_jsx_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXChild<'a>) {
         match it {
             JSXChild::Text(it) => visitor.visit_jsx_text(it),
@@ -3240,17 +3416,20 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_text<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXText<'a>) {
         let kind = AstKind::JSXText(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_spread_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXSpreadChild<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_expression(&it.expression);
     }
 
+    #[inline]
     pub fn walk_jsx_spread_attribute<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &JSXSpreadAttribute<'a>,
@@ -3261,6 +3440,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_closing_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXClosingElement<'a>) {
         let kind = AstKind::JSXClosingElement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3268,6 +3448,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_class_body<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassBody<'a>) {
         let kind = AstKind::ClassBody(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3275,12 +3456,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_class_elements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, ClassElement<'a>>) {
         for el in it.iter() {
             visitor.visit_class_element(el);
         }
     }
 
+    #[inline]
     pub fn walk_class_element<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassElement<'a>) {
         match it {
             ClassElement::StaticBlock(it) => visitor.visit_static_block(it),
@@ -3291,6 +3474,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_static_block<'a, V: Visit<'a>>(visitor: &mut V, it: &StaticBlock<'a>) {
         visitor.enter_scope(ScopeFlags::ClassStaticBlock);
         let kind = AstKind::StaticBlock(visitor.alloc(it));
@@ -3300,6 +3484,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_method_definition<'a, V: Visit<'a>>(visitor: &mut V, it: &MethodDefinition<'a>) {
         let kind = AstKind::MethodDefinition(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3317,6 +3502,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_property_definition<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &PropertyDefinition<'a>,
@@ -3334,6 +3520,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_accessor_property<'a, V: Visit<'a>>(visitor: &mut V, it: &AccessorProperty<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_property_key(&it.key);
@@ -3343,6 +3530,7 @@ pub mod walk {
         visitor.visit_decorators(&it.decorators);
     }
 
+    #[inline]
     pub fn walk_ts_class_implementses<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSClassImplements<'a>>,
@@ -3352,6 +3540,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_class_implements<'a, V: Visit<'a>>(visitor: &mut V, it: &TSClassImplements<'a>) {
         let kind = AstKind::TSClassImplements(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3362,12 +3551,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_empty_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &EmptyStatement) {
         let kind = AstKind::EmptyStatement(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_expression_statement<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ExpressionStatement<'a>,
@@ -3378,6 +3569,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_for_in_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForInStatement<'a>) {
         let scope_events_cond = it.left.is_lexical_declaration();
         if scope_events_cond {
@@ -3394,6 +3586,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_for_statement_left<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatementLeft<'a>) {
         match it {
             ForStatementLeft::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
@@ -3404,6 +3597,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_variable_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &VariableDeclaration<'a>,
@@ -3414,6 +3608,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_variable_declarators<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, VariableDeclarator<'a>>,
@@ -3423,6 +3618,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_variable_declarator<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &VariableDeclarator<'a>,
@@ -3436,6 +3632,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_using_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &UsingDeclaration<'a>) {
         let kind = AstKind::UsingDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3443,6 +3640,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_for_of_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForOfStatement<'a>) {
         let scope_events_cond = it.left.is_lexical_declaration();
         if scope_events_cond {
@@ -3459,6 +3657,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_for_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatement<'a>) {
         let scope_events_cond =
             it.init.as_ref().is_some_and(ForStatementInit::is_lexical_declaration);
@@ -3483,6 +3682,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_for_statement_init<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatementInit<'a>) {
         let kind = AstKind::ForStatementInit(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3494,6 +3694,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_if_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &IfStatement<'a>) {
         let kind = AstKind::IfStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3505,6 +3706,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_labeled_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &LabeledStatement<'a>) {
         let kind = AstKind::LabeledStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3513,6 +3715,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_return_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ReturnStatement<'a>) {
         let kind = AstKind::ReturnStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3522,6 +3725,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_switch_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &SwitchStatement<'a>) {
         let kind = AstKind::SwitchStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3532,12 +3736,14 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_switch_cases<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, SwitchCase<'a>>) {
         for el in it.iter() {
             visitor.visit_switch_case(el);
         }
     }
 
+    #[inline]
     pub fn walk_switch_case<'a, V: Visit<'a>>(visitor: &mut V, it: &SwitchCase<'a>) {
         let kind = AstKind::SwitchCase(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3548,6 +3754,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_throw_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ThrowStatement<'a>) {
         let kind = AstKind::ThrowStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3555,6 +3762,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_try_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &TryStatement<'a>) {
         let kind = AstKind::TryStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3568,6 +3776,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_catch_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &CatchClause<'a>) {
         let scope_events_cond = it.param.is_some();
         if scope_events_cond {
@@ -3585,6 +3794,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_catch_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &CatchParameter<'a>) {
         let kind = AstKind::CatchParameter(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3592,6 +3802,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_finally_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
         visitor.enter_scope(ScopeFlags::empty());
         let kind = AstKind::FinallyClause(visitor.alloc(it));
@@ -3601,6 +3812,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WhileStatement<'a>) {
         let kind = AstKind::WhileStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3609,6 +3821,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_with_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WithStatement<'a>) {
         let kind = AstKind::WithStatement(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3636,6 +3849,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_alias_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSTypeAliasDeclaration<'a>,
@@ -3650,6 +3864,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_interface_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSInterfaceDeclaration<'a>,
@@ -3667,6 +3882,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_interface_heritages<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSInterfaceHeritage<'a>>,
@@ -3676,6 +3892,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_interface_heritage<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSInterfaceHeritage<'a>,
@@ -3689,11 +3906,13 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_interface_body<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInterfaceBody<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_ts_signatures(&it.body);
     }
 
+    #[inline]
     pub fn walk_ts_enum_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumDeclaration<'a>) {
         let kind = AstKind::TSEnumDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3704,12 +3923,14 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_ts_enum_members<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSEnumMember<'a>>) {
         for el in it.iter() {
             visitor.visit_ts_enum_member(el);
         }
     }
 
+    #[inline]
     pub fn walk_ts_enum_member<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMember<'a>) {
         let kind = AstKind::TSEnumMember(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3720,6 +3941,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_enum_member_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMemberName<'a>) {
         match it {
             TSEnumMemberName::StaticIdentifier(it) => visitor.visit_identifier_name(it),
@@ -3729,6 +3951,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_module_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSModuleDeclaration<'a>,
@@ -3750,6 +3973,7 @@ pub mod walk {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_ts_module_declaration_name<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSModuleDeclarationName<'a>,
@@ -3760,6 +3984,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_module_declaration_body<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSModuleDeclarationBody<'a>,
@@ -3772,6 +3997,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_module_block<'a, V: Visit<'a>>(visitor: &mut V, it: &TSModuleBlock<'a>) {
         let kind = AstKind::TSModuleBlock(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3780,6 +4006,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_import_equals_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSImportEqualsDeclaration<'a>,
@@ -3791,6 +4018,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_module_reference<'a, V: Visit<'a>>(visitor: &mut V, it: &TSModuleReference<'a>) {
         match it {
             TSModuleReference::ExternalModuleReference(it) => {
@@ -3802,6 +4030,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_ts_external_module_reference<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSExternalModuleReference<'a>,
@@ -3832,6 +4061,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_import_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportDeclaration<'a>) {
         let kind = AstKind::ImportDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3845,6 +4075,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_import_declaration_specifiers<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, ImportDeclarationSpecifier<'a>>,
@@ -3854,6 +4085,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_import_declaration_specifier<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ImportDeclarationSpecifier<'a>,
@@ -3869,6 +4101,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_import_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportSpecifier<'a>) {
         let kind = AstKind::ImportSpecifier(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3877,6 +4110,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_module_export_name<'a, V: Visit<'a>>(visitor: &mut V, it: &ModuleExportName<'a>) {
         match it {
             ModuleExportName::IdentifierName(it) => visitor.visit_identifier_name(it),
@@ -3885,6 +4119,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_import_default_specifier<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ImportDefaultSpecifier<'a>,
@@ -3895,6 +4130,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_import_namespace_specifier<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ImportNamespaceSpecifier<'a>,
@@ -3905,12 +4141,14 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_with_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &WithClause<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_identifier_name(&it.attributes_keyword);
         visitor.visit_import_attributes(&it.with_entries);
     }
 
+    #[inline]
     pub fn walk_import_attributes<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, ImportAttribute<'a>>,
@@ -3920,12 +4158,14 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportAttribute<'a>) {
         // NOTE: AstKind doesn't exists!
         visitor.visit_import_attribute_key(&it.key);
         visitor.visit_string_literal(&it.value);
     }
 
+    #[inline]
     pub fn walk_import_attribute_key<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ImportAttributeKey<'a>,
@@ -3936,6 +4176,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_export_all_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ExportAllDeclaration<'a>,
@@ -3952,6 +4193,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_export_default_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ExportDefaultDeclaration<'a>,
@@ -3963,6 +4205,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_export_default_declaration_kind<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ExportDefaultDeclarationKind<'a>,
@@ -3980,6 +4223,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_export_named_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &ExportNamedDeclaration<'a>,
@@ -3999,6 +4243,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_export_specifiers<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, ExportSpecifier<'a>>,
@@ -4008,6 +4253,7 @@ pub mod walk {
         }
     }
 
+    #[inline]
     pub fn walk_export_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ExportSpecifier<'a>) {
         let kind = AstKind::ExportSpecifier(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -4016,6 +4262,7 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_export_assignment<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSExportAssignment<'a>,
@@ -4024,6 +4271,7 @@ pub mod walk {
         visitor.visit_expression(&it.expression);
     }
 
+    #[inline]
     pub fn walk_ts_namespace_export_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSNamespaceExportDeclaration<'a>,

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -1340,6 +1340,7 @@ pub trait VisitMut<'a>: Sized {
 pub mod walk_mut {
     use super::*;
 
+    #[inline]
     pub fn walk_program<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Program<'a>) {
         visitor.enter_scope({
             let mut flags = ScopeFlags::Top;
@@ -1359,12 +1360,14 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_directives<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Directive<'a>>) {
         for el in it.iter_mut() {
             visitor.visit_directive(el);
         }
     }
 
+    #[inline]
     pub fn walk_directive<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Directive<'a>) {
         let kind = AstType::Directive;
         visitor.enter_node(kind);
@@ -1372,18 +1375,21 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_string_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StringLiteral<'a>) {
         let kind = AstType::StringLiteral;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_hashbang<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Hashbang<'a>) {
         let kind = AstType::Hashbang;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_statements<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Statement<'a>>) {
         for el in it.iter_mut() {
             visitor.visit_statement(el);
@@ -1417,6 +1423,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_block_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BlockStatement<'a>) {
         visitor.enter_scope(ScopeFlags::empty());
         let kind = AstType::BlockStatement;
@@ -1426,6 +1433,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_break_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BreakStatement<'a>) {
         let kind = AstType::BreakStatement;
         visitor.enter_node(kind);
@@ -1435,6 +1443,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_label_identifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut LabelIdentifier<'a>,
@@ -1444,6 +1453,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_continue_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ContinueStatement<'a>,
@@ -1456,6 +1466,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_debugger_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut DebuggerStatement,
@@ -1465,6 +1476,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_do_while_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut DoWhileStatement<'a>,
@@ -1530,36 +1542,42 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_boolean_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BooleanLiteral) {
         let kind = AstType::BooleanLiteral;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_null_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NullLiteral) {
         let kind = AstType::NullLiteral;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_numeric_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NumericLiteral<'a>) {
         let kind = AstType::NumericLiteral;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_big_int_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BigIntLiteral<'a>) {
         let kind = AstType::BigIntLiteral;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_reg_exp_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut RegExpLiteral<'a>) {
         let kind = AstType::RegExpLiteral;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_template_literal<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TemplateLiteral<'a>,
@@ -1571,6 +1589,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_template_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TemplateElement<'a>>,
@@ -1580,6 +1599,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_template_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TemplateElement<'a>,
@@ -1587,6 +1607,7 @@ pub mod walk_mut {
         // NOTE: AstType doesn't exists!
     }
 
+    #[inline]
     pub fn walk_expressions<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, Expression<'a>>,
@@ -1596,6 +1617,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_identifier_reference<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut IdentifierReference<'a>,
@@ -1605,6 +1627,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_meta_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut MetaProperty<'a>) {
         let kind = AstType::MetaProperty;
         visitor.enter_node(kind);
@@ -1613,18 +1636,21 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_identifier_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IdentifierName<'a>) {
         let kind = AstType::IdentifierName;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_super<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Super) {
         let kind = AstType::Super;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_array_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ArrayExpression<'a>,
@@ -1635,6 +1661,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_array_expression_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, ArrayExpressionElement<'a>>,
@@ -1644,6 +1671,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_array_expression_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ArrayExpressionElement<'a>,
@@ -1660,6 +1688,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_spread_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SpreadElement<'a>) {
         let kind = AstType::SpreadElement;
         visitor.enter_node(kind);
@@ -1667,6 +1696,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_elision<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Elision) {
         let kind = AstType::Elision;
         visitor.enter_node(kind);
@@ -1733,6 +1763,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_arrow_function_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ArrowFunctionExpression<'a>,
@@ -1758,6 +1789,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_formal_parameters<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut FormalParameters<'a>,
@@ -1771,6 +1803,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_formal_parameter_list<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, FormalParameter<'a>>,
@@ -1780,6 +1813,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_formal_parameter<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut FormalParameter<'a>,
@@ -1791,6 +1825,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binding_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BindingPattern<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_binding_pattern_kind(&mut it.kind);
@@ -1799,6 +1834,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_binding_pattern_kind<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut BindingPatternKind<'a>,
@@ -1811,6 +1847,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_binding_identifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut BindingIdentifier<'a>,
@@ -1820,6 +1857,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_object_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectPattern<'a>) {
         let kind = AstType::ObjectPattern;
         visitor.enter_node(kind);
@@ -1830,6 +1868,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binding_properties<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, BindingProperty<'a>>,
@@ -1839,6 +1878,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_binding_property<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut BindingProperty<'a>,
@@ -1848,6 +1888,7 @@ pub mod walk_mut {
         visitor.visit_binding_pattern(&mut it.value);
     }
 
+    #[inline]
     pub fn walk_property_key<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut PropertyKey<'a>) {
         let kind = AstType::PropertyKey;
         visitor.enter_node(kind);
@@ -1859,6 +1900,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_private_identifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut PrivateIdentifier<'a>,
@@ -1868,6 +1910,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binding_rest_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut BindingRestElement<'a>,
@@ -1878,6 +1921,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_array_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArrayPattern<'a>) {
         let kind = AstType::ArrayPattern;
         visitor.enter_node(kind);
@@ -1890,6 +1934,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_pattern<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentPattern<'a>,
@@ -1901,6 +1946,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_annotation<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeAnnotation<'a>,
@@ -1954,18 +2000,21 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_any_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSAnyKeyword) {
         let kind = AstType::TSAnyKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_big_int_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSBigIntKeyword) {
         let kind = AstType::TSBigIntKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_boolean_keyword<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSBooleanKeyword,
@@ -1975,6 +2024,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_intrinsic_keyword<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSIntrinsicKeyword,
@@ -1984,42 +2034,49 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_never_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNeverKeyword) {
         let kind = AstType::TSNeverKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_null_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNullKeyword) {
         let kind = AstType::TSNullKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_number_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNumberKeyword) {
         let kind = AstType::TSNumberKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_object_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSObjectKeyword) {
         let kind = AstType::TSObjectKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_string_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSStringKeyword) {
         let kind = AstType::TSStringKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_symbol_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSymbolKeyword) {
         let kind = AstType::TSSymbolKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_undefined_keyword<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSUndefinedKeyword,
@@ -2029,6 +2086,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_unknown_keyword<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSUnknownKeyword,
@@ -2038,17 +2096,20 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_void_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSVoidKeyword) {
         let kind = AstType::TSVoidKeyword;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_array_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSArrayType<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_ts_type(&mut it.element_type);
     }
 
+    #[inline]
     pub fn walk_ts_conditional_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSConditionalType<'a>,
@@ -2060,6 +2121,7 @@ pub mod walk_mut {
         visitor.visit_ts_type(&mut it.false_type);
     }
 
+    #[inline]
     pub fn walk_ts_constructor_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSConstructorType<'a>,
@@ -2072,6 +2134,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_parameter_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeParameterDeclaration<'a>,
@@ -2082,6 +2145,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_parameters<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSTypeParameter<'a>>,
@@ -2091,6 +2155,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_parameter<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeParameter<'a>,
@@ -2109,6 +2174,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_ts_function_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSFunctionType<'a>,
@@ -2124,6 +2190,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_this_parameter<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSThisParameter<'a>,
@@ -2137,6 +2204,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_import_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSImportType<'a>) {
         let kind = AstType::TSImportType;
         visitor.enter_node(kind);
@@ -2153,6 +2221,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeName<'a>) {
         let kind = AstType::TSTypeName;
         visitor.enter_node(kind);
@@ -2163,6 +2232,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_qualified_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSQualifiedName<'a>,
@@ -2174,6 +2244,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_import_attributes<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSImportAttributes<'a>,
@@ -2182,6 +2253,7 @@ pub mod walk_mut {
         visitor.visit_ts_import_attribute_list(&mut it.elements);
     }
 
+    #[inline]
     pub fn walk_ts_import_attribute_list<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSImportAttribute<'a>>,
@@ -2191,6 +2263,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_import_attribute<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSImportAttribute<'a>,
@@ -2200,6 +2273,7 @@ pub mod walk_mut {
         visitor.visit_expression(&mut it.value);
     }
 
+    #[inline]
     pub fn walk_ts_import_attribute_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSImportAttributeName<'a>,
@@ -2210,6 +2284,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_parameter_instantiation<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeParameterInstantiation<'a>,
@@ -2220,12 +2295,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_types<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, TSType<'a>>) {
         for el in it.iter_mut() {
             visitor.visit_ts_type(el);
         }
     }
 
+    #[inline]
     pub fn walk_ts_indexed_access_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSIndexedAccessType<'a>,
@@ -2237,6 +2314,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_infer_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSInferType<'a>) {
         let kind = AstType::TSInferType;
         visitor.enter_node(kind);
@@ -2244,6 +2322,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_intersection_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSIntersectionType<'a>,
@@ -2254,6 +2333,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_literal_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteralType<'a>) {
         let kind = AstType::TSLiteralType;
         visitor.enter_node(kind);
@@ -2274,6 +2354,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_unary_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut UnaryExpression<'a>,
@@ -2284,6 +2365,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_mapped_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSMappedType<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_ts_type_parameter(&mut it.type_parameter);
@@ -2295,6 +2377,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_named_tuple_member<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSNamedTupleMember<'a>,
@@ -2306,6 +2389,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_tuple_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTupleElement<'a>,
@@ -2317,6 +2401,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_optional_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSOptionalType<'a>,
@@ -2325,11 +2410,13 @@ pub mod walk_mut {
         visitor.visit_ts_type(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_rest_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSRestType<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_ts_type(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_template_literal_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTemplateLiteralType<'a>,
@@ -2341,17 +2428,20 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_this_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSThisType) {
         let kind = AstType::TSThisType;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_tuple_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTupleType<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_ts_tuple_elements(&mut it.element_types);
     }
 
+    #[inline]
     pub fn walk_ts_tuple_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSTupleElement<'a>>,
@@ -2361,6 +2451,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeLiteral<'a>) {
         let kind = AstType::TSTypeLiteral;
         visitor.enter_node(kind);
@@ -2368,6 +2459,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_signatures<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSSignature<'a>>,
@@ -2377,6 +2469,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_signature<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSignature<'a>) {
         match it {
             TSSignature::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
@@ -2391,6 +2484,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_index_signature<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSIndexSignature<'a>,
@@ -2400,6 +2494,7 @@ pub mod walk_mut {
         visitor.visit_ts_type_annotation(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_index_signature_names<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSIndexSignatureName<'a>>,
@@ -2409,6 +2504,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_index_signature_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSIndexSignatureName<'a>,
@@ -2417,6 +2513,7 @@ pub mod walk_mut {
         visitor.visit_ts_type_annotation(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_property_signature<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSPropertySignature<'a>,
@@ -2430,6 +2527,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_call_signature_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSCallSignatureDeclaration<'a>,
@@ -2447,6 +2545,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_construct_signature_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSConstructSignatureDeclaration<'a>,
@@ -2461,6 +2560,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_method_signature<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSMethodSignature<'a>,
@@ -2481,6 +2581,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_operator<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeOperator<'a>,
@@ -2489,6 +2590,7 @@ pub mod walk_mut {
         visitor.visit_ts_type(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_ts_type_predicate<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypePredicate<'a>,
@@ -2500,6 +2602,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_predicate_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypePredicateName<'a>,
@@ -2510,6 +2613,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_query<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeQuery<'a>) {
         let kind = AstType::TSTypeQuery;
         visitor.enter_node(kind);
@@ -2520,6 +2624,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_query_expr_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeQueryExprName<'a>,
@@ -2532,6 +2637,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_reference<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeReference<'a>,
@@ -2545,6 +2651,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_union_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSUnionType<'a>) {
         let kind = AstType::TSUnionType;
         visitor.enter_node(kind);
@@ -2552,6 +2659,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_parenthesized_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSParenthesizedType<'a>,
@@ -2562,6 +2670,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_js_doc_nullable_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSDocNullableType<'a>,
@@ -2570,6 +2679,7 @@ pub mod walk_mut {
         visitor.visit_ts_type(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_js_doc_non_nullable_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSDocNonNullableType<'a>,
@@ -2578,6 +2688,7 @@ pub mod walk_mut {
         visitor.visit_ts_type(&mut it.type_annotation);
     }
 
+    #[inline]
     pub fn walk_js_doc_unknown_type<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSDocUnknownType,
@@ -2585,12 +2696,14 @@ pub mod walk_mut {
         // NOTE: AstType doesn't exists!
     }
 
+    #[inline]
     pub fn walk_decorators<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Decorator<'a>>) {
         for el in it.iter_mut() {
             visitor.visit_decorator(el);
         }
     }
 
+    #[inline]
     pub fn walk_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
         let kind = AstType::Decorator;
         visitor.enter_node(kind);
@@ -2598,6 +2711,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_function_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut FunctionBody<'a>) {
         let kind = AstType::FunctionBody;
         visitor.enter_node(kind);
@@ -2606,6 +2720,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentExpression<'a>,
@@ -2617,6 +2732,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_target<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTarget<'a>,
@@ -2662,6 +2778,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_as_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSAsExpression<'a>,
@@ -2673,6 +2790,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_satisfies_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSSatisfiesExpression<'a>,
@@ -2684,6 +2802,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_non_null_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSNonNullExpression<'a>,
@@ -2694,6 +2813,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_type_assertion<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeAssertion<'a>,
@@ -2705,6 +2825,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_instantiation_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSInstantiationExpression<'a>,
@@ -2716,6 +2837,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_member_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut MemberExpression<'a>,
@@ -2736,6 +2858,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_computed_member_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ComputedMemberExpression<'a>,
@@ -2745,6 +2868,7 @@ pub mod walk_mut {
         visitor.visit_expression(&mut it.expression);
     }
 
+    #[inline]
     pub fn walk_static_member_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut StaticMemberExpression<'a>,
@@ -2754,6 +2878,7 @@ pub mod walk_mut {
         visitor.visit_identifier_name(&mut it.property);
     }
 
+    #[inline]
     pub fn walk_private_field_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut PrivateFieldExpression<'a>,
@@ -2763,6 +2888,7 @@ pub mod walk_mut {
         visitor.visit_private_identifier(&mut it.field);
     }
 
+    #[inline]
     pub fn walk_assignment_target_pattern<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetPattern<'a>,
@@ -2777,6 +2903,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_array_assignment_target<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ArrayAssignmentTarget<'a>,
@@ -2790,6 +2917,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_maybe_default<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetMaybeDefault<'a>,
@@ -2804,6 +2932,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_with_default<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetWithDefault<'a>,
@@ -2815,6 +2944,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_assignment_target_rest<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetRest<'a>,
@@ -2823,6 +2953,7 @@ pub mod walk_mut {
         visitor.visit_assignment_target(&mut it.target);
     }
 
+    #[inline]
     pub fn walk_object_assignment_target<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ObjectAssignmentTarget<'a>,
@@ -2834,6 +2965,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_properties<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
@@ -2843,6 +2975,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_property<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetProperty<'a>,
@@ -2857,6 +2990,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_property_identifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetPropertyIdentifier<'a>,
@@ -2868,6 +3002,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_assignment_target_property_property<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetPropertyProperty<'a>,
@@ -2877,6 +3012,7 @@ pub mod walk_mut {
         visitor.visit_assignment_target_maybe_default(&mut it.binding);
     }
 
+    #[inline]
     pub fn walk_await_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AwaitExpression<'a>,
@@ -2887,6 +3023,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_binary_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut BinaryExpression<'a>,
@@ -2898,6 +3035,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_call_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CallExpression<'a>) {
         let kind = AstType::CallExpression;
         visitor.enter_node(kind);
@@ -2909,12 +3047,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_arguments<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Argument<'a>>) {
         for el in it.iter_mut() {
             visitor.visit_argument(el);
         }
     }
 
+    #[inline]
     pub fn walk_argument<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Argument<'a>) {
         let kind = AstType::Argument;
         visitor.enter_node(kind);
@@ -2925,6 +3065,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_chain_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ChainExpression<'a>,
@@ -2935,6 +3076,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_chain_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ChainElement<'a>) {
         match it {
             ChainElement::CallExpression(it) => visitor.visit_call_expression(it),
@@ -3026,6 +3168,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_conditional_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ConditionalExpression<'a>,
@@ -3072,6 +3215,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_import_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportExpression<'a>,
@@ -3083,6 +3227,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_logical_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut LogicalExpression<'a>,
@@ -3094,6 +3239,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_new_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NewExpression<'a>) {
         let kind = AstType::NewExpression;
         visitor.enter_node(kind);
@@ -3105,6 +3251,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_object_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ObjectExpression<'a>,
@@ -3115,6 +3262,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_object_property_kinds<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, ObjectPropertyKind<'a>>,
@@ -3124,6 +3272,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_object_property_kind<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ObjectPropertyKind<'a>,
@@ -3134,6 +3283,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_object_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectProperty<'a>) {
         let kind = AstType::ObjectProperty;
         visitor.enter_node(kind);
@@ -3145,6 +3295,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_parenthesized_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ParenthesizedExpression<'a>,
@@ -3155,6 +3306,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_sequence_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut SequenceExpression<'a>,
@@ -3165,6 +3317,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_tagged_template_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TaggedTemplateExpression<'a>,
@@ -3179,12 +3332,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_this_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ThisExpression) {
         let kind = AstType::ThisExpression;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_update_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut UpdateExpression<'a>,
@@ -3195,6 +3350,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_yield_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut YieldExpression<'a>,
@@ -3207,6 +3363,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_private_in_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut PrivateInExpression<'a>,
@@ -3218,6 +3375,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXElement<'a>) {
         let kind = AstType::JSXElement;
         visitor.enter_node(kind);
@@ -3229,6 +3387,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_opening_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXOpeningElement<'a>,
@@ -3243,6 +3402,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_element_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXElementName<'a>,
@@ -3257,12 +3417,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_identifier<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXIdentifier<'a>) {
         let kind = AstType::JSXIdentifier;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_namespaced_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXNamespacedName<'a>,
@@ -3274,6 +3436,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_member_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXMemberExpression<'a>,
@@ -3285,6 +3448,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_member_expression_object<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXMemberExpressionObject<'a>,
@@ -3300,6 +3464,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_items<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, JSXAttributeItem<'a>>,
@@ -3309,6 +3474,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_item<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXAttributeItem<'a>,
@@ -3322,6 +3488,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_attribute<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXAttribute<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_jsx_attribute_name(&mut it.name);
@@ -3330,6 +3497,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXAttributeName<'a>,
@@ -3340,6 +3508,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_attribute_value<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXAttributeValue<'a>,
@@ -3354,6 +3523,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_expression_container<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXExpressionContainer<'a>,
@@ -3364,6 +3534,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXExpression<'a>) {
         match it {
             JSXExpression::EmptyExpression(it) => visitor.visit_jsx_empty_expression(it),
@@ -3371,6 +3542,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_empty_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXEmptyExpression,
@@ -3378,6 +3550,7 @@ pub mod walk_mut {
         // NOTE: AstType doesn't exists!
     }
 
+    #[inline]
     pub fn walk_jsx_fragment<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXFragment<'a>) {
         let kind = AstType::JSXFragment;
         visitor.enter_node(kind);
@@ -3385,12 +3558,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_children<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, JSXChild<'a>>) {
         for el in it.iter_mut() {
             visitor.visit_jsx_child(el);
         }
     }
 
+    #[inline]
     pub fn walk_jsx_child<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXChild<'a>) {
         match it {
             JSXChild::Text(it) => visitor.visit_jsx_text(it),
@@ -3401,12 +3576,14 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_jsx_text<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXText<'a>) {
         let kind = AstType::JSXText;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_spread_child<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXSpreadChild<'a>,
@@ -3415,6 +3592,7 @@ pub mod walk_mut {
         visitor.visit_expression(&mut it.expression);
     }
 
+    #[inline]
     pub fn walk_jsx_spread_attribute<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXSpreadAttribute<'a>,
@@ -3425,6 +3603,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_jsx_closing_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut JSXClosingElement<'a>,
@@ -3435,6 +3614,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_class_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassBody<'a>) {
         let kind = AstType::ClassBody;
         visitor.enter_node(kind);
@@ -3442,6 +3622,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_class_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, ClassElement<'a>>,
@@ -3451,6 +3632,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_class_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassElement<'a>) {
         match it {
             ClassElement::StaticBlock(it) => visitor.visit_static_block(it),
@@ -3461,6 +3643,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_static_block<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StaticBlock<'a>) {
         visitor.enter_scope(ScopeFlags::ClassStaticBlock);
         let kind = AstType::StaticBlock;
@@ -3470,6 +3653,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_method_definition<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut MethodDefinition<'a>,
@@ -3490,6 +3674,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_property_definition<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut PropertyDefinition<'a>,
@@ -3507,6 +3692,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_accessor_property<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AccessorProperty<'a>,
@@ -3519,6 +3705,7 @@ pub mod walk_mut {
         visitor.visit_decorators(&mut it.decorators);
     }
 
+    #[inline]
     pub fn walk_ts_class_implementses<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSClassImplements<'a>>,
@@ -3528,6 +3715,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_class_implements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSClassImplements<'a>,
@@ -3541,12 +3729,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_empty_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut EmptyStatement) {
         let kind = AstType::EmptyStatement;
         visitor.enter_node(kind);
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_expression_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ExpressionStatement<'a>,
@@ -3557,6 +3747,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_for_in_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ForInStatement<'a>,
@@ -3576,6 +3767,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_for_statement_left<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ForStatementLeft<'a>,
@@ -3589,6 +3781,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_variable_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut VariableDeclaration<'a>,
@@ -3599,6 +3792,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_variable_declarators<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, VariableDeclarator<'a>>,
@@ -3608,6 +3802,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_variable_declarator<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut VariableDeclarator<'a>,
@@ -3621,6 +3816,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_using_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut UsingDeclaration<'a>,
@@ -3631,6 +3827,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_for_of_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ForOfStatement<'a>,
@@ -3650,6 +3847,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_for_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ForStatement<'a>) {
         let scope_events_cond =
             it.init.as_ref().is_some_and(ForStatementInit::is_lexical_declaration);
@@ -3674,6 +3872,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_for_statement_init<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ForStatementInit<'a>,
@@ -3688,6 +3887,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_if_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IfStatement<'a>) {
         let kind = AstType::IfStatement;
         visitor.enter_node(kind);
@@ -3699,6 +3899,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_labeled_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut LabeledStatement<'a>,
@@ -3710,6 +3911,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_return_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ReturnStatement<'a>,
@@ -3722,6 +3924,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_switch_statement<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut SwitchStatement<'a>,
@@ -3735,6 +3938,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_switch_cases<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, SwitchCase<'a>>,
@@ -3744,6 +3948,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_switch_case<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SwitchCase<'a>) {
         let kind = AstType::SwitchCase;
         visitor.enter_node(kind);
@@ -3754,6 +3959,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_throw_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ThrowStatement<'a>) {
         let kind = AstType::ThrowStatement;
         visitor.enter_node(kind);
@@ -3761,6 +3967,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_try_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TryStatement<'a>) {
         let kind = AstType::TryStatement;
         visitor.enter_node(kind);
@@ -3774,6 +3981,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_catch_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CatchClause<'a>) {
         let scope_events_cond = it.param.is_some();
         if scope_events_cond {
@@ -3791,6 +3999,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_catch_parameter<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CatchParameter<'a>) {
         let kind = AstType::CatchParameter;
         visitor.enter_node(kind);
@@ -3798,6 +4007,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_finally_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BlockStatement<'a>) {
         visitor.enter_scope(ScopeFlags::empty());
         let kind = AstType::FinallyClause;
@@ -3807,6 +4017,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_while_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WhileStatement<'a>) {
         let kind = AstType::WhileStatement;
         visitor.enter_node(kind);
@@ -3815,6 +4026,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_with_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithStatement<'a>) {
         let kind = AstType::WithStatement;
         visitor.enter_node(kind);
@@ -3842,6 +4054,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_type_alias_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSTypeAliasDeclaration<'a>,
@@ -3856,6 +4069,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_interface_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSInterfaceDeclaration<'a>,
@@ -3873,6 +4087,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_interface_heritages<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSInterfaceHeritage<'a>>,
@@ -3882,6 +4097,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_interface_heritage<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSInterfaceHeritage<'a>,
@@ -3895,6 +4111,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_interface_body<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSInterfaceBody<'a>,
@@ -3903,6 +4120,7 @@ pub mod walk_mut {
         visitor.visit_ts_signatures(&mut it.body);
     }
 
+    #[inline]
     pub fn walk_ts_enum_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSEnumDeclaration<'a>,
@@ -3916,6 +4134,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_ts_enum_members<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSEnumMember<'a>>,
@@ -3925,6 +4144,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_enum_member<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSEnumMember<'a>) {
         let kind = AstType::TSEnumMember;
         visitor.enter_node(kind);
@@ -3935,6 +4155,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_enum_member_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSEnumMemberName<'a>,
@@ -3947,6 +4168,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_module_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSModuleDeclaration<'a>,
@@ -3968,6 +4190,7 @@ pub mod walk_mut {
         visitor.leave_scope();
     }
 
+    #[inline]
     pub fn walk_ts_module_declaration_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSModuleDeclarationName<'a>,
@@ -3978,6 +4201,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_module_declaration_body<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSModuleDeclarationBody<'a>,
@@ -3990,6 +4214,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_module_block<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSModuleBlock<'a>) {
         let kind = AstType::TSModuleBlock;
         visitor.enter_node(kind);
@@ -3998,6 +4223,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_import_equals_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSImportEqualsDeclaration<'a>,
@@ -4009,6 +4235,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_module_reference<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSModuleReference<'a>,
@@ -4023,6 +4250,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_ts_external_module_reference<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSExternalModuleReference<'a>,
@@ -4056,6 +4284,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_import_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportDeclaration<'a>,
@@ -4072,6 +4301,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_import_declaration_specifiers<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, ImportDeclarationSpecifier<'a>>,
@@ -4081,6 +4311,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_import_declaration_specifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportDeclarationSpecifier<'a>,
@@ -4096,6 +4327,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_import_specifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportSpecifier<'a>,
@@ -4107,6 +4339,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_module_export_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ModuleExportName<'a>,
@@ -4118,6 +4351,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_import_default_specifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportDefaultSpecifier<'a>,
@@ -4128,6 +4362,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_import_namespace_specifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportNamespaceSpecifier<'a>,
@@ -4138,12 +4373,14 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_with_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithClause<'a>) {
         // NOTE: AstType doesn't exists!
         visitor.visit_identifier_name(&mut it.attributes_keyword);
         visitor.visit_import_attributes(&mut it.with_entries);
     }
 
+    #[inline]
     pub fn walk_import_attributes<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, ImportAttribute<'a>>,
@@ -4153,6 +4390,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_import_attribute<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportAttribute<'a>,
@@ -4162,6 +4400,7 @@ pub mod walk_mut {
         visitor.visit_string_literal(&mut it.value);
     }
 
+    #[inline]
     pub fn walk_import_attribute_key<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ImportAttributeKey<'a>,
@@ -4172,6 +4411,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_export_all_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ExportAllDeclaration<'a>,
@@ -4188,6 +4428,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_export_default_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ExportDefaultDeclaration<'a>,
@@ -4199,6 +4440,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_export_default_declaration_kind<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ExportDefaultDeclarationKind<'a>,
@@ -4216,6 +4458,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_export_named_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ExportNamedDeclaration<'a>,
@@ -4235,6 +4478,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_export_specifiers<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, ExportSpecifier<'a>>,
@@ -4244,6 +4488,7 @@ pub mod walk_mut {
         }
     }
 
+    #[inline]
     pub fn walk_export_specifier<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ExportSpecifier<'a>,
@@ -4255,6 +4500,7 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
+    #[inline]
     pub fn walk_ts_export_assignment<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSExportAssignment<'a>,
@@ -4263,6 +4509,7 @@ pub mod walk_mut {
         visitor.visit_expression(&mut it.expression);
     }
 
+    #[inline]
     pub fn walk_ts_namespace_export_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSNamespaceExportDeclaration<'a>,


### PR DESCRIPTION
~~Attempt to improve the performance of visitors, It is mostly for experiments. I'm not sure how much performance is there to gain back.~~

- [x] inline plural visits (eg: visit_statements)
- [x] inline enums when there are 5 or fewer match cases
- [x] inline structs when there are 5 or less fields 
- [x] inline `Visit::alloc` 