### PR TITLE
perf(semantic): initialize builder storage with pre-allocated capacity

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -114,10 +114,6 @@ impl<'a> SemanticBuilder<'a> {
         let mut unresolved_references = vec![];
         unresolved_references.resize_with(16, Default::default);
 
-        // Most TS modules are not nested, and those that are are usually only 1 level deep.
-        let namespace_stack =
-            if source_type.is_typescript() { Vec::with_capacity(2) } else { Vec::new() };
-
         let trivias = Trivias::default();
         Self {
             source_text,
@@ -131,8 +127,9 @@ impl<'a> SemanticBuilder<'a> {
             current_scope_id,
             current_scope_depth: 0,
             function_stack: Vec::with_capacity(4),
-            namespace_stack,
-            nodes: AstNodes::with_capacity(source_text.len() >> 8 | 2),
+            // Most TS modules are not nested, and those that are are usually only 1 level deep.
+            namespace_stack: Vec::with_capacity(2),
+            nodes: AstNodes::with_capacity(source_text.len() >> 4),
             scope,
             symbols: SymbolTable::with_capacity(8),
             unresolved_references,

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -114,6 +114,10 @@ impl<'a> SemanticBuilder<'a> {
         let mut unresolved_references = vec![];
         unresolved_references.resize_with(16, Default::default);
 
+        // Most TS modules are not nested, and those that are are usually only 1 level deep.
+        let namespace_stack =
+            if source_type.is_typescript() { Vec::with_capacity(2) } else { Vec::new() };
+
         let trivias = Trivias::default();
         Self {
             source_text,
@@ -127,9 +131,8 @@ impl<'a> SemanticBuilder<'a> {
             current_scope_id,
             current_scope_depth: 0,
             function_stack: Vec::with_capacity(4),
-            // Most TS modules are not nested, and those that are are usually only 1 level deep.
-            namespace_stack: Vec::with_capacity(2),
-            nodes: AstNodes::with_capacity(source_text.len() >> 4),
+            namespace_stack,
+            nodes: AstNodes::with_capacity(source_text.len() >> 8 | 2),
             scope,
             symbols: SymbolTable::with_capacity(8),
             unresolved_references,

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -69,6 +69,16 @@ pub struct AstNodes<'a> {
 }
 
 impl<'a> AstNodes<'a> {
+    /// Create a new `AstNodes` initialized with enough memory to contain at least `capacity`
+    /// nodes.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            root: None,
+            nodes: IndexVec::with_capacity(capacity),
+            parent_ids: IndexVec::with_capacity(capacity),
+        }
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &AstNode<'a>> + '_ {
         self.nodes.iter()
     }

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -39,7 +39,7 @@ impl ScopeTree {
             node_ids: IndexVec::with_capacity(capacity),
             flags: IndexVec::with_capacity(capacity),
             bindings: IndexVec::with_capacity(capacity),
-            root_unresolved_references: UnresolvedReferences::default(),
+            root_unresolved_references: Default::default(),
         }
     }
 

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -32,6 +32,17 @@ pub struct ScopeTree {
 }
 
 impl ScopeTree {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            parent_ids: IndexVec::with_capacity(capacity),
+            child_ids: IndexVec::with_capacity(capacity),
+            node_ids: IndexVec::with_capacity(capacity),
+            flags: IndexVec::with_capacity(capacity),
+            bindings: IndexVec::with_capacity(capacity),
+            root_unresolved_references: Default::default(),
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.parent_ids.len()
     }

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -39,7 +39,7 @@ impl ScopeTree {
             node_ids: IndexVec::with_capacity(capacity),
             flags: IndexVec::with_capacity(capacity),
             bindings: IndexVec::with_capacity(capacity),
-            root_unresolved_references: Default::default(),
+            root_unresolved_references: UnresolvedReferences::default(),
         }
     }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -41,6 +41,20 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
+    /// Create a [`SymbolTable`] with enough capacity to hold at least `capacity` symbols.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            spans: IndexVec::with_capacity(capacity),
+            names: IndexVec::with_capacity(capacity),
+            flags: IndexVec::with_capacity(capacity),
+            scope_ids: IndexVec::with_capacity(capacity),
+            declarations: IndexVec::with_capacity(capacity),
+            resolved_references: IndexVec::with_capacity(capacity),
+            references: IndexVec::with_capacity(capacity),
+            redeclare_variables: IndexVec::with_capacity(capacity),
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.spans.len()
     }


### PR DESCRIPTION
## What This PR Does

Initializes `nodes`, `scopes`, `symbols`, and several other internal stacks with some capacity already allocated. This should reduce the number of re-allocations `Semantic` needs to make while traversing a program.