### PR TITLE
build: compile macro crates with some optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,11 @@ ignored = ["napi", "oxc_transform_napi", "prettyplease"]
 # and we don't rely on it for debugging that much.
 debug = false
 
+[profile.dev.package]
+# Compile macros with some optimizations to make consuming crates build faster
+oxc_macros.opt-level     = 1
+oxc_ast_macros.opt-level = 1
+
 [profile.release.package.oxc_wasm]
 opt-level = 'z'
 


### PR DESCRIPTION
## What This PR Does
Compile `oxc_macros` and `oxc_ast_macros` with `O1` in debug builds.

This should make consuming crates compile faster, as well as test binaries (oxc_linter tests take a while to compile when developing rules locally)