### PR TITLE
fix(minifier): omit dce `undefined` which can be a shadowed variable

### DIFF
--- a/crates/oxc_minifier/src/compressor/ast_util.rs
+++ b/crates/oxc_minifier/src/compressor/ast_util.rs
@@ -485,7 +485,8 @@ pub fn get_boolean_value(expr: &Expression) -> Option<bool> {
                 .map(|cooked| !cooked.is_empty())
         }
         Expression::Identifier(ident) => {
-            if expr.is_undefined() || ident.name == "NaN" {
+            /* `undefined` can be a shadowed variable expr.is_undefined() || */
+            if ident.name == "NaN" {
                 Some(false)
             } else if ident.name == "Infinity" {
                 Some(true)

--- a/crates/oxc_minifier/tests/oxc/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/oxc/remove_dead_code.rs
@@ -41,4 +41,10 @@ fn remove_dead_code() {
 
     test("!!false ? foo : bar;", "bar");
     test("!!true ? foo : bar;", "foo");
+
+    // Shadowed `undefined` as a variable should not be erased.
+    test(
+        "function foo(undefined) { if (!undefined) { } }",
+        "function foo(undefined){if(!undefined){}}",
+    );
 }


### PR DESCRIPTION
```
 // Shadowed `undefined` as a variable should not be erased.
    test(
        "function foo(undefined) { if (!undefined) { } }",
        "function foo(undefined){if(!undefined){}}",
    );
```

I'm not using the cheap `ident.reference_id.get().is_some()` here yet because I don't know what I'm doing - how should minifier consume `Semantic`?