### PR TITLE
feat: support SourceMapBuilder#token_chunks

### DIFF
--- a/crates/oxc_sourcemap/src/lib.rs
+++ b/crates/oxc_sourcemap/src/lib.rs
@@ -14,4 +14,4 @@ pub use error::Error;
 pub use sourcemap::SourceMap;
 pub use sourcemap_builder::SourceMapBuilder;
 pub use sourcemap_visualizer::SourcemapVisualizer;
-pub use token::{SourceViewToken, Token};
+pub use token::{SourceViewToken, Token, TokenChunk};

--- a/crates/oxc_sourcemap/src/sourcemap_builder.rs
+++ b/crates/oxc_sourcemap/src/sourcemap_builder.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
-use crate::{token::Token, SourceMap};
+use crate::{
+    token::{Token, TokenChunk},
+    SourceMap,
+};
 
 /// The `SourceMapBuilder` is a helper to generate sourcemap.
 #[derive(Debug, Default)]
@@ -14,6 +17,7 @@ pub struct SourceMapBuilder {
     pub(crate) sources_map: FxHashMap<Arc<str>, u32>,
     pub(crate) source_contents: Vec<Arc<str>>,
     pub(crate) tokens: Vec<Token>,
+    pub(crate) token_chunks: Option<Vec<TokenChunk>>,
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -66,6 +70,11 @@ impl SourceMapBuilder {
         self.file = Some(file.into());
     }
 
+    /// Set the `SourceMap::token_chunks` to make the sourcemap to vlq mapping at parallel.
+    pub fn set_token_chunks(&mut self, token_chunks: Vec<TokenChunk>) {
+        self.token_chunks = Some(token_chunks);
+    }
+
     pub fn into_sourcemap(self) -> SourceMap {
         SourceMap::new(
             self.file,
@@ -74,7 +83,7 @@ impl SourceMapBuilder {
             self.sources,
             Some(self.source_contents),
             self.tokens,
-            None,
+            self.token_chunks,
         )
     }
 }


### PR DESCRIPTION
Because the `token_chunks` need to pre-visit tokens and collect, it could be done at add tokens phase. So here export it let rolldown could be improve `renderChunks` sourcemap encode. 