### PR TITLE
refactor(ast): pass final `ScopeFlags` into `visit_function`

### DIFF
--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -136,7 +136,7 @@ impl<'a> Visit<'a> for FunctionReturnType<'a> {
         }
     }
 
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: Option<ScopeFlags>) {
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {
         // We don't care about nested functions
     }
 

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -231,7 +231,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
         }
     }
 
-    fn visit_function(&mut self, func: &Function<'a>, flags: Option<ScopeFlags>) {
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         walk_function(self, func, flags);
         if func.type_parameters.is_some() {
             self.leave_scope();

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -105,7 +105,7 @@ impl<'a> Visit<'a> for AwaitFinder {
 
     fn visit_arrow_function_expression(&mut self, _expr: &ArrowFunctionExpression<'a>) {}
 
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: Option<ScopeFlags>) {}
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
 }
 
 #[test]

--- a/crates/oxc_minifier/src/ast_passes/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/ast_passes/remove_dead_code.rs
@@ -151,7 +151,7 @@ impl<'a> Visit<'a> for KeepVar<'a> {
         }
     }
 
-    fn visit_function(&mut self, _it: &Function<'a>, _flags: Option<ScopeFlags>) {
+    fn visit_function(&mut self, _it: &Function<'a>, _flags: ScopeFlags) {
         /* skip functions */
     }
 

--- a/crates/oxc_parser/examples/visitor.rs
+++ b/crates/oxc_parser/examples/visitor.rs
@@ -46,7 +46,7 @@ struct CountASTNodes {
 }
 
 impl<'a> Visit<'a> for CountASTNodes {
-    fn visit_function(&mut self, func: &Function<'a>, flags: Option<ScopeFlags>) {
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         self.functions += 1;
         walk::walk_function(self, func, flags);
     }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1441,7 +1441,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
-    fn visit_function(&mut self, func: &Function<'a>, flags: Option<ScopeFlags>) {
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         /* cfg */
         let (before_function_graph_ix, error_harness, function_graph_ix) =
             control_flow!(self, |cfg| {
@@ -1460,7 +1460,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_node(kind);
         self.enter_scope(
             {
-                let mut flags = flags.unwrap_or(ScopeFlags::empty()) | ScopeFlags::Function;
+                let mut flags = flags;
                 if func.is_strict() {
                     flags |= ScopeFlags::StrictMode;
                 }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -549,7 +549,7 @@ impl<'a> Visit<'a> for ChildScopeCollector {
         self.scope_ids.push(clause.scope_id.get().unwrap());
     }
 
-    fn visit_function(&mut self, func: &Function<'a>, _flags: Option<ScopeFlags>) {
+    fn visit_function(&mut self, func: &Function<'a>, _flags: ScopeFlags) {
         self.scope_ids.push(func.scope_id.get().unwrap());
     }
 

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -254,7 +254,7 @@ impl<'a> VisitBuilder<'a> {
 
         let as_param_type = self.with_ref_pat(&as_type);
         let (extra_params, extra_args) = if ident == "Function" {
-            (quote!(, flags: Option<ScopeFlags>,), quote!(, flags))
+            (quote!(, flags: ScopeFlags,), quote!(, flags))
         } else {
             (TokenStream::default(), TokenStream::default())
         };


### PR DESCRIPTION
We have a strange workaround for `visit_function` where we pass in `ScopeFlags`, to support creating the scope inside `Function`, but setting different flags for `MethodDefinition`s.

Previously `visit_function` took `Option<ScopeFlags>` and then did `flags.unwrap_or(ScopeFlags::empty()) | ScopeFlags::Function` to it. Personally, I found this confusing. When I was looking at `MethodDefinition`, I was wondering "It's a function, why doesn't it set Function flag too?"

This changes makes it more explicit and clear what `ScopeFlags` everything has.