### PR TITLE
fix(codegen): print `JSXAttributeValue::StringLiteral` directly

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2239,7 +2239,7 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for JSXAttributeValue<'a> {
             Self::Element(el) => el.gen(p, ctx),
             Self::StringLiteral(lit) => {
                 p.print_char(b'"');
-                print_unquoted_str(&lit.value, b'"', p);
+                p.print_str(&lit.value);
                 p.print_char(b'"');
             }
             Self::ExpressionContainer(expr_container) => expr_container.gen(p, ctx),

--- a/tasks/coverage/codegen_typescript.snap
+++ b/tasks/coverage/codegen_typescript.snap
@@ -2,7 +2,5 @@ commit: d8086f14
 
 codegen_typescript Summary:
 AST Parsed     : 5283/5283 (100.00%)
-Positive Passed: 5280/5283 (99.94%)
-Normal failed: "compiler/jsxMultilineAttributeStringValues.tsx"
-Normal failed: "compiler/jsxMultilineAttributeValuesReact.tsx"
+Positive Passed: 5282/5283 (99.98%)
 Normal failed: "conformance/jsx/tsxReactEmitEntities.tsx"


### PR DESCRIPTION
jsx attribute string is interpreted as is without escaping.

The transformer is responsible for converting it to plain js string.