### PR TITLE
fix(codegen): missing TypeParameters in TSConstructSignature

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3106,6 +3106,9 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for TSSignature<'a> {
             }
             Self::TSConstructSignatureDeclaration(signature) => {
                 p.print_str(b"new ");
+                if let Some(type_parameters) = signature.type_parameters.as_ref() {
+                    type_parameters.gen(p, ctx);
+                }
                 p.print_str(b"(");
                 signature.params.gen(p, ctx);
                 p.print_str(b")");

--- a/crates/oxc_codegen/tests/mod.rs
+++ b/crates/oxc_codegen/tests/mod.rs
@@ -200,6 +200,7 @@ fn typescript() {
         false,
     );
     test_ts("let foo: { <T>(t: T): void }", "let foo: {<T>(t: T): void};\n", false);
+    test_ts("let foo: { new <T>(t: T): void }", "let foo: {new <T>(t: T): void};\n", false);
     test_ts("function <const T>(){}", "function<const T>() {}\n", false);
     test_ts("class A {m?(): void}", "class A {\n\tm?(): void;\n}\n", false);
     test_ts(


### PR DESCRIPTION
Similar to https://github.com/oxc-project/oxc/pull/4021 but for construct signature