### PR TITLE
fix(semantic): avoid var hosting insert the var variable to the `CatchClause` scope

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -46,8 +46,13 @@ impl<'a> Binder for VariableDeclarator<'a> {
         let mut var_scope_ids = vec![];
         if !builder.current_scope_flags().is_var() {
             for scope_id in builder.scope.ancestors(current_scope_id).skip(1) {
+                let flag = builder.scope.get_flags(scope_id);
+                // Skip the catch clause, the scope bindings have been cloned to the child block scope
+                if flag.is_catch_clause() {
+                    continue;
+                }
                 var_scope_ids.push(scope_id);
-                if builder.scope.get_flags(scope_id).is_var() {
+                if flag.is_var() {
                     break;
                 }
             }

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: d8086f14
 
 parser_typescript Summary:
 AST Parsed     : 6444/6456 (99.81%)
-Positive Passed: 6421/6456 (99.46%)
+Positive Passed: 6422/6456 (99.47%)
 Negative Passed: 1160/5653 (20.52%)
 Expect Syntax Error: "compiler/ClassDeclaration10.ts"
 Expect Syntax Error: "compiler/ClassDeclaration11.ts"
@@ -4639,19 +4639,6 @@ Expect to Parse: "compiler/withStatementInternalComments.ts"
  2 │ /*1*/ with /*2*/ ( /*3*/ false /*4*/ ) /*5*/ {}
    ·       ────
    ╰────
-Expect to Parse: "conformance/async/es6/asyncWithVarShadowing_es6.ts"
-
-  × Identifier `x` has already been declared
-     ╭─[conformance/async/es6/asyncWithVarShadowing_es6.ts:130:14]
- 129 │     }
- 130 │     catch ({ x }) {
-     ·              ┬
-     ·              ╰── `x` has already been declared here
- 131 │         var x;
-     ·             ┬
-     ·             ╰── It can not be redeclared here
- 132 │     }
-     ╰────
 Expect to Parse: "conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts"
 
   × Classes may not have a static property named prototype


### PR DESCRIPTION
related: #4192 #4323

I will figure it out #4323 later