### PR TITLE
fix(parser): avoid crashing on invalid const modifier

### DIFF
--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -414,7 +414,11 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         let kind = self.cur_kind();
 
-        if matches!(self.cur_kind(), Kind::Const) && permit_const_as_modifier {
+        if matches!(self.cur_kind(), Kind::Const) {
+            if !permit_const_as_modifier {
+                return None;
+            }
+
             // We need to ensure that any subsequent modifiers appear on the same line
             // so that when 'const' is a standalone declaration, we don't issue
             // an error.

--- a/tasks/coverage/misc/fail/oxc-4212-1.ts
+++ b/tasks/coverage/misc/fail/oxc-4212-1.ts
@@ -1,0 +1,1 @@
+class a { const enum b(); }

--- a/tasks/coverage/parser_misc.snap
+++ b/tasks/coverage/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 24/24 (100.00%)
 Positive Passed: 24/24 (100.00%)
-Negative Passed: 12/12 (100.00%)
+Negative Passed: 13/13 (100.00%)
 
   × Unexpected token
    ╭─[fail/oxc-169.js:2:1]
@@ -163,6 +163,13 @@ Negative Passed: 12/12 (100.00%)
    ╭─[fail/oxc-4111-1.js:1:35]
  1 │ funtransientction as longciiConÞr>ol(cde) {
    ·                                  ▲
+   ╰────
+  help: Try insert a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[fail/oxc-4212-1.ts:1:16]
+ 1 │ class a { const enum b(); }
+   ·                ▲
    ╰────
   help: Try insert a semicolon here
 


### PR DESCRIPTION
Followup on https://github.com/oxc-project/oxc/pull/3977, fixing one of the crashes at https://github.com/oxc-project/oxc/pull/3977.