### PR TITLE
perf(semantic): inline ast record functions

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -249,12 +249,14 @@ impl<'a> SemanticBuilder<'a> {
         }
     }
 
+    #[inline]
     fn record_ast_nodes(&mut self) {
         if self.cfg.is_some() {
             self.ast_node_records.push(AstNodeId::dummy());
         }
     }
 
+    #[inline]
     #[allow(clippy::unnecessary_wraps)]
     fn retrieve_recorded_ast_node(&mut self) -> Option<AstNodeId> {
         if self.cfg.is_some() {
@@ -264,6 +266,7 @@ impl<'a> SemanticBuilder<'a> {
         }
     }
 
+    #[inline]
     fn record_ast_node(&mut self) {
         if self.cfg.is_some() {
             if let Some(record) = self.ast_node_records.last_mut() {


### PR DESCRIPTION
Inline these functions so that when CFG is disabled, it doesn't cost a function call just for the trivial `if self.cfg.is_some()` check.

Based on @rzvxa's suggestion in https://github.com/oxc-project/oxc/pull/4263#pullrequestreview-2176762670.