### PR TITLE
perf(semantic): fast path for resolving references in scopes with no bindings

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -369,6 +369,8 @@ impl<'a> SemanticBuilder<'a> {
         let parent_refs = iter.nth(self.current_scope_depth - 1).unwrap();
         let current_refs = iter.next().unwrap();
 
+        // Dummy comment to run benchmarks again
+
         let bindings = self.scope.get_bindings(self.current_scope_id);
         if !bindings.is_empty() {
             // Try to resolve references in current scope.


### PR DESCRIPTION
Scopes with no bindings are fairly common e.g.:

```js
if (foo) {
    // This block contains no bindings
    doStuff(foo);
}
```

Fast path for this case when resolving references in semantic.