### PR TITLE
refactor(visit): add `#[inline]` to empty functions

### DIFF
--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -27,10 +27,14 @@ use walk::*;
 
 /// Syntax tree traversal
 pub trait Visit<'a>: Sized {
+    #[inline]
     fn enter_node(&mut self, kind: AstKind<'a>) {}
+    #[inline]
     fn leave_node(&mut self, kind: AstKind<'a>) {}
 
+    #[inline]
     fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}
+    #[inline]
     fn leave_scope(&mut self) {}
 
     #[inline]

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -27,10 +27,14 @@ use walk_mut::*;
 
 /// Syntax tree traversal
 pub trait VisitMut<'a>: Sized {
+    #[inline]
     fn enter_node(&mut self, kind: AstType) {}
+    #[inline]
     fn leave_node(&mut self, kind: AstType) {}
 
+    #[inline]
     fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}
+    #[inline]
     fn leave_scope(&mut self) {}
 
     #[inline]

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -122,12 +122,16 @@ fn generate_visit<const MUT: bool>(ctx: &CodegenCtx) -> TokenStream {
 
         /// Syntax tree traversal
         pub trait #trait_name <'a>: Sized {
+            #[inline]
             fn enter_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
+            #[inline]
             fn leave_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
 
             endl!();
 
+            #[inline]
             fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}
+            #[inline]
             fn leave_scope(&mut self) {}
 
             endl!();


### PR DESCRIPTION
Add `#[inline]` to empty default implementations of `enter_node` etc. Hopefully compiler will inline them automatically within Oxc even cross-crate because we compile with LTO, but maybe not for external consumers who don't use LTO.