### PR TITLE
refactor(ast): move `enter_scope` after `visit_binding_identifier`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1590,8 +1590,8 @@ pub struct Class<'a> {
     #[cfg_attr(feature = "serialize", serde(flatten))]
     pub span: Span,
     pub decorators: Vec<'a, Decorator<'a>>,
-    #[scope(enter_before)]
     pub id: Option<BindingIdentifier<'a>>,
+    #[scope(enter_before)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     #[visit_as(ClassHeritage)]
     pub super_class: Option<Expression<'a>>,

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -2925,10 +2925,10 @@ pub mod walk {
         let kind = AstKind::Class(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_decorators(&it.decorators);
-        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
         if let Some(id) = &it.id {
             visitor.visit_binding_identifier(id);
         }
+        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -3049,10 +3049,10 @@ pub mod walk_mut {
         let kind = AstType::Class;
         visitor.enter_node(kind);
         visitor.visit_decorators(&mut it.decorators);
-        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
         if let Some(id) = &mut it.id {
             visitor.visit_binding_identifier(id);
         }
+        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -137,15 +137,8 @@ pub fn check_identifier<'a>(name: &str, span: Span, node: &AstNode<'a>, ctx: &Se
         if ctx.source_type.is_module() {
             return ctx.error(reserved_keyword(name, span));
         }
-
         // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
-        if (matches!(ctx.nodes.parent_kind(node.id()), Some(AstKind::Class(_)))
-            && ctx
-                .scope
-                .get_parent_id(node.scope_id())
-                .is_some_and(|id| ctx.scope.get_flags(id).is_class_static_block()))
-            || ctx.current_scope_flags().is_class_static_block()
-        {
+        if ctx.scope.get_flags(node.scope_id()).is_class_static_block() {
             return ctx.error(class_static_block_await(span));
         }
     }

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -2459,6 +2459,12 @@ pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_ID) as *mut Option<BindingIdentifier>)
+    {
+        ctx.retag_stack(AncestorType::ClassId);
+        walk_binding_identifier(traverser, field as *mut _, ctx);
+    }
     let mut previous_scope_id = None;
     if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_CLASS_SCOPE_ID)
         as *mut Cell<Option<ScopeId>>))
@@ -2466,12 +2472,6 @@ pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     {
         previous_scope_id = Some(ctx.current_scope_id());
         ctx.set_current_scope_id(scope_id);
-    }
-    if let Some(field) =
-        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_ID) as *mut Option<BindingIdentifier>)
-    {
-        ctx.retag_stack(AncestorType::ClassId);
-        walk_binding_identifier(traverser, field as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_TYPE_PARAMETERS)
         as *mut Option<Box<TSTypeParameterDeclaration>>)


### PR DESCRIPTION
This is now consistent with other ASTs that require bind

https://github.com/oxc-project/oxc/blob/2019043e726cbbe2d2cd4bb49620110298798294/crates/oxc_ast/src/ast/ts.rs#L814-L815