### PR TITLE
fix(isolated-declarations): should emit `export {}` when only having `ImportDeclaration`

### DIFF
--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -317,7 +317,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
         }
 
-        if last_transformed_len == transformed_indexes.len() {
+        if !transformed_indexes.is_empty() && last_transformed_len == transformed_indexes.len() {
             need_empty_export_marker = false;
         }
 

--- a/crates/oxc_isolated_declarations/tests/fixtures/empty-export2.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/empty-export2.ts
@@ -1,0 +1,1 @@
+import * as a from "mod";

--- a/crates/oxc_isolated_declarations/tests/snapshots/empty-export2.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/empty-export2.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/empty-export2.ts
+---
+==================== .D.TS ====================
+
+export {};


### PR DESCRIPTION
close: #4023
