### PR TITLE
perf(semantic): remove a branch from `record_ast_node`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -275,6 +275,7 @@ impl<'a> SemanticBuilder<'a> {
                 *record = self.current_node_id;
             }
         }
+        // Dummy comment to re-run benchmark. TODO Remove me.
     }
 
     pub fn current_scope_flags(&self) -> ScopeFlags {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -275,7 +275,6 @@ impl<'a> SemanticBuilder<'a> {
                 *record = self.current_node_id;
             }
         }
-        // Dummy comment to re-run benchmark. TODO Remove me.
     }
 
     pub fn current_scope_flags(&self) -> ScopeFlags {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -268,11 +268,11 @@ impl<'a> SemanticBuilder<'a> {
 
     #[inline]
     fn record_ast_node(&mut self) {
-        if self.cfg.is_some() {
-            if let Some(record) = self.ast_node_records.last_mut() {
-                if *record == AstNodeId::dummy() {
-                    *record = self.current_node_id;
-                }
+        // NB: If CFG is disabled, `ast_node_records` is always empty, so this is skipped.
+        // No need for a `if self.cfg.is_some()` guard.
+        if let Some(record) = self.ast_node_records.last_mut() {
+            if *record == AstNodeId::dummy() {
+                *record = self.current_node_id;
             }
         }
     }


### PR DESCRIPTION
Remove an unnecessary branch from `record_ast_node`. As suggested by @rzvxa in https://github.com/oxc-project/oxc/pull/4263#pullrequestreview-2176762670.