### PR TITLE
feat(isolated-declarations): support optional class methods

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2413,6 +2413,9 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for MethodDefinition<'a> {
         if self.computed {
             p.print(b']');
         }
+        if self.optional {
+            p.print(b'?');
+        }
         if let Some(type_parameters) = self.value.type_parameters.as_ref() {
             type_parameters.gen(p, ctx);
         }

--- a/crates/oxc_codegen/tests/mod.rs
+++ b/crates/oxc_codegen/tests/mod.rs
@@ -201,6 +201,7 @@ fn typescript() {
     );
     test_ts("let foo: { <T>(t: T): void }", "let foo: {<T>(t: T): void};\n", false);
     test_ts("function <const T>(){}", "function<const T>() {}\n", false);
+    test_ts("class A {m?(): void}", "class A {\n\tm?(): void;\n}\n", false);
 }
 
 fn test_comment_helper(source_text: &str, expected: &str) {

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -336,7 +336,9 @@ impl<'a> IsolatedDeclarations<'a> {
             match element {
                 ClassElement::StaticBlock(_) => {}
                 ClassElement::MethodDefinition(ref method) => {
-                    if !method.r#type.is_abstract() && method.value.body.is_none() {
+                    if !(method.r#type.is_abstract() || method.optional)
+                        && method.value.body.is_none()
+                    {
                         is_function_overloads = true;
                     } else if is_function_overloads {
                         // Skip implementation of function overloads

--- a/crates/oxc_isolated_declarations/tests/fixtures/class.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class.ts
@@ -14,6 +14,7 @@ export class Zoo {
 
 export abstract class Qux {
   abstract foo(): void;
+  protected foo2?(): void;
   bar(): void {}
   baz(): void {}
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -15,6 +15,7 @@ export declare class Zoo {
 }
 export declare abstract class Qux {
 	abstract foo(): void;
+	protected foo2?(): void;
 	bar(): void;
 	baz(): void;
 }


### PR DESCRIPTION
Example class
```
export class A {
  m1?(): void;
  m2(): void {}
}
```

Before the fix:
```
export declare class A {
  m1(): void;
}
```

with the fix:
```
export declare class A {
  m1?(): void;
  m2(): void;
}
```