### PR TITLE
fix(isolated_declarations): add mapped-type constraint to the scope

### DIFF
--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -261,16 +261,18 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
         }
     }
 
-    /// `type D<T> = { [K in keyof T]: K };`
+    /// `type D = { [K in keyof T]: K };`
     ///             ^^^^^^^^^^^^^^^^^^^^
-    ///                `K` is a type parameter
-    /// We need to add `K` to the scope
+    /// We need to add both `T` and `K` to the scope
     fn visit_ts_mapped_type(&mut self, ty: &TSMappedType<'a>) {
         // copy from walk_ts_mapped_type
         self.enter_scope(ScopeFlags::empty());
         self.add_type_binding(ty.type_parameter.name.name.clone());
         if let Some(name) = &ty.name_type {
             self.visit_ts_type(name);
+        }
+        if let Some(constraint) = &ty.type_parameter.constraint {
+            self.visit_ts_type(constraint);
         }
         if let Some(type_annotation) = &ty.type_annotation {
             self.visit_ts_type(type_annotation);

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -261,7 +261,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
         }
     }
 
-    /// `type D = { [K in keyof T]: K };`
+    /// `type D = { [key in keyof T]: K };`
     ///             ^^^^^^^^^^^^^^^^^^^^
     /// We need to add both `T` and `K` to the scope
     fn visit_ts_mapped_type(&mut self, ty: &TSMappedType<'a>) {

--- a/crates/oxc_isolated_declarations/tests/fixtures/mapped-types.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/mapped-types.ts
@@ -1,0 +1,6 @@
+import {K} from 'foo'
+import {T} from 'bar'
+
+export interface I {
+	prop: {[key in K]: T}
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/mapped-types.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/mapped-types.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/mapped-types.ts
+---
+==================== .D.TS ====================
+
+import { K } from 'foo';
+import { T } from 'bar';
+export interface I {
+	prop: { [key in K] : T};
+}


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/4020

Example:
```ts
import {K} from 'foo'
import {T} from 'bar'

export interface I {
    prop: {[key in K]: T}
}
```

Before:
```ts
import {T} from 'bar'
export interface I {
    prop: {[key in K]: T}
}
```

After:
```ts
import {K} from 'foo'
import {T} from 'bar'
export interface I {
    prop: {[key in K]: T}
}
```

TSC:
```ts
import { K } from 'foo';
import { T } from 'bar';
export interface I {
    prop: {
        [key in K]: T;
    };
}

```