### PR TITLE
perf(linter): optimize no-dupe-keys

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
@@ -43,7 +43,11 @@ impl Rule for NoDupeKeys {
         let AstKind::ObjectExpression(obj_expr) = node.kind() else {
             return;
         };
-        let mut map = FxHashMap::default();
+        let len = obj_expr.properties.len();
+        if len <= 1 {
+            return;
+        }
+        let mut map = FxHashMap::with_capacity_and_hasher(len, FxBuildHasher);
         for prop in &obj_expr.properties {
             let ObjectPropertyKind::ObjectProperty(prop) = prop else {
                 continue;


### PR DESCRIPTION
This tweaks the `no-dupe-keys` lint in order to try to optimize it.
The lints reliably shows up in both CPU and memory profiling,
due to the cost of allocating/growing the hashmap and hashing into it.
This PR tries to tackle both by skipping trivial cases and by
pre-allocating a larger hashmap.