### PR TITLE
fix(isolated_declarations): Emit computed properties when they are well known symbols

### DIFF
--- a/crates/oxc_isolated_declarations/src/global_symbol_binding_tracker.rs
+++ b/crates/oxc_isolated_declarations/src/global_symbol_binding_tracker.rs
@@ -1,0 +1,251 @@
+use std::cell::Cell;
+
+#[allow(clippy::wildcard_imports)]
+use oxc_ast::ast::*;
+#[allow(clippy::wildcard_imports)]
+use oxc_ast::{visit::walk::*, Visit};
+use oxc_span::{Atom, GetSpan, Span};
+use oxc_syntax::scope::{ScopeFlags, ScopeId};
+use rustc_hash::FxHashSet;
+
+pub struct GlobalSymbolBindingTracker {
+    depth: u8,
+    symbol_binding_depth: Option<u8>,
+    global_this_binding_depth: Option<u8>,
+    computed_properties_using_non_global_symbol: FxHashSet<Span>,
+    computed_properties_using_non_global_global_this: FxHashSet<Span>,
+}
+
+impl GlobalSymbolBindingTracker {
+    pub fn new() -> Self {
+        Self {
+            depth: 0,
+            symbol_binding_depth: None,
+            global_this_binding_depth: None,
+            computed_properties_using_non_global_symbol: FxHashSet::default(),
+            computed_properties_using_non_global_global_this: FxHashSet::default(),
+        }
+    }
+
+    fn does_computed_property_reference_non_global_symbol(&self, key: &PropertyKey) -> bool {
+        self.computed_properties_using_non_global_symbol.contains(&key.span())
+    }
+
+    fn does_computed_property_reference_non_global_global_this(&self, key: &PropertyKey) -> bool {
+        self.computed_properties_using_non_global_global_this.contains(&key.span())
+    }
+
+    pub fn does_computed_property_reference_well_known_symbol(&self, key: &PropertyKey) -> bool {
+        if let PropertyKey::StaticMemberExpression(expr) = key {
+            if let Expression::Identifier(identifier) = &expr.object {
+                identifier.name == "Symbol"
+                    && !self.does_computed_property_reference_non_global_symbol(key)
+            } else if let Expression::StaticMemberExpression(static_member) = &expr.object {
+                if let Expression::Identifier(identifier) = &static_member.object {
+                    identifier.name == "globalThis"
+                        && static_member.property.name == "Symbol"
+                        && !self.does_computed_property_reference_non_global_global_this(key)
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    fn handle_name_binding(&mut self, name: &Atom) {
+        match name.as_str() {
+            "Symbol" if self.symbol_binding_depth.is_none() => {
+                self.symbol_binding_depth = Some(self.depth);
+            }
+            "globalThis" if self.global_this_binding_depth.is_none() => {
+                self.global_this_binding_depth = Some(self.depth);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> Visit<'a> for GlobalSymbolBindingTracker {
+    fn enter_scope(&mut self, _: ScopeFlags, _: &Cell<Option<ScopeId>>) {
+        self.depth += 1;
+    }
+
+    fn leave_scope(&mut self) {
+        if self.symbol_binding_depth == Some(self.depth) {
+            self.symbol_binding_depth = None;
+        }
+        if self.global_this_binding_depth == Some(self.depth) {
+            self.global_this_binding_depth = None;
+        }
+        self.depth -= 1;
+    }
+
+    fn visit_ts_type(&mut self, _: &TSType<'a>) {
+        // Optimization: we don't need to traverse down into types.
+    }
+
+    fn visit_statement(&mut self, statement: &Statement<'a>) {
+        // Optimizations: Only try to visit parts of statements containing other statements.
+        match statement {
+            Statement::TSEnumDeclaration(_)
+            | Statement::TSTypeAliasDeclaration(_)
+            | Statement::TSInterfaceDeclaration(_) => (),
+            Statement::WhileStatement(stmt) => walk_statement(self, &stmt.body),
+            Statement::DoWhileStatement(stmt) => walk_statement(self, &stmt.body),
+            Statement::ForStatement(stmt) => walk_statement(self, &stmt.body),
+            Statement::ForInStatement(stmt) => walk_statement(self, &stmt.body),
+            Statement::ForOfStatement(stmt) => walk_statement(self, &stmt.body),
+            Statement::IfStatement(stmt) => {
+                walk_statement(self, &stmt.consequent);
+                if let Some(alt) = &stmt.alternate {
+                    walk_statement(self, alt);
+                }
+            }
+            Statement::SwitchStatement(stmt) => {
+                walk_switch_cases(self, &stmt.cases);
+            }
+            _ => walk_statement(self, statement),
+        }
+    }
+
+    fn visit_binding_pattern(&mut self, pattern: &BindingPattern<'a>) {
+        if let BindingPatternKind::BindingIdentifier(ident) = &pattern.kind {
+            self.handle_name_binding(&ident.name);
+        }
+        walk_binding_pattern(self, pattern);
+    }
+
+    fn visit_assignment_pattern(&mut self, pattern: &AssignmentPattern<'a>) {
+        // If the left side of the assignment already has a type annotation, we don't need to visit the right side.
+        if pattern.left.type_annotation.is_some() {
+            self.visit_binding_pattern(&pattern.left);
+            return;
+        }
+        walk_assignment_pattern(self, pattern);
+    }
+
+    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        // If the variable already has a type annotation, we don't need to visit the initializer.
+        if decl.id.type_annotation.is_some() {
+            self.visit_binding_pattern(&decl.id);
+        } else {
+            walk_variable_declarator(self, decl);
+        }
+    }
+
+    fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'a>) {
+        // If the left side of the assignment is a member expression, it won't affect emitted declarations.
+        if expr.left.is_member_expression() {
+            return;
+        }
+        walk_assignment_expression(self, expr);
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        // Async and generator functions always need explicit declarations.
+        if func.generator || func.r#async {
+            return;
+        }
+
+        if let Some(id) = func.id.as_ref() {
+            self.handle_name_binding(&id.name);
+        }
+
+        // If the function already has a return type annotation, we don't need to visit the body.
+        if func.return_type.is_some() {
+            return;
+        }
+
+        walk_function(self, func, flags);
+    }
+
+    fn visit_arrow_function_expression(&mut self, func: &ArrowFunctionExpression<'a>) {
+        // If the arrow function already has a return type annotation, we don't need to visit the body.
+        if func.return_type.is_some() {
+            return;
+        }
+
+        walk_arrow_function_expression(self, func);
+    }
+
+    fn visit_expression(&mut self, expr: &Expression<'a>) {
+        match expr {
+            Expression::ArrowFunctionExpression(_)
+            | Expression::Identifier(_)
+            | Expression::ArrayExpression(_)
+            | Expression::AssignmentExpression(_)
+            | Expression::ClassExpression(_)
+            | Expression::FunctionExpression(_)
+            | Expression::ObjectExpression(_)
+            | Expression::ParenthesizedExpression(_) => {
+                // Expressions whose types can be inferred, but excluding trivial ones
+                // whose types will never contain a Symbol computed property.
+                walk_expression(self, expr);
+            }
+            _ => (),
+        }
+    }
+
+    fn visit_declaration(&mut self, declaration: &Declaration<'a>) {
+        match declaration {
+            Declaration::VariableDeclaration(_) | Declaration::FunctionDeclaration(_) => {
+                // handled in BindingPattern and Function
+            }
+            Declaration::ClassDeclaration(decl) => {
+                if let Some(id) = decl.id.as_ref() {
+                    self.handle_name_binding(&id.name);
+                }
+            }
+            Declaration::TSModuleDeclaration(decl) => {
+                if let TSModuleDeclarationName::Identifier(ident) = &decl.id {
+                    self.handle_name_binding(&ident.name);
+                }
+            }
+            Declaration::TSImportEqualsDeclaration(decl) => {
+                self.handle_name_binding(&decl.id.name);
+                return;
+            }
+            Declaration::TSEnumDeclaration(decl) => {
+                self.handle_name_binding(&decl.id.name);
+                return;
+            }
+            Declaration::TSTypeAliasDeclaration(_) | Declaration::TSInterfaceDeclaration(_) => {
+                return;
+            }
+        }
+        walk_declaration(self, declaration);
+    }
+
+    fn visit_object_property(&mut self, prop: &ObjectProperty<'a>) {
+        if prop.computed {
+            if let PropertyKey::StaticMemberExpression(expr) = &prop.key {
+                if self.symbol_binding_depth.is_some() {
+                    if let Expression::Identifier(identifier) = &expr.object {
+                        if identifier.name == "Symbol" {
+                            self.computed_properties_using_non_global_symbol.insert(expr.span);
+                        }
+                    }
+                }
+
+                if self.global_this_binding_depth.is_some() {
+                    if let Expression::StaticMemberExpression(static_member) = &expr.object {
+                        if let Expression::Identifier(identifier) = &static_member.object {
+                            if identifier.name == "globalThis"
+                                && static_member.property.name == "Symbol"
+                            {
+                                self.computed_properties_using_non_global_global_this
+                                    .insert(expr.span);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        walk_object_property(self, prop);
+    }
+}

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -129,7 +129,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
                     let property_signature = self.ast.ts_signature_property_signature(
                         object.span,
-                        false,
+                        object.computed,
                         false,
                         is_const,
                         // SAFETY: `ast.copy` is unsound! We need to fix.

--- a/crates/oxc_isolated_declarations/tests/fixtures/well-known-symbols.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/well-known-symbols.ts
@@ -1,0 +1,52 @@
+// Correct
+export const foo = {
+  [Symbol.iterator]: (): void => {},
+  [Symbol.asyncIterator]: async (): Promise<void> => {},
+  [globalThis.Symbol.iterator]: (): void => {},
+  get [Symbol.toStringTag]() { return 'foo'; },
+}
+
+export abstract class Foo {
+  [Symbol.iterator](): void {}
+  async [Symbol.asyncIterator](): Promise<void> {}
+  [globalThis.Symbol.iterator](): void {}
+  get [Symbol.toStringTag]() { return 'Foo'; }
+}
+
+// OK because these are not exported
+
+namespace Foo {
+  const Symbol = {};
+  const globalThis = {};
+
+  export const foo = {
+    [Symbol.iterator]: (): void => {},
+    [globalThis.Symbol.iterator]: (): void => {},
+  }
+}
+
+function bar(Symbol: {}, globalThis: {}) {
+  return {
+    [Symbol.iterator]: (): void => {},
+    [globalThis.Symbol.iterator]: (): void => {},
+  }
+}
+
+// Incorrect
+
+export namespace Foo {
+  const Symbol = {};
+  const globalThis = {};
+
+  export const foo = {
+    [Symbol.iterator]: (): void => {},
+    [globalThis.Symbol.iterator]: (): void => {},
+  }
+}
+
+export function bar(Symbol: {}, globalThis: {}) {
+  return {
+    [Symbol.iterator]: (): void => {},
+    [globalThis.Symbol.iterator]: (): void => {},
+  }
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/well-known-symbols.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/well-known-symbols.snap
@@ -1,0 +1,65 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/well-known-symbols.ts
+---
+```
+==================== .D.TS ====================
+
+export declare const foo: {
+	[Symbol.iterator]: () => void;
+	[Symbol.asyncIterator]: () => Promise<void>;
+	[globalThis.Symbol.iterator]: () => void;
+	[Symbol.toStringTag]: () => string;
+};
+export declare abstract class Foo {
+	[Symbol.iterator](): void;
+	[Symbol.asyncIterator](): Promise<void>;
+	[globalThis.Symbol.iterator](): void;
+	get [Symbol.toStringTag](): string;
+}
+export declare namespace Foo {
+	const foo: {};
+}
+export declare function bar(Symbol: {}, globalThis: {}): {};
+
+
+==================== Errors ====================
+
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[42:6]
+ 41 |   export const foo = {
+ 42 |     [Symbol.iterator]: (): void => {},
+    :      ^^^^^^^^^^^^^^^
+ 43 |     [globalThis.Symbol.iterator]: (): void => {},
+    `----
+
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[43:6]
+ 42 |     [Symbol.iterator]: (): void => {},
+ 43 |     [globalThis.Symbol.iterator]: (): void => {},
+    :      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 44 |   }
+    `----
+
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[49:6]
+ 48 |   return {
+ 49 |     [Symbol.iterator]: (): void => {},
+    :      ^^^^^^^^^^^^^^^
+ 50 |     [globalThis.Symbol.iterator]: (): void => {},
+    `----
+
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[50:6]
+ 49 |     [Symbol.iterator]: (): void => {},
+ 50 |     [globalThis.Symbol.iterator]: (): void => {},
+    :      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 51 |   }
+    `----
+
+
+```

--- a/tasks/coverage/snapshots/transpile.snap
+++ b/tasks/coverage/snapshots/transpile.snap
@@ -97,12 +97,16 @@ export interface B {
 	[Math.random() > 0.5 ? "f1" : "f2"]: number;
 }
 export declare class C {
+	[Symbol.iterator]: number;
+	[globalThis.Symbol.toStringTag]: number;
 	[1]: number;
 	["2"]: number;
 }
 export declare const D: {
-	1: number;
-	"2": number;
+	[Symbol.iterator]: number;
+	[globalThis.Symbol.toStringTag]: number;
+	[1]: number;
+	["2"]: number;
 };
 export {};
   x TS9010: Variable must have an explicit type annotation with
@@ -215,24 +219,6 @@ export {};
 
   x TS9038: Computed property names on class or object literals cannot be
   | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:39:6]
- 38 |     [presentNs.a]: number = 1;
- 39 |     [Symbol.iterator]: number = 1;
-    :      ^^^^^^^^^^^^^^^
- 40 |     [globalThis.Symbol.toStringTag]: number = 1;
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:40:6]
- 39 |     [Symbol.iterator]: number = 1;
- 40 |     [globalThis.Symbol.toStringTag]: number = 1;
-    :      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 41 |     [(globalThis.Symbol).unscopables]: number = 1;
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
     ,-[declarationComputedPropertyNames.d.ts:41:6]
  40 |     [globalThis.Symbol.toStringTag]: number = 1;
  41 |     [(globalThis.Symbol).unscopables]: number = 1;
@@ -292,24 +278,6 @@ export {};
  52 |     [presentNs.a]: 1,
     :      ^^^^^^^^^^^
  53 |     [Symbol.iterator]: 1,
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:53:6]
- 52 |     [presentNs.a]: 1,
- 53 |     [Symbol.iterator]: 1,
-    :      ^^^^^^^^^^^^^^^
- 54 |     [globalThis.Symbol.toStringTag]: 1,
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:54:6]
- 53 |     [Symbol.iterator]: 1,
- 54 |     [globalThis.Symbol.toStringTag]: 1,
-    :      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 55 |     [(globalThis.Symbol).unscopables]: 1,
     `----
 
   x TS9038: Computed property names on class or object literals cannot be


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/4016.

To fully comply with the reference behavior of the TypeScript compiler, we need to be able to detect the case when `Symbol` or `globalThis.Symbol` do not refer to the global `Symbol`. I achieve this by creating a similar structure to `ScopeTree` called `GlobalSymbolBindingTracker` (will take suggestions for a better name) and have it visit the entire program before we begin transformation. We can keep track of which computed properties reference non-global `Symbol` by storing a set of their spans, which should each be uniquely identifying since we're in the context of a single file.
Later, if and when we transform the computed property into a type declaration, we can refer back to this set to see if it should be allowed.


