### PR TITLE
fix(semantic): incorrect resolve references for `ExportSpecifier`

### DIFF
--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
         "node": "VariableDeclarator",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlag(Read | Type)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -22,7 +22,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
         "id": 0,
         "name": "A",
         "node": "TSTypeAliasDeclaration",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read | Type)",
+            "id": 0,
+            "name": "A",
+            "node_id": 8
+          }
+        ]
       }
     ]
   }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -22,7 +22,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
         "id": 0,
         "name": "V",
         "node": "TSTypeAliasDeclaration",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Read | Type)",
+            "id": 0,
+            "name": "V",
+            "node_id": 8
+          }
+        ]
       }
     ]
   }

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -99,6 +99,10 @@ impl ReferenceFlag {
         self.contains(Self::Type)
     }
 
+    pub const fn is_type_only(self) -> bool {
+        matches!(self, Self::Type)
+    }
+
     pub const fn is_value(&self) -> bool {
         self.intersects(Self::Value)
     }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -95,7 +95,11 @@ impl SymbolFlags {
     }
 
     pub fn is_type(&self) -> bool {
-        self.intersects(Self::Type | Self::TypeImport | Self::Import)
+        self.intersects(Self::Type | Self::TypeImport)
+    }
+
+    pub fn is_can_be_referenced_by_type(&self) -> bool {
+        self.is_type() || self.contains(Self::Import)
     }
 
     pub fn is_value(&self) -> bool {


### PR DESCRIPTION
```ts
type A = any;
const B = 0;
export { A, B } 
       ^^^^^^^^ ExportSpecifiers

export { A } 
       ^^^^^ type-only ExportSpecifiers

```

non-type-only `ExportSpecifier` can reference value and type symbols. but currently, `IdentifierReference` in ExportSpecifier only has a `ReferenceFlags::Read`
