### PR TITLE
chore(tasks/rulegen): generate `options` for fix cases

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -129,8 +129,13 @@ impl TestCase {
     fn output(&self) -> Option<String> {
         let code = format_code_snippet(self.code.as_ref()?);
         let output = format_code_snippet(self.output.as_ref()?);
+        let config = self.config.as_ref().map_or_else(
+            || "None".to_string(),
+            |config| format!("Some(serde_json::json!({config}))"),
+        );
+
         // ("null==null", "null === null", None),
-        Some(format!(r#"({code}, {output}, None)"#))
+        Some(format!(r#"({code}, {output}, {config})"#))
     }
 }
 


### PR DESCRIPTION
Our fixer support rule option, and we need to generate `options` for them.

https://github.com/oxc-project/oxc/blob/328445b4ca821056ea01c19548f784d8df76a5d2/crates/oxc_linter/src/tester.rs#L238

cc @eryue0220 