### PR TITLE
perf(semantic): reduce index_vec allocation

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -115,7 +115,7 @@ impl Linter {
             rule.run_once(ctx);
         }
 
-        for symbol in semantic.symbols().symbol_ids() {
+        for symbol in semantic.symbols().iter() {
             for (rule, ctx) in &rules {
                 rule.run_on_symbol(symbol, ctx);
             }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -115,7 +115,7 @@ impl Linter {
             rule.run_once(ctx);
         }
 
-        for symbol in semantic.symbols().iter() {
+        for symbol in semantic.symbols().symbol_ids() {
             for (rule, ctx) in &rules {
                 rule.run_on_symbol(symbol, ctx);
             }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -4,7 +4,7 @@ use std::{
     ops::Deref,
 };
 
-use oxc_semantic::SymbolId;
+use oxc_semantic::Symbol;
 
 use crate::{context::LintContext, AllowWarnDeny, AstNode, RuleEnum};
 
@@ -18,7 +18,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
     fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
 
     /// Visit each symbol
-    fn run_on_symbol(&self, _symbol_id: SymbolId, _ctx: &LintContext<'_>) {}
+    fn run_on_symbol(&self, _symbol: &Symbol, _ctx: &LintContext<'_>) {}
 
     /// Run only once. Useful for inspecting scopes and trivias etc.
     fn run_once(&self, _ctx: &LintContext) {}

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -1,6 +1,6 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::SymbolId;
+use oxc_semantic::Symbol;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -35,14 +35,13 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoClassAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_class() {
-            for reference in symbol_table.get_resolved_references(symbol_id) {
+    fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
+        if symbol.flag.is_class() {
+            for reference in ctx.symbols().get_references_from_ids(&symbol.resolved_references) {
                 if reference.is_write() {
                     ctx.diagnostic(no_class_assign_diagnostic(
-                        symbol_table.get_name(symbol_id),
-                        symbol_table.get_span(symbol_id),
+                        symbol.name.as_str(),
+                        symbol.span,
                         reference.span(),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -1,6 +1,6 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::SymbolId;
+use oxc_semantic::Symbol;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -36,14 +36,13 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_const_variable() {
-            for reference in symbol_table.get_resolved_references(symbol_id) {
+    fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
+        if symbol.flag.is_const_variable() {
+            for reference in ctx.symbols().get_references_from_ids(&symbol.resolved_references) {
                 if reference.is_write() {
                     ctx.diagnostic(no_const_assign_diagnostic(
-                        symbol_table.get_name(symbol_id),
-                        symbol_table.get_span(symbol_id),
+                        &symbol.name,
+                        symbol.span,
                         reference.span(),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -1,6 +1,6 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::SymbolId;
+use oxc_semantic::Symbol;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -36,10 +36,9 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_catch_variable() {
-            for reference in symbol_table.get_resolved_references(symbol_id) {
+    fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
+        if symbol.flag.is_catch_variable() {
+            for reference in ctx.symbols().get_references_from_ids(&symbol.resolved_references) {
                 if reference.is_write() {
                     ctx.diagnostic(no_ex_assign_diagnostic(reference.span()));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::SymbolId;
+use oxc_semantic::Symbol;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
@@ -32,14 +32,12 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFuncAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.semantic().symbols();
-        let decl = symbol_table.get_declaration(symbol_id);
-        if let AstKind::Function(_) = ctx.nodes().kind(decl) {
-            for reference in symbol_table.get_resolved_references(symbol_id) {
+    fn run_on_symbol(&self, symbol: &Symbol, ctx: &LintContext<'_>) {
+        if let AstKind::Function(_) = ctx.nodes().kind(symbol.declaration) {
+            for reference in ctx.symbols().get_references_from_ids(&symbol.resolved_references) {
                 if reference.is_write() {
                     ctx.diagnostic(no_func_assign_diagnostic(
-                        symbol_table.get_name(symbol_id),
+                        symbol.name.as_str(),
                         reference.span(),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -57,16 +57,13 @@ impl Rule for NoRedeclare {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let symbol_table = ctx.semantic().symbols();
-
-        for symbol_id in ctx.symbols().iter() {
-            let decl = symbol_table.get_declaration(symbol_id);
-            let symbol_name = symbol_table.get_name(symbol_id);
+        for symbol in ctx.symbols().iter() {
+            let decl = symbol.declaration;
             match ctx.nodes().kind(decl) {
                 AstKind::VariableDeclarator(var) => {
                     if let BindingPatternKind::BindingIdentifier(ident) = &var.id.kind {
-                        if symbol_name == ident.name.as_str() {
-                            for span in ctx.symbols().get_redeclare_variables(symbol_id) {
+                        if symbol.name == ident.name.as_str() {
+                            for span in &symbol.redeclare_variables {
                                 self.report_diagnostic(ctx, *span, ident);
                             }
                         }
@@ -74,8 +71,8 @@ impl Rule for NoRedeclare {
                 }
                 AstKind::FormalParameter(param) => {
                     if let BindingPatternKind::BindingIdentifier(ident) = &param.pattern.kind {
-                        if symbol_name == ident.name.as_str() {
-                            for span in ctx.symbols().get_redeclare_variables(symbol_id) {
+                        if symbol.name == ident.name.as_str() {
+                            for span in &symbol.redeclare_variables {
                                 self.report_diagnostic(ctx, *span, ident);
                             }
                         }

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -94,7 +94,7 @@ impl Rule for NoConfusingSetTimeout {
             collect_jest_reference_id(reference_ids, &mut jest_reference_id_list, ctx);
         }
 
-        for reference_ids in &symbol_table.resolved_references {
+        for reference_ids in symbol_table.resolved_references() {
             collect_jest_reference_id(reference_ids, &mut jest_reference_id_list, ctx);
         }
 
@@ -108,7 +108,7 @@ impl Rule for NoConfusingSetTimeout {
             );
         }
 
-        for reference_id_list in &symbol_table.resolved_references {
+        for reference_id_list in symbol_table.resolved_references() {
             handle_jest_set_time_out(
                 ctx,
                 reference_id_list,

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -195,21 +195,20 @@ fn collect_ids_referenced_to_import<'a>(
     ctx: &LintContext<'a>,
 ) -> Vec<(ReferenceId, Option<&'a str>)> {
     ctx.symbols()
-        .resolved_references
-        .iter_enumerated()
-        .filter_map(|(symbol_id, reference_ids)| {
-            if ctx.symbols().get_flag(symbol_id).is_import_binding() {
-                let id = ctx.symbols().get_declaration(symbol_id);
+        .iter()
+        .filter_map(|symbol| {
+            if symbol.flag.is_import_binding() {
+                let id = symbol.declaration;
                 let Some(AstKind::ImportDeclaration(import_decl)) = ctx.nodes().parent_kind(id)
                 else {
                     return None;
                 };
-                let name = ctx.symbols().get_name(symbol_id);
+                let name = &symbol.name;
 
                 if matches!(import_decl.source.value.as_str(), "@jest/globals" | "vitest") {
                     let original = find_original_name(import_decl, name);
                     let mut ret = vec![];
-                    for reference_id in reference_ids {
+                    for reference_id in &symbol.resolved_references {
                         ret.push((*reference_id, original));
                     }
 

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -107,9 +107,9 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub(super) fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContext<'a>) {
+            pub(super) fn run_on_symbol<'a>(&self, symbol: &oxc_semantic::Symbol, ctx: &LintContext<'a>) {
                 match self {
-                    #(Self::#struct_names(rule) => rule.run_on_symbol(symbol_id, ctx)),*
+                    #(Self::#struct_names(rule) => rule.run_on_symbol(symbol, ctx)),*
                 }
             }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -393,7 +393,7 @@ impl<'a> SemanticBuilder<'a> {
                 for reference_id in &reference_ids {
                     self.symbols.references[*reference_id].set_symbol_id(symbol_id);
                 }
-                self.symbols.resolved_references[symbol_id].extend(reference_ids);
+                self.symbols.extend_reference_ids(symbol_id, reference_ids);
             } else if let Some(parent_reference_ids) = parent_refs.get_mut(&name) {
                 parent_reference_ids.extend(reference_ids);
             } else {

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -32,7 +32,7 @@ use rustc_hash::FxHashSet;
 pub use crate::{
     reference::{Reference, ReferenceFlag, ReferenceId},
     scope::ScopeTree,
-    symbol::SymbolTable,
+    symbol::{Symbol, SymbolTable},
 };
 
 pub struct Semantic<'a> {

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -77,7 +77,11 @@ impl SymbolTable {
         self.len() == 0
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = SymbolId> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &Symbol> + '_ {
+        self.symbols.iter()
+    }
+
+    pub fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + '_ {
         self.symbols.iter_enumerated().map(|(symbol_id, _)| symbol_id)
     }
 
@@ -87,6 +91,10 @@ impl SymbolTable {
 
     pub fn names(&self) -> impl Iterator<Item = &CompactStr> {
         self.symbols.iter().map(|symbol| &symbol.name)
+    }
+
+    pub fn resolved_references(&self) -> impl Iterator<Item = &Vec<ReferenceId>> {
+        self.symbols.iter().map(|symbol| &symbol.resolved_references)
     }
 
     pub fn name(&self, symbol_id: SymbolId) -> &CompactStr {

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -222,6 +222,13 @@ impl SymbolTable {
             .map(|reference_id| &self.references[*reference_id])
     }
 
+    pub fn get_references_from_ids<'a>(
+        &'a self,
+        reference_ids: &'a [ReferenceId],
+    ) -> impl Iterator<Item = &Reference> + '_ {
+        reference_ids.iter().map(|id| &self.references[*id])
+    }
+
     /// Determine whether evaluating the specific input `node` is a consequenceless reference. ie.
     /// evaluating it won't result in potentially arbitrary code from being ran. The following are
     /// allowed and determined not to cause side effects:

--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -25,7 +25,7 @@ impl<'a> BoundIdentifier<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Self {
         let symbol_id = ctx.generate_uid(name, scope_id, flags);
-        let name = ctx.ast.atom(&ctx.symbols().names[symbol_id]);
+        let name = ctx.ast.atom(ctx.symbols().name(symbol_id));
         Self { name, symbol_id }
     }
 

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -118,7 +118,7 @@ impl<'a> AutomaticScriptBindings<'a> {
     ) -> BoundIdentifier<'a> {
         let symbol_id =
             ctx.generate_uid_in_root_scope(variable_name, SymbolFlags::FunctionScopedVariable);
-        let variable_name = ctx.ast.atom(&ctx.symbols().names[symbol_id]);
+        let variable_name = ctx.ast.atom(ctx.symbols().name(symbol_id));
 
         let import = NamedImport::new(variable_name.clone(), None, symbol_id);
         self.ctx.module_imports.add_require(source, import, front);
@@ -219,7 +219,7 @@ impl<'a> AutomaticModuleBindings<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let symbol_id = ctx.generate_uid_in_root_scope(name, SymbolFlags::FunctionScopedVariable);
-        let local = ctx.ast.atom(&ctx.symbols().names[symbol_id]);
+        let local = ctx.ast.atom(ctx.symbols().name(symbol_id));
 
         let import = NamedImport::new(Atom::from(name), Some(local.clone()), symbol_id);
         self.ctx.module_imports.add_import(source, import);

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -270,7 +270,7 @@ impl TraverseScoping {
         let reference =
             Reference::new_with_symbol_id(SPAN, name, AstNodeId::dummy(), symbol_id, flag);
         let reference_id = self.symbols.create_reference(reference);
-        self.symbols.resolved_references[symbol_id].push(reference_id);
+        self.symbols.get_resolved_reference_ids_mut(symbol_id).push(reference_id);
         reference_id
     }
 
@@ -448,7 +448,7 @@ impl TraverseScoping {
 
     fn name_is_unique(&self, name: &str) -> bool {
         // Check if any bindings in program with this name
-        if self.symbols.names.iter().any(|n| n.as_str() == name) {
+        if self.symbols.names().any(|n| n.as_str() == name) {
             return false;
         }
 


### PR DESCRIPTION
Combining some SymbolTable fields to the `Symbol` struct, we can reduce allocating `IndexVec`. After my changes, I suddenly realized the api is much easier to use now. We no longer need the `symbol_id` to get the various field value you want, you just need the `Symbol`