### PR TITLE
refactor(semantic): rename function param

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -13,7 +13,8 @@ use oxc_span::SourceType;
 use crate::{scope::ScopeFlags, symbol::SymbolFlags, SemanticBuilder};
 
 pub trait Binder {
-    fn bind(&self, _builder: &mut SemanticBuilder) {}
+    #[allow(unused_variables)]
+    fn bind(&self, builder: &mut SemanticBuilder) {}
 }
 
 impl<'a> Binder for VariableDeclarator<'a> {


### PR DESCRIPTION
Small style nit. It's nicer to have Rust Analyser's param name hint show `builder` rather than `_builder`.