### PR TITLE
ci: run tests and conformance on all PRs in a stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,40 @@ jobs:
           graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  test:
+  test-ubuntu:
+    name: Test (ubuntu-latest)
+    runs-on: ubuntu-latest
+    env:
+      # https://github.com/mozilla/sccache/blob/main/docs/S3.md
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_ENDPOINT }}
+      SCCACHE_REGION: auto
+      RUSTC_WRAPPER: ${{ vars.USE_SCCACHE == 'true' && 'sccache' || '' }}
+      CARGO_INCREMENTAL: 0
+      SCCACHE_LOCAL_RW_MODE:
+    steps:
+      - uses: taiki-e/checkout-action@v1
+      - uses: Boshen/setup-rust@main
+        with:
+          # warm cache factory for all other CI jobs
+          # cache `target` directory to avoid download crates
+          save-cache: ${{ github.ref_name == 'main' }}
+          cache-key: warm
+      # cache build outputs to speed up compilation
+      - uses: mozilla-actions/sccache-action@v0.0.5
+        if: ${{ vars.USE_SCCACHE == 'true' }}
+      - run: cargo ck
+      - run: cargo test --no-run
+      - run: cargo test
+      - run: git diff --exit-code # Must commit everything
+
+  test-macos:
     needs: optimize_ci
     if: needs.optimize_ci.outputs.skip == 'false'
-    name: Test
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # - os: windows-latest # See `test-windows` job below
-          - os: ubuntu-latest
-          - os: macos-14
-    runs-on: ${{ matrix.os }}
+    name: Test (macos-14)
+    runs-on: macos-14
     env:
       # https://github.com/mozilla/sccache/blob/main/docs/S3.md
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -252,8 +274,6 @@ jobs:
       - run: RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items
 
   conformance:
-    needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     name: Conformance
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Run tests (on Ubuntu only) and conformance on all PRs in a stack.

Before this change, they run only on the bottom PR in stack.

When I'm working on my desktop machine, it is quite slow, so I prefer to push and let CI run tests + conformance rather than waiting for them to run locally.

@Boshen Are you OK with this change? I'm sure you had a reason for disabling them.