### PR TITLE
fix(isolated_declarations): correct emit for private static methods

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -142,6 +142,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         r#type: PropertyDefinitionType,
         key: PropertyKey<'a>,
+        r#static: bool,
         r#override: bool,
         accessibility: Option<TSAccessibility>,
     ) -> ClassElement<'a> {
@@ -151,7 +152,7 @@ impl<'a> IsolatedDeclarations<'a> {
             key,
             None,
             false,
-            false,
+            r#static,
             false,
             r#override,
             false,
@@ -205,6 +206,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 self.create_class_property(
                     r#type,
                     self.ast.copy(&method.key),
+                    method.r#static,
                     method.r#override,
                     self.transform_accessibility(method.accessibility),
                 )

--- a/crates/oxc_isolated_declarations/tests/fixtures/class.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class.ts
@@ -22,6 +22,10 @@ export abstract class Qux {
 export class Baz {
   readonly prop1 = 'some string';
   prop2 = 'another string';
+  private prop3 = 'yet another string';
+  private prop4(): void {}
+  private static prop5 = 'yet another string';
+  private static prop6(): void {}
 }
 
 export class Boo {

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -22,6 +22,10 @@ export declare abstract class Qux {
 export declare class Baz {
 	readonly prop1: 'some string';
 	prop2: string;
+	private prop3;
+	private prop4;
+	private static prop5;
+	private static prop6;
 }
 export declare class Boo {
 	readonly prop: number;


### PR DESCRIPTION
Fixes issue where `static` gets dropped in `private static` methods.