### PR TITLE
fix(lexer): incorrect lexing of large hex/octal/binary literals

### DIFF
--- a/tasks/coverage/codegen_misc.snap
+++ b/tasks/coverage/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 23/23 (100.00%)
-Positive Passed: 23/23 (100.00%)
+AST Parsed     : 24/24 (100.00%)
+Positive Passed: 24/24 (100.00%)

--- a/tasks/coverage/misc/pass/oxc-4072.ts
+++ b/tasks/coverage/misc/pass/oxc-4072.ts
@@ -1,0 +1,14 @@
+// Tests large numbers that may overflow integer parsing, but are all small
+// enough to be valid f64s. Related to PR #4072 and issue #3347.
+
+let HEX_INT_LARGER_THAN_MAX_SAFE_INTEGER: number = 0x10000000000000000
+let OCT_INT_LARGER_THAN_MAX_SAFE_INTEGER: number = 0o40000000000000000
+let BIN_INT_LARGER_THAN_MAX_SAFE_INTEGER: number = 0b00010000000000000000000000000000000000000000000000000000000000000000;
+
+if (
+    HEX_INT_LARGER_THAN_MAX_SAFE_INTEGER === 0 ||
+    OCT_INT_LARGER_THAN_MAX_SAFE_INTEGER === 0 ||
+    BIN_INT_LARGER_THAN_MAX_SAFE_INTEGER === 0
+) {
+    throw new Error('Large numeric literals are overflowing when parsed')
+}

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 23/23 (100.00%)
-Positive Passed: 23/23 (100.00%)
+AST Parsed     : 24/24 (100.00%)
+Positive Passed: 24/24 (100.00%)
 Negative Passed: 12/12 (100.00%)
 
   × Unexpected token

--- a/tasks/coverage/transformer_misc.snap
+++ b/tasks/coverage/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 23/23 (100.00%)
-Positive Passed: 23/23 (100.00%)
+AST Parsed     : 24/24 (100.00%)
+Positive Passed: 24/24 (100.00%)


### PR DESCRIPTION
Closes #3347. Implementation follows the approach described by @overlookmotel [here](https://github.com/oxc-project/oxc/issues/3347#issuecomment-2119004288).