### PR TITLE
refactor(semantic): directly record `current_node_id` when adding a scope

### DIFF
--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -179,12 +179,17 @@ impl ScopeTree {
         &mut self.bindings[scope_id]
     }
 
-    pub fn add_scope(&mut self, parent_id: Option<ScopeId>, flags: ScopeFlags) -> ScopeId {
+    pub fn add_scope(
+        &mut self,
+        parent_id: Option<ScopeId>,
+        node_id: AstNodeId,
+        flags: ScopeFlags,
+    ) -> ScopeId {
         let scope_id = self.parent_ids.push(parent_id);
         _ = self.child_ids.push(vec![]);
         _ = self.flags.push(flags);
         _ = self.bindings.push(Bindings::default());
-        _ = self.node_ids.push(AstNodeId::dummy());
+        _ = self.node_ids.push(node_id);
 
         // Set this scope as child of parent scope.
         if let Some(parent_id) = parent_id {
@@ -192,10 +197,6 @@ impl ScopeTree {
         }
 
         scope_id
-    }
-
-    pub(crate) fn set_node_id(&mut self, scope_id: ScopeId, node_id: AstNodeId) {
-        self.node_ids[scope_id] = node_id;
     }
 
     pub fn add_binding(&mut self, scope_id: ScopeId, name: CompactStr, symbol_id: SymbolId) {

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -121,7 +121,7 @@ impl TraverseScoping {
     /// `flags` provided are amended to inherit from parent scope's flags.
     pub fn create_scope_child_of_current(&mut self, flags: ScopeFlags) -> ScopeId {
         let flags = self.scopes.get_new_scope_flags(flags, self.current_scope_id);
-        self.scopes.add_scope(Some(self.current_scope_id), flags)
+        self.scopes.add_scope(Some(self.current_scope_id), AstNodeId::dummy(), flags)
     }
 
     /// Insert a scope into scope tree below a statement.


### PR DESCRIPTION
close: #4234
