### PR TITLE
fix(semantic): incorrect resolve references for `TSTypeQuery`

### DIFF
--- a/crates/oxc_linter/src/snapshots/consistent_type_imports.snap
+++ b/crates/oxc_linter/src/snapshots/consistent_type_imports.snap
@@ -310,7 +310,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import Type from 'foo';
    ·               ───────────────────────
- 3 │         
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -318,7 +318,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import { Type } from 'foo';
    ·               ───────────────────────────
- 3 │         
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -326,7 +326,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import * as Type from 'foo';
    ·               ────────────────────────────
- 3 │         
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
@@ -334,7 +334,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import type Type from 'foo';
    ·               ────────────────────────────
- 3 │         
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
@@ -342,7 +342,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import type { Type } from 'foo';
    ·               ────────────────────────────────
- 3 │         
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
@@ -350,7 +350,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import type * as Type from 'foo';
    ·               ─────────────────────────────────
- 3 │               
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
@@ -374,7 +374,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │               DefType from 'foo';
  5 │               import type /*comment*/ { Type } from 'foo';
    ·               ────────────────────────────────────────────
- 6 │               
+ 6 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Rest are only used as type.
@@ -446,7 +446,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │               import { A, B } from 'foo';
    ·               ───────────────────────────
- 3 │               
+ 3 │ 
    ╰────
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1714,8 +1714,14 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::TSTypeName(_) => {
                 match self.nodes.parent_kind(self.current_node_id) {
-                    Some(AstKind::TSModuleReference(_)) => {
+                    Some(
+                        // type A = typeof a;
+                        //          ^^^^^^^^
+                        AstKind::TSTypeQuery(_)
                         // import A = a;
+                        //            ^
+                        | AstKind::TSModuleReference(_)
+                    ) => {
                         self.current_reference_flag = ReferenceFlag::Read;
                     }
                     Some(AstKind::TSQualifiedName(_)) => {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/README.md
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/README.md
@@ -1,1 +1,0 @@
-These fixtures were copied from https://github.com/typescript-eslint/typescript-eslint/tree/a5b652da1ebb09ecbca8f4b032bf05ebc0e03dc9/packages/scope-manager/tests/fixtures. We used them to test out semantic [ScopeTree](../../src/scope.rs) and [SymbolTable](../../src/symbol.rs)

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlag(Read)",
             "id": 1,
             "name": "A",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
@@ -22,14 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         "id": 0,
         "name": "foo",
         "node": "ImportDefaultSpecifier",
-        "references": [
-          {
-            "flag": "ReferenceFlag(Type)",
-            "id": 0,
-            "name": "foo",
-            "node_id": 10
-          }
-        ]
+        "references": []
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -22,14 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "id": 0,
         "name": "foo",
         "node": "ImportSpecifier",
-        "references": [
-          {
-            "flag": "ReferenceFlag(Type)",
-            "id": 0,
-            "name": "foo",
-            "node_id": 11
-          }
-        ]
+        "references": []
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -22,14 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "id": 0,
         "name": "foo",
         "node": "ImportSpecifier",
-        "references": [
-          {
-            "flag": "ReferenceFlag(Type)",
-            "id": 0,
-            "name": "foo",
-            "node_id": 11
-          }
-        ]
+        "references": []
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -78,6 +78,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flag": "ReferenceFlag(Read)",
             "id": 0,
             "name": "makeBox",
+            "node_id": 27
+          },
+          {
+            "flag": "ReferenceFlag(Read)",
+            "id": 1,
+            "name": "makeBox",
             "node_id": 36
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -22,7 +22,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "id": 0,
         "name": "arg",
         "node": "VariableDeclarator",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read)",
+            "id": 0,
+            "name": "arg",
+            "node_id": 15
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -43,7 +43,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "id": 1,
         "name": "k",
         "node": "VariableDeclarator",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read)",
+            "id": 0,
+            "name": "k",
+            "node_id": 21
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -29,7 +29,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read)",
+            "id": 0,
+            "name": "x",
+            "node_id": 21
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -73,7 +73,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read)",
+            "id": 0,
+            "name": "foo",
+            "node_id": 29
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(Export | TypeAlias)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -29,7 +29,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read)",
+            "id": 0,
+            "name": "x",
+            "node_id": 9
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(TypeAlias)",

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -279,3 +279,16 @@ fn test_type_used_as_value() {
     .has_number_of_reads(0)
     .test();
 }
+
+#[test]
+fn test_type_query() {
+    SemanticTester::ts(
+        "
+    type T = number;
+    let x: typeof T;
+    ",
+    )
+    .has_some_symbol("T")
+    .has_number_of_reads(0)
+    .test();
+}

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,8 +2,10 @@ commit: d8086f14
 
 transformer_typescript Summary:
 AST Parsed     : 6456/6456 (100.00%)
-Positive Passed: 6452/6456 (99.94%)
+Positive Passed: 6450/6456 (99.91%)
 Mismatch: "compiler/constEnumNamespaceReferenceCausesNoImport2.ts"
 Mismatch: "compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts"
+Mismatch: "conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts"
 Mismatch: "conformance/externalModules/typeOnly/exportDeclaration.ts"
+Mismatch: "conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts"
 Mismatch: "conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx"

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 473/927
+Passed: 472/927
 
 # All Passed:
 * babel-preset-react
@@ -445,13 +445,14 @@ Passed: 473/927
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (129/151)
+# babel-plugin-transform-typescript (128/151)
 * class/accessor-allowDeclareFields-false/input.ts
 * class/accessor-allowDeclareFields-true/input.ts
 * enum/mix-references/input.ts
 * enum/ts5.0-const-foldable/input.ts
 * exports/declared-types/input.ts
 * exports/interface/input.ts
+* imports/elide-typeof/input.ts
 * imports/elision-locations/input.ts
 * imports/only-remove-type-imports/input.ts
 * imports/type-only-export-specifier-2/input.ts


### PR DESCRIPTION
```ts
type A = typeof Foo
                ^^^ Only allow reference to value symbol
```

I have verified the changed snapshot. That's correct