### PR TITLE
perf(semantic): reduce `AstNodeId` to `u32`

### DIFF
--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 use oxc_index::define_index_type;
 
 define_index_type! {
-    pub struct AstNodeId = usize;
+    pub struct AstNodeId = u32;
 }
 
 impl AstNodeId {


### PR DESCRIPTION
`AstNodeId` was a `usize`. This seems excessive.

Parser has a limit on size of a JS file of 4 GiB. While it is *possible* for a JS file of that size to create an AST with more than `1 << 32` (~4 billion) AST nodes, that would be insanely large.

So make `AstNodeId` `u32` instead.