### PR TITLE
fix(codegen): choose the right quote for jsx attribute string

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2238,9 +2238,10 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for JSXAttributeValue<'a> {
             Self::Fragment(fragment) => fragment.gen(p, ctx),
             Self::Element(el) => el.gen(p, ctx),
             Self::StringLiteral(lit) => {
-                p.print_char(b'"');
+                let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
+                p.print_char(quote);
                 p.print_str(&lit.value);
-                p.print_char(b'"');
+                p.print_char(quote);
             }
             Self::ExpressionContainer(expr_container) => expr_container.gen(p, ctx),
         }

--- a/tasks/coverage/codegen_typescript.snap
+++ b/tasks/coverage/codegen_typescript.snap
@@ -2,5 +2,4 @@ commit: d8086f14
 
 codegen_typescript Summary:
 AST Parsed     : 5283/5283 (100.00%)
-Positive Passed: 5282/5283 (99.98%)
-Normal failed: "conformance/jsx/tsxReactEmitEntities.tsx"
+Positive Passed: 5283/5283 (100.00%)


### PR DESCRIPTION
jsx attribute string doesn't have escaped characters (e.g. `"\""`), so it's safe to choose the right quote by searching for the right quote. 