### PR TITLE
chore: update the branding to use the `universal` variant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/oxc-project/oxc-assets/preview-dark-bubbles.png" width="700">
-    <img alt="OXC Logo" src="https://github.com/oxc-project/oxc-assets/raw/main/preview-white-bubbles.png" width="700">
-  </picture>
+  <img alt="OXC Logo" src="https://raw.githubusercontent.com/oxc-project/oxc-assets/main/preview-universal.png" width="700">
 </p>
 
 <div align="center">

--- a/npm/oxlint/README.md
+++ b/npm/oxlint/README.md
@@ -1,8 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Boshen/oxc-assets/main/preview-dark-transparent.png" width="600">
-    <img alt="OXC Logo" src="https://raw.githubusercontent.com/Boshen/oxc-assets/main/preview-white.png" width="600">
-  </picture>
+  <img alt="OXC Logo" src="https://raw.githubusercontent.com/oxc-project/oxc-assets/main/preview-universal.png" width="600">
 </p>
 
 <div align="center">


### PR DESCRIPTION
Have the same spirit as this one https://github.com/oxc-project/.github/pull/2

Makes the `OXC` visible on any background no matter the contrast.