### PR TITLE
fix(isolated_declarations): Don't report an error for parameters if they are ObjectPattern or ArrayPattern with an explicit type

### DIFF
--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -48,9 +48,13 @@ impl<'a> IsolatedDeclarations<'a> {
         is_remaining_params_have_required: bool,
     ) -> Option<FormalParameter<'a>> {
         let pattern = &param.pattern;
-        if pattern.type_annotation.is_none() && pattern.kind.is_destructuring_pattern() {
-            self.error(parameter_must_have_explicit_type(param.span));
-            return None;
+        if let BindingPatternKind::AssignmentPattern(pattern) = &pattern.kind {
+            if pattern.left.kind.is_destructuring_pattern()
+                && pattern.left.type_annotation.is_none()
+            {
+                self.error(parameter_must_have_explicit_type(param.span));
+                return None;
+            }
         }
 
         let is_assignment_pattern = pattern.kind.is_assignment_pattern();

--- a/crates/oxc_isolated_declarations/tests/snapshots/function-parameters.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/function-parameters.snap
@@ -6,8 +6,8 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/function-parameters.
 
 export declare function fnDeclGood(p?: T, rParam?: string): void;
 export declare function fnDeclGood2(p?: T, rParam?: number): void;
-export declare function fooGood(): number;
-export declare const fooGood2: () => number;
+export declare function fooGood([a, b]?: any[]): number;
+export declare const fooGood2: ({ a, b }?: object) => number;
 export declare function fnDeclBad<T>(p: T, rParam: T, r2: T): void;
 export declare function fnDeclBad2<T>(p: T, r2: T): void;
 export declare function fnDeclBad3<T>(p: T, rParam?: T, r2: T): void;
@@ -16,24 +16,6 @@ export declare const fooBad2: () => number;
 
 
 ==================== Errors ====================
-
-  x TS9011: Parameter must have an explicit type annotation with
-  | --isolatedDeclarations.
-   ,-[5:25]
- 4 | 
- 5 | export function fooGood([a, b]: any[] = [1, 2]): number {
-   :                         ^^^^^^^^^^^^^^^^^^^^^^
- 6 |   return 2;
-   `----
-
-  x TS9011: Parameter must have an explicit type annotation with
-  | --isolatedDeclarations.
-    ,-[9:26]
-  8 | 
-  9 | export const fooGood2 = ({a, b}: object = { a: 1, b: 2 }): number => {
-    :                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 10 |   return 2;
-    `----
 
   x TS9025: Declaration emit for this parameter requires implicitly adding
   | undefined to it's type. This is not supported with --isolatedDeclarations.


### PR DESCRIPTION
The logic in https://github.com/oxc-project/oxc/pull/3810 was slightly off as demonstrated by the snapshot test.