### PR TITLE
refactor(semantic): correct scope in CatchClause

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1300,7 +1300,7 @@ pub struct TryStatement<'a> {
 }
 
 #[visited_node]
-#[scope(if(self.param.is_some()))]
+#[scope]
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[cfg_attr(feature = "serialize", serde(tag = "type"))]

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -3690,10 +3690,7 @@ pub mod walk {
 
     #[inline]
     pub fn walk_catch_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &CatchClause<'a>) {
-        let scope_events_cond = it.param.is_some();
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         let kind = AstKind::CatchClause(visitor.alloc(it));
         visitor.enter_node(kind);
         if let Some(param) = &it.param {
@@ -3701,9 +3698,7 @@ pub mod walk {
         }
         visitor.visit_block_statement(&it.body);
         visitor.leave_node(kind);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
     }
 
     #[inline]

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -3895,10 +3895,7 @@ pub mod walk_mut {
 
     #[inline]
     pub fn walk_catch_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CatchClause<'a>) {
-        let scope_events_cond = it.param.is_some();
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         let kind = AstType::CatchClause;
         visitor.enter_node(kind);
         if let Some(param) = &mut it.param {
@@ -3906,9 +3903,7 @@ pub mod walk_mut {
         }
         visitor.visit_block_statement(&mut it.body);
         visitor.leave_node(kind);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
     }
 
     #[inline]

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -62,13 +62,6 @@ impl Rule for EmptyBraceSpaces {
             AstKind::BlockStatement(block_stmt) => {
                 remove_empty_braces_spaces(ctx, block_stmt.body.is_empty(), block_stmt.span);
             }
-            AstKind::CatchClause(catch_clause) => {
-                remove_empty_braces_spaces(
-                    ctx,
-                    catch_clause.body.body.is_empty(),
-                    catch_clause.body.span,
-                );
-            }
             AstKind::FinallyClause(finally_clause) => {
                 remove_empty_braces_spaces(
                     ctx,

--- a/crates/oxc_semantic/tests/integration/snapshots/labeled_block_break.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/labeled_block_break.snap
@@ -23,6 +23,7 @@ bb4: {
 	statement
 	statement
 	statement
+	statement
 }
 
 bb5: {
@@ -55,7 +56,7 @@ digraph {
     1 [ label = "TryStatement" ]
     2 [ label = "" ]
     3 [ label = "BlockStatement" ]
-    4 [ label = "LabeledStatement\nBlockStatement\nIfStatement" ]
+    4 [ label = "BlockStatement\nLabeledStatement\nBlockStatement\nIfStatement" ]
     5 [ label = "Condition(IdentifierReference(condition))" ]
     6 [ label = "BlockStatement\nbreak <LABEL>" ]
     7 [ label = "unreachable" ]

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: d8086f14
 
 parser_typescript Summary:
 AST Parsed     : 5279/5283 (99.92%)
-Positive Passed: 5272/5283 (99.79%)
+Positive Passed: 5271/5283 (99.77%)
 Negative Passed: 1094/4875 (22.44%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
@@ -3818,6 +3818,19 @@ Expect to Parse: "compiler/withStatementInternalComments.ts"
  2 │ /*1*/ with /*2*/ ( /*3*/ false /*4*/ ) /*5*/ {}
    ·       ────
    ╰────
+Expect to Parse: "conformance/async/es6/asyncWithVarShadowing_es6.ts"
+
+  × Identifier `x` has already been declared
+     ╭─[conformance/async/es6/asyncWithVarShadowing_es6.ts:130:14]
+ 129 │     }
+ 130 │     catch ({ x }) {
+     ·              ┬
+     ·              ╰── `x` has already been declared here
+ 131 │         var x;
+     ·             ┬
+     ·             ╰── It can not be redeclared here
+ 132 │     }
+     ╰────
 Expect to Parse: "conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts"
 
   × Classes may not have a static property named prototype


### PR DESCRIPTION
close: #4186

CatchClause has two scopes. The first one is `CatchClause`, which will add a `CatchParameter` to it. The second one is `Block`, which will add binding that declares in the current block scope.

The spec has a syntax error about `CatchParameter`
- It is a Syntax Error if any element of the BoundNames of CatchParameter also occurs in the LexicallyDeclaredNames of Block.
