### PR TITLE
fix(oxc_codegen):  avoid print same pure comments multiple time

### DIFF
--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -2,7 +2,7 @@
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;
-use oxc_codegen::{CodeGenerator, CommentOptions, WhitespaceRemover};
+use oxc_codegen::{CodeGenerator, WhitespaceRemover};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
@@ -29,14 +29,7 @@ fn main() -> std::io::Result<()> {
     println!("Original:");
     println!("{source_text}");
 
-    let printed = CodeGenerator::new()
-        .enable_comment(
-            &source_text,
-            ret.trivias,
-            CommentOptions { preserve_annotate_comments: true },
-        )
-        .build(&ret.program)
-        .source_text;
+    let printed = CodeGenerator::new().build(&ret.program).source_text;
     println!("Printed:");
     println!("{printed}");
 

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -2,7 +2,7 @@
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;
-use oxc_codegen::{CodeGenerator, WhitespaceRemover};
+use oxc_codegen::{CodeGenerator, CommentOptions, WhitespaceRemover};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
@@ -29,7 +29,14 @@ fn main() -> std::io::Result<()> {
     println!("Original:");
     println!("{source_text}");
 
-    let printed = CodeGenerator::new().build(&ret.program).source_text;
+    let printed = CodeGenerator::new()
+        .enable_comment(
+            &source_text,
+            ret.trivias,
+            CommentOptions { preserve_annotate_comments: true },
+        )
+        .build(&ret.program)
+        .source_text;
     println!("Printed:");
     println!("{printed}");
 

--- a/crates/oxc_codegen/src/annotation_comment.rs
+++ b/crates/oxc_codegen/src/annotation_comment.rs
@@ -34,7 +34,6 @@ pub fn get_leading_annotate_comment<const MINIFY: bool>(
 }
 
 pub fn print_comment<const MINIFY: bool>(comment: Comment, p: &mut Codegen<{ MINIFY }>) {
-    // Avoid multiple ast node share the same comment, e.g.
     // ```js
     // /*#__PURE__*/
     // Object.getOwnPropertyNames(Symbol)

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -97,6 +97,7 @@ pub struct Codegen<'a, const MINIFY: bool> {
     /// the first element of value is the start of the comment
     /// the second element of value includes the end of the comment and comment kind.
     move_comment_map: MoveCommentMap,
+    latest_consumed_comment_end: u32,
 }
 
 impl<'a, const MINIFY: bool> Default for Codegen<'a, MINIFY> {
@@ -141,6 +142,7 @@ impl<'a, const MINIFY: bool> Codegen<'a, MINIFY> {
             quote: b'"',
             sourcemap_builder: None,
             move_comment_map: MoveCommentMap::default(),
+            latest_consumed_comment_end: 0,
         }
     }
 

--- a/crates/oxc_codegen/tests/mod.rs
+++ b/crates/oxc_codegen/tests/mod.rs
@@ -421,6 +421,18 @@ const staticCacheMap = /*#__PURE__*/ new WeakMap()
 ",
         "const staticCacheMap = /*#__PURE__*/ new WeakMap();\n",
     );
+
+    test_comment_helper(
+        r"
+const builtInSymbols = new Set(
+  /*#__PURE__*/
+  Object.getOwnPropertyNames(Symbol)
+    .filter(key => key !== 'arguments' && key !== 'caller')
+)
+
+",
+        "const builtInSymbols = new Set(/*#__PURE__*/ Object.getOwnPropertyNames(Symbol).filter((key) => key !== \"arguments\" && key !== \"caller\"));\n",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Before 
```bash
Original:
const builtInSymbols = new Set(
  /*#__PURE__*/
  Object.getOwnPropertyNames(Symbol)
    .filter(key => key !== 'arguments' && key !== 'caller')
)


Printed:
const builtInSymbols = new Set(/*#__PURE__*/ /*#__PURE__*/ Object.getOwnPropertyNames(Symbol).filter((key) => key !== "arguments" && key !== "caller"));

Minified:
const builtInSymbols=new Set(Object.getOwnPropertyNames(Symbol).filter((key)=>key!=="arguments"&&key!=="caller"))

```

## After
```bash
Original:
const builtInSymbols = new Set(
  /*#__PURE__*/
  Object.getOwnPropertyNames(Symbol)
    .filter(key => key !== 'arguments' && key !== 'caller')
)


Printed:
const builtInSymbols = new Set(/*#__PURE__*/  Object.getOwnPropertyNames(Symbol).filter((key) => key !== "arguments" && key !== "caller"));

Minified:
const builtInSymbols=new Set(Object.getOwnPropertyNames(Symbol).filter((key)=>key!=="arguments"&&key!=="caller"))

```