### PR TITLE
chore: move mangler example to minifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,14 +1561,10 @@ name = "oxc_mangler"
 version = "0.20.0"
 dependencies = [
  "itertools 0.13.0",
- "oxc_allocator",
  "oxc_ast",
- "oxc_codegen",
  "oxc_index",
- "oxc_parser",
  "oxc_semantic",
  "oxc_span",
- "pico-args",
 ]
 
 [[package]]

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -26,9 +26,3 @@ oxc_ast      = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_index    = { workspace = true }
 itertools    = { workspace = true }
-
-[dev-dependencies]
-oxc_allocator = { workspace = true }
-oxc_parser    = { workspace = true }
-oxc_codegen   = { workspace = true }
-pico-args     = { workspace = true }

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -10,7 +10,7 @@ use pico_args::Arguments;
 
 // Instruction:
 // create a `test.js`,
-// run `cargo run -p oxc_mangler --example mangler` or `just example mangler`
+// run `cargo run -p oxc_minifier --example mangler`
 
 fn main() -> std::io::Result<()> {
     let mut args = Arguments::from_env();


### PR DESCRIPTION
```
Error: Circular dependency detected: oxc_codegen -> oxc_mangler
```