### PR TITLE
fix(semantic): do not resolve references after `FormalParameters` in TS type

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1745,7 +1745,7 @@ impl<'a> SemanticBuilder<'a> {
                 self.function_stack.pop();
             }
             AstKind::FormalParameters(parameters) => {
-                if parameters.has_parameter() {
+                if parameters.kind != FormalParameterKind::Signature && parameters.has_parameter() {
                     // `function foo({bar: identifier_reference}) {}`
                     //                     ^^^^^^^^^^^^^^^^^^^^ Parameter initializer must be resolved
                     //                                          after all parameters have been declared


### PR DESCRIPTION
Semantic resolves references when exiting `FormalParameters` to ensure references in param initializers don't get bound to bindings inside the function body.

However, it shouldn't do this for `FormalParameters` in TS types e.g. `TSTypeAnnotation` because they don't have their own scopes.