### PR TITLE
fix(linter): panic in `get_enclosing_function`

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -201,7 +201,7 @@ pub fn get_enclosing_function<'a, 'b>(
         {
             return Some(current_node);
         }
-        current_node = ctx.nodes().parent_node(current_node.id()).unwrap();
+        current_node = ctx.nodes().parent_node(current_node.id())?;
     }
 }
 


### PR DESCRIPTION
Fixes one of the panics described in #4111