### PR TITLE
feat(ast_codegen): add cli arguments to use with `oxc_ast_codegen` executable.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
 name = "oxc_ast_codegen"
 version = "0.0.0"
 dependencies = [
+ "bpaf",
  "convert_case",
  "itertools 0.13.0",
  "lazy_static",
@@ -1345,6 +1346,7 @@ dependencies = [
  "quote",
  "regex",
  "serde",
+ "serde_json",
  "syn",
 ]
 

--- a/tasks/ast_codegen/Cargo.toml
+++ b/tasks/ast_codegen/Cargo.toml
@@ -27,7 +27,9 @@ quote = { workspace = true }
 proc-macro2 = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 regex = { workspace = true }
 prettyplease = { workspace = true }
 lazy_static = { workspace = true }
 convert_case = { workspace = true }
+bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }

--- a/tasks/ast_codegen/src/util.rs
+++ b/tasks/ast_codegen/src/util.rs
@@ -220,3 +220,10 @@ impl TokenStreamExt for TokenStream {
             .collect()
     }
 }
+
+pub fn write_all_to<S: AsRef<str>>(data: &[u8], path: S) -> std::io::Result<()> {
+    use std::{fs, io::Write};
+    let mut file = fs::File::create(path.as_ref())?;
+    file.write_all(data)?;
+    Ok(())
+}


### PR DESCRIPTION
```
Usage: oxc_ast_codegen [--dry-run] [--no-fmt] [--schema=ARG]

Available options:
        --dry-run     Runs all generators but won't write anything down.
        --no-fmt      Don't run cargo fmt at the end
        --schema=ARG  Path of output `schema.json`.
    -h, --help        Prints help information
```