### PR TITLE
chore(justfile): add `just check` to the `just ast` command.

### DIFF
--- a/justfile
+++ b/justfile
@@ -156,4 +156,5 @@ website path:
 
 # sync ast changes
 ast:
-    cargo run -p oxc_ast_codegen
+  cargo run -p oxc_ast_codegen
+  just check


### PR DESCRIPTION
I use this in my local environment when I'm developing the ast_codegen and want a thorough build with the newly generated files. If you find it useful merge otherwise feel free to close.