### PR TITLE
perf(semantic): reduce memory copies

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -389,8 +389,10 @@ impl<'a> SemanticBuilder<'a> {
                     self.symbols.references[*reference_id].set_symbol_id(symbol_id);
                 }
                 self.symbols.resolved_references[symbol_id].extend(reference_ids);
+            } else if let Some(parent_reference_ids) = parent_refs.get_mut(&name) {
+                parent_reference_ids.extend(reference_ids);
             } else {
-                parent_refs.entry(name).or_default().extend(reference_ids);
+                parent_refs.insert(name, reference_ids);
             }
         }
     }


### PR DESCRIPTION
Reduce memory copies when resolving references in `Semantic`.

If parent scope has no unresolved references for `name`, there is no need to generate a new `Vec<ReferenceId>` for `name` and copy in contents from current scope. Just move the existing `Vec` to the parent.