### PR TITLE
fix(eslint/radix): detect yield Number.parseInt variant

### DIFF
--- a/crates/oxc_linter/src/snapshots/radix.snap
+++ b/crates/oxc_linter/src/snapshots/radix.snap
@@ -150,3 +150,9 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (Number?.parseInt)("10");
    · ────────────────────────
    ╰────
+
+  ⚠ eslint(radix): Missing parameters.
+   ╭─[radix.tsx:1:21]
+ 1 │ function *f(){ yield(Number).parseInt() }
+   ·                     ───────────────────
+   ╰────


### PR DESCRIPTION
The eslint rule perfer-numeric-literals has a test for the yield variant which the radix testsuite did not have. See https://github.com/oxc-project/oxc/pull/4109