### PR TITLE
fix(linter): global variables should always check the builtin variables

### DIFF
--- a/crates/oxc_linter/src/context.rs
+++ b/crates/oxc_linter/src/context.rs
@@ -137,7 +137,7 @@ impl<'a> LintContext<'a> {
     }
 
     pub fn env_contains_var(&self, var: &str) -> bool {
-        if GLOBALS["builtin"].contains_key("var") {
+        if GLOBALS["builtin"].contains_key(var) {
             return true;
         }
         for env in self.env().iter() {


### PR DESCRIPTION
This fixes commit dbbb6fca567cf06df8a548c6a7f87730fd38b4c2.

Closes #3374