### PR TITLE
refactor(semantic): update the order of `visit_function` and `Visit` fields in the builder to be consistent

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1439,7 +1439,7 @@ pub struct BindingRestElement<'a> {
 #[scope(
     // TODO: `ScopeFlags::Function` is not correct if this is a `MethodDefinition`
     flags(flags.unwrap_or(ScopeFlags::empty()) | ScopeFlags::Function),
-    strict_if(self.body.as_ref().is_some_and(|body| body.has_use_strict_directive())),
+    strict_if(self.is_strict()),
 )]
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
@@ -1470,8 +1470,8 @@ pub struct Function<'a> {
     /// ```
     pub this_param: Option<TSThisParameter<'a>>,
     pub params: Box<'a, FormalParameters<'a>>,
-    pub body: Option<Box<'a, FunctionBody<'a>>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    pub body: Option<Box<'a, FunctionBody<'a>>>,
     pub scope_id: Cell<Option<ScopeId>>,
 }
 

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -150,8 +150,8 @@ impl<'a> AstBuilder<'a> {
             Option::<TSTypeParameterDeclaration>::None,
             None,
             params,
-            body,
             Option::<TSTypeAnnotation>::None,
+            body,
         ))
     }
 

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -554,14 +554,14 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
         params: T2,
-        body: T3,
-        return_type: T4,
+        return_type: T3,
+        body: T4,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
         T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Expression::FunctionExpression(self.alloc(self.function(
             r#type,
@@ -573,8 +573,8 @@ impl<'a> AstBuilder<'a> {
             type_parameters,
             this_param,
             params,
-            body,
             return_type,
+            body,
         )))
     }
 
@@ -2689,14 +2689,14 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
         params: T2,
-        body: T3,
-        return_type: T4,
+        return_type: T3,
+        body: T4,
     ) -> Declaration<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
         T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Declaration::FunctionDeclaration(self.alloc(self.function(
             r#type,
@@ -2708,8 +2708,8 @@ impl<'a> AstBuilder<'a> {
             type_parameters,
             this_param,
             params,
-            body,
             return_type,
+            body,
         )))
     }
 
@@ -3720,14 +3720,14 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
         params: T2,
-        body: T3,
-        return_type: T4,
+        return_type: T3,
+        body: T4,
     ) -> Function<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
         T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
             r#type,
@@ -3739,8 +3739,8 @@ impl<'a> AstBuilder<'a> {
             type_parameters: type_parameters.into_in(self.allocator),
             this_param,
             params: params.into_in(self.allocator),
-            body: body.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
+            body: body.into_in(self.allocator),
             scope_id: Default::default(),
         }
     }
@@ -3757,14 +3757,14 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
         params: T2,
-        body: T3,
-        return_type: T4,
+        return_type: T3,
+        body: T4,
     ) -> Box<'a, Function<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
         T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         self.function(
             r#type,
@@ -3776,8 +3776,8 @@ impl<'a> AstBuilder<'a> {
             type_parameters,
             this_param,
             params,
-            body,
             return_type,
+            body,
         )
         .into_in(self.allocator)
     }
@@ -4901,14 +4901,14 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         this_param: Option<TSThisParameter<'a>>,
         params: T2,
-        body: T3,
-        return_type: T4,
+        return_type: T3,
+        body: T4,
     ) -> ExportDefaultDeclarationKind<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
         T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         ExportDefaultDeclarationKind::FunctionDeclaration(self.alloc(self.function(
             r#type,
@@ -4920,8 +4920,8 @@ impl<'a> AstBuilder<'a> {
             type_parameters,
             this_param,
             params,
-            body,
             return_type,
+            body,
         )))
     }
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -3038,7 +3038,7 @@ pub mod walk {
         visitor.enter_scope(
             {
                 let mut flags = flags.unwrap_or(ScopeFlags::empty()) | ScopeFlags::Function;
-                if it.body.as_ref().is_some_and(|body| body.has_use_strict_directive()) {
+                if it.is_strict() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags
@@ -3055,11 +3055,11 @@ pub mod walk {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&it.params);
-        if let Some(body) = &it.body {
-            visitor.visit_function_body(body);
-        }
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
+        }
+        if let Some(body) = &it.body {
+            visitor.visit_function_body(body);
         }
         visitor.leave_scope();
         visitor.leave_node(kind);

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -3171,7 +3171,7 @@ pub mod walk_mut {
         visitor.enter_scope(
             {
                 let mut flags = flags.unwrap_or(ScopeFlags::empty()) | ScopeFlags::Function;
-                if it.body.as_ref().is_some_and(|body| body.has_use_strict_directive()) {
+                if it.is_strict() {
                     flags |= ScopeFlags::StrictMode;
                 }
                 flags
@@ -3188,11 +3188,11 @@ pub mod walk_mut {
             visitor.visit_ts_this_parameter(this_param);
         }
         visitor.visit_formal_parameters(&mut it.params);
-        if let Some(body) = &mut it.body {
-            visitor.visit_function_body(body);
-        }
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
+        }
+        if let Some(body) = &mut it.body {
+            visitor.visit_function_body(body);
         }
         visitor.leave_scope();
         visitor.leave_node(kind);

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -123,8 +123,8 @@ impl<'a> IsolatedDeclarations<'a> {
             self.ast.copy(&function.type_parameters),
             self.ast.copy(&function.this_param),
             params,
-            Option::<FunctionBody>::None,
             return_type,
+            Option::<FunctionBody>::None,
         );
 
         self.ast.class_element_method_definition(

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -37,8 +37,8 @@ impl<'a> IsolatedDeclarations<'a> {
                 self.ast.copy(&func.type_parameters),
                 self.ast.copy(&func.this_param),
                 params,
-                Option::<FunctionBody>::None,
                 return_type,
+                Option::<FunctionBody>::None,
             ))
         }
     }

--- a/crates/oxc_linter/src/snapshots/ban_types.snap
+++ b/crates/oxc_linter/src/snapshots/ban_types.snap
@@ -209,6 +209,14 @@ source: crates/oxc_linter/src/tester.rs
   help: The `Function` type accepts any function-like value
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
+   ╭─[ban_types.tsx:5:24]
+ 4 │ 
+ 5 │           arg(): Array<String> {
+   ·                        ──────
+ 6 │             const foo: String = 1 as String;
+   ╰────
+
+  ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:6:24]
  5 │           arg(): Array<String> {
  6 │             const foo: String = 1 as String;
@@ -222,14 +230,6 @@ source: crates/oxc_linter/src/tester.rs
  6 │             const foo: String = 1 as String;
    ·                                      ──────
  7 │           }
-   ╰────
-
-  ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
-   ╭─[ban_types.tsx:5:24]
- 4 │ 
- 5 │           arg(): Array<String> {
-   ·                        ──────
- 6 │             const foo: String = 1 as String;
    ╰────
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -181,8 +181,8 @@ impl<'a> ParserImpl<'a> {
             type_parameters,
             this_param,
             params,
-            body,
             return_type,
+            body,
         ))
     }
 

--- a/crates/oxc_traverse/src/ancestor.rs
+++ b/crates/oxc_traverse/src/ancestor.rs
@@ -143,8 +143,8 @@ pub(crate) enum AncestorType {
     FunctionTypeParameters = 111,
     FunctionThisParam = 112,
     FunctionParams = 113,
-    FunctionBody = 114,
-    FunctionReturnType = 115,
+    FunctionReturnType = 114,
+    FunctionBody = 115,
     FormalParametersItems = 116,
     FormalParametersRest = 117,
     FormalParameterDecorators = 118,
@@ -531,8 +531,8 @@ pub enum Ancestor<'a> {
         AncestorType::FunctionTypeParameters as u16,
     FunctionThisParam(FunctionWithoutThisParam<'a>) = AncestorType::FunctionThisParam as u16,
     FunctionParams(FunctionWithoutParams<'a>) = AncestorType::FunctionParams as u16,
-    FunctionBody(FunctionWithoutBody<'a>) = AncestorType::FunctionBody as u16,
     FunctionReturnType(FunctionWithoutReturnType<'a>) = AncestorType::FunctionReturnType as u16,
+    FunctionBody(FunctionWithoutBody<'a>) = AncestorType::FunctionBody as u16,
     FormalParametersItems(FormalParametersWithoutItems<'a>) =
         AncestorType::FormalParametersItems as u16,
     FormalParametersRest(FormalParametersWithoutRest<'a>) =
@@ -1242,8 +1242,8 @@ impl<'a> Ancestor<'a> {
                 | Self::FunctionTypeParameters(_)
                 | Self::FunctionThisParam(_)
                 | Self::FunctionParams(_)
-                | Self::FunctionBody(_)
                 | Self::FunctionReturnType(_)
+                | Self::FunctionBody(_)
         )
     }
 
@@ -5194,8 +5194,8 @@ pub(crate) const OFFSET_FUNCTION_DECLARE: usize = offset_of!(Function, declare);
 pub(crate) const OFFSET_FUNCTION_TYPE_PARAMETERS: usize = offset_of!(Function, type_parameters);
 pub(crate) const OFFSET_FUNCTION_THIS_PARAM: usize = offset_of!(Function, this_param);
 pub(crate) const OFFSET_FUNCTION_PARAMS: usize = offset_of!(Function, params);
-pub(crate) const OFFSET_FUNCTION_BODY: usize = offset_of!(Function, body);
 pub(crate) const OFFSET_FUNCTION_RETURN_TYPE: usize = offset_of!(Function, return_type);
+pub(crate) const OFFSET_FUNCTION_BODY: usize = offset_of!(Function, body);
 pub(crate) const OFFSET_FUNCTION_SCOPE_ID: usize = offset_of!(Function, scope_id);
 
 #[repr(transparent)]
@@ -5253,18 +5253,18 @@ impl<'a> FunctionWithoutId<'a> {
     }
 
     #[inline]
-    pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
-        }
-    }
-
-    #[inline]
     pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
+                as *const Option<Box<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -5331,18 +5331,18 @@ impl<'a> FunctionWithoutTypeParameters<'a> {
     }
 
     #[inline]
-    pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
-        }
-    }
-
-    #[inline]
     pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
+                as *const Option<Box<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -5409,18 +5409,18 @@ impl<'a> FunctionWithoutThisParam<'a> {
     }
 
     #[inline]
-    pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
-        }
-    }
-
-    #[inline]
     pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
+                as *const Option<Box<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -5487,96 +5487,18 @@ impl<'a> FunctionWithoutParams<'a> {
     }
 
     #[inline]
+    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
     pub fn body(&self) -> &Option<Box<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
                 as *const Option<Box<'a, FunctionBody<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(&self) -> &Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_SCOPE_ID) as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Debug)]
-pub struct FunctionWithoutBody<'a>(pub(crate) *const Function<'a>);
-
-impl<'a> FunctionWithoutBody<'a> {
-    #[inline]
-    pub fn r#type(&self) -> &FunctionType {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
-    }
-
-    #[inline]
-    pub fn span(&self) -> &Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn id(&self) -> &Option<BindingIdentifier<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_ID)
-                as *const Option<BindingIdentifier<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn generator(&self) -> &bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_GENERATOR) as *const bool) }
-    }
-
-    #[inline]
-    pub fn r#async(&self) -> &bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_ASYNC) as *const bool) }
-    }
-
-    #[inline]
-    pub fn declare(&self) -> &bool {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_DECLARE) as *const bool) }
-    }
-
-    #[inline]
-    pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn this_param(&self) -> &Option<TSThisParameter<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn params(&self) -> &Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -5655,6 +5577,84 @@ impl<'a> FunctionWithoutReturnType<'a> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
                 as *const Option<Box<'a, FunctionBody<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(&self) -> &Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_SCOPE_ID) as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct FunctionWithoutBody<'a>(pub(crate) *const Function<'a>);
+
+impl<'a> FunctionWithoutBody<'a> {
+    #[inline]
+    pub fn r#type(&self) -> &FunctionType {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE) as *const FunctionType) }
+    }
+
+    #[inline]
+    pub fn span(&self) -> &Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn id(&self) -> &Option<BindingIdentifier<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_ID)
+                as *const Option<BindingIdentifier<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn generator(&self) -> &bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_GENERATOR) as *const bool) }
+    }
+
+    #[inline]
+    pub fn r#async(&self) -> &bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_ASYNC) as *const bool) }
+    }
+
+    #[inline]
+    pub fn declare(&self) -> &bool {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_FUNCTION_DECLARE) as *const bool) }
+    }
+
+    #[inline]
+    pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn this_param(&self) -> &Option<TSThisParameter<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
+                as *const Option<TSThisParameter<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(&self) -> &Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
         }
     }
 

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -2287,17 +2287,17 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
             as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
-        as *mut Option<Box<FunctionBody>>)
-    {
-        ctx.retag_stack(AncestorType::FunctionBody);
-        walk_function_body(traverser, (&mut **field) as *mut _, ctx);
-    }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_RETURN_TYPE)
         as *mut Option<Box<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FunctionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
+        as *mut Option<Box<FunctionBody>>)
+    {
+        ctx.retag_stack(AncestorType::FunctionBody);
+        walk_function_body(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack();
     traverser.exit_function(&mut *node, ctx);

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -20872,10 +20872,10 @@ Expect to Parse: "conformance/types/typeRelationships/typeAndMemberIdentity/obje
  17 │     // Type parameters and top-level local types are in same declaration space
  18 │     function f<T>() {
     ·                ┬
-    ·                ╰── It can not be redeclared here
+    ·                ╰── `T` has already been declared here
  19 │         interface T { }
     ·                   ┬
-    ·                   ╰── `T` has already been declared here
+    ·                   ╰── It can not be redeclared here
  20 │         return undefined;
     ╰────
 


### PR DESCRIPTION
Same as #4195 
