### PR TITLE
refactor(ast/ast_builder)!: shorter allocator utility method names.

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -27,34 +27,34 @@ impl<'a> AstBuilder<'a> {
     }
 
     #[inline]
-    pub fn new_vec<T>(self) -> Vec<'a, T> {
+    pub fn vec<T>(self) -> Vec<'a, T> {
         Vec::new_in(self.allocator)
     }
 
     #[inline]
-    pub fn new_vec_with_capacity<T>(self, capacity: usize) -> Vec<'a, T> {
+    pub fn vec_with_capacity<T>(self, capacity: usize) -> Vec<'a, T> {
         Vec::with_capacity_in(capacity, self.allocator)
     }
 
     #[inline]
-    pub fn new_vec_single<T>(self, value: T) -> Vec<'a, T> {
-        let mut vec = self.new_vec_with_capacity(1);
+    pub fn vec1<T>(self, value: T) -> Vec<'a, T> {
+        let mut vec = self.vec_with_capacity(1);
         vec.push(value);
         vec
     }
 
     #[inline]
-    pub fn new_vec_from_iter<T, I: IntoIterator<Item = T>>(self, iter: I) -> Vec<'a, T> {
+    pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(self, iter: I) -> Vec<'a, T> {
         Vec::from_iter_in(iter, self.allocator)
     }
 
     #[inline]
-    pub fn new_str(self, value: &str) -> &'a str {
+    pub fn str(self, value: &str) -> &'a str {
         String::from_str_in(value, self.allocator).into_bump_str()
     }
 
     #[inline]
-    pub fn new_atom(self, value: &str) -> Atom<'a> {
+    pub fn atom(self, value: &str) -> Atom<'a> {
         Atom::from(String::from_str_in(value, self.allocator).into_bump_str())
     }
 
@@ -86,7 +86,7 @@ impl<'a> AstBuilder<'a> {
 
     #[inline]
     pub fn move_statement_vec(self, stmts: &mut Vec<'a, Statement<'a>>) -> Vec<'a, Statement<'a>> {
-        mem::replace(stmts, self.new_vec())
+        mem::replace(stmts, self.vec())
     }
 
     #[inline]
@@ -100,7 +100,7 @@ impl<'a> AstBuilder<'a> {
         let empty_decl = self.variable_declaration(
             Span::default(),
             VariableDeclarationKind::Var,
-            self.new_vec(),
+            self.vec(),
             false,
         );
         let empty_decl = Declaration::VariableDeclaration(self.alloc(empty_decl));
@@ -128,7 +128,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         pattern: BindingPattern<'a>,
     ) -> FormalParameter<'a> {
-        self.formal_parameter(span, pattern, None, false, false, self.new_vec())
+        self.formal_parameter(span, pattern, None, false, false, self.vec())
     }
 
     #[inline]
@@ -166,7 +166,7 @@ impl<'a> AstBuilder<'a> {
         self.alloc(self.export_named_declaration(
             span,
             Some(declaration),
-            self.new_vec(),
+            self.vec(),
             None,
             ImportOrExportKind::Value,
             None,

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -90,7 +90,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.ast.class_element_property_definition(
             property.r#type,
             property.span,
-            self.ast.new_vec(),
+            self.ast.vec(),
             self.ast.copy(&property.key),
             value,
             property.computed,
@@ -130,7 +130,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.ast.class_element_method_definition(
             definition.r#type,
             definition.span,
-            self.ast.new_vec(),
+            self.ast.vec(),
             self.ast.copy(&definition.key),
             value,
             definition.kind,
@@ -153,7 +153,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.ast.class_element_property_definition(
             r#type,
             SPAN,
-            self.ast.new_vec(),
+            self.ast.vec(),
             key,
             None,
             false,
@@ -181,7 +181,7 @@ impl<'a> IsolatedDeclarations<'a> {
         Some(self.ast.class_element_property_definition(
             PropertyDefinitionType::PropertyDefinition,
             param.span,
-            self.ast.new_vec(),
+            self.ast.vec(),
             key,
             None,
             false,
@@ -219,7 +219,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 let params = self.ast.alloc_formal_parameters(
                     SPAN,
                     FormalParameterKind::Signature,
-                    self.ast.new_vec(),
+                    self.ast.vec(),
                     Option::<BindingRestElement>::None,
                 );
                 self.transform_class_method_definition(method, params, None)
@@ -239,7 +239,7 @@ impl<'a> IsolatedDeclarations<'a> {
         function: &Function<'a>,
         params: &FormalParameters<'a>,
     ) -> oxc_allocator::Vec<'a, ClassElement<'a>> {
-        let mut elements = self.ast.new_vec();
+        let mut elements = self.ast.vec();
         for (index, param) in function.params.items.iter().enumerate() {
             if param.accessibility.is_some() || param.readonly {
                 let type_annotation = if param.accessibility.is_some_and(|a| a.is_private()) {
@@ -278,7 +278,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 let Some(name) = method.key.static_name() else {
                     continue;
                 };
-                let name = self.ast.new_atom(&name);
+                let name = self.ast.atom(&name);
                 if inferred_accessor_types.contains_key(&name) {
                     // We've inferred that accessor type already
                     continue;
@@ -337,7 +337,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         let mut has_private_key = false;
-        let mut elements = self.ast.new_vec();
+        let mut elements = self.ast.vec();
         let mut is_function_overloads = false;
         for element in &decl.body.body {
             match element {
@@ -373,7 +373,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 self.transform_set_accessor_params(
                                     &function.params,
                                     inferred_accessor_types
-                                        .get(&self.ast.new_atom(&n))
+                                        .get(&self.ast.atom(&n))
                                         .map(|t| self.ast.copy(t)),
                                 )
                             },
@@ -403,7 +403,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         MethodDefinitionKind::Get => {
                             let rt = method.key.static_name().and_then(|name| {
                                 inferred_accessor_types
-                                    .get(&self.ast.new_atom(&name))
+                                    .get(&self.ast.atom(&name))
                                     .map(|t| self.ast.copy(t))
                             });
                             if rt.is_none() {
@@ -448,7 +448,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         None,
                         property.computed,
                         property.r#static,
-                        self.ast.new_vec(),
+                        self.ast.vec(),
                     );
                     elements.push(new_element);
                 }
@@ -462,7 +462,7 @@ impl<'a> IsolatedDeclarations<'a> {
             // Prevents other classes with the same public members from being used in place of the current class
             let ident = self.ast.property_key_private_identifier(SPAN, "private");
             let r#type = PropertyDefinitionType::PropertyDefinition;
-            let decorators = self.ast.new_vec();
+            let decorators = self.ast.vec();
             let element = self.ast.class_element_property_definition(
                 r#type,
                 SPAN,
@@ -488,7 +488,7 @@ impl<'a> IsolatedDeclarations<'a> {
         Some(self.ast.alloc_class(
             decl.r#type,
             decl.span,
-            self.ast.new_vec(),
+            self.ast.vec(),
             self.ast.copy(&decl.id),
             self.ast.copy(&decl.super_class),
             body,
@@ -525,8 +525,8 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Box<'a, FormalParameters<'a>> {
         let pattern = BindingPattern { kind, type_annotation, optional: false };
         let parameter =
-            self.ast.formal_parameter(SPAN, pattern, None, false, false, self.ast.new_vec());
-        let items = self.ast.new_vec_single(parameter);
+            self.ast.formal_parameter(SPAN, pattern, None, false, false, self.ast.vec());
+        let items = self.ast.vec1(parameter);
         self.ast.alloc_formal_parameters(
             SPAN,
             FormalParameterKind::Signature,

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -23,7 +23,7 @@ impl<'a> IsolatedDeclarations<'a> {
             None
         } else {
             let declarations =
-                self.ast.new_vec_from_iter(decl.declarations.iter().filter_map(|declarator| {
+                self.ast.vec_from_iter(decl.declarations.iter().filter_map(|declarator| {
                     self.transform_variable_declarator(declarator, check_binding)
                 }));
             Some(self.transform_variable_declaration_with_new_declarations(decl, declarations))
@@ -38,7 +38,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.ast.alloc_variable_declaration(
             decl.span,
             decl.kind,
-            self.ast.new_vec_from_iter(declarations),
+            self.ast.vec_from_iter(declarations),
             self.is_declare(),
         )
     }
@@ -111,7 +111,7 @@ impl<'a> IsolatedDeclarations<'a> {
         check_binding: bool,
     ) -> Box<'a, VariableDeclaration<'a>> {
         let declarations =
-            self.ast.new_vec_from_iter(decl.declarations.iter().filter_map(|declarator| {
+            self.ast.vec_from_iter(decl.declarations.iter().filter_map(|declarator| {
                 self.transform_variable_declarator(declarator, check_binding)
             }));
         self.transform_using_declaration_with_new_declarations(decl, declarations)
@@ -138,7 +138,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.scope.enter_scope(ScopeFlags::TsModuleBlock);
         let stmts = self.transform_statements_on_demand(&block.body);
         self.scope.leave_scope();
-        self.ast.alloc_ts_module_block(SPAN, self.ast.new_vec(), stmts)
+        self.ast.alloc_ts_module_block(SPAN, self.ast.vec(), stmts)
     }
 
     pub fn transform_ts_module_declaration(

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -20,7 +20,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &mut self,
         decl: &TSEnumDeclaration<'a>,
     ) -> Option<Declaration<'a>> {
-        let mut members = self.ast.new_vec();
+        let mut members = self.ast.vec();
         let mut prev_initializer_value = Some(ConstantValue::Number(-1.0));
         let mut prev_members = FxHashMap::default();
         for member in &decl.members {
@@ -63,10 +63,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
                         // Infinity
                         let expr = if v.is_infinite() {
-                            self.ast.expression_identifier_reference(
-                                SPAN,
-                                self.ast.new_atom("Infinity"),
-                            )
+                            self.ast.expression_identifier_reference(SPAN, "Infinity")
                         } else {
                             let value = if is_negative { -v } else { v };
                             self.ast.expression_numeric_literal(

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -93,7 +93,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 SPAN,
                                 self.ast.ts_type_union_type(
                                     SPAN,
-                                    self.ast.new_vec_from_iter([
+                                    self.ast.vec_from_iter([
                                         ts_type,
                                         self.ast.ts_type_undefined_keyword(SPAN),
                                     ]),
@@ -113,7 +113,7 @@ impl<'a> IsolatedDeclarations<'a> {
             );
         }
 
-        Some(self.ast.formal_parameter(param.span, pattern, None, false, false, self.ast.new_vec()))
+        Some(self.ast.formal_parameter(param.span, pattern, None, false, false, self.ast.vec()))
     }
 
     pub fn transform_formal_parameters(
@@ -124,15 +124,14 @@ impl<'a> IsolatedDeclarations<'a> {
             return self.ast.alloc(self.ast.copy(params));
         }
 
-        let items = self.ast.new_vec_from_iter(params.items.iter().enumerate().filter_map(
-            |(index, item)| {
+        let items =
+            self.ast.vec_from_iter(params.items.iter().enumerate().filter_map(|(index, item)| {
                 let is_remaining_params_have_required =
                     params.items.iter().skip(index).any(|item| {
                         !(item.pattern.optional || item.pattern.kind.is_assignment_pattern())
                     });
                 self.transform_formal_parameter(item, is_remaining_params_have_required)
-            },
-        ));
+            }));
 
         if let Some(rest) = &params.rest {
             if rest.argument.type_annotation.is_none() {

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -56,7 +56,7 @@ impl<'a> IsolatedDeclarations<'a> {
     /// Returns `Vec<Error>` if any errors were collected during the transformation.
     pub fn build(mut self, program: &Program<'a>) -> IsolatedDeclarationsReturn<'a> {
         let source_type = SourceType::default().with_module(true).with_typescript_definition(true);
-        let directives = self.ast.new_vec();
+        let directives = self.ast.vec();
         let stmts = self.transform_program(program);
         let program = self.ast.program(SPAN, source_type, directives, None, stmts);
         IsolatedDeclarationsReturn { program, errors: self.take_errors() }
@@ -98,7 +98,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &mut self,
         stmts: &oxc_allocator::Vec<'a, Statement<'a>>,
     ) -> oxc_allocator::Vec<'a, Statement<'a>> {
-        let mut new_ast_stmts = self.ast.new_vec::<Statement<'a>>();
+        let mut new_ast_stmts = self.ast.vec::<Statement<'a>>();
         for stmt in Self::remove_function_overloads_implementation(self.ast.copy(stmts)) {
             if let Some(decl) = stmt.as_declaration() {
                 if let Some(decl) = self.transform_declaration(decl, false) {
@@ -256,7 +256,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         // 6. Transform variable/using declarations, import statements, remove unused imports
         // 7. Return transformed statements
-        let mut new_ast_stmts = self.ast.new_vec_with_capacity(transformed_indexes.len());
+        let mut new_ast_stmts = self.ast.vec_with_capacity(transformed_indexes.len());
         for (index, stmt) in new_stmts.into_iter().enumerate() {
             match stmt {
                 _ if transformed_indexes.contains(&index) => {
@@ -272,7 +272,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         let variables_declaration = self
                             .transform_variable_declaration_with_new_declarations(
                                 &decl,
-                                self.ast.new_vec_from_iter(
+                                self.ast.vec_from_iter(
                                     declarations
                                         .into_iter()
                                         .enumerate()
@@ -294,7 +294,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         let variable_declaration = self
                             .transform_using_declaration_with_new_declarations(
                                 &decl,
-                                self.ast.new_vec_from_iter(
+                                self.ast.vec_from_iter(
                                     declarations
                                         .into_iter()
                                         .enumerate()
@@ -323,7 +323,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         if need_empty_export_marker {
-            let specifiers = self.ast.new_vec();
+            let specifiers = self.ast.vec();
             let kind = ImportOrExportKind::Value;
             let empty_export =
                 self.ast.alloc_export_named_declaration(SPAN, None, specifiers, None, kind, None);

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -15,7 +15,7 @@ impl<'a> IsolatedDeclarations<'a> {
         Some(ExportNamedDeclaration {
             span: decl.span(),
             declaration: Some(decl),
-            specifiers: self.ast.new_vec(),
+            specifiers: self.ast.vec(),
             source: None,
             export_kind: ImportOrExportKind::Value,
             with_clause: None,
@@ -23,10 +23,10 @@ impl<'a> IsolatedDeclarations<'a> {
     }
 
     pub fn create_unique_name(&mut self, name: &str) -> Atom<'a> {
-        let mut binding = self.ast.new_atom(name);
+        let mut binding = self.ast.atom(name);
         let mut i = 1;
         while self.scope.has_reference(&binding) {
-            binding = self.ast.new_atom(format!("{name}_{i}").as_str());
+            binding = self.ast.atom(format!("{name}_{i}").as_str());
             i += 1;
         }
         binding
@@ -64,9 +64,8 @@ impl<'a> IsolatedDeclarations<'a> {
                     }
 
                     let id = self.ast.binding_pattern(id, type_annotation, false);
-                    let declarations = self
-                        .ast
-                        .new_vec_single(self.ast.variable_declarator(SPAN, kind, id, None, true));
+                    let declarations =
+                        self.ast.vec1(self.ast.variable_declarator(SPAN, kind, id, None, true));
 
                     Some((
                         Some(VariableDeclaration {
@@ -84,10 +83,8 @@ impl<'a> IsolatedDeclarations<'a> {
         };
 
         declaration.map(|(var_decl, declaration)| {
-            let exported = ModuleExportName::IdentifierName(IdentifierName::new(
-                SPAN,
-                self.ast.new_atom("default"),
-            ));
+            let exported =
+                ModuleExportName::IdentifierName(self.ast.identifier_name(SPAN, "default"));
             (var_decl, ExportDefaultDeclaration { span: decl.span, declaration, exported })
         })
     }

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -106,7 +106,7 @@ impl<'a> FunctionReturnType<'a> {
         if visitor.return_statement_count > 1 {
             let types = transformer
                 .ast
-                .new_vec_from_iter([expr_type, transformer.ast.ts_type_undefined_keyword(SPAN)]);
+                .vec_from_iter([expr_type, transformer.ast.ts_type_undefined_keyword(SPAN)]);
             expr_type = transformer.ast.ts_type_union_type(SPAN, types);
         }
         Some(expr_type)

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -38,8 +38,7 @@ pub struct ScopeTree<'a> {
 impl<'a> ScopeTree<'a> {
     pub fn new(allocator: &'a Allocator) -> Self {
         let ast = AstBuilder::new(allocator);
-        let mut levels = ast.new_vec_with_capacity(1);
-        levels.push(Scope::new(ScopeFlags::Top));
+        let levels = ast.vec1(Scope::new(ScopeFlags::Top));
         Self { levels }
     }
 

--- a/crates/oxc_minifier/src/compressor/mod.rs
+++ b/crates/oxc_minifier/src/compressor/mod.rs
@@ -125,7 +125,7 @@ impl<'a> Compressor<'a> {
         }
 
         // Reconstruct the stmts array by joining consecutive ranges
-        let mut new_stmts = self.ast.new_vec_with_capacity(stmts.len() - capacity);
+        let mut new_stmts = self.ast.vec_with_capacity(stmts.len() - capacity);
         for (i, stmt) in stmts.drain(..).enumerate() {
             if i > 0 && ranges.iter().any(|range| range.contains(&(i - 1)) && range.contains(&i)) {
                 if let Statement::VariableDeclaration(prev_decl) = new_stmts.last_mut().unwrap() {

--- a/crates/oxc_minifier/src/folder/mod.rs
+++ b/crates/oxc_minifier/src/folder/mod.rs
@@ -698,7 +698,7 @@ impl<'a> Folder<'a> {
             // or: false_with_sideeffects && foo() => false_with_sideeffects, foo()
             let left = self.move_out_expression(&mut logic_expr.left);
             let right = self.move_out_expression(&mut logic_expr.right);
-            let mut vec = self.ast.new_vec_with_capacity(2);
+            let mut vec = self.ast.vec_with_capacity(2);
             vec.push(left);
             vec.push(right);
             let sequence_expr = self.ast.expression_sequence(logic_expr.span, vec);

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -333,7 +333,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn consume_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
         let decorators = std::mem::take(&mut self.state.decorators);
-        self.ast.new_vec_from_iter(decorators)
+        self.ast.vec_from_iter(decorators)
     }
 
     pub(crate) fn parse_normal_list<F, T>(
@@ -346,7 +346,7 @@ impl<'a> ParserImpl<'a> {
         F: Fn(&mut Self) -> Result<Option<T>>,
     {
         self.expect(open)?;
-        let mut list = self.ast.new_vec();
+        let mut list = self.ast.vec();
         loop {
             let kind = self.cur_kind();
             if kind == close || kind == Kind::Eof {
@@ -372,7 +372,7 @@ impl<'a> ParserImpl<'a> {
     where
         F: Fn(&mut Self) -> Result<T>,
     {
-        let mut list = self.ast.new_vec();
+        let mut list = self.ast.vec();
         let mut first = true;
         loop {
             let kind = self.cur_kind();
@@ -406,7 +406,7 @@ impl<'a> ParserImpl<'a> {
         R: Fn(&mut Self) -> Result<B>,
         B: GetSpan,
     {
-        let mut list = self.ast.new_vec();
+        let mut list = self.ast.vec();
         let mut rest = None;
         let mut first = true;
         loop {

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -223,7 +223,7 @@ impl<'a> ParserImpl<'a> {
             self.ast.alloc_formal_parameters(
                 params_span,
                 FormalParameterKind::ArrowFormalParameters,
-                self.ast.new_vec_single(formal_parameter),
+                self.ast.vec1(formal_parameter),
                 Option::<BindingRestElement>::None,
             )
         };
@@ -293,11 +293,7 @@ impl<'a> ParserImpl<'a> {
             let expr = self.parse_assignment_expression_or_higher()?;
             let span = expr.span();
             let expr_stmt = self.ast.statement_expression(span, expr);
-            self.ast.alloc_function_body(
-                span,
-                self.ast.new_vec(),
-                self.ast.new_vec_single(expr_stmt),
-            )
+            self.ast.alloc_function_body(span, self.ast.vec(), self.ast.vec1(expr_stmt))
         } else {
             self.parse_function_body()?
         };

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -134,7 +134,7 @@ impl<'a> ParserImpl<'a> {
     /// extends `LeftHandSideExpression`[?Yield, ?Await]
     fn parse_extends_clause(&mut self) -> Result<Extends<'a>> {
         self.bump_any(); // bump `extends`
-        let mut extends = self.ast.new_vec();
+        let mut extends = self.ast.vec();
 
         let span = self.start_span();
         let mut first_extends = self.parse_lhs_expression_or_higher()?;

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -56,7 +56,7 @@ impl<'a> ParserImpl<'a> {
         };
         self.bump_any();
 
-        let mut declarations = self.ast.new_vec();
+        let mut declarations = self.ast.vec();
         loop {
             let declaration = self.parse_variable_declarator(decl_ctx, kind)?;
             declarations.push(declaration);
@@ -162,7 +162,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
-        let mut declarations: oxc_allocator::Vec<'_, VariableDeclarator<'_>> = self.ast.new_vec();
+        let mut declarations: oxc_allocator::Vec<'_, VariableDeclarator<'_>> = self.ast.vec();
         loop {
             let declaration = self.parse_variable_declarator(
                 VariableDeclarationContext::new(VariableDeclarationParent::Statement),

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -349,7 +349,7 @@ impl<'a> ParserImpl<'a> {
         self.ast.reg_exp_literal(
             self.end_span(span),
             EmptyObject,
-            RegExp { pattern: self.ast.new_atom(pattern), flags },
+            RegExp { pattern: self.ast.atom(pattern), flags },
         )
     }
 
@@ -409,8 +409,8 @@ impl<'a> ParserImpl<'a> {
     ///     `SubstitutionTemplate`[?Yield, ?Await, ?Tagged]
     fn parse_template_literal(&mut self, tagged: bool) -> Result<TemplateLiteral<'a>> {
         let span = self.start_span();
-        let mut expressions = self.ast.new_vec();
-        let mut quasis = self.ast.new_vec();
+        let mut expressions = self.ast.vec();
+        let mut quasis = self.ast.vec();
         match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
                 quasis.push(self.parse_template_element(tagged));
@@ -490,7 +490,7 @@ impl<'a> ParserImpl<'a> {
         let cur_src = self.cur_src();
         let raw = &cur_src[1..cur_src.len() - end_offset as usize];
         let raw = Atom::from(if cooked.is_some() && raw.contains('\r') {
-            self.ast.new_str(raw.replace("\r\n", "\n").replace('\r', "\n").as_str())
+            self.ast.str(raw.replace("\r\n", "\n").replace('\r', "\n").as_str())
         } else {
             raw
         });
@@ -506,11 +506,11 @@ impl<'a> ParserImpl<'a> {
         }
 
         let tail = matches!(cur_kind, Kind::TemplateTail | Kind::NoSubstitutionTemplate);
-        TemplateElement {
+        self.ast.template_element(
             span,
             tail,
-            value: TemplateElementValue { raw, cooked: cooked.map(Atom::from) },
-        }
+            TemplateElementValue { raw, cooked: cooked.map(Atom::from) },
+        )
     }
 
     /// Section 13.3 Meta Property
@@ -727,7 +727,7 @@ impl<'a> ParserImpl<'a> {
             self.expect(Kind::RParen)?;
             call_arguments
         } else {
-            self.ast.new_vec()
+            self.ast.vec()
         };
 
         if matches!(callee, Expression::ImportExpression(_)) {
@@ -1071,7 +1071,7 @@ impl<'a> ParserImpl<'a> {
         span: Span,
         first_expression: Expression<'a>,
     ) -> Result<Expression<'a>> {
-        let mut expressions = self.ast.new_vec_single(first_expression);
+        let mut expressions = self.ast.vec1(first_expression);
         while self.eat(Kind::Comma) {
             let expression = self.parse_assignment_expression_or_higher()?;
             expressions.push(expression);

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -66,7 +66,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
 
 impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
     fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
-        let mut elements = p.ast.new_vec();
+        let mut elements = p.ast.vec();
         let mut rest = None;
 
         let len = expr.elements.len();
@@ -126,7 +126,7 @@ impl<'a> CoverGrammar<'a, AssignmentExpression<'a>> for AssignmentTargetWithDefa
 
 impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
-        let mut properties = p.ast.new_vec();
+        let mut properties = p.ast.vec();
         let mut rest = None;
 
         let len = expr.properties.len();

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -17,7 +17,7 @@ impl<'a> ParserImpl<'a> {
         self.ctx = self.ctx.and_in(true);
 
         let expression = self.parse_assignment_expression_or_higher()?;
-        let mut arguments = self.ast.new_vec();
+        let mut arguments = self.ast.vec();
         if self.eat(Kind::Comma) && !self.at(Kind::RParen) {
             arguments.push(self.parse_assignment_expression_or_higher()?);
         }
@@ -74,7 +74,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_import_declaration_specifiers(
         &mut self,
     ) -> Result<Vec<'a, ImportDeclarationSpecifier<'a>>> {
-        let mut specifiers = self.ast.new_vec();
+        let mut specifiers = self.ast.vec();
         // import defaultExport from "module-name";
         if self.cur_kind().is_binding_identifier() {
             specifiers.push(self.parse_import_default_specifier()?);
@@ -344,7 +344,7 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.alloc_export_named_declaration(
             span,
             Some(declaration),
-            self.ast.new_vec(),
+            self.ast.vec(),
             None,
             ImportOrExportKind::Value,
             None,

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -32,8 +32,8 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         is_top_level: bool,
     ) -> Result<(Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>)> {
-        let mut directives = self.ast.new_vec();
-        let mut statements = self.ast.new_vec();
+        let mut directives = self.ast.vec();
+        let mut statements = self.ast.vec();
 
         let mut expecting_directives = true;
         while !self.at(Kind::Eof) {
@@ -137,7 +137,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_block(&mut self) -> Result<Box<'a, BlockStatement<'a>>> {
         let span = self.start_span();
         self.expect(Kind::LCurly)?;
-        let mut body = self.ast.new_vec();
+        let mut body = self.ast.vec();
         while !self.at(Kind::RCurly) && !self.at(Kind::Eof) {
             let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
             body.push(stmt);
@@ -457,7 +457,7 @@ impl<'a> ParserImpl<'a> {
             _ => return Err(self.unexpected()),
         };
         self.expect(Kind::Colon)?;
-        let mut consequent = self.ast.new_vec();
+        let mut consequent = self.ast.vec();
         while !matches!(self.cur_kind(), Kind::Case | Kind::Default | Kind::RCurly | Kind::Eof) {
             let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
             consequent.push(stmt);

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -62,11 +62,8 @@ impl<'a> ParserImpl<'a> {
     fn parse_jsx_element(&mut self, in_jsx_child: bool) -> Result<Box<'a, JSXElement<'a>>> {
         let span = self.start_span();
         let opening_element = self.parse_jsx_opening_element(span, in_jsx_child)?;
-        let children = if opening_element.self_closing {
-            self.ast.new_vec()
-        } else {
-            self.parse_jsx_children()?
-        };
+        let children =
+            if opening_element.self_closing { self.ast.vec() } else { self.parse_jsx_children()? };
         let closing_element = if opening_element.self_closing {
             None
         } else {
@@ -194,7 +191,7 @@ impl<'a> ParserImpl<'a> {
     /// `JSXChildren` :
     ///   `JSXChild` `JSXChildren_opt`
     fn parse_jsx_children(&mut self) -> Result<Vec<'a, JSXChild<'a>>> {
-        let mut children = self.ast.new_vec();
+        let mut children = self.ast.vec();
         while !self.at(Kind::Eof) {
             if let Some(child) = self.parse_jsx_child()? {
                 children.push(child);
@@ -295,7 +292,7 @@ impl<'a> ParserImpl<'a> {
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
     fn parse_jsx_attributes(&mut self) -> Result<Vec<'a, JSXAttributeItem<'a>>> {
-        let mut attributes = self.ast.new_vec();
+        let mut attributes = self.ast.vec();
         while !matches!(self.cur_kind(), Kind::Eof | Kind::LAngle | Kind::RAngle | Kind::Slash) {
             let attribute = match self.cur_kind() {
                 Kind::LCurly => {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -328,9 +328,9 @@ impl<'a> ParserImpl<'a> {
                 let program = self.ast.program(
                     Span::default(),
                     self.source_type,
-                    self.ast.new_vec(),
+                    self.ast.vec(),
                     None,
-                    self.ast.new_vec(),
+                    self.ast.vec(),
                 );
                 (program, true)
             }

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -296,7 +296,7 @@ impl std::fmt::Display for ModifierKind {
 impl<'a> ParserImpl<'a> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Result<Modifiers<'a>> {
         let mut flags = ModifierFlags::empty();
-        let mut modifiers = self.ast.new_vec();
+        let mut modifiers = self.ast.vec();
         while self.at_modifier() {
             let span = self.start_span();
             let modifier_flag = self.cur_kind().into();
@@ -360,7 +360,7 @@ impl<'a> ParserImpl<'a> {
         let mut has_leading_modifier = false;
         let mut has_trailing_decorator = false;
 
-        let mut modifiers = self.ast.new_vec();
+        let mut modifiers = self.ast.vec();
         let mut modifier_flags = ModifierFlags::empty();
 
         // parse leading decorators

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -159,7 +159,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_ts_implements_clause(&mut self) -> Result<Vec<'a, TSClassImplements<'a>>> {
         self.expect(Kind::Implements)?;
         let first = self.parse_ts_implement_name()?;
-        let mut implements = self.ast.new_vec();
+        let mut implements = self.ast.vec();
         implements.push(first);
 
         while self.eat(Kind::Comma) {
@@ -219,7 +219,7 @@ impl<'a> ParserImpl<'a> {
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
         let mut ty = parse_constituent_type(self)?;
         if self.at(kind) || has_leading_operator {
-            let mut types = self.ast.new_vec_single(ty);
+            let mut types = self.ast.vec1(ty);
             while self.eat(kind) {
                 types.push(
                     /*parseFunctionOrConstructorTypeToError(isUnionType) || */
@@ -685,8 +685,8 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_template_type(&mut self, tagged: bool) -> Result<TSType<'a>> {
         let span = self.start_span();
-        let mut types = self.ast.new_vec();
-        let mut quasis = self.ast.new_vec();
+        let mut types = self.ast.vec();
+        let mut quasis = self.ast.vec();
         match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
                 quasis.push(self.parse_template_element(tagged));
@@ -1288,7 +1288,7 @@ impl<'a> ParserImpl<'a> {
 
         self.bump(Kind::LBrack);
         let index_name = self.parse_ts_index_signature_name()?;
-        let mut parameters = self.ast.new_vec();
+        let mut parameters = self.ast.vec();
         parameters.push(index_name);
         self.expect(Kind::RBrack)?;
 
@@ -1332,7 +1332,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         let mut flags = ModifierFlags::empty();
-        let mut modifiers: Vec<Modifier> = self.ast.new_vec();
+        let mut modifiers: Vec<Modifier> = self.ast.vec();
 
         loop {
             if !self.is_nth_at_modifier(0, is_constructor_parameter) {

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -132,7 +132,7 @@ impl<'a> ArrowFunctions<'a> {
             let stmt = self.ctx.ast.alloc_variable_declaration(
                 SPAN,
                 VariableDeclarationKind::Var,
-                self.ctx.ast.new_vec_single(variable_declarator),
+                self.ctx.ast.vec1(variable_declarator),
                 false,
             );
 

--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -25,7 +25,7 @@ impl<'a> BoundIdentifier<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Self {
         let symbol_id = ctx.generate_uid(name, scope_id, flags);
-        let name = ctx.ast.new_atom(&ctx.symbols().names[symbol_id]);
+        let name = ctx.ast.atom(&ctx.symbols().names[symbol_id]);
         Self { name, symbol_id }
     }
 

--- a/crates/oxc_transformer/src/helpers/module_imports.rs
+++ b/crates/oxc_transformer/src/helpers/module_imports.rs
@@ -73,12 +73,12 @@ impl<'a> ModuleImports<'a> {
     }
 
     pub fn get_import_statements(&self) -> Vec<'a, Statement<'a>> {
-        self.ast.new_vec_from_iter(self.imports.borrow_mut().drain(..).map(
-            |(import_type, names)| match import_type.kind {
+        self.ast.vec_from_iter(self.imports.borrow_mut().drain(..).map(|(import_type, names)| {
+            match import_type.kind {
                 ImportKind::Import => self.get_named_import(import_type.source, names),
                 ImportKind::Require => self.get_require(import_type.source, names),
-            },
-        ))
+            }
+        }))
     }
 
     fn get_named_import(
@@ -86,7 +86,7 @@ impl<'a> ModuleImports<'a> {
         source: Atom<'a>,
         names: std::vec::Vec<NamedImport<'a>>,
     ) -> Statement<'a> {
-        let specifiers = self.ast.new_vec_from_iter(names.into_iter().map(|name| {
+        let specifiers = self.ast.vec_from_iter(names.into_iter().map(|name| {
             let local = name.local.unwrap_or_else(|| name.imported.clone());
             ImportDeclarationSpecifier::ImportSpecifier(self.ast.alloc(ImportSpecifier {
                 span: SPAN,
@@ -121,7 +121,7 @@ impl<'a> ModuleImports<'a> {
         let callee = self.ast.expression_identifier_reference(SPAN, Atom::from("require"));
         let args = {
             let arg = Argument::from(self.ast.expression_string_literal(SPAN, source));
-            self.ast.new_vec_single(arg)
+            self.ast.vec1(arg)
         };
         let name = names.into_iter().next().unwrap();
         let id = {
@@ -145,7 +145,7 @@ impl<'a> ModuleImports<'a> {
                 false,
             );
             let decl = self.ast.variable_declarator(SPAN, var_kind, id, Some(init), false);
-            self.ast.new_vec_single(decl)
+            self.ast.vec1(decl)
         };
         let var_decl = self.ast.declaration_variable(SPAN, var_kind, decl, false);
         self.ast.statement_declaration(var_decl)

--- a/crates/oxc_transformer/src/react/display_name.rs
+++ b/crates/oxc_transformer/src/react/display_name.rs
@@ -67,7 +67,7 @@ impl<'a> ReactDisplayName<'a> {
                     // whereas we also handle e.g. `{"foo-bar": React.createClass({})}`,
                     // so we diverge from Babel here, but that's probably an improvement
                     if let Some(name) = prop.key().static_name() {
-                        FinderRet::Found(ctx.ast.new_atom(&name))
+                        FinderRet::Found(ctx.ast.atom(&name))
                     } else {
                         FinderRet::Stop
                     }
@@ -75,7 +75,7 @@ impl<'a> ReactDisplayName<'a> {
                 // `export default React.createClass({})`
                 // Uses the current file name as the display name.
                 Ancestor::ExportDefaultDeclarationDeclaration(_) => {
-                    FinderRet::Found(ctx.ast.new_atom(&self.ctx.filename))
+                    FinderRet::Found(ctx.ast.atom(&self.ctx.filename))
                 }
                 // Stop crawling up when hit a statement
                 _ if ancestor.is_via_statement() => FinderRet::Stop,

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -118,7 +118,7 @@ impl<'a> AutomaticScriptBindings<'a> {
     ) -> BoundIdentifier<'a> {
         let symbol_id =
             ctx.generate_uid_in_root_scope(variable_name, SymbolFlags::FunctionScopedVariable);
-        let variable_name = ctx.ast.new_atom(&ctx.symbols().names[symbol_id]);
+        let variable_name = ctx.ast.atom(&ctx.symbols().names[symbol_id]);
 
         let import = NamedImport::new(variable_name.clone(), None, symbol_id);
         self.ctx.module_imports.add_require(source, import, front);
@@ -219,7 +219,7 @@ impl<'a> AutomaticModuleBindings<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let symbol_id = ctx.generate_uid_in_root_scope(name, SymbolFlags::FunctionScopedVariable);
-        let local = ctx.ast.new_atom(&ctx.symbols().names[symbol_id]);
+        let local = ctx.ast.atom(&ctx.symbols().names[symbol_id]);
 
         let import = NamedImport::new(Atom::from(name), Some(local.clone()), symbol_id);
         self.ctx.module_imports.add_import(source, import);
@@ -260,12 +260,12 @@ impl<'a> Pragma<'a> {
                     if property_name.is_empty() || parts.next().is_some() {
                         return Self::invalid(default_property_name, ctx);
                     }
-                    Some(ctx.ast.new_atom(property_name))
+                    Some(ctx.ast.atom(property_name))
                 }
                 None => None,
             };
 
-            let object = ctx.ast.new_atom(object_name);
+            let object = ctx.ast.atom(object_name);
             Self { object, property }
         } else {
             Self::default(default_property_name)
@@ -321,7 +321,7 @@ impl<'a> ReactJsx<'a> {
                             }
                             Ok(source_len) => source_len,
                         };
-                        let jsx_runtime_importer = ctx.ast.new_atom(&format!(
+                        let jsx_runtime_importer = ctx.ast.atom(&format!(
                             "{}/jsx-{}runtime",
                             import_source,
                             if is_development { "dev-" } else { "" }
@@ -497,13 +497,13 @@ impl<'a> ReactJsx<'a> {
         let is_automatic = !is_classic;
         let is_development = self.options.development;
 
-        let mut arguments = self.ast().new_vec();
+        let mut arguments = self.ast().vec();
 
         // The key prop in `<div key={true} />`
         let mut key_prop = None;
 
         // The object properties for the second argument of `React.createElement`
-        let mut properties = self.ast().new_vec();
+        let mut properties = self.ast().vec();
 
         let mut self_attr_span = None;
         let mut source_attr_span = None;
@@ -713,8 +713,7 @@ impl<'a> ReactJsx<'a> {
                 if self.options.throw_if_namespace {
                     self.ctx.error(diagnostics::namespace_does_not_support(namespaced.span));
                 }
-                let name = self.ast().new_atom(&namespaced.to_string());
-                self.ast().expression_string_literal(namespaced.span, name)
+                self.ast().expression_string_literal(namespaced.span, namespaced.to_string())
             }
         }
     }
@@ -884,7 +883,7 @@ impl<'a> ReactJsx<'a> {
                 }
             }
             JSXAttributeName::NamespacedName(namespaced) => {
-                let name = self.ast().new_atom(&namespaced.to_string());
+                let name = self.ast().atom(&namespaced.to_string());
                 let expr = self.ast().expression_string_literal(namespaced.span, name);
                 self.ast().property_key_expression(expr)
             }

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -139,7 +139,7 @@ impl<'a> ReactJsxSource<'a> {
             )
         };
 
-        let mut properties = self.ctx.ast.new_vec_with_capacity(3);
+        let mut properties = self.ctx.ast.vec_with_capacity(3);
         properties.push(filename);
         properties.push(line_number);
         properties.push(column_number);
@@ -161,7 +161,7 @@ impl<'a> ReactJsxSource<'a> {
                 .ast
                 .expression_string_literal(SPAN, self.ctx.source_path.to_string_lossy());
             let decl = self.ctx.ast.variable_declarator(SPAN, var_kind, id, Some(init), false);
-            self.ctx.ast.new_vec_single(decl)
+            self.ctx.ast.vec1(decl)
         };
         let var_decl = self.ctx.ast.alloc_variable_declaration(SPAN, var_kind, decl, false);
         Some(Statement::VariableDeclaration(var_decl))

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -145,7 +145,7 @@ impl<'a> TypeScriptAnnotations<'a> {
         // still considered a module
         if no_modules_remaining && some_modules_deleted {
             let export_decl = ModuleDeclaration::ExportNamedDeclaration(
-                self.ctx.ast.plain_export_named_declaration(SPAN, self.ctx.ast.new_vec(), None),
+                self.ctx.ast.plain_export_named_declaration(SPAN, self.ctx.ast.vec(), None),
             );
             program.body.push(self.ctx.ast.statement_module_declaration(export_decl));
         }
@@ -278,8 +278,8 @@ impl<'a> TypeScriptAnnotations<'a> {
                     .get_or_insert_with(|| {
                         self.ctx.ast.alloc_function_body(
                             SPAN,
-                            self.ctx.ast.new_vec(),
-                            self.ctx.ast.new_vec(),
+                            self.ctx.ast.vec(),
+                            self.ctx.ast.vec(),
                         )
                     })
                     .statements
@@ -350,7 +350,7 @@ impl<'a> TypeScriptAnnotations<'a> {
                 matches!(stmt, Statement::ExpressionStatement(stmt) if stmt.expression.is_super_call_expression())
             });
             if has_super_call {
-                let mut new_stmts = self.ctx.ast.new_vec();
+                let mut new_stmts = self.ctx.ast.vec();
                 for stmt in stmts.drain(..) {
                     let is_super_call = matches!(stmt, Statement::ExpressionStatement(ref stmt) if stmt.expression.is_super_call_expression());
                     new_stmts.push(stmt);
@@ -420,11 +420,8 @@ impl<'a> TypeScriptAnnotations<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let scope_id = ctx.insert_scope_below_statement(&stmt, ScopeFlags::empty());
-        let block = BlockStatement {
-            span,
-            body: ctx.ast.new_vec_single(stmt),
-            scope_id: Cell::new(Some(scope_id)),
-        };
+        let block =
+            BlockStatement { span, body: ctx.ast.vec1(stmt), scope_id: Cell::new(Some(scope_id)) };
         Statement::BlockStatement(ctx.ast.alloc(block))
     }
 
@@ -457,7 +454,7 @@ impl<'a> TypeScriptAnnotations<'a> {
             let scope_id = ctx.create_scope_child_of_current(ScopeFlags::empty());
             let block = BlockStatement {
                 span: stmt.span(),
-                body: ctx.ast.new_vec(),
+                body: ctx.ast.vec(),
                 scope_id: Cell::new(Some(scope_id)),
             };
             *stmt = Statement::BlockStatement(ctx.ast.alloc(block));

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -89,8 +89,8 @@ impl<'a> TypeScriptEnum<'a> {
         let id = ast.binding_pattern(kind, Option::<TSTypeAnnotation>::None, false);
 
         // ((Foo) => {
-        let params = ast.formal_parameter(SPAN, id, None, false, false, ast.new_vec());
-        let params = ast.new_vec_single(params);
+        let params = ast.formal_parameter(SPAN, id, None, false, false, ast.vec());
+        let params = ast.vec1(params);
         let params = ast.alloc_formal_parameters(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
@@ -101,7 +101,7 @@ impl<'a> TypeScriptEnum<'a> {
         // Foo[Foo["X"] = 0] = "X";
         let is_already_declared = self.enums.contains_key(&enum_name);
         let statements = self.transform_ts_enum_members(&decl.members, enum_name.clone(), ctx);
-        let body = ast.alloc_function_body(decl.span, ast.new_vec(), statements);
+        let body = ast.alloc_function_body(decl.span, ast.vec(), statements);
         let callee = Expression::FunctionExpression(ctx.alloc(Function {
             r#type: FunctionType::FunctionExpression,
             span: SPAN,
@@ -120,8 +120,8 @@ impl<'a> TypeScriptEnum<'a> {
         let var_symbol_id = decl.id.symbol_id.get().unwrap();
         let arguments = if (is_export || is_not_top_scope) && !is_already_declared {
             // }({});
-            let object_expr = ast.expression_object(SPAN, ast.new_vec(), None);
-            ast.new_vec_single(Argument::from(object_expr))
+            let object_expr = ast.expression_object(SPAN, ast.vec(), None);
+            ast.vec1(Argument::from(object_expr))
         } else {
             // }(Foo || {});
             let op = LogicalOperator::Or;
@@ -132,9 +132,9 @@ impl<'a> TypeScriptEnum<'a> {
                 ReferenceFlag::Read,
             );
             let left = ast.expression_from_identifier_reference(left);
-            let right = ast.expression_object(SPAN, ast.new_vec(), None);
+            let right = ast.expression_object(SPAN, ast.vec(), None);
             let expression = ast.expression_logical(SPAN, left, op, right);
-            ast.new_vec_single(Argument::from(expression))
+            ast.vec1(Argument::from(expression))
         };
 
         let call_expression = ast.expression_call(
@@ -170,7 +170,7 @@ impl<'a> TypeScriptEnum<'a> {
             let binding =
                 ast.binding_pattern(binding_pattern_kind, Option::<TSTypeAnnotation>::None, false);
             let decl = ast.variable_declarator(SPAN, kind, binding, Some(call_expression), false);
-            ast.new_vec_single(decl)
+            ast.vec1(decl)
         };
         let variable_declaration = ast.declaration_variable(decl.span, kind, decls, false);
 
@@ -195,7 +195,7 @@ impl<'a> TypeScriptEnum<'a> {
 
         let ast = ctx.ast;
 
-        let mut statements = ast.new_vec();
+        let mut statements = ast.vec();
         let mut prev_constant_value = Some(ConstantValue::Number(-1.0));
         let mut previous_enum_members = self.enums.entry(enum_name.clone()).or_default().clone();
         let mut prev_member_name: Option<Atom<'a>> = None;

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -54,7 +54,7 @@ impl<'a> TypeScript<'a> {
                     }
 
                     let callee = self.ctx.ast.expression_identifier_reference(SPAN, "require");
-                    let arguments = self.ctx.ast.new_vec_single(Argument::from(
+                    let arguments = self.ctx.ast.vec1(Argument::from(
                         self.ctx.ast.expression_from_string_literal(reference.expression.clone()),
                     ));
                     self.ctx.ast.expression_call(
@@ -66,7 +66,7 @@ impl<'a> TypeScript<'a> {
                     )
                 }
             };
-            self.ctx.ast.new_vec_single(self.ctx.ast.variable_declarator(
+            self.ctx.ast.vec1(self.ctx.ast.variable_declarator(
                 SPAN,
                 kind,
                 binding,


### PR DESCRIPTION
This PR serves two purposes, First off it would lower the amount of characters we have to type in for a simple operation such as wrapping an expression in a vector. Secondly, it would follow the generated names more closely since nowhere else in the builder we do have `new_xxx`, We always say `xxx` since a builder always constructs something.

```
new_vec -> vec
new_vec_single -> vec1*
new_vec_from_iter -> vec_from_iter
new_vec_with_capacity -> vec_with_capacity
new_str -> str
new_atom -> atom
```

`*` This one is the main motivation behind this PR, It saves 10 characters!