### PR TITLE
perf(semantic): reduce cloning `CompactStr`s when declaring references

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -347,13 +347,17 @@ impl<'a> SemanticBuilder<'a> {
     ///
     /// # Panics
     pub fn declare_reference(&mut self, reference: Reference) -> ReferenceId {
-        let reference_name = reference.name().clone();
         let reference_id = self.symbols.create_reference(reference);
+        let reference_name = self.symbols.get_reference(reference_id).name();
 
-        self.unresolved_references[self.current_scope_depth]
-            .entry(reference_name)
-            .or_default()
-            .push(reference_id);
+        let current_unresolved_references =
+            &mut self.unresolved_references[self.current_scope_depth];
+        if let Some(reference_ids) = current_unresolved_references.get_mut(reference_name) {
+            reference_ids.push(reference_id);
+        } else {
+            current_unresolved_references.insert(reference_name.clone(), vec![reference_id]);
+        }
+
         reference_id
     }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -136,10 +136,12 @@ impl SymbolTable {
         self.redeclare_variables[symbol_id].push(span);
     }
 
+    #[inline]
     pub fn create_reference(&mut self, reference: Reference) -> ReferenceId {
         self.references.push(reference)
     }
 
+    #[inline]
     pub fn get_reference(&self, reference_id: ReferenceId) -> &Reference {
         &self.references[reference_id]
     }


### PR DESCRIPTION
The hash map `Entry` API requires an owned key. Avoid using it so don't have to clone the reference name `CompactStr` unless  the hashmap need an insertion.

Using `Atom` instead of `CompactStr` as hash map key (#3972) would be a better long-term solution, but that's [not possible currently](https://github.com/oxc-project/oxc/pull/3974).