### PR TITLE
fix(tasks/ast_codegen): run `cargo fmt` synchronously

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,6 @@ jobs:
       - name: Check AST Changes
         if: steps.filter.outputs.src == 'true'
         run: |
-          cargo run -p oxc_ast_codegen -- --no-fmt
-          # FIXME:
-          # remove the following command and `--no-fmt` flag
-          # for some reason in the CI `cargo fmt` in the `oxc_ast_codegen` doesn't produce formatted code,
-          # Even though it is running succesfully and produces no errors.
-          # It also prints the right results for `cargo fmt --version` so it can find the right binary for sure.
-          cargo fmt
+          cargo run -p oxc_ast_codegen
           echo 'AST changes must be commited to the repo.'
           git diff --exit-code

--- a/tasks/ast_codegen/src/fmt.rs
+++ b/tasks/ast_codegen/src/fmt.rs
@@ -59,14 +59,7 @@ pub fn pprint(input: &TokenStream) -> String {
     result
 }
 
-/// Runs cargo fmt in the `root` path.
-pub fn cargo_fmt(root: &str) -> std::io::Result<()> {
-    let mut cmd = Command::new("cargo");
-    cmd.arg("fmt")
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .current_dir(root);
-    cmd.spawn()?;
-    Ok(())
+/// Runs cargo fmt.
+pub fn cargo_fmt() {
+    Command::new("cargo").arg("fmt").status().unwrap();
 }

--- a/tasks/ast_codegen/src/main.rs
+++ b/tasks/ast_codegen/src/main.rs
@@ -245,7 +245,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     }
 
     if !cli_options.no_fmt {
-        cargo_fmt(".")?;
+        cargo_fmt();
     }
 
     if let CliOptions { schema: Some(schema_path), dry_run: false, .. } = cli_options {


### PR DESCRIPTION
relates #4152

This is my wild guess, because it works in my other script https://github.com/oxc-project/oxc-browserslist/blob/143685deb1dec9ffce3bc3ba4d9abf7d3fe300ad/xtask/src/main.rs#L21