### PR TITLE
fix(ast): put `decorators` before everything else.

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1511,11 +1511,11 @@ pub struct FormalParameters<'a> {
 pub struct FormalParameter<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
+    pub decorators: Vec<'a, Decorator<'a>>,
     pub pattern: BindingPattern<'a>,
     pub accessibility: Option<TSAccessibility>,
     pub readonly: bool,
     pub r#override: bool,
-    pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1776,11 +1776,11 @@ pub struct AccessorProperty<'a> {
     pub r#type: AccessorPropertyType,
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
+    pub decorators: Vec<'a, Decorator<'a>>,
     pub key: PropertyKey<'a>,
     pub value: Option<Expression<'a>>,
     pub computed: bool,
     pub r#static: bool,
-    pub decorators: Vec<'a, Decorator<'a>>,
 }
 
 #[visited_node]

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -128,7 +128,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         pattern: BindingPattern<'a>,
     ) -> FormalParameter<'a> {
-        self.formal_parameter(span, pattern, None, false, false, self.vec())
+        self.formal_parameter(span, self.vec(), pattern, None, false, false)
     }
 
     #[inline]

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -3814,26 +3814,26 @@ impl<'a> AstBuilder<'a> {
     pub fn formal_parameter(
         self,
         span: Span,
+        decorators: Vec<'a, Decorator<'a>>,
         pattern: BindingPattern<'a>,
         accessibility: Option<TSAccessibility>,
         readonly: bool,
         r#override: bool,
-        decorators: Vec<'a, Decorator<'a>>,
     ) -> FormalParameter<'a> {
-        FormalParameter { span, pattern, accessibility, readonly, r#override, decorators }
+        FormalParameter { span, decorators, pattern, accessibility, readonly, r#override }
     }
 
     #[inline]
     pub fn alloc_formal_parameter(
         self,
         span: Span,
+        decorators: Vec<'a, Decorator<'a>>,
         pattern: BindingPattern<'a>,
         accessibility: Option<TSAccessibility>,
         readonly: bool,
         r#override: bool,
-        decorators: Vec<'a, Decorator<'a>>,
     ) -> Box<'a, FormalParameter<'a>> {
-        self.formal_parameter(span, pattern, accessibility, readonly, r#override, decorators)
+        self.formal_parameter(span, decorators, pattern, accessibility, readonly, r#override)
             .into_in(self.allocator)
     }
 
@@ -4131,14 +4131,14 @@ impl<'a> AstBuilder<'a> {
         self,
         r#type: AccessorPropertyType,
         span: Span,
+        decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
-        decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         ClassElement::AccessorProperty(self.alloc(
-            self.accessor_property(r#type, span, key, value, computed, r#static, decorators),
+            self.accessor_property(r#type, span, decorators, key, value, computed, r#static),
         ))
     }
 
@@ -4510,13 +4510,13 @@ impl<'a> AstBuilder<'a> {
         self,
         r#type: AccessorPropertyType,
         span: Span,
+        decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
-        decorators: Vec<'a, Decorator<'a>>,
     ) -> AccessorProperty<'a> {
-        AccessorProperty { r#type, span, key, value, computed, r#static, decorators }
+        AccessorProperty { r#type, span, decorators, key, value, computed, r#static }
     }
 
     #[inline]
@@ -4524,13 +4524,13 @@ impl<'a> AstBuilder<'a> {
         self,
         r#type: AccessorPropertyType,
         span: Span,
+        decorators: Vec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
-        decorators: Vec<'a, Decorator<'a>>,
     ) -> Box<'a, AccessorProperty<'a>> {
-        self.accessor_property(r#type, span, key, value, computed, r#static, decorators)
+        self.accessor_property(r#type, span, decorators, key, value, computed, r#static)
             .into_in(self.allocator)
     }
 

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -444,11 +444,11 @@ impl<'a> IsolatedDeclarations<'a> {
                     let new_element = self.ast.class_element_accessor_property(
                         property.r#type,
                         property.span,
+                        self.ast.vec(),
                         self.ast.copy(&property.key),
                         None,
                         property.computed,
                         property.r#static,
-                        self.ast.vec(),
                     );
                     elements.push(new_element);
                 }
@@ -525,7 +525,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Box<'a, FormalParameters<'a>> {
         let pattern = BindingPattern { kind, type_annotation, optional: false };
         let parameter =
-            self.ast.formal_parameter(SPAN, pattern, None, false, false, self.ast.vec());
+            self.ast.formal_parameter(SPAN, self.ast.vec(), pattern, None, false, false);
         let items = self.ast.vec1(parameter);
         self.ast.alloc_formal_parameters(
             SPAN,

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -113,7 +113,7 @@ impl<'a> IsolatedDeclarations<'a> {
             );
         }
 
-        Some(self.ast.formal_parameter(param.span, pattern, None, false, false, self.ast.vec()))
+        Some(self.ast.formal_parameter(param.span, self.ast.vec(), pattern, None, false, false))
     }
 
     pub fn transform_formal_parameters(

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -498,11 +498,11 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.class_element_accessor_property(
             r#type,
             self.end_span(span),
+            decorators,
             key,
             value,
             computed,
             r#static,
-            decorators,
         ))
     }
 }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -89,11 +89,11 @@ impl<'a> ParserImpl<'a> {
         let decorators = self.consume_decorators();
         Ok(self.ast.formal_parameter(
             self.end_span(span),
+            decorators,
             pattern,
             modifiers.accessibility(),
             modifiers.contains_readonly(),
             modifiers.contains_override(),
-            decorators,
         ))
     }
 

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -89,7 +89,7 @@ impl<'a> TypeScriptEnum<'a> {
         let id = ast.binding_pattern(kind, Option::<TSTypeAnnotation>::None, false);
 
         // ((Foo) => {
-        let params = ast.formal_parameter(SPAN, id, None, false, false, ast.vec());
+        let params = ast.formal_parameter(SPAN, ast.vec(), id, None, false, false);
         let params = ast.vec1(params);
         let params = ast.alloc_formal_parameters(
             SPAN,


### PR DESCRIPTION
Won't fix #4142 

It is similar to #3994 but for those types that weren't relying on this order. It seems to be the right order.
technically speaking it is a breaking change but I know as a fact that it won't have a big difference on our downstream. If you want it to be chronically correct feel free to merge as a breaking change.