### PR TITLE
feat(semantic): add `ReferenceFlags::TSTypeQuery` to indicate referenced by `TSTypeQuery`

### DIFF
--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -80,6 +80,6 @@ impl Reference {
     }
 
     pub fn is_type(&self) -> bool {
-        self.flag.is_type()
+        self.flag.is_type() || self.flag.is_ts_type_query()
     }
 }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 1,
             "name": "A",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -52,14 +52,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "id": 4,
             "name": "T",
             "node": "TSTypeParameter",
-            "references": [
-              {
-                "flag": "ReferenceFlag(Type)",
-                "id": 0,
-                "name": "T",
-                "node_id": 31
-              }
-            ]
+            "references": []
           }
         ]
       }
@@ -75,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         "node": "Function(makeBox)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 0,
             "name": "makeBox",
             "node_id": 27

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 0,
             "name": "arg",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 0,
             "name": "k",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 0,
             "name": "x",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -52,14 +52,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "id": 4,
             "name": "T",
             "node": "TSTypeParameter",
-            "references": [
-              {
-                "flag": "ReferenceFlag(Type)",
-                "id": 0,
-                "name": "T",
-                "node_id": 33
-              }
-            ]
+            "references": []
           }
         ]
       }
@@ -75,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "Function(foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 29

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | TSTypeQuery)",
             "id": 0,
             "name": "x",
             "node_id": 9

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -45,6 +45,8 @@ bitflags! {
         const Write = 1 << 1;
         // Used in type definitions.
         const Type = 1 << 2;
+        // Used in `typeof xx`
+        const TSTypeQuery = 1 << 3;
         const Value = Self::Read.bits() | Self::Write.bits();
     }
 }
@@ -85,6 +87,11 @@ impl ReferenceFlag {
     /// The identifier is both read from and written to, e.g `a += 1`.
     pub fn is_read_write(&self) -> bool {
         self.contains(Self::Read | Self::Write)
+    }
+
+    /// The identifier is used in a type referenced
+    pub fn is_ts_type_query(&self) -> bool {
+        self.contains(Self::TSTypeQuery)
     }
 
     /// The identifier is used in a type definition.

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,10 +2,8 @@ commit: d8086f14
 
 transformer_typescript Summary:
 AST Parsed     : 6456/6456 (100.00%)
-Positive Passed: 6450/6456 (99.91%)
+Positive Passed: 6452/6456 (99.94%)
 Mismatch: "compiler/constEnumNamespaceReferenceCausesNoImport2.ts"
 Mismatch: "compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts"
-Mismatch: "conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts"
 Mismatch: "conformance/externalModules/typeOnly/exportDeclaration.ts"
-Mismatch: "conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts"
 Mismatch: "conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx"

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 473/927
+Passed: 474/927
 
 # All Passed:
 * babel-preset-react
@@ -445,14 +445,13 @@ Passed: 473/927
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (129/151)
+# babel-plugin-transform-typescript (130/151)
 * class/accessor-allowDeclareFields-false/input.ts
 * class/accessor-allowDeclareFields-true/input.ts
 * enum/mix-references/input.ts
 * enum/ts5.0-const-foldable/input.ts
 * exports/declared-types/input.ts
 * exports/interface/input.ts
-* imports/elide-typeof/input.ts
 * imports/only-remove-type-imports/input.ts
 * imports/type-only-export-specifier-2/input.ts
 * imports/type-only-import-specifier-4/input.ts


### PR DESCRIPTION
`ReferenceFlags::TSTypeQuery` can be used to help us insist on whether the reference is referenced by the type or not.