### PR TITLE
refactor(linter): use diagnostic codes in lint rules

### DIFF
--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -100,6 +100,11 @@ impl Diagnostic for OxcDiagnostic {
             .map(Box::new)
             .map(|b| b as Box<dyn Iterator<Item = LabeledSpan>>)
     }
+
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        // self.code.is_some().then(|| Box::new(&self.code) as Box<dyn Display>)
+        None
+    }
 }
 
 impl OxcDiagnostic {
@@ -138,21 +143,29 @@ impl OxcDiagnostic {
 
     #[inline]
     pub fn with_error_code_scope<T: Into<Cow<'static, str>>>(mut self, code_scope: T) -> Self {
-        self.inner.code.scope = Some(code_scope.into());
+        self.inner.code.scope = match self.inner.code.scope {
+            Some(scope) => Some(scope),
+            None => Some(code_scope.into()),
+        };
         debug_assert!(
             self.inner.code.scope.as_ref().is_some_and(|s| !s.is_empty()),
             "Error code scopes cannot be empty"
         );
+
         self
     }
 
     #[inline]
     pub fn with_error_code_num<T: Into<Cow<'static, str>>>(mut self, code_num: T) -> Self {
-        self.inner.code.number = Some(code_num.into());
+        self.inner.code.number = match self.inner.code.number {
+            Some(num) => Some(num),
+            None => Some(code_num.into()),
+        };
         debug_assert!(
             self.inner.code.number.as_ref().is_some_and(|n| !n.is_empty()),
             "Error code numbers cannot be empty"
         );
+
         self
     }
 

--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -13,7 +13,7 @@ use oxc_linter::{
         AstroPartialLoader, JavaScriptSource, SveltePartialLoader, VuePartialLoader,
         LINT_PARTIAL_LOADER_EXT,
     },
-    FixKind, LintContext, Linter,
+    FixKind, Linter,
 };
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -304,12 +304,7 @@ impl IsolatedLintHandler {
                 return Some(Self::wrap_diagnostics(path, &original_source_text, reports, start));
             };
 
-            let lint_ctx = LintContext::new(
-                path.to_path_buf().into_boxed_path(),
-                Rc::new(semantic_ret.semantic),
-            );
-
-            let result = linter.run(lint_ctx);
+            let result = linter.run(path, Rc::new(semantic_ret.semantic));
 
             let reports = result
                 .into_iter()

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -1,0 +1,85 @@
+use bitflags::bitflags;
+use oxc_semantic::ModuleRecord;
+use std::{hash, path::Path};
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FrameworkFlags: u32 {
+        // front-end frameworks
+
+        /// Uses [React](https://reactjs.org/).
+        ///
+        /// May be part of a meta-framework like Next.js.
+        const React = 1 << 0;
+        /// Uses [Preact](https://preactjs.com/).
+        const Preact = 1 << 1;
+        /// Uses [Next.js](https://nextjs.org/).
+        const NextOnly = 1 << 2;
+        const Next = Self::NextOnly.bits() | Self::React.bits();
+        const JsxLike = Self::React.bits() | Self::Preact.bits() | Self::Next.bits();
+
+        const Vue = 1 << 3;
+        const NuxtOnly = 1 << 4;
+        const Nuxt = Self::NuxtOnly.bits() | Self::Vue.bits();
+
+        const Angular = 1 << 5;
+
+        const Svelte = 1 << 6;
+        const SvelteKitOnly = 1 << 7;
+        const SvelteKit = Self::SvelteKitOnly.bits() | Self::Svelte.bits();
+
+        const Astro = 1 << 8;
+
+        // Testing frameworks
+        const Jest = 1 << 9;
+        const Vitest = 1 << 10;
+        const OtherTest = 1 << 11;
+        const Test = Self::Jest.bits() | Self::Vitest.bits() | Self::OtherTest.bits();
+    }
+}
+
+impl Default for FrameworkFlags {
+    #[inline]
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+impl hash::Hash for FrameworkFlags {
+    #[inline]
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        state.write_u32(self.bits());
+    }
+}
+
+impl FrameworkFlags {
+    #[inline]
+    pub const fn is_test(self) -> bool {
+        self.intersects(Self::Test)
+    }
+
+    #[inline]
+    pub const fn is_vitest(self) -> bool {
+        self.contains(Self::Vitest)
+    }
+}
+
+/// <https://jestjs.io/docs/configuration#testmatch-arraystring>
+pub(crate) fn is_jestlike_file(path: &Path) -> bool {
+    use std::ffi::OsStr;
+
+    if path.components().any(|c| match c {
+        std::path::Component::Normal(p) => p == OsStr::new("__tests__"),
+        _ => false,
+    }) {
+        return true;
+    }
+
+    path.file_name() // foo/bar/baz.test.ts -> baz.test.ts
+        .and_then(OsStr::to_str)
+        .and_then(|filename| filename.split('.').rev().nth(1)) // baz.test.ts -> test
+        .is_some_and(|name_or_first_ext| name_or_first_ext == "test" || name_or_first_ext == "spec")
+}
+
+pub(crate) fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
+    module_record.import_entries.iter().any(|entry| entry.module_request.name() == "vitest")
+}

--- a/crates/oxc_linter/src/options.rs
+++ b/crates/oxc_linter/src/options.rs
@@ -7,7 +7,7 @@ use serde_json::{Number, Value};
 
 use crate::{
     config::OxlintConfig, fixer::FixKind, rules::RULES, utils::is_jest_rule_adapted_to_vitest,
-    RuleCategory, RuleEnum, RuleWithSeverity,
+    FrameworkFlags, RuleCategory, RuleEnum, RuleWithSeverity,
 };
 
 #[derive(Debug)]
@@ -33,6 +33,8 @@ pub struct LintOptions {
     pub nextjs_plugin: bool,
     pub react_perf_plugin: bool,
     pub promise_plugin: bool,
+
+    pub framework_hints: FrameworkFlags,
 }
 
 impl Default for LintOptions {
@@ -53,6 +55,8 @@ impl Default for LintOptions {
             nextjs_plugin: false,
             react_perf_plugin: false,
             promise_plugin: false,
+
+            framework_hints: FrameworkFlags::default(),
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -18,19 +18,15 @@ use crate::{
 };
 
 fn expect_return(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(array-callback-return): Missing return on some path for array method {x0:?}"
-    ))
-    .with_help(format!("Array method {x0:?} needs to have valid return on all code paths"))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("Missing return on some path for array method {x0:?}"))
+        .with_help(format!("Array method {x0:?} needs to have valid return on all code paths"))
+        .with_label(span1)
 }
 
 fn expect_no_return(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(array-callback-return): Unexpected return for array method {x0:?}"
-    ))
-    .with_help(format!("Array method {x0:?} expects no useless return from the function"))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("Unexpected return for array method {x0:?}"))
+        .with_help(format!("Array method {x0:?} expects no useless return from the function"))
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -4,12 +4,12 @@ use oxc_macros::declare_oxc_lint;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 // #[derive(Debug, Error, Diagnostic)]
-// #[error("eslint(constructor-super): Expected to call 'super()'.")]
+// #[error("Expected to call 'super()'.")]
 // #[diagnostic(severity(warning), help("Ensure 'super()' is called from constructor"))]
 // struct ConstructorSuperDiagnostic(#[label] pub Span);
 
 // #[derive(Debug, Error, Diagnostic)]
-// #[error("eslint(constructor-super): Unexpected 'super()' because 'super' is not a constructor.")]
+// #[error("Unexpected 'super()' because 'super' is not a constructor.")]
 // #[diagnostic(severity(warning), help("Do not call 'super()' from constructor."))]
 // struct SuperNotConstructorDiagnostic(
 //     #[label("unexpected 'super()'")] pub Span,

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -7,7 +7,7 @@ use regex::{Regex, RegexBuilder};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn default_case_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(default-case): Require default cases in switch statements.")
+    OxcDiagnostic::warn("Require default cases in switch statements.")
         .with_help("Add a default case.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -6,10 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn default_case_last_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(default-case-last): Enforce default clauses in switch statements to be last",
-    )
-    .with_label(span0.label("Default clause should be the last clause."))
+    OxcDiagnostic::warn("Enforce default clauses in switch statements to be last")
+        .with_label(span0.label("Default clause should be the last clause."))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn default_param_last_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(default-param-last): Default parameters should be last")
+    OxcDiagnostic::warn("Default parameters should be last")
         .with_help("Enforce default parameters to be last.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -10,7 +10,7 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn eqeqeq_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(eqeqeq): Expected {x1} and instead saw {x0}"))
+    OxcDiagnostic::warn(format!("Expected {x1} and instead saw {x0}"))
         .with_help(format!("Prefer {x1} operator"))
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -13,7 +13,7 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator, Up
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn for_direction_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(for-direction): The update clause in this loop moves the variable in the wrong direction")
+    OxcDiagnostic::warn("The update clause in this loop moves the variable in the wrong direction")
         .with_help("Use while loop for intended infinite loop")
         .with_labels([
             span0.label("This test moves in the wrong direction"),

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -19,7 +19,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn getter_return_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(getter-return): Expected to always return a value in getter.")
+    OxcDiagnostic::warn("Expected to always return a value in getter.")
         .with_help("Return a value from all code paths in getter.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
+++ b/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn guard_for_in_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(guard-for-in): Require `for-in` loops to include an `if` statement")
+    OxcDiagnostic::warn("Require `for-in` loops to include an `if` statement")
         .with_help("The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -8,11 +8,9 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule};
 
 fn max_classes_per_file_diagnostic(total: usize, max: usize, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(max-classes-per-file): File has too many classes ({total}). Maximum allowed is {max}",
-    ))
-    .with_help("Reduce the number of classes in this file")
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("File has too many classes ({total}). Maximum allowed is {max}",))
+        .with_help("Reduce the number of classes in this file")
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule};
 
 fn max_lines_diagnostic(count: usize, max: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(max-lines): File has too many lines ({count})."))
+    OxcDiagnostic::warn(format!("File has too many lines ({count})."))
         .with_help(format!("Maximum allowed is {max}."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn max_params_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(max-params): {x0:?}"))
+    OxcDiagnostic::warn(format!("{x0:?}"))
         .with_help(
             "This rule enforces a maximum number of parameters allowed in function definitions.",
         )

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_array_constructor_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-array-constructor): Disallow `Array` constructors")
+    OxcDiagnostic::warn("Disallow `Array` constructors")
         .with_help("Use array literal instead")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -9,10 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_async_promise_executor_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-async-promise-executor): Promise executor functions should not be `async`.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Promise executor functions should not be `async`.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -9,8 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_await_in_loop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-await-in-loop): Unexpected `await` inside a loop.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Unexpected `await` inside a loop.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::BinaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_bitwise_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-bitwise): Unexpected use of {x0:?}"))
+    OxcDiagnostic::warn(format!("Unexpected use of {x0:?}"))
         .with_help("bitwise operators are not allowed, maybe you mistyped `&&` or `||`")
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_caller_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-caller): Disallow the use of arguments.caller or arguments.callee")
+    OxcDiagnostic::warn("Disallow the use of arguments.caller or arguments.callee")
         .with_help("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -9,10 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_case_declarations_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-case-declarations): Unexpected lexical declaration in case block.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected lexical declaration in case block.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -6,11 +6,10 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_class_assign_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-class-assign): Unexpected re-assignment of class {x0}"))
-        .with_labels([
-            span1.label(format!("{x0} is declared as class here")),
-            span2.label(format!("{x0} is re-assigned here")),
-        ])
+    OxcDiagnostic::warn(format!("Unexpected re-assignment of class {x0}")).with_labels([
+        span1.label(format!("{x0} is declared as class here")),
+        span2.label(format!("{x0} is re-assigned here")),
+    ])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -7,11 +7,9 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_compare_neg_zero_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-compare-neg-zero): Do not use the {x0} operator to compare against -0."
-    ))
-    .with_help("Use Object.is(x, -0) to test equality with -0 and use 0 for other cases")
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("Do not use the {x0} operator to compare against -0."))
+        .with_help("Use Object.is(x, -0) to test equality with -0 and use 0 for other cases")
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -9,11 +9,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_cond_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-cond-assign): Expected a conditional expression and instead saw an assignment",
-    )
-    .with_help("Consider wrapping the assignment in additional parentheses")
-    .with_label(span0)
+    OxcDiagnostic::warn("Expected a conditional expression and instead saw an assignment")
+        .with_help("Consider wrapping the assignment in additional parentheses")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_console_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-console): Unexpected console statement.").with_label(span0)
+    OxcDiagnostic::warn("Unexpected console statement.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -6,10 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_const_assign_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-const-assign): Unexpected re-assignment of const variable {x0}"
-    ))
-    .with_labels([
+    OxcDiagnostic::warn(format!("Unexpected re-assignment of const variable {x0}")).with_labels([
         span1.label(format!("{x0} is declared here as const")),
         span2.label(format!("{x0} is re-assigned here")),
     ])

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -49,29 +49,29 @@ declare_oxc_lint!(
 );
 
 fn constant_short_circuit(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-constant-binary-expression): Unexpected constant {x0:?} on the left-hand side of a {x1:?} expression"))
-        .with_help("This expression always evaluates to the constant on the left-hand side")
-        .with_label(span2)
-}
-
-fn constant_binary_operand(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-constant-binary-expression): Unexpected constant binary expression",
-    )
-    .with_help(format!("This compares constantly with the {x0}-hand side of the {x1}"))
+    OxcDiagnostic::warn(format!(
+        "Unexpected constant {x0:?} on the left-hand side of a {x1:?} expression"
+    ))
+    .with_help("This expression always evaluates to the constant on the left-hand side")
     .with_label(span2)
 }
 
+fn constant_binary_operand(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected constant binary expression")
+        .with_help(format!("This compares constantly with the {x0}-hand side of the {x1}"))
+        .with_label(span2)
+}
+
 fn constant_always_new(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-constant-binary-expression): Unexpected comparison to newly constructed object",
-    )
-    .with_help("These two values can never be equal")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected comparison to newly constructed object")
+        .with_help("These two values can never be equal")
+        .with_label(span0)
 }
 
 fn constant_both_always_new(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-constant-binary-expression): Unexpected comparison of two newly constructed objects").with_help("These two values can never be equal").with_label(span0)
+    OxcDiagnostic::warn("Unexpected comparison of two newly constructed objects")
+        .with_help("These two values can never be equal")
+        .with_label(span0)
 }
 
 impl Rule for NoConstantBinaryExpression {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{ast_util::IsConstant, context::LintContext, rule::Rule, AstNode};
 
 fn no_constant_condition_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-constant-condition): Unexpected constant condition")
+    OxcDiagnostic::warn("Unexpected constant condition")
         .with_help("Constant expression as a test condition is not allowed")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -10,10 +10,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_constructor_return_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-constructor-return): Unexpected return statement in constructor.",
-    )
-    .with_label(span)
+    OxcDiagnostic::warn("Unexpected return statement in constructor.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_continue_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-continue): Unexpected use of `continue` statement.")
+    OxcDiagnostic::warn("Unexpected use of `continue` statement.")
         .with_help("Do not use the `continue` statement.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -11,7 +11,7 @@ use regex::{Matches, Regex};
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
 fn no_control_regex_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-control-regex): Unexpected control character(s)")
+    OxcDiagnostic::warn("Unexpected control character(s)")
         .with_help(format!("Unexpected control character(s) in regular expression: \"{x0}\""))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_debugger_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-debugger): `debugger` statement is not allowed")
-        .with_label(span0)
+    OxcDiagnostic::warn("`debugger` statement is not allowed").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_delete_var_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-delete-var): variables should not be deleted").with_label(span0)
+    OxcDiagnostic::warn("variables should not be deleted").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_div_regex_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-div-regex): A regular expression literal can be confused with '/='.",
-    )
-    .with_help("Rewrite `/=` into `/[=]`")
-    .with_label(span0)
+    OxcDiagnostic::warn("A regular expression literal can be confused with '/='.")
+        .with_help("Rewrite `/=` into `/[=]`")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -10,7 +10,7 @@ fn no_dupe_class_members_diagnostic(
     span1: Span,
     span2: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-dupe-class-members): Duplicate class member: {x0:?}"))
+    OxcDiagnostic::warn(format!("Duplicate class member: {x0:?}"))
         .with_help("The last declaration overwrites previous ones, remove one of them or rename if both should be retained")
         .with_labels([
             span1.label(format!("{x0:?} is previously declared here")),

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -10,7 +10,7 @@ use oxc_syntax::operator::LogicalOperator;
 use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
 
 fn no_dupe_else_if_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-dupe-else-if): duplicate conditions in if-else-if chains")
+    OxcDiagnostic::warn("duplicate conditions in if-else-if chains")
         .with_help("This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_dupe_keys_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-dupe-keys): Disallow duplicate keys in object literals")
+    OxcDiagnostic::warn("Disallow duplicate keys in object literals")
         .with_help("Consider removing the duplicated key")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
 
 fn no_duplicate_case_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-duplicate-case): Disallow duplicate case labels")
+    OxcDiagnostic::warn("Disallow duplicate case labels")
         .with_help("Remove the duplicated case")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-empty): Disallow empty block statements")
+    OxcDiagnostic::warn("Disallow empty block statements")
         .with_help(format!("Add comment inside empty {x0} statement"))
         .with_label(span1.label(format!("Empty {x0} statement")))
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_character_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-empty-character-class): Empty character class")
+    OxcDiagnostic::warn("Empty character class")
         .with_help("Try to remove empty character class `[]` in regexp literal")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_function_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-empty-function): Disallow empty functions")
+    OxcDiagnostic::warn("Disallow empty functions")
         .with_help("Unexpected empty function block")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_pattern_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-empty-pattern): Disallow empty destructuring patterns.")
+    OxcDiagnostic::warn("Disallow empty destructuring patterns.")
         .with_help("Passing `null` or `undefined` will result in runtime error because `null` and `undefined` cannot be destructured.")
         .with_label(
             span1.label(format!("Empty {x0} binding pattern")),

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_static_block_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-empty-static-block): Disallow empty static blocks")
+    OxcDiagnostic::warn("Disallow empty static blocks")
         .with_help("Unexpected empty static block.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -9,7 +9,7 @@ use oxc_syntax::operator::BinaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_eq_null_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-eq-null): Use '===' to compare with null")
+    OxcDiagnostic::warn("Use '===' to compare with null")
         .with_help("Disallow `null` comparisons without type-checking operators.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -8,7 +8,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_eval_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-eval): eval can be harmful.").with_label(span0)
+    OxcDiagnostic::warn("eval can be harmful.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_ex_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-ex-assign): Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_label(span0)
+    OxcDiagnostic::warn("Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -8,13 +8,13 @@ use oxc_syntax::operator::{LogicalOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_extra_double_negation_cast_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-extra-boolean-cast): Redundant double negation")
+    OxcDiagnostic::warn("Redundant double negation")
         .with_help("Remove the double negation as it will already be coerced to a boolean")
         .with_label(span0)
 }
 
 fn no_extra_boolean_cast_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-extra-boolean-cast): Redundant Boolean call")
+    OxcDiagnostic::warn("Redundant Boolean call")
         .with_help("Remove the Boolean call as it will already be coerced to a boolean")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -21,18 +21,18 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_fallthrough_case_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("eslint(no-fallthrough): Expected a 'break' statement before 'case'.")
-        .with_label(span)
+    OxcDiagnostic::error("Expected a 'break' statement before 'case'.").with_label(span)
 }
 
 fn no_fallthrough_default_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("eslint(no-fallthrough): Expected a 'break' statement before 'default'.")
-        .with_label(span)
+    OxcDiagnostic::error("Expected a 'break' statement before 'default'.").with_label(span)
 }
 
 fn no_unused_fallthrough_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("eslint(no-fallthrough): Found a comment that would permit fallthrough, but case cannot fall through.")
-        .with_label(span)
+    OxcDiagnostic::error(
+        "Found a comment that would permit fallthrough, but case cannot fall through.",
+    )
+    .with_label(span)
 }
 
 const DEFAULT_FALLTHROUGH_COMMENT_PATTERN: &str = r"falls?\s?through";

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_func_assign_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-func-assign): '{x0}' is a function."))
+    OxcDiagnostic::warn(format!("'{x0}' is a function."))
         .with_label(span1.label(format!("{x0} is re-assigned here")))
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -5,10 +5,8 @@ use oxc_span::{CompactStr, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_global_assign_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-global-assign): Read-only global '{x0}' should not be modified."
-    ))
-    .with_label(span1.label(format!("Read-only global '{x0}' should not be modified.")))
+    OxcDiagnostic::warn(format!("Read-only global '{x0}' should not be modified."))
+        .with_label(span1.label(format!("Read-only global '{x0}' should not be modified.")))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -9,7 +9,7 @@ use phf::phf_set;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_import_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-import-assign): do not assign to imported bindings")
+    OxcDiagnostic::warn("do not assign to imported bindings")
         .with_help("imported bindings are readonly")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_inner_declarations_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks")
+    OxcDiagnostic::warn("Variable or `function` declarations are not allowed in nested blocks")
         .with_help(format!("Move {x0} declaration to {x1} root"))
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -5,7 +5,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_irregular_whitespace_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-irregular-whitespace): Unexpected irregular whitespace")
+    OxcDiagnostic::warn("Unexpected irregular whitespace")
         .with_help("Try to remove the irregular whitespace")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_iterator_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-iterator): Reserved name '__iterator__'")
+    OxcDiagnostic::warn("Reserved name '__iterator__'")
         .with_help("Disallow the use of the `__iterator__` property.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -6,13 +6,11 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_label_var_diagnostic(x0: &str, span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-label-var): Found identifier '{x0}' with the same name as a label."
-    ))
-    .with_labels([
-        span0.label(format!("Identifier '{x0}' found here.")),
-        span1.label("Label with the same name."),
-    ])
+    OxcDiagnostic::warn(format!("Found identifier '{x0}' with the same name as a label."))
+        .with_labels([
+            span0.label(format!("Identifier '{x0}' found here.")),
+            span1.label("Label with the same name."),
+        ])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -8,10 +8,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_loss_of_precision_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-loss-of-precision): This number literal will lose precision at runtime.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("This number literal will lose precision at runtime.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_multi_str_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-multi-str): Unexpected multi string.").with_label(span0)
+    OxcDiagnostic::warn("Unexpected multi string.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-new): Do not use 'new' for side effects.").with_label(span0)
+    OxcDiagnostic::warn("Do not use 'new' for side effects.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -6,10 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_native_nonconstructor_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-new-native-nonconstructor): `{x0}` cannot be called as a constructor."
-    ))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("`{x0}` cannot be called as a constructor.")).with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_wrappers_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-new-wrappers): Disallow new operators with the String, Number, and Boolean objects")
+    OxcDiagnostic::warn("Disallow new operators with the String, Number, and Boolean objects")
         .with_help(format!("do not use {x0} as a constructor, consider removing the new operator."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -8,19 +8,15 @@ use regex::{Captures, Regex};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn replacement(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-nonoctal-decimal-escape): Don't use '{x0}' escape sequence."
-    ))
-    .with_help(format!("Replace '{x0}' with '{x1}'. This maintains the current functionality."))
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("Don't use '{x0}' escape sequence."))
+        .with_help(format!("Replace '{x0}' with '{x1}'. This maintains the current functionality."))
+        .with_label(span2)
 }
 
 fn escape_backslash(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-nonoctal-decimal-escape): Don't use '{x0}' escape sequence."
-    ))
-    .with_help(format!("Replace '{x0}' with '{x1}' to include the actual backslash character."))
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("Don't use '{x0}' escape sequence."))
+        .with_help(format!("Replace '{x0}' with '{x1}' to include the actual backslash character."))
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -13,7 +13,7 @@ const GLOBAL_THIS: &str = "globalThis";
 const NON_CALLABLE_GLOBALS: [&str; 5] = ["Atomics", "Intl", "JSON", "Math", "Reflect"];
 
 fn no_obj_calls_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-obj-calls): Disallow calling some global objects as functions")
+    OxcDiagnostic::warn("Disallow calling some global objects as functions")
         .with_help(format!("{x0} is not a function."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_proto_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-proto): The '__proto__' property is deprecated")
+    OxcDiagnostic::warn("The '__proto__' property is deprecated")
         .with_help("Disallow the use of the `__proto__` property.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -6,8 +6,10 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_prototype_builtins_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-prototype-builtins): do not access Object.prototype method {x0:?} from target object"))
-        .with_help(format!("to avoid prototype pollution, use `Object.prototype.{x0}.call` instead"))
+    OxcDiagnostic::warn(format!("do not access Object.prototype method {x0:?} from target object"))
+        .with_help(format!(
+            "to avoid prototype pollution, use `Object.prototype.{x0}.call` instead"
+        ))
         .with_label(span1)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -9,17 +9,17 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_redeclare_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-redeclare): '{x0}' is already defined.")).with_labels([
+    OxcDiagnostic::warn(format!("'{x0}' is already defined.")).with_labels([
         span1.label(format!("'{x0}' is already defined.")),
         span2.label("It can not be redeclare here."),
     ])
 }
 
 fn no_redeclare_as_builti_in_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-redeclare): '{x0}' is already defined as a built-in global variable."
-    ))
-    .with_label(span1.label(format!("'{x0}' is already defined as a built-in global variable.")))
+    OxcDiagnostic::warn(format!("'{x0}' is already defined as a built-in global variable."))
+        .with_label(
+            span1.label(format!("'{x0}' is already defined as a built-in global variable.")),
+        )
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -10,7 +10,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_regex_spaces_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-regex-spaces): Spaces are hard to count.")
+    OxcDiagnostic::warn("Spaces are hard to count.")
         .with_help("Use a quantifier, e.g. {2}")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -9,9 +9,9 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_restricted_globals(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     let warn_text = if x1.is_empty() {
-        format!("eslint(no-restricted-globals): Unexpected use of '{x0}'.")
+        format!("Unexpected use of '{x0}'.")
     } else {
-        format!("eslint(no-restricted-globals): Unexpected use of '{x0}'. {x1}")
+        format!("Unexpected use of '{x0}'. {x1}")
     };
 
     OxcDiagnostic::warn(warn_text).with_label(span2)

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_script_url_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-script-url): Script URL is a form of eval")
+    OxcDiagnostic::warn("Script URL is a form of eval")
         .with_help("Disallow `javascript:` urls")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -14,8 +14,7 @@ use oxc_syntax::operator::AssignmentOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_self_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-self-assign): this expression is assigned to itself")
-        .with_label(span0)
+    OxcDiagnostic::warn("this expression is assigned to itself").with_label(span0)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -6,11 +6,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{ast_util::calculate_hash, context::LintContext, rule::Rule, AstNode};
 
 fn no_self_compare_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-self-compare): Disallow comparisons where both sides are exactly the same",
-    )
-    .with_help("If you are testing for NaN, you can use Number.isNaN function.")
-    .with_labels([span0, span1])
+    OxcDiagnostic::warn("Disallow comparisons where both sides are exactly the same")
+        .with_help("If you are testing for NaN, you can use Number.isNaN function.")
+        .with_labels([span0, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_setter_return_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-setter-return): Setter cannot return a value").with_label(span0)
+    OxcDiagnostic::warn("Setter cannot return a value").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, globals::PRE_DEFINE_VAR, rule::Rule};
 
 fn no_shadow_restricted_names_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-shadow-restricted-names): Shadowing of global properties such as 'undefined' is not allowed.")
+    OxcDiagnostic::warn("Shadowing of global properties such as 'undefined' is not allowed.")
         .with_help(format!("Shadowing of global properties '{x0}'."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -46,11 +46,9 @@ impl Rule for NoSparseArrays {
             if !violations.is_empty() {
                 if violations.len() < 10 {
                     ctx.diagnostic(
-                        OxcDiagnostic::warn(
-                            "eslint(no-sparse-arrays): Unexpected comma in middle of array",
-                        )
-                        .with_help("remove the comma or insert `undefined`")
-                        .with_labels(violations),
+                        OxcDiagnostic::warn("Unexpected comma in middle of array")
+                            .with_help("remove the comma or insert `undefined`")
+                            .with_labels(violations),
                     );
                 } else {
                     let span = if (array_expr.span.end - array_expr.span.start) < 50 {
@@ -64,7 +62,7 @@ impl Rule for NoSparseArrays {
 
                     ctx.diagnostic(
                         OxcDiagnostic::warn(format!(
-                            "eslint(no-sparse-arrays): {} unexpected commas in middle of array",
+                            "{} unexpected commas in middle of array",
                             violations.len()
                         ))
                         .with_help("remove the comma or insert `undefined`")

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_template_curly_in_string_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-template-curly-in-string): Unexpected template string expression",
-    )
-    .with_help("Disallow template literal placeholder syntax in regular strings")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected template string expression")
+        .with_help("Disallow template literal placeholder syntax in regular strings")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_ternary_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-ternary): Unexpected use of ternary expression")
+    OxcDiagnostic::warn("Unexpected use of ternary expression")
         .with_help("Do not use the ternary expression.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -16,7 +16,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_this_before_super_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-this-before-super): Expected to always call super() before this/super property access.")
+    OxcDiagnostic::warn("Expected to always call super() before this/super property access.")
         .with_help("Call super() before this/super property access.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_undef_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-undef): Disallow the use of undeclared variables.")
+    OxcDiagnostic::warn("Disallow the use of undeclared variables.")
         .with_help(format!("'{x0}' is not defined."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,7 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-undefined): Disallow the use of `undefined` as an identifier")
+    OxcDiagnostic::warn("Disallow the use of `undefined` as an identifier")
         .with_help("Unexpected use of undefined.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -13,7 +13,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unreachable_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("eslint(no-unreachable): Unreachable code.").with_label(span)
+    OxcDiagnostic::error("Unreachable code.").with_label(span)
 }
 
 /// <https://github.com/eslint/eslint/blob/069aa680c78b8516b9a1b568519f1d01e74fb2a2/lib/rules/no-unreachable.js#L196>

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unsafe_finally_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-unsafe-finally): Unsafe finally block")
+    OxcDiagnostic::warn("Unsafe finally block")
         .with_help("Control flow inside try or catch blocks will be overwritten by this statement")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -10,17 +10,15 @@ use oxc_syntax::operator::LogicalOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unsafe_optional_chaining_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining")
+    OxcDiagnostic::warn("Unsafe usage of optional chaining")
         .with_help("If this short-circuits with 'undefined' the evaluation will throw TypeError")
         .with_label(span0)
 }
 
 fn no_unsafe_arithmetic_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(no-unsafe-optional-chaining): Unsafe arithmetic operation on optional chaining",
-    )
-    .with_help("This can result in NaN.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unsafe arithmetic operation on optional chaining")
+        .with_help("This can result in NaN.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unused_labels_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-unused-labels): Disallow unused labels")
+    OxcDiagnostic::warn("Disallow unused labels")
         .with_help(format!("'{x0}:' is defined but never used."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -9,10 +9,7 @@ use oxc_syntax::class::ElementKind;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unused_private_class_members_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-unused-private-class-members): '{x0}' is defined but never used."
-    ))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("'{x0}' is defined but never used.")).with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -9,12 +9,12 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_catch_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-useless-catch): Unnecessary try/catch wrapper")
+    OxcDiagnostic::warn("Unnecessary try/catch wrapper")
         .with_labels([catch.label("is caught here"), rethrow.label("and re-thrown here")])
 }
 
 fn no_useless_catch_finalizer_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-useless-catch): Unnecessary catch clause")
+    OxcDiagnostic::warn("Unnecessary catch clause")
         .with_labels([catch.label("is caught here"), rethrow.label("and re-thrown here")])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -13,7 +13,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub struct NoUselessConcat;
 
 fn no_useless_concat_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-useless-concat): Unexpected string concatenation of literals.")
+    OxcDiagnostic::warn("Unexpected string concatenation of literals.")
         .with_help("Rewrite into one string literal")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -12,12 +12,12 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_constructor(constructor_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-useless-constructor): Empty constructors are unnecessary")
+    OxcDiagnostic::warn("Empty constructors are unnecessary")
         .with_label(constructor_span)
         .with_help("Remove the constructor or add code to it.")
 }
 fn no_redundant_super_call(constructor_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-useless-constructor): Redundant super call in constructor")
+    OxcDiagnostic::warn("Redundant super call in constructor")
         .with_label(constructor_span).with_help("Constructors of subclasses invoke super() automatically if they are empty. Remove this constructor or add code to it.")
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -8,8 +8,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_escape_diagnostic(x0: char, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(no-useless-escape): Unnecessary escape character {x0:?}"))
-        .with_label(span1)
+    OxcDiagnostic::warn(format!("Unnecessary escape character {x0:?}")).with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -9,9 +9,11 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_rename_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-useless-rename): Disallow renaming import, export, and destructured assignments to the same name")
-        .with_help("Either remove the renaming or rename the variable.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Disallow renaming import, export, and destructured assignments to the same name",
+    )
+    .with_help("Either remove the renaming or rename the variable.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_var_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-var): Unexpected var, use let or const instead.")
+    OxcDiagnostic::warn("Unexpected var, use let or const instead.")
         .with_help("Replace var with let or const")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_void_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-void): Disallow `void` operators")
+    OxcDiagnostic::warn("Disallow `void` operators")
         .with_help("Expected 'undefined' and instead saw 'void'.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_with_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-with): Unexpected use of `with` statement.")
+    OxcDiagnostic::warn("Unexpected use of `with` statement.")
         .with_help("Do not use the `with` statement.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -12,10 +12,7 @@ use crate::{
 pub struct PreferExponentiationOperator;
 
 fn prefer_exponentian_operator_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer `**` over `Math.pow`.").with_label(span0)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -9,22 +9,20 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn missing_parameters(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(radix): Missing parameters.").with_label(span0)
+    OxcDiagnostic::warn("Missing parameters.").with_label(span0)
 }
 
 fn missing_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(radix): Missing radix parameter.").with_label(span0)
+    OxcDiagnostic::warn("Missing radix parameter.").with_label(span0)
 }
 
 fn redundant_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(radix): Redundant radix parameter.").with_label(span0)
+    OxcDiagnostic::warn("Redundant radix parameter.").with_label(span0)
 }
 
 fn invalid_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Invalid radix parameter, must be an integer between 2 and 36.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -14,8 +14,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub struct RequireAwait;
 
 fn require_await_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(require-await): Async function has no 'await' expression.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Async function has no 'await' expression.").with_label(span0)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn require_yield_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(require-yield): This generator function does not have 'yield'")
-        .with_label(span0)
+    OxcDiagnostic::warn("This generator function does not have 'yield'").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -19,20 +19,18 @@ fn unexpected_syntax_order_diagnostic(
     x1: &ImportKind,
     span2: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(sort-imports): Expected '{x0}' syntax before '{x1}' syntax."
-    ))
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("Expected '{x0}' syntax before '{x1}' syntax.")).with_label(span2)
 }
 
 fn sort_imports_alphabetically_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(sort-imports): Imports should be sorted alphabetically.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span0)
 }
 
 fn sort_members_alphabetically_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint(sort-imports): Member '{x0}' of the import declaration should be sorted alphabetically."))
-        .with_label(span0)
+    OxcDiagnostic::warn(format!(
+        "Member '{x0}' of the import declaration should be sorted alphabetically."
+    ))
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -9,8 +9,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 pub struct SymbolDescription;
 
 fn symbol_description_diagnostic(span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(symbol-description): Expected Symbol to have a description.")
-        .with_label(span1)
+    OxcDiagnostic::warn("Expected Symbol to have a description.").with_label(span1)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -5,13 +5,13 @@ use oxc_span::{Span, SPAN};
 use crate::{context::LintContext, rule::Rule};
 
 fn unexpected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(unicode-bom): Unexpected Unicode BOM (Byte Order Mark)")
+    OxcDiagnostic::warn("Unexpected Unicode BOM (Byte Order Mark)")
         .with_help("File must not begin with the Unicode BOM")
         .with_label(span0)
 }
 
 fn expected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(unicode-bom): Expected Unicode BOM (Byte Order Mark)")
+    OxcDiagnostic::warn("Expected Unicode BOM (Byte Order Mark)")
         .with_help("File must begin with the Unicode BOM")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -10,13 +10,13 @@ use oxc_syntax::operator::BinaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn comparison_with_na_n(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
+    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help("Use the isNaN function to compare with NaN.")
         .with_label(span0)
 }
 
 fn switch_na_n(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
+    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help(
             "'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.",
         )
@@ -24,13 +24,13 @@ fn switch_na_n(span0: Span) -> OxcDiagnostic {
 }
 
 fn case_na_n(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
+    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help("'case NaN' can never match. Use Number.isNaN before the switch.")
         .with_label(span0)
 }
 
 fn index_of_na_n(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(use-isnan): Requires calls to isNaN() when checking for NaN")
+    OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help(format!("Array prototype method '{x0}' cannot find NaN."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -8,10 +8,8 @@ use phf::{phf_set, Set};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn not_string(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(
-        "eslint(valid-typeof): Typeof comparisons should be to string literals.",
-    )
-    .with_label(span1);
+    let mut d =
+        OxcDiagnostic::warn("Typeof comparisons should be to string literals.").with_label(span1);
     if let Some(x) = x0 {
         d = d.with_help(x);
     }
@@ -19,8 +17,7 @@ fn not_string(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
 }
 
 fn invalid_value(x0: Option<&'static str>, span1: Span) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn("eslint(valid-typeof): Invalid typeof comparison value.")
-        .with_label(span1);
+    let mut d = OxcDiagnostic::warn("Invalid typeof comparison value.").with_label(span1);
     if let Some(x) = x0 {
         d = d.with_help(x);
     }

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -6,11 +6,9 @@ use oxc_syntax::module_record::ImportImportName;
 use crate::{context::LintContext, rule::Rule};
 
 fn default_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(default): No default export found in imported module {x0:?}"
-    ))
-    .with_help(format!("does {x0:?} have the default export?"))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("No default export found in imported module {x0:?}"))
+        .with_help(format!("does {x0:?} have the default export?"))
+        .with_label(span1)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md>

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -9,10 +9,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_named_export(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(export): No named exports found in module '{x1}'"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("No named exports found in module '{x1}'")).with_label(span0)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md>
@@ -89,10 +86,8 @@ impl Rule for Export {
                 let labels = spans.into_iter().map(LabeledSpan::underline).collect::<Vec<_>>();
 
                 ctx.diagnostic(
-                    OxcDiagnostic::warn(format!(
-                        "eslint-plugin-import(export): Multiple exports of name '{name}'."
-                    ))
-                    .with_labels(labels),
+                    OxcDiagnostic::warn(format!("Multiple exports of name '{name}'."))
+                        .with_labels(labels),
                 );
             }
         }
@@ -103,8 +98,7 @@ impl Rule for Export {
                 spans.push(span);
                 let labels = spans.into_iter().map(LabeledSpan::underline).collect::<Vec<_>>();
                 ctx.diagnostic(
-                    OxcDiagnostic::warn("eslint-plugin-import(export): Multiple default exports.")
-                        .with_labels(labels),
+                    OxcDiagnostic::warn("Multiple default exports.").with_labels(labels),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule};
 
 fn max_dependencies_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-import(max-dependencies): {x0:?}"))
+    OxcDiagnostic::warn(format!("{x0:?}"))
         .with_help("Reduce the number of dependencies in this file")
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -6,7 +6,7 @@ use oxc_syntax::module_record::{ExportImportName, ImportImportName};
 use crate::{context::LintContext, rule::Rule};
 
 fn named_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-import(named): named import {x0:?} not found"))
+    OxcDiagnostic::warn(format!("named import {x0:?} not found"))
         .with_help(format!("does {x1:?} have the export {x0:?}?"))
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -13,28 +13,23 @@ use oxc_syntax::module_record::{ExportExportName, ExportImportName, ImportImport
 use crate::{context::LintContext, rule::Rule};
 
 fn no_export(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(namespace): {x1:?} not found in imported namespace {x2:?}."
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("{x1:?} not found in imported namespace {x2:?}.")).with_label(span0)
 }
 
 fn no_export_in_deeply_imported_namespace(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(namespace): {x1:?} not found in deeply imported namespace {x2:?}."
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("{x1:?} not found in deeply imported namespace {x2:?}."))
+        .with_label(span0)
 }
 
 fn computed_reference(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-import(namespace): Unable to validate computed reference to imported namespace {x1:?}.")).with_label(span0)
+    OxcDiagnostic::warn(format!(
+        "Unable to validate computed reference to imported namespace {x1:?}."
+    ))
+    .with_label(span0)
 }
 
 fn assignment(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(namespace): Assignment to member of namespace {x1:?}.'"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Assignment to member of namespace {x1:?}.'")).with_label(span0)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -9,11 +9,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_amd_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-import(no-amd): Do not use AMD `require` and `define` calls.",
-    )
-    .with_help(format!("Expected imports instead of AMD {x1}()"))
-    .with_label(span0)
+    OxcDiagnostic::warn("Do not use AMD `require` and `define` calls.")
+        .with_help(format!("Expected imports instead of AMD {x1}()"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -12,7 +12,7 @@ use oxc_syntax::{
 use crate::{context::LintContext, rule::Rule};
 
 fn no_cycle_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-import(no-cycle): Dependency cycle detected")
+    OxcDiagnostic::warn("Dependency cycle detected")
         .with_help(format!("These paths form a cycle: \n{x1}"))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -5,8 +5,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_default_export_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-import(no-default-export): Prefer named exports")
-        .with_label(span0)
+    OxcDiagnostic::warn("Prefer named exports").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/import/no_deprecated.rs
@@ -5,7 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{context::LintContext, rule::Rule};
 
 // #[derive(Debug, Error, Diagnostic)]
-// #[error("eslint-plugin-import(namespace): ")]
+// #[error("")]
 // #[diagnostic(severity(warning), help(""))]
 // struct NoDeprecatedDiagnostic(CompactStr, #[label] pub Span);
 

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -51,7 +51,12 @@ impl Rule for NoDuplicates {
                         .iter()
                         .map(|requested_module| LabeledSpan::underline(requested_module.span()))
                         .collect::<Vec<_>>();
-                    ctx.diagnostic(OxcDiagnostic::warn("eslint-plugin-import(no-duplicates): Forbid repeated import of the same module in multiple places").with_labels(labels));
+                    ctx.diagnostic(
+                        OxcDiagnostic::warn(
+                            "Forbid repeated import of the same module in multiple places",
+                        )
+                        .with_labels(labels),
+                    );
                 }
             }
         };

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -6,7 +6,7 @@ use oxc_syntax::module_record::ImportImportName;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_named_as_default_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-import(no-named-as-default): Module {x2:?} has named export {x1:?}"))
+    OxcDiagnostic::warn(format!("Module {x2:?} has named export {x1:?}"))
         .with_help(format!("Using default import as {x1:?} can be confusing. Use another name for default import to avoid confusion."))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -17,11 +17,9 @@ fn no_named_as_default_member_dignostic(
     x2: &str,
     x3: &str,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(no-named-as-default-member): {x1:?} also has a named export {x2:?}"
-    ))
-    .with_help(format!("Check if you meant to write `import {{{x2:}}} from {x3:?}`"))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("{x1:?} also has a named export {x2:?}"))
+        .with_help(format!("Check if you meant to write `import {{{x2:}}} from {x3:?}`"))
+        .with_label(span0)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md>

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -5,10 +5,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_self_import_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-import(no-self-import): module importing itself is not allowed",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("module importing itself is not allowed").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -4,7 +4,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_exports_found(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-import(no-unused-modules): No exports found")
+    OxcDiagnostic::warn("No exports found")
         .with_label(span0)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -10,11 +10,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_named_as_default_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-import(no-webpack-loader-syntax): Unexpected `!` in `{x0}`."
-    ))
-    .with_help("Do not use import syntax to configure webpack loaders")
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Unexpected `!` in `{x0}`."))
+        .with_help("Do not use import syntax to configure webpack loaders")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -11,30 +11,21 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        collect_possible_jest_call_node, get_test_plugin_name, parse_jest_fn_call, JestFnKind,
-        JestGeneralFnKind, ParsedJestFnCallNew, PossibleJestNode, TestPluginName,
+        collect_possible_jest_call_node, parse_jest_fn_call, JestFnKind, JestGeneralFnKind,
+        ParsedJestFnCallNew, PossibleJestNode,
     },
 };
 
-fn consistent_method(x0: TestPluginName, x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "{x0}(consistent-test-it): Enforce `test` and `it` usage conventions",
-    ))
-    .with_help(format!("Prefer using {x1:?} instead of {x2:?}"))
-    .with_label(span0)
+fn consistent_method(x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Enforce `test` and `it` usage conventions".to_string())
+        .with_help(format!("Prefer using {x1:?} instead of {x2:?}"))
+        .with_label(span0)
 }
 
-fn consistent_method_within_describe(
-    x0: TestPluginName,
-    x1: &str,
-    x2: &str,
-    span0: Span,
-) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "{x0}(consistent-test-it): Enforce `test` and `it` usage conventions",
-    ))
-    .with_help(format!("Prefer using {x1:?} instead of {x2:?} within describe"))
-    .with_label(span0)
+fn consistent_method_within_describe(x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Enforce `test` and `it` usage conventions".to_string())
+        .with_help(format!("Prefer using {x1:?} instead of {x2:?} within describe"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -201,13 +192,12 @@ impl Rule for ConsistentTestIt {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let plugin_name = get_test_plugin_name(ctx);
         let mut describe_nesting_hash: FxHashMap<ScopeId, i32> = FxHashMap::default();
         let mut possible_jest_nodes = collect_possible_jest_call_node(ctx);
         possible_jest_nodes.sort_by_key(|n| n.node.id());
 
         for possible_jest_node in &possible_jest_nodes {
-            self.run(&mut describe_nesting_hash, plugin_name, possible_jest_node, ctx);
+            self.run(&mut describe_nesting_hash, possible_jest_node, ctx);
         }
     }
 }
@@ -216,7 +206,6 @@ impl ConsistentTestIt {
     fn run<'a>(
         &self,
         describe_nesting_hash: &mut FxHashMap<ScopeId, i32>,
-        plugin_name: TestPluginName,
         possible_jest_node: &PossibleJestNode<'a, '_>,
         ctx: &LintContext<'a>,
     ) {
@@ -248,7 +237,7 @@ impl ConsistentTestIt {
                 &fn_to_str,
             ) {
                 ctx.diagnostic_with_fix(
-                    consistent_method(plugin_name, &fn_to_str, &opposite_test_keyword, span),
+                    consistent_method(&fn_to_str, &opposite_test_keyword, span),
                     |fixer| fixer.replace(span, prefer_test_name),
                 );
             }
@@ -268,7 +257,6 @@ impl ConsistentTestIt {
             ) {
                 ctx.diagnostic_with_fix(
                     consistent_method_within_describe(
-                        plugin_name,
                         &describe_to_str,
                         &opposite_test_keyword,
                         span,

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn exceeded_max_assertion(x0: usize, x1: usize, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(max-expects): Enforces a maximum number assertion calls in a test body.")
+    OxcDiagnostic::warn("Enforces a maximum number assertion calls in a test body.")
         .with_help(format!("Too many assertion calls ({x0:?}) - maximum allowed is {x1:?}"))
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -14,11 +14,9 @@ use crate::{
 };
 
 fn exceeded_max_depth(current: usize, max: usize, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(max-nested-describe): Enforces a maximum depth to nested describe calls.",
-    )
-    .with_help(format!("Too many nested describe calls ({current}) - maximum allowed is {max}"))
-    .with_label(span0)
+    OxcDiagnostic::warn("Enforces a maximum depth to nested describe calls.")
+        .with_help(format!("Too many nested describe calls ({current}) - maximum allowed is {max}"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -6,19 +6,11 @@ use oxc_span::Span;
 use crate::{
     context::LintContext,
     rule::Rule,
-    utils::{
-        collect_possible_jest_call_node, get_test_plugin_name, parse_expect_jest_fn_call,
-        PossibleJestNode, TestPluginName,
-    },
+    utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
-fn no_alias_methods_diagnostic(
-    x0: TestPluginName,
-    x1: &str,
-    x2: &str,
-    span3: Span,
-) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0}(no-alias-methods): Unexpected alias {x1:?}"))
+fn no_alias_methods_diagnostic(x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected alias {x1:?}"))
         .with_help(format!("Replace {x1:?} with its canonical name of {x2:?}"))
         .with_label(span3)
 }
@@ -96,10 +88,8 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
                     span.end -= 1;
                 }
 
-                let plugin_name = get_test_plugin_name(ctx);
-
                 ctx.diagnostic_with_fix(
-                    no_alias_methods_diagnostic(plugin_name, name, canonical_name, matcher.span),
+                    no_alias_methods_diagnostic(name, canonical_name, matcher.span),
                     // || Fix::new(canonical_name, Span::new(start, end)),
                     |fixer| fixer.replace(span, canonical_name),
                 );

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -7,11 +7,9 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_commented_out_tests_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-commented-out-tests): Some tests seem to be commented",
-    )
-    .with_help("Remove or uncomment this comment")
-    .with_label(span0)
+    OxcDiagnostic::warn("Some tests seem to be commented")
+        .with_help("Remove or uncomment this comment")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn no_conditional_expect_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-conditional-expect): Unexpected conditional expect")
+    OxcDiagnostic::warn("Unexpected conditional expect")
         .with_help("Avoid calling `expect` conditionally`")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -13,20 +13,17 @@ use crate::{
 };
 
 fn no_global_set_timeout_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-confusing-set-timeout)")
-        .with_help("`jest.setTimeout` should be call in `global` scope")
-        .with_label(span0)
+    OxcDiagnostic::warn("`jest.setTimeout` should be call in `global` scope").with_label(span0)
 }
 
 fn no_multiple_set_timeouts_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-confusing-set-timeout)")
-        .with_help("Do not call `jest.setTimeout` multiple times, as only the last call will have an effect")
+    OxcDiagnostic::warn("Do not call `jest.setTimeout` multiple times")
+        .with_help("Only the last call to `jest.setTimeout` will have an effect.")
         .with_label(span0)
 }
 
 fn no_unorder_set_timeout_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-confusing-set-timeout)")
-        .with_help("`jest.setTimeout` should be placed before any other jest methods")
+    OxcDiagnostic::warn("`jest.setTimeout` should be placed before any other jest methods")
         .with_label(span0)
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -9,11 +9,9 @@ use phf::{phf_map, Map};
 use crate::{context::LintContext, rule::Rule};
 
 fn deprecated_function(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-deprecated-functions): Disallow use of deprecated functions",
-    )
-    .with_help(format!("{x0:?} has been deprecated in favor of {x1:?}"))
-    .with_label(span2)
+    OxcDiagnostic::warn("Disallow use of deprecated functions")
+        .with_help(format!("{x0:?} has been deprecated in favor of {x1:?}"))
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -16,19 +16,15 @@ use crate::{
 };
 
 fn no_done_callback(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-done-callback): Function parameter(s) use the `done` argument",
-    )
-    .with_help("Return a Promise instead of relying on callback parameter")
-    .with_label(span0)
+    OxcDiagnostic::warn("Function parameter(s) use the `done` argument")
+        .with_help("Return a Promise instead of relying on callback parameter")
+        .with_label(span0)
 }
 
 fn use_await_instead_of_callback(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-done-callback): Function parameter(s) use the `done` argument",
-    )
-    .with_help("Use await instead of callback in async functions")
-    .with_label(span0)
+    OxcDiagnostic::warn("Function parameter(s) use the `done` argument")
+        .with_help("Use await instead of callback in async functions")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -16,11 +16,9 @@ use crate::{
 };
 
 fn no_duplicate_hooks_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-duplicate-hooks): Disallow duplicate setup and teardown hooks.",
-    )
-    .with_help(format!("Duplicate {x0:?} in describe block."))
-    .with_label(span0)
+    OxcDiagnostic::warn("Disallow duplicate setup and teardown hooks.")
+        .with_help(format!("Duplicate {x0:?} in describe block."))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -5,7 +5,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::is_jest_file};
 
 fn no_export_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-export): Do not export from a test file.")
+    OxcDiagnostic::warn("Do not export from a test file.")
         .with_help("If you want to share code between tests, move it into a separate file and import it from there.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -7,24 +7,15 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        collect_possible_jest_call_node, get_test_plugin_name, parse_general_jest_fn_call,
-        JestFnKind, JestGeneralFnKind, MemberExpressionElement, ParsedGeneralJestFnCall,
-        PossibleJestNode, TestPluginName,
+        collect_possible_jest_call_node, parse_general_jest_fn_call, JestFnKind, JestGeneralFnKind,
+        MemberExpressionElement, ParsedGeneralJestFnCall, PossibleJestNode,
     },
 };
 
-fn no_focused_tests_diagnostic(span0: Span, x1: TestPluginName) -> OxcDiagnostic {
-    match x1 {
-        TestPluginName::Jest => {
-            OxcDiagnostic::warn(format!("{x1}(no-focused-tests): Unexpected focused test."))
-                .with_help("Remove focus from test.")
-                .with_label(span0)
-        }
-        TestPluginName::Vitest => {
-            OxcDiagnostic::warn(format!("{x1}(no-focused-tests): Focused tests are not allowed."))
-                .with_label(span0)
-        }
-    }
+fn no_focused_tests_diagnostic(span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected focused test.")
+        .with_help("Remove focus from test.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -75,18 +66,13 @@ declare_oxc_lint!(
 
 impl Rule for NoFocusedTests {
     fn run_once(&self, ctx: &LintContext) {
-        let plugin_name = get_test_plugin_name(ctx);
         for node in &collect_possible_jest_call_node(ctx) {
-            run(node, plugin_name, ctx);
+            run(node, ctx);
         }
     }
 }
 
-fn run<'a>(
-    possible_jest_node: &PossibleJestNode<'a, '_>,
-    plugin_name: TestPluginName,
-    ctx: &LintContext<'a>,
-) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
     let node = possible_jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return;
@@ -101,13 +87,10 @@ fn run<'a>(
 
     if name.starts_with('f') {
         ctx.diagnostic_with_fix(
-            no_focused_tests_diagnostic(
-                Span::new(
-                    call_expr.span.start,
-                    call_expr.span.start + u32::try_from(name.len()).unwrap_or(1),
-                ),
-                plugin_name,
-            ),
+            no_focused_tests_diagnostic(Span::new(
+                call_expr.span.start,
+                call_expr.span.start + u32::try_from(name.len()).unwrap_or(1),
+            )),
             |fixer| fixer.delete_range(Span::sized(call_expr.span.start, 1)),
         );
 
@@ -116,16 +99,13 @@ fn run<'a>(
 
     let only_node = members.iter().find(|member| member.is_name_equal("only"));
     if let Some(only_node) = only_node {
-        ctx.diagnostic_with_fix(
-            no_focused_tests_diagnostic(only_node.span, plugin_name),
-            |fixer| {
-                let mut span = only_node.span.expand_left(1);
-                if !matches!(only_node.element, MemberExpressionElement::IdentName(_)) {
-                    span = span.expand_right(1);
-                }
-                fixer.delete_range(span)
-            },
-        );
+        ctx.diagnostic_with_fix(no_focused_tests_diagnostic(only_node.span), |fixer| {
+            let mut span = only_node.span.expand_left(1);
+            if !matches!(only_node.element, MemberExpressionElement::IdentName(_)) {
+                span = span.expand_right(1);
+            }
+            fixer.delete_range(span)
+        });
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -13,8 +13,7 @@ use crate::{
 };
 
 fn unexpected_hook_diagonsitc(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-hooks): Disallow setup and teardown hooks.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Disallow setup and teardown hooks.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -20,13 +20,15 @@ use crate::{
 };
 
 fn describe_repeat(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.")
+    OxcDiagnostic::warn("Describe block title is used multiple times in the same describe block.")
         .with_help("Change the title of describe block.")
         .with_label(span0)
 }
 
 fn test_repeat(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.").with_help("Change the title of test.").with_label(span0)
+    OxcDiagnostic::warn("Test title is used multiple times in the same describe block.")
+        .with_help("Change the title of test.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 fn no_interpolation_in_snapshots_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-interpolation-in-snapshots): Do not use string interpolation inside of snapshots")
+    OxcDiagnostic::warn("Do not use string interpolation inside of snapshots")
         .with_help("Remove string interpolation from snapshots")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -11,9 +11,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_jasmine_globals_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jest(no-jasmine-globals): {x0:?}"))
-        .with_help(format!("{x1:?}"))
-        .with_label(span2)
+    OxcDiagnostic::warn(format!("{x0:?}")).with_help(format!("{x1:?}")).with_label(span2)
 }
 
 /// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-jasmine-globals.md>

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -17,13 +17,13 @@ use crate::{
 };
 
 fn no_snapshot(x0: usize, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-large-snapshots): Disallow large snapshots.")
+    OxcDiagnostic::warn("Disallow large snapshots.")
         .with_help(format!("`{x0:?}`s should begin with lowercase"))
         .with_label(span0)
 }
 
 fn too_long_snapshots(x0: usize, x1: usize, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-large-snapshots): Disallow large snapshots.")
+    OxcDiagnostic::warn("Disallow large snapshots.")
         .with_help(format!(
             "Expected Jest snapshot to be smaller than {x0:?} lines but was {x1:?} lines long"
         ))

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -8,7 +8,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_mocks_import_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-mocks-import): Mocks should not be manually imported from a `__mocks__` directory.")
+    OxcDiagnostic::warn("Mocks should not be manually imported from a `__mocks__` directory.")
         .with_help("Instead use `jest.mock` and import from the original module path.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -14,19 +14,15 @@ use crate::{
 };
 
 fn restricted_jest_method(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-restricted-jest-methods): Disallow specific `jest.` methods",
-    )
-    .with_help(format!("Use of `{x0:?}` is disallowed"))
-    .with_label(span1)
+    OxcDiagnostic::warn("Disallow specific `jest.` methods")
+        .with_help(format!("Use of `{x0:?}` is disallowed"))
+        .with_label(span1)
 }
 
 fn restricted_jest_method_with_message(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-restricted-jest-methods): Disallow specific `jest.` methods",
-    )
-    .with_help(format!("{x0:?}"))
-    .with_label(span1)
+    OxcDiagnostic::warn("Disallow specific `jest.` methods")
+        .with_help(format!("{x0:?}"))
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -17,19 +17,15 @@ use crate::{
 };
 
 fn restricted_chain(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-restricted-matchers): Disallow specific matchers & modifiers",
-    )
-    .with_help(format!("Use of `{x0:?}` is disallowed`"))
-    .with_label(span1)
+    OxcDiagnostic::warn("Disallow specific matchers & modifiers")
+        .with_help(format!("Use of `{x0:?}` is disallowed`"))
+        .with_label(span1)
 }
 
 fn restricted_chain_with_message(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-restricted-matchers): Disallow specific matchers & modifiers",
-    )
-    .with_help(format!("{x0:?}"))
-    .with_label(span1)
+    OxcDiagnostic::warn("Disallow specific matchers & modifiers")
+        .with_help(format!("{x0:?}"))
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -18,11 +18,9 @@ use crate::{
 };
 
 fn no_standalone_expect_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-standalone-expect): Expect must be inside of a test block.",
-    )
-    .with_help("Did you forget to wrap `expect` in a `test` or `it` block?")
-    .with_label(span0)
+    OxcDiagnostic::warn("Expect must be inside of a test block.")
+        .with_help("Did you forget to wrap `expect` in a `test` or `it` block?")
+        .with_label(span0)
 }
 
 /// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md>

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -7,14 +7,13 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        collect_possible_jest_call_node, get_test_plugin_name, parse_general_jest_fn_call,
-        JestGeneralFnKind, KnownMemberExpressionProperty, ParsedGeneralJestFnCall,
-        PossibleJestNode, TestPluginName,
+        collect_possible_jest_call_node, parse_general_jest_fn_call, JestGeneralFnKind,
+        KnownMemberExpressionProperty, ParsedGeneralJestFnCall, PossibleJestNode,
     },
 };
 
-fn no_test_prefixes_diagnostic(x0: TestPluginName, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0}(no-test-prefixes): Use {x1:?} instead.")).with_label(span2)
+fn no_test_prefixes_diagnostic(x1: &str, span2: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use {x1:?} instead.")).with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -95,12 +94,10 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
     };
 
     let preferred_node_name = get_preferred_node_names(&jest_fn_call);
-    let plugin_name = get_test_plugin_name(ctx);
 
-    ctx.diagnostic_with_fix(
-        no_test_prefixes_diagnostic(plugin_name, &preferred_node_name, span),
-        |fixer| fixer.replace(span, preferred_node_name),
-    );
+    ctx.diagnostic_with_fix(no_test_prefixes_diagnostic(&preferred_node_name, span), |fixer| {
+        fixer.replace(span, preferred_node_name)
+    });
 }
 
 fn get_preferred_node_names(jest_fn_call: &ParsedGeneralJestFnCall) -> String {

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -15,10 +15,7 @@ use crate::{
 };
 
 fn no_test_return_statement_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Jest tests should not return a value").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -13,9 +13,11 @@ use crate::{
 };
 
 fn add_type_parameter_to_module_mock_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(no-untyped-mock-factory): Disallow using `jest.mock()` factories without an explicit type parameter.")
-        .with_help(format!("Add a type parameter to the mock factory such as `typeof import({x0:?})`"))
-        .with_label(span1)
+    OxcDiagnostic::warn(
+        "Disallow using `jest.mock()` factories without an explicit type parameter.",
+    )
+    .with_help(format!("Add a type parameter to the mock factory such as `typeof import({x0:?})`"))
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -10,13 +10,13 @@ use crate::{
 };
 
 fn use_to_be_called_with(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
+    OxcDiagnostic::warn("Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
         .with_help("Prefer toBeCalledWith(/* expected args */)")
         .with_label(span0)
 }
 
 fn use_have_been_called_with(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
+    OxcDiagnostic::warn("Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
         .with_help("Prefer toHaveBeenCalledWith(/* expected args */)")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 fn use_to_be_comparison(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-comparison-matcher): Suggest using the built-in comparison matchers")
+    OxcDiagnostic::warn("Suggest using the built-in comparison matchers")
         .with_help(format!("Prefer using `{x0:?}` instead"))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn use_equality_matcher_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-equality-matcher): Suggest using the built-in equality matchers.")
+    OxcDiagnostic::warn("Suggest using the built-in equality matchers.")
         .with_help("Prefer using one of the equality matchers instead")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 fn expect_resolves(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-expect-resolves): Prefer `await expect(...).resolves` over `expect(await ...)` syntax.")
+    OxcDiagnostic::warn("Prefer `await expect(...).resolves` over `expect(await ...)` syntax.")
         .with_help("Use `await expect(...).resolves` instead")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -9,17 +9,14 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        get_test_plugin_name, parse_jest_fn_call, JestFnKind, JestGeneralFnKind,
-        ParsedJestFnCallNew, PossibleJestNode, TestPluginName,
+        parse_jest_fn_call, JestFnKind, JestGeneralFnKind, ParsedJestFnCallNew, PossibleJestNode,
     },
 };
 
-fn reorder_hooks(x0: TestPluginName, x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "{x0}(prefer-hooks-in-order): Prefer having hooks in a consistent order.",
-    ))
-    .with_help(format!("{x1:?} hooks should be before any {x2:?} hooks"))
-    .with_label(span0)
+fn reorder_hooks(x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer having hooks in a consistent order.")
+        .with_help(format!("{x1:?} hooks should be before any {x2:?} hooks"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -191,14 +188,8 @@ impl PreferHooksInOrder {
             let Some(previous_hook_name) = hook_orders.get(previous_hook_pos) else {
                 return;
             };
-            let plugin_name = get_test_plugin_name(ctx);
 
-            ctx.diagnostic(reorder_hooks(
-                plugin_name,
-                &hook_name,
-                previous_hook_name,
-                call_expr.span,
-            ));
+            ctx.diagnostic(reorder_hooks(&hook_name, previous_hook_name, call_expr.span));
             return;
         }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -16,11 +16,9 @@ use crate::{
 };
 
 fn no_hook_on_top(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(prefer-hooks-on-top): Suggest having hooks before any test cases.",
-    )
-    .with_help("Hooks should come before test cases")
-    .with_label(span0)
+    OxcDiagnostic::warn("Suggest having hooks before any test cases.")
+        .with_help("Hooks should come before test cases")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
@@ -10,11 +10,9 @@ use phf::{phf_set, Set};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn use_jest_mocked(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(prefer-jest-mocked): Prefer `jest.mocked()` over `fn as jest.Mock`.",
-    )
-    .with_help("Prefer `jest.mocked()`")
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer `jest.mocked()` over `fn as jest.Mock`.")
+        .with_help("Prefer `jest.mocked()`")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 fn unexpected_lowercase(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names")
+    OxcDiagnostic::warn("Enforce lowercase test names")
         .with_help(format!("`{x0:?}`s should begin with lowercase"))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -9,7 +9,9 @@ use oxc_span::{Atom, Span};
 use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, utils::get_node_name};
 
 fn use_mock_shorthand(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-mock-promise-shorthand): Prefer mock resolved/rejected shorthands for promises").with_help(format!("Prefer {x0:?}")).with_label(span1)
+    OxcDiagnostic::warn("Prefer mock resolved/rejected shorthands for promises")
+        .with_help(format!("Prefer {x0:?}"))
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 fn use_jest_spy_on(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-spy-on): Suggest using `jest.spyOn()`.")
+    OxcDiagnostic::warn("Suggest using `jest.spyOn()`.")
         .with_help("Use jest.spyOn() instead")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 fn use_to_strict_equal(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-strict-equal): Suggest using `toStrictEqual()`.")
+    OxcDiagnostic::warn("Suggest using `toStrictEqual()`.")
         .with_help("Use `toStrictEqual()` instead")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -16,30 +16,23 @@ use crate::{
 };
 
 fn use_to_be(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(prefer-to-be): Use `toBe` when expecting primitive literals.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Use `toBe` when expecting primitive literals.").with_label(span0)
 }
 
 fn use_to_be_undefined(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-to-be): Use `toBeUndefined` instead.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Use `toBeUndefined` instead.").with_label(span0)
 }
 
 fn use_to_be_defined(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-to-be): Use `toBeDefined` instead.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Use `toBeDefined` instead.").with_label(span0)
 }
 
 fn use_to_be_null(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-to-be): Use `toBeNull` instead.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Use `toBeNull` instead.").with_label(span0)
 }
 
 fn use_to_be_na_n(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-to-be): Use `toBeNaN` instead.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Use `toBeNaN` instead.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -16,8 +16,7 @@ use crate::{
 };
 
 fn use_to_contain(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-to-contain): Suggest using `toContain()`.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Suggest using `toContain()`.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -17,10 +17,7 @@ use crate::{
 };
 
 fn use_to_have_length(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Suggest using `toHaveLength()`.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -17,13 +17,11 @@ use crate::{
 };
 
 fn empty_test(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span0)
 }
 
 fn un_implemented_test_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jest(prefer-todo): Suggest using `test.todo`.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -18,11 +18,9 @@ use crate::{
 };
 
 fn use_hook(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(require-hook): Require setup and teardown code to be within a hook.",
-    )
-    .with_help("This should be done within a hook")
-    .with_label(span0)
+    OxcDiagnostic::warn("Require setup and teardown code to be within a hook.")
+        .with_help("This should be done within a hook")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -10,11 +10,9 @@ use crate::{
 };
 
 fn require_to_throw_message_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-jest(require-to-throw-message): Require a message for {x0:?}."
-    ))
-    .with_help(format!("Add an error message to {x0:?}"))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("Require a message for {x0:?}."))
+        .with_help(format!("Add an error message to {x0:?}"))
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -16,27 +16,23 @@ use crate::{
 };
 
 fn too_many_describes(max: usize, repeat: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block",
-    )
-    .with_help(format!("There should not be more than {max:?} describe{repeat} at the top level."))
-    .with_label(span0)
+    OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
+        .with_help(format!(
+            "There should not be more than {max:?} describe{repeat} at the top level."
+        ))
+        .with_label(span0)
 }
 
 fn unexpected_test_case(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block",
-    )
-    .with_help("All test cases must be wrapped in a describe block.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
+        .with_help("All test cases must be wrapped in a describe block.")
+        .with_label(span0)
 }
 
 fn unexpected_hook(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block",
-    )
-    .with_help("All hooks must be wrapped in a describe block.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
+        .with_help("All hooks must be wrapped in a describe block.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -10,20 +10,17 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        collect_possible_jest_call_node, get_test_plugin_name, parse_general_jest_fn_call,
-        JestFnKind, JestGeneralFnKind, PossibleJestNode, TestPluginName,
+        collect_possible_jest_call_node, parse_general_jest_fn_call, JestFnKind, JestGeneralFnKind,
+        PossibleJestNode,
     },
 };
 
 fn valid_describe_callback_diagnostic(
-    x0: TestPluginName,
-    x1: &str,
-    x2: &str,
+    x1: &'static str,
+    x2: &'static str,
     span3: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0}(valid-describe-callback): {x1:?}"))
-        .with_help(format!("{x2:?}"))
-        .with_label(span3)
+    OxcDiagnostic::warn(x1).with_help(x2).with_label(span3)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -167,8 +164,7 @@ fn find_first_return_stmt_span(function_body: &FunctionBody) -> Option<Span> {
 
 fn diagnostic(ctx: &LintContext, span: Span, message: Message) {
     let (error, help) = message.details();
-    let plugin_name = get_test_plugin_name(ctx);
-    ctx.diagnostic(valid_describe_callback_diagnostic(plugin_name, error, help, span));
+    ctx.diagnostic(valid_describe_callback_diagnostic(error, help, span));
 }
 
 #[derive(Clone, Copy)]

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -19,9 +19,7 @@ use crate::{
 };
 
 fn valid_title_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jest(valid-title): {x0:?}"))
-        .with_help(format!("{x1:?}"))
-        .with_label(span2)
+    OxcDiagnostic::warn(format!("{x0:?}")).with_help(format!("{x1:?}")).with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -7,17 +7,17 @@ use rustc_hash::FxHashSet;
 use crate::{context::LintContext, rule::Rule, utils::should_ignore_as_internal};
 
 fn invalid_access_level(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(check-access): Invalid access level is specified or missing.",
-    )
-    .with_help("Valid access levels are `package`, `private`, `protected`, and `public`.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Invalid access level is specified or missing.")
+        .with_help("Valid access levels are `package`, `private`, `protected`, and `public`.")
+        .with_label(span0)
 }
 
 fn redundant_access_tags(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(check-access): Mixing of @access with @public, @private, @protected, or @package on the same doc block.")
-        .with_help("There should be only one instance of access tag in a JSDoc comment.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Mixing of @access with @public, @private, @protected, or @package on the same doc block.",
+    )
+    .with_help("There should be only one instance of access tag in a JSDoc comment.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -10,11 +10,9 @@ use crate::{
 };
 
 fn no_root(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(check-property-names): No root defined for @property path.",
-    )
-    .with_help(format!("@property path declaration `{x1}` appears before any real property."))
-    .with_label(span0)
+    OxcDiagnostic::warn("No root defined for @property path.")
+        .with_help(format!("@property path declaration `{x1}` appears before any real property."))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -108,11 +106,11 @@ impl Rule for CheckPropertyNames {
                     })
                     .collect::<Vec<_>>();
                 ctx.diagnostic(
-                    OxcDiagnostic::warn(
-                        "eslint-plugin-jsdoc(check-property-names): Duplicate @property found.",
-                    )
-                    .with_help(format!("@property `{type_name}` is duplicated on the same block."))
-                    .with_labels(labels),
+                    OxcDiagnostic::warn("Duplicate @property found.")
+                        .with_help(format!(
+                            "@property `{type_name}` is duplicated on the same block."
+                        ))
+                        .with_labels(labels),
                 );
             }
         }

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -11,9 +11,7 @@ use crate::{
 };
 
 fn check_tag_names_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.")
-        .with_help(x1.to_string())
-        .with_label(span0)
+    OxcDiagnostic::warn("Invalid tag name found.").with_help(x1.to_string()).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -7,11 +7,9 @@ use serde::Deserialize;
 use crate::{context::LintContext, rule::Rule, utils::should_ignore_as_private};
 
 fn empty_tags_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(empty-tags): Expects the void tags to be empty of any content.",
-    )
-    .with_help(format!("`@{x1}` tag should not have body."))
-    .with_label(span0)
+    OxcDiagnostic::warn("Expects the void tags to be empty of any content.")
+        .with_help(format!("`@{x1}` tag should not have body."))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 fn implements_on_classes_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(implements-on-classes): `@implements` used on a non-constructor function")
+    OxcDiagnostic::warn("`@implements` used on a non-constructor function")
         .with_help("Add `@class` tag or use ES6 class syntax.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -12,9 +12,7 @@ use crate::{
 };
 
 fn no_defaults_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(no-defaults): Defaults are not permitted.")
-        .with_help(x1.to_string())
-        .with_label(span0)
+    OxcDiagnostic::warn("Defaults are not permitted.").with_help(x1.to_string()).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -246,7 +246,7 @@ impl Rule for RequireParam {
                 .map(|span| LabeledSpan::new_with_span(None, *span))
                 .collect::<Vec<_>>();
             ctx.diagnostic(
-                OxcDiagnostic::warn("eslint-plugin-jsdoc(require-param): Missing JSDoc `@param` declaration for function parameters.")
+                OxcDiagnostic::warn("Missing JSDoc `@param` declaration for function parameters.")
                     .with_help("Add `@param` tag with name.")
                     .with_labels(labels),
             );

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -14,11 +14,9 @@ use crate::{
 };
 
 fn missing_type_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(require-param-description): Missing JSDoc `@param` description.",
-    )
-    .with_help("Add description to `@param` tag.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing JSDoc `@param` description.")
+        .with_help("Add description to `@param` tag.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn missing_name_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-param-name): Missing JSDoc `@param` name.")
+    OxcDiagnostic::warn("Missing JSDoc `@param` name.")
         .with_help("Add name to `@param` tag.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn missing_type_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-param-type): Missing JSDoc `@param` type.")
+    OxcDiagnostic::warn("Missing JSDoc `@param` type.")
         .with_help("Add {type} to `@param` tag.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -9,9 +9,11 @@ use crate::{
 };
 
 fn require_property_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-property): The `@typedef` and `@namespace` tags must include a `@property` tag with the type Object.")
-        .with_help("Consider adding a `@property` tag or replacing it with a more specific type.")
-        .and_label(span)
+    OxcDiagnostic::warn(
+        "The `@typedef` and `@namespace` tags must include a `@property` tag with the type Object.",
+    )
+    .with_help("Consider adding a `@property` tag or replacing it with a more specific type.")
+    .and_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -9,11 +9,9 @@ use crate::{
 };
 
 fn require_property_description_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(require-property-description): Missing description in @property tag.",
-    )
-    .with_help("Add a description to this @property tag.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing description in @property tag.")
+        .with_help("Add a description to this @property tag.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -9,11 +9,9 @@ use crate::{
 };
 
 fn require_property_name_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(require-property-name): Missing name in @property tag.",
-    )
-    .with_help("Add a type name to this @property tag.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing name in @property tag.")
+        .with_help("Add a type name to this @property tag.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -9,11 +9,9 @@ use crate::{
 };
 
 fn require_property_type_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(require-property-type): Missing type in @property tag.",
-    )
-    .with_help("Add a {type} to this @property tag.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing type in @property tag.")
+        .with_help("Add a {type} to this @property tag.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -20,14 +20,12 @@ use crate::{
 };
 
 fn missing_returns_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(require-returns): Missing JSDoc `@returns` declaration for function.",
-    )
-    .with_help("Add `@returns` tag to the JSDoc comment.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing JSDoc `@returns` declaration for function.")
+        .with_help("Add `@returns` tag to the JSDoc comment.")
+        .with_label(span0)
 }
 fn duplicate_returns_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-returns): Duplicate `@returns` tags.")
+    OxcDiagnostic::warn("Duplicate `@returns` tags.")
         .with_help("Remove redundunt `@returns` tag.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -11,11 +11,9 @@ use crate::{
 };
 
 fn missing_description_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsdoc(require-returns-description): Missing JSDoc `@returns` description.",
-    )
-    .with_help("Add description comment to `@returns` tag.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing JSDoc `@returns` description.")
+        .with_help("Add description comment to `@returns` tag.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn missing_type_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-returns-type): Missing JSDoc `@returns` type.")
+    OxcDiagnostic::warn("Missing JSDoc `@returns` type.")
         .with_help("Add {type} to `@returns` tag.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -17,19 +17,19 @@ use crate::{
 };
 
 fn missing_yields(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.")
+    OxcDiagnostic::warn("Missing JSDoc `@yields` declaration for generator function.")
         .with_help("Add `@yields` tag to the JSDoc comment.")
         .with_label(span0)
 }
 
 fn duplicate_yields(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-yields): Duplicate `@yields` tags.")
+    OxcDiagnostic::warn("Duplicate `@yields` tags.")
         .with_help("Remove redundunt `@yields` tag.")
         .with_label(span0)
 }
 
 fn missing_yields_with_generator(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsdoc(require-yields): `@yields` tag is required when using `@generator` tag.")
+    OxcDiagnostic::warn("`@yields` tag is required when using `@generator` tag.")
         .with_help("Add `@yields` tag to the JSDoc comment.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -17,13 +17,13 @@ use crate::{
 };
 
 fn missing_alt_prop(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): Missing `alt` attribute.")
+    OxcDiagnostic::warn("Missing `alt` attribute.")
         .with_help("Must have `alt` prop, either with meaningful text, or an empty string for decorative images.")
         .with_label(span0)
 }
 
 fn missing_alt_value(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): Invalid `alt` value.")
+    OxcDiagnostic::warn("Invalid `alt` value.")
         .with_help(
             "Must have meaningful value for `alt` prop. Use alt=\"\" for presentational images.",
         )
@@ -31,39 +31,37 @@ fn missing_alt_value(span0: Span) -> OxcDiagnostic {
 }
 
 fn aria_label_value(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): Missing value for aria-label attribute.")
+    OxcDiagnostic::warn("Missing value for aria-label attribute.")
         .with_help("The aria-label attribute must have a value. The alt attribute is preferred over aria-label for images.")
         .with_label(span0)
 }
 
 fn aria_labelled_by_value(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsx-a11y(alt-text): Missing value for aria-labelledby attribute.",
-    )
-    .with_help("The alt attribute is preferred over aria-labelledby for images.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing value for aria-labelledby attribute.")
+        .with_help("The alt attribute is preferred over aria-labelledby for images.")
+        .with_label(span0)
 }
 
 fn prefer_alt(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): ARIA used where native HTML could suffice.")
+    OxcDiagnostic::warn("ARIA used where native HTML could suffice.")
         .with_help("Prefer alt=\"\" over presentational role. Native HTML attributes should be preferred for accessibility before resorting to ARIA attributes.")
         .with_label(span0)
 }
 
 fn object(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): Missing alternative text.")
+    OxcDiagnostic::warn("Missing alternative text.")
         .with_help("Embedded <object> elements must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.")
         .with_label(span0)
 }
 
 fn area(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): Missing alternative text.")
+    OxcDiagnostic::warn("Missing alternative text.")
         .with_help("Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.")
         .with_label(span0)
 }
 
 fn input_type_image(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(alt-text): Missing alternative text.")
+    OxcDiagnostic::warn("Missing alternative text.")
         .with_help("<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 fn missing_content(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(anchor-has-content): Missing accessible content when using `a` elements.")
+    OxcDiagnostic::warn("Missing accessible content when using `a` elements.")
         .with_help("Provide screen reader accessible content when using `a` elements.")
         .with_label(span0)
 }
 
 fn remove_aria_hidden(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(anchor-has-content): Missing accessible content when using `a` elements.")
+    OxcDiagnostic::warn("Missing accessible content when using `a` elements.")
         .with_help("Remove the `aria-hidden` attribute to allow the anchor element and its content visible to assistive technologies.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -14,27 +14,21 @@ use crate::{
 };
 
 fn missing_href_attribute(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsx-a11y(anchor-is-valid): Missing `href` attribute for the `a` element.",
-    )
-    .with_help("Provide an href for the `a` element.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing `href` attribute for the `a` element.")
+        .with_help("Provide an href for the `a` element.")
+        .with_label(span0)
 }
 
 fn incorrect_href(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsx-a11y(anchor-is-valid): Use an incorrect href for the 'a' element.",
-    )
-    .with_help("Provide a correct href for the `a` element.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Use an incorrect href for the 'a' element.")
+        .with_help("Provide a correct href for the `a` element.")
+        .with_label(span0)
 }
 
 fn cant_be_anchor(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsx-a11y(anchor-is-valid):  The a element has `href` and `onClick`.",
-    )
-    .with_help("Use a `button` element instead of an `a` element.")
-    .with_label(span0)
+    OxcDiagnostic::warn(" The a element has `href` and `onClick`.")
+        .with_help("Use a `button` element instead of an `a` element.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -15,8 +15,10 @@ use crate::{
 };
 
 fn aria_activedescendant_has_tabindex_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(aria-activedescendant-has-tabindex): Enforce elements with aria-activedescendant are tabbable.")
-        .with_help("An element that manages focus with `aria-activedescendant` must have a tabindex.")
+    OxcDiagnostic::warn("Enforce elements with aria-activedescendant are tabbable.")
+        .with_help(
+            "An element that manages focus with `aria-activedescendant` must have a tabindex.",
+        )
         .with_label(span0)
 }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -9,9 +9,7 @@ use crate::{
 };
 
 fn aria_props_diagnostic(span: Span, prop_name: &str, suggestion: Option<&str>) -> OxcDiagnostic {
-    let mut err = OxcDiagnostic::warn(format!(
-        "eslint-plugin-jsx-a11y(aria-props): '{prop_name}' is not a valid ARIA attribute."
-    ));
+    let mut err = OxcDiagnostic::warn(format!("'{prop_name}' is not a valid ARIA attribute."));
 
     if let Some(suggestion) = suggestion {
         err = err.with_help(format!("Did you mean '{suggestion}'?"));

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn aria_role_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(aria-role): Elements with ARIA roles must use a valid, non-abstract ARIA role.")
+    OxcDiagnostic::warn("Elements with ARIA roles must use a valid, non-abstract ARIA role.")
         .with_help(format!("Set a valid, non-abstract ARIA role for element with ARIA{x1}"))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -34,7 +34,7 @@ declare_oxc_lint! {
 pub struct AriaUnsupportedElements;
 
 fn aria_unsupported_elements_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(aria-unsupported-elements): This element does not support ARIA roles, states and properties.")
+    OxcDiagnostic::warn("This element does not support ARIA roles, states and properties.")
         .with_help(format!("Try removing the prop `{x1}`."))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn autocomplete_valid_diagnostic(span: Span, autocomplete: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(autocomplete-valid): `{autocomplete}` is not a valid value for autocomplete."))
+    OxcDiagnostic::warn(format!("`{autocomplete}` is not a valid value for autocomplete."))
         .with_help(format!("Change `{autocomplete}` to a valid value for autocomplete."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn click_events_have_key_events_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.")
+    OxcDiagnostic::warn("Enforce a clickable non-interactive element has at least one keyboard event listener.")
         .with_help("Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -11,9 +11,11 @@ use crate::{
 };
 
 fn heading_has_content_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.")
-        .with_help("Provide screen reader accessible content when using heading elements.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Headings must have content and the content must be accessible by a screen reader.",
+    )
+    .with_help("Provide screen reader accessible content when using heading elements.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 fn missing_lang_prop(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(html-has-lang): Missing lang attribute.")
+    OxcDiagnostic::warn("Missing lang attribute.")
         .with_help("Add a lang attribute to the html element whose value represents the primary language of document.")
         .with_label(span0)
 }
 
 fn missing_lang_value(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(html-has-lang): Missing value for lang attribute")
+    OxcDiagnostic::warn("Missing value for lang attribute")
         .with_help("Must have meaningful value for `lang` prop.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn iframe_has_title_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(iframe-has-title): Missing `title` attribute for the `iframe` element.")
+    OxcDiagnostic::warn("Missing `title` attribute for the `iframe` element.")
         .with_help("Provide title property for iframe element.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 fn img_redundant_alt_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(img-redundant-alt): Redundant alt attribute.").with_help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.").with_label(span0)
+    OxcDiagnostic::warn("Redundant alt attribute.").with_help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn lang_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(lang): Lang attribute must have a valid value.")
+    OxcDiagnostic::warn("Lang attribute must have a valid value.")
         .with_help("Set a valid value for lang attribute.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::get_element_type, AstNode};
 
 fn media_has_caption_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(media-has-caption): Missing <track> element with captions inside <audio> or <video> element")
+    OxcDiagnostic::warn("Missing <track> element with captions inside <audio> or <video> element")
         .with_help("Media elements such as <audio> and <video> must have a <track> for captions.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -12,13 +12,13 @@ use crate::{
 };
 
 fn miss_on_focus(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(mouse-events-have-key-events): {x1} must be accompanied by onFocus for accessibility."))
+    OxcDiagnostic::warn(format!("{x1} must be accompanied by onFocus for accessibility."))
         .with_help("Try to add onFocus.")
         .with_label(span0)
 }
 
 fn miss_on_blur(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(mouse-events-have-key-events): {x1} must be accompanied by onBlur for accessibility."))
+    OxcDiagnostic::warn(format!("{x1} must be accompanied by onBlur for accessibility."))
         .with_help("Try to add onBlur.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_lowercase, AstNode};
 
 fn no_access_key_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(no-access-key): No access key attribute allowed.")
+    OxcDiagnostic::warn("No access key attribute allowed.")
         .with_help("Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn no_aria_hidden_on_focusable_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(no-aria-hidden-on-focusable): `aria-hidden` must not be true on focusable elements.")
+    OxcDiagnostic::warn("`aria-hidden` must not be true on focusable elements.")
         .with_help("Remove `aria-hidden=\"true\"` from focusable elements or modify the element to be not focusable.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 fn no_autofocus_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(no-autofocus): The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users")
+    OxcDiagnostic::warn("The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users")
         .with_help("Remove `autofocus` attribute")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 use crate::{rule::Rule, utils::get_element_type, LintContext};
 
 fn no_distracting_elements_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-jsx-a11y(no-distracting-elements): Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.")
+    OxcDiagnostic::warn("Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.")
         .with_help("Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -16,7 +16,7 @@ use crate::{
 
 fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "eslint-plugin-jsx-a11y(no-redundant-roles): The element `{element}` has an implicit role of `{role}`. Defining this explicitly is redundant and should be avoided."
+        "The element `{element}` has an implicit role of `{role}`. Defining this explicitly is redundant and should be avoided."
     ))
     .with_help(format!("Remove the redundant role `{role}` from the element `{element}`."))
     .with_label(span)

--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 fn prefer_tag_over_role_diagnostic(span: Span, tag: &str, role: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(prefer-tag-over-role): Prefer `{tag}` over `role` attribute `{role}`."))
+    OxcDiagnostic::warn(format!("Prefer `{tag}` over `role` attribute `{role}`."))
         .with_help(format!("Replace HTML elements with `role` attribute `{role}` to corresponding semantic HTML tag `{tag}`."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -10,7 +10,7 @@ use phf::{phf_map, phf_set};
 use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_lowercase, AstNode};
 
 fn role_has_required_aria_props_diagnostic(span: Span, role: &str, props: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(role-has-required-aria-props): `{role}` role is missing required aria props `{props}`."))
+    OxcDiagnostic::warn(format!("`{role}` role is missing required aria props `{props}`."))
         .with_help(format!("Add missing aria props `{props}` to the element with `{role}` role."))
         .and_label(span)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -48,13 +48,13 @@ declare_oxc_lint!(
 pub struct RoleSupportsAriaProps;
 
 fn default(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute {x1} is not supported by the role {x2}."))
+    OxcDiagnostic::warn(format!("The attribute {x1} is not supported by the role {x2}."))
         .with_help(format!("Try to remove invalid attribute {x1}."))
         .with_label(span0)
 }
 
 fn is_implicit_diagnostic(span0: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-jsx-a11y(role-supports-aria-props): The attribute {x1} is not supported by the role {x2}. This role is implicit on the element {x3}."))
+    OxcDiagnostic::warn(format!("The attribute {x1} is not supported by the role {x2}. This role is implicit on the element {x3}."))
         .with_help(format!("Try to remove invalid attribute {x1}."))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -12,11 +12,9 @@ use crate::{
 };
 
 fn scope_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsx-a11y(scope): The scope prop can only be used on <th> elements",
-    )
-    .with_help("Must use scope prop only on <th> elements")
-    .with_label(span0)
+    OxcDiagnostic::warn("The scope prop can only be used on <th> elements")
+        .with_help("Must use scope prop only on <th> elements")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -11,11 +11,9 @@ use crate::{
 };
 
 fn tabindex_no_positive_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-jsx-a11y(tabindex-no-positive): Avoid positive integer values for tabIndex.",
-    )
-    .with_help("Change the tabIndex prop to a non-negative value")
-    .with_label(span0)
+    OxcDiagnostic::warn("Avoid positive integer values for tabIndex.")
+        .with_help("Change the tabIndex prop to a non-negative value")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -11,17 +11,17 @@ use crate::{
 };
 
 fn font_display_parameter_missing(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(google-font-display): A font-display parameter is missing (adding `&display=optional` is recommended).")
-        .with_help("See https://nextjs.org/docs/messages/google-font-display")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "A font-display parameter is missing (adding `&display=optional` is recommended).",
+    )
+    .with_help("See https://nextjs.org/docs/messages/google-font-display")
+    .with_label(span0)
 }
 
 fn not_recommended_font_display_value(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-next(google-font-display): `{x1}` is not a recommended font-display value."
-    ))
-    .with_help("See https://nextjs.org/docs/messages/google-font-display")
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("`{x1}` is not a recommended font-display value."))
+        .with_help("See https://nextjs.org/docs/messages/google-font-display")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn google_font_preconnect_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(r#"eslint-plugin-next(google-font-preconnect): `rel="preconnect"` is missing from Google Font."#)
+    OxcDiagnostic::warn(r#"`rel="preconnect"` is missing from Google Font."#)
         .with_help("See: https://nextjs.org/docs/messages/google-font-preconnect")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -10,9 +10,11 @@ use rustc_hash::FxHashSet;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn inline_script_id_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(inline-script-id): `next/script` components with inline content must specify an `id` attribute.")
-        .with_help("See https://nextjs.org/docs/messages/inline-script-id")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "`next/script` components with inline content must specify an `id` attribute.",
+    )
+    .with_help("See https://nextjs.org/docs/messages/inline-script-id")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -17,9 +17,11 @@ use crate::{
 };
 
 fn next_script_for_ga_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(next-script-for-ga): Prefer `next/script` component when using the inline script for Google Analytics.")
-        .with_help("See https://nextjs.org/docs/messages/next-script-for-ga")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Prefer `next/script` component when using the inline script for Google Analytics.",
+    )
+    .with_help("See https://nextjs.org/docs/messages/next-script-for-ga")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_assign_module_variable_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-next(no-assign-module-variable): Do not assign to the variable `module`.",
-    )
-    .with_help("See https://nextjs.org/docs/messages/no-assign-module-variable")
-    .with_label(span0)
+    OxcDiagnostic::warn("Do not assign to the variable `module`.")
+        .with_help("See https://nextjs.org/docs/messages/no-assign-module-variable")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule};
 
 fn no_async_client_component_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.")
+    OxcDiagnostic::warn("Prevent client components from being async functions.")
         .with_help("See: https://nextjs.org/docs/messages/no-async-client-component")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn no_before_interactive_script_outside_document_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-before-interactive-script-outside-document): next/script's `beforeInteractive` strategy should not be used outside of `pages/_document.js`")
+    OxcDiagnostic::warn("next/script's `beforeInteractive` strategy should not be used outside of `pages/_document.js`")
         .with_help("See https://nextjs.org/docs/messages/no-before-interactive-script-outside-document")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::get_string_literal_prop_value, AstNode};
 
 fn no_css_tags_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-css-tags): Do not include stylesheets manually.")
+    OxcDiagnostic::warn("Do not include stylesheets manually.")
         .with_help("See https://nextjs.org/docs/messages/no-css-tags")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::is_document_page, AstNode};
 
 fn no_document_import_in_page_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-document-import-in-page): `<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-import-in-page").with_help("Prevent importing `next/document` outside of `pages/_document.js`.").with_label(span0)
+    OxcDiagnostic::warn("`<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-import-in-page").with_help("Prevent importing `next/document` outside of `pages/_document.js`.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -74,7 +74,7 @@ impl Rule for NoDuplicateHead {
         }
 
         ctx.diagnostic(
-            OxcDiagnostic::warn("eslint-plugin-next(no-duplicate-head): Do not include multiple instances of `<Head/>`")
+            OxcDiagnostic::warn("Do not include multiple instances of `<Head/>`")
                 .with_help("Only use a single `<Head />` component in your custom document in `pages/_document.js`. See: https://nextjs.org/docs/messages/no-duplicate-head")
                 .with_labels(labels),
         );

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::is_in_app_dir, AstNode};
 
 fn no_head_element_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-head-element): Do not use `<head>` element. Use `<Head />` from `next/head` instead.")
+    OxcDiagnostic::warn("Do not use `<head>` element. Use `<Head />` from `next/head` instead.")
         .with_help("See https://nextjs.org/docs/messages/no-head-element")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_head_import_in_document_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-head-import-in-document): Prevent usage of `next/head` in `pages/_document.js`.")
+    OxcDiagnostic::warn("Prevent usage of `next/head` in `pages/_document.js`.")
         .with_help("See https://nextjs.org/docs/messages/no-head-import-in-document")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_img_element_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-img-element): Prevent usage of `<img>` element due to slower LCP and higher bandwidth.")
+    OxcDiagnostic::warn("Prevent usage of `<img>` element due to slower LCP and higher bandwidth.")
         .with_help("See https://nextjs.org/docs/messages/no-img-element")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -9,13 +9,13 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn not_added_in_document(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-page-custom-font): Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged.")
+    OxcDiagnostic::warn("Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged.")
         .with_help("See: https://nextjs.org/docs/messages/no-page-custom-font")
         .with_label(span0)
 }
 
 fn link_outside_of_head(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-page-custom-font): Using `<link />` outside of `<Head>` will disable automatic font optimization. This is discouraged.")
+    OxcDiagnostic::warn("Using `<link />` outside of `<Head>` will disable automatic font optimization. This is discouraged.")
         .with_help("See: 'https://nextjs.org/docs/messages/no-page-custom-font")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_script_component_in_head_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-script-component-in-head): Prevent usage of `next/script` in `next/head` component.")
+    OxcDiagnostic::warn("Prevent usage of `next/script` in `next/head` component.")
         .with_help("See https://nextjs.org/docs/messages/no-script-component-in-head")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_styled_jsx_in_document_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-styled-jsx-in-document): `styled-jsx` should not be used in `pages/_document.js`")
+    OxcDiagnostic::warn("`styled-jsx` should not be used in `pages/_document.js`")
         .with_help("Possible to fix it please see: https://nextjs.org/docs/messages/no-styled-jsx-in-document#possible-ways-to-fix-it")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_sync_scripts_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-sync-scripts): Prevent synchronous scripts.")
+    OxcDiagnostic::warn("Prevent synchronous scripts.")
         .with_help("See https://nextjs.org/docs/messages/no-sync-scripts")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_title_in_document_head_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-next(no-title-in-document-head): Prevent usage of `<title>` with `Head` component from `next/document`.")
+    OxcDiagnostic::warn("Prevent usage of `<title>` with `Head` component from `next/document`.")
         .with_help("See https://nextjs.org/docs/messages/no-title-in-document-head")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -10,11 +10,9 @@ use phf::phf_set;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_typos_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-next(no-typos): {x0} may be a typo. Did you mean {x1}?"
-    ))
-    .with_help("Prevent common typos in Next.js's data fetching functions")
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("{x0} may be a typo. Did you mean {x1}?"))
+        .with_help("Prevent common typos in Next.js's data fetching functions")
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -11,9 +11,11 @@ use phf::{phf_set, Set};
 use crate::{context::LintContext, rule::Rule, utils::get_next_script_import_local_name};
 
 fn no_unwanted_polyfillio_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-next(no-unwanted-polyfillio): No duplicate polyfills from Polyfill.io are allowed. {x0} already shipped with Next.js."))
-        .with_help("See https://nextjs.org/docs/messages/no-unwanted-polyfillio")
-        .with_label(span1)
+    OxcDiagnostic::warn(format!(
+        "No duplicate polyfills from Polyfill.io are allowed. {x0} already shipped with Next.js."
+    ))
+    .with_help("See https://nextjs.org/docs/messages/no-unwanted-polyfillio")
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -10,7 +10,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn approx_constant_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("oxc(approx-constant): Approximate value of `{x1}` found."))
+    OxcDiagnostic::warn(format!("Approximate value of `{x1}` found."))
         .with_help(format!("Use `Math.{x1}` instead"))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn bad_array_method_on_arguments_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-array-method-on-arguments): Bad array method on arguments")
+    OxcDiagnostic::warn("Bad array method on arguments")
         .with_help(format!(
             "The 'arguments' object does not have '{x0}()' method. If an array method was intended, consider converting the 'arguments' object to an array or using ES6 rest parameter instead."
         ))

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -10,7 +10,7 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn bad_bitwise_operator_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-bitwise-operator): Bad bitwise operator")
+    OxcDiagnostic::warn("Bad bitwise operator")
         .with_help(format!(
             "Bitwise operator '{x0}' seems unintended. Did you mean logical operator '{x1}'?"
         ))

--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -11,7 +11,7 @@ fn bad_char_at_comparison_diagnostic(
     compared_string: Span,
     x2: usize,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-char-at-comparison): Invalid comparison with `charAt` method")
+    OxcDiagnostic::warn("Invalid comparison with `charAt` method")
         .with_help("`String.prototype.charAt` returns a string of length 1. If the return value is compared with a string of length greater than 1, the comparison will always be false.")
         .with_labels([
             char_at.label("`charAt` called here"),

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn bad_comparison_sequence_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-comparison-sequence): Bad comparison sequence").with_help("Comparison result should not be used directly as an operand of another comparison. If you need to compare three or more operands, you should connect each comparison operation with logical AND operator (`&&`)").with_label(span0)
+    OxcDiagnostic::warn("Bad comparison sequence").with_help("Comparison result should not be used directly as an operand of another comparison. If you need to compare three or more operands, you should connect each comparison operation with logical AND operator (`&&`)").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -9,13 +9,11 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn bad_min_max_func_diagnostic(x0: f64, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "oxc(bad-min-max-func): Math.min and Math.max combination leads to constant result",
-    )
-    .with_help(format!(
-        "This evaluates to {x0:?} because of the incorrect `Math.min`/`Math.max` combination"
-    ))
-    .with_label(span1)
+    OxcDiagnostic::warn("Math.min and Math.max combination leads to constant result")
+        .with_help(format!(
+            "This evaluates to {x0:?} because of the incorrect `Math.min`/`Math.max` combination"
+        ))
+        .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::BinaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn object_comparison(span0: Span, x1: bool) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-object-literal-comparison): Unexpected object literal comparison.")
+    OxcDiagnostic::warn("Unexpected object literal comparison.")
         .with_help(format!(
             "This comparison will always return {x1:?} as object literals are never equal to each other. Consider using `Object.entries()` of `Object.keys()` and comparing their lengths."
         ))
@@ -15,7 +15,7 @@ fn object_comparison(span0: Span, x1: bool) -> OxcDiagnostic {
 }
 
 fn array_comparison(span0: Span, x1: bool) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-object-literal-comparison): Unexpected array literal comparison.")
+    OxcDiagnostic::warn("Unexpected array literal comparison.")
         .with_help(format!("This comparison will always return {x1:?} as array literals are never equal to each other. Consider using `Array.length` if empty checking was intended."))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn bad_replace_all_arg_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(bad-replace-all-arg): Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.")
+    OxcDiagnostic::warn("Global flag (g) is missing in the regular expression supplied to the `replaceAll` method.")
         .with_help("To replace all occurrences of a string, use the `replaceAll` method with the global flag (g) in the regular expression.")
         .with_labels([
             span0.label("`replaceAll` called here"),

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -13,7 +13,7 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
 fn redundant_left_hand_side(span0: Span, span1: Span, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(const-comparisons): Left-hand side of `&&` operator has no effect.")
+    OxcDiagnostic::warn("Left-hand side of `&&` operator has no effect.")
         .with_help(x2.to_string())
         .with_labels([
             span0.label("If this evaluates to `true`"),
@@ -22,7 +22,7 @@ fn redundant_left_hand_side(span0: Span, span1: Span, x2: &str) -> OxcDiagnostic
 }
 
 fn redundant_right_hand_side(span0: Span, span1: Span, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(const-comparisons): Right-hand side of `&&` operator has no effect.")
+    OxcDiagnostic::warn("Right-hand side of `&&` operator has no effect.")
         .with_help(x2.to_string())
         .with_labels([
             span0.label("If this evaluates to `true`"),
@@ -31,12 +31,10 @@ fn redundant_right_hand_side(span0: Span, span1: Span, x2: &str) -> OxcDiagnosti
 }
 
 fn impossible(span0: Span, span1: Span, x2: &str, x3: &str, x4: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(const-comparisons): Unexpected constant comparison")
-        .with_help(x4.to_string())
-        .with_labels([
-            span0.label(format!("Requires that {x2}")),
-            span1.label(format!("Requires that {x3}")),
-        ])
+    OxcDiagnostic::warn("Unexpected constant comparison").with_help(x4.to_string()).with_labels([
+        span0.label(format!("Requires that {x2}")),
+        span1.label(format!("Requires that {x3}")),
+    ])
 }
 
 /// <https://rust-lang.github.io/rust-clippy/master/index.html#/impossible>

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
 fn double_comparisons_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(double-comparisons): Unexpected double comparisons.")
+    OxcDiagnostic::warn("Unexpected double comparisons.")
         .with_help(format!(
             "This logical expression can be simplified. Try using the `{x1}` operator instead."
         ))

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -11,7 +11,7 @@ use oxc_syntax::operator::BinaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn erasing_op_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(erasing-op): Unexpected erasing operation. This expression will always evaluate to zero.")
+    OxcDiagnostic::warn("Unexpected erasing operation. This expression will always evaluate to zero.")
         .with_help("This is most likely not the intended outcome. Consider removing the operation, or directly assigning zero to the variable")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -16,9 +16,11 @@ use crate::{
 };
 
 fn misrefactored_assign_op_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(misrefactored-assign-op): Misrefactored assign op. Variable appears on both sides of an assignment operation")
-        .with_help(format!("Did you mean `{x1}`?"))
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Misrefactored assign op. Variable appears on both sides of an assignment operation",
+    )
+    .with_help(format!("Did you mean `{x1}`?"))
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/oxc/missing_throw.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn missing_throw_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(missing-throw): Missing throw")
+    OxcDiagnostic::warn("Missing throw")
         .with_help("The `throw` keyword seems to be missing in front of this 'new' expression")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn likely_array(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(no-accumulating-spread): Do not spread accumulators in Array.prototype.reduce()")
+    OxcDiagnostic::warn("Do not spread accumulators in Array.prototype.reduce()")
         .with_help("It looks like you're spreading an `Array`. Consider using the `Array.push` or `Array.concat` methods to mutate the accumulator instead.\nUsing spreads within accumulators leads to `O(n^2)` time complexity.")
         .with_labels([
             span0.label("From this spread"),
@@ -24,7 +24,7 @@ fn likely_array(span0: Span, span1: Span) -> OxcDiagnostic {
 }
 
 fn likely_object(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(no-accumulating-spread): Do not spread accumulators in Array.prototype.reduce()")
+    OxcDiagnostic::warn("Do not spread accumulators in Array.prototype.reduce()")
         .with_help("It looks like you're spreading an `Object`. Consider using the `Object.assign` or assignment operators to mutate the accumulator instead.\nUsing spreads within accumulators leads to `O(n^2)` time complexity.")
         .with_labels([
             span0.label("From this spread"),
@@ -33,7 +33,7 @@ fn likely_object(span0: Span, span1: Span) -> OxcDiagnostic {
 }
 
 fn unknown(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(no-accumulating-spread): Do not spread accumulators in Array.prototype.reduce()")
+    OxcDiagnostic::warn("Do not spread accumulators in Array.prototype.reduce()")
         .with_help("Consider using `Object.assign()` or `Array.prototype.push()` to mutate the accumulator instead.\nUsing spreads within accumulators leads to `O(n^2)` time complexity.")
         .with_labels([
             span0.label("From this spread"),

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_async_await_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(no-async-await): Unexpected async/await")
+    OxcDiagnostic::warn("Unexpected async/await")
         .with_help("Async/await is not allowed")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -97,7 +97,7 @@ impl Rule for NoBarrelFile {
         let threshold = self.threshold;
         if total >= threshold {
             let diagnostic = OxcDiagnostic::warn(format!(
-                "oxc(no-barrel-file): Barrel file detected, {total} modules are loaded."
+                "Barrel file detected, {total} modules are loaded."
             ))
             .with_help(format!("Loading {total} modules is slow for runtimes and bundlers.\nThe configured threshold is {threshold}.\nSee also: <https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7>."))
             .with_labels(labels);

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_const_enum_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(no-const-enum): Unexpected const enum")
+    OxcDiagnostic::warn("Unexpected const enum")
         .with_help("Const enums are not supported by bundlers and are incompatible with the isolatedModules mode. Their use can lead to import nonexistent values (because const enums are erased).")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -7,10 +7,9 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_optional_chaining_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
     if x1.is_empty() {
-        OxcDiagnostic::warn("oxc(no-optional-chaining): Optional chaining is not allowed.")
-            .with_label(span0)
+        OxcDiagnostic::warn("Optional chaining is not allowed.").with_label(span0)
     } else {
-        OxcDiagnostic::warn("oxc(no-optional-chaining): Optional chaining is not allowed.")
+        OxcDiagnostic::warn("Optional chaining is not allowed.")
             .with_help(x1.to_owned())
             .with_label(span0)
     }

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_rest_spread_properties_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("oxc(no-rest-spread-properties): {x1} are not allowed. {x2}"))
-        .with_label(span0)
+    OxcDiagnostic::warn(format!("{x1} are not allowed. {x2}")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -11,9 +11,13 @@ fn number_arg_out_of_range_diagnostic(
     x2: usize,
     span3: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(number-arg-out-of-range): Radix or precision arguments of number-related functions should not exceed the limit")
-        .with_help(format!("The first argument of 'Number.prototype.{x0}' should be a number between {x1} and {x2}"))
-        .with_label(span3)
+    OxcDiagnostic::warn(
+        "Radix or precision arguments of number-related functions should not exceed the limit",
+    )
+    .with_help(format!(
+        "The first argument of 'Number.prototype.{x0}' should be a number between {x1} and {x2}"
+    ))
+    .with_label(span3)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -10,7 +10,7 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn only_used_in_recursion_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "oxc(only-used-in-recursion): Parameter `{x1}` is only used in recursive calls"
+        "Parameter `{x1}` is only used in recursive calls"
     ))
     .with_help(
         "Remove the argument and its usage. Alternatively, use the argument in the function body.",

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn uninvoked_array_callback_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("oxc(uninvoked-array-callback): Uninvoked array callback")
+    OxcDiagnostic::warn("Uninvoked array callback")
         .with_help(
             "consider filling the array with `undefined` values using `Array.prototype.fill()`",
         )

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn avoid_new_promise_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-promise(avoid-new): Avoid creating new promises")
-        .with_label(span0)
+    OxcDiagnostic::warn("Avoid creating new promises").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -6,10 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn static_promise_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-promise(no-new-statics): Disallow calling `new` on a `Promise.{x0}`"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{x0}`")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -10,7 +10,8 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn param_names_diagnostic(span0: Span, x0: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `{x0}`")).with_label(span0)
+    OxcDiagnostic::warn(format!("Promise constructor parameters must be named to match `{x0}`"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -17,13 +17,13 @@ use crate::{
 };
 
 fn missing_type_prop(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(button-has-type): `button` elements must have an explicit `type` attribute.")
+    OxcDiagnostic::warn("`button` elements must have an explicit `type` attribute.")
         .with_help("Add a `type` attribute to the `button` element.")
         .with_label(span0)
 }
 
 fn invalid_type_prop(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(button-has-type): `button` elements must have a valid `type` attribute.")
+    OxcDiagnostic::warn("`button` elements must have a valid `type` attribute.")
         .with_help("Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 fn missing_property(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(checked-requires-onchange-or-readonly): `checked` should be used with either `onChange` or `readOnly`.")
+    OxcDiagnostic::warn("`checked` should be used with either `onChange` or `readOnly`.")
         .with_help("Add either `onChange` or `readOnly`.")
         .with_label(span)
 }
 
 fn exclusive_checked_attribute(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(checked-requires-onchange-or-readonly): Use either `checked` or `defaultChecked`, but not both.")
+    OxcDiagnostic::warn("Use either `checked` or `defaultChecked`, but not both.")
         .with_help("Remove either `checked` or `defaultChecked`.")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -9,12 +9,11 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn missing_key_prop_for_element_in_array(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(r#"eslint-plugin-react(jsx-key): Missing "key" prop for element in array."#)
-        .with_label(span0)
+    OxcDiagnostic::warn(r#"Missing "key" prop for element in array."#).with_label(span0)
 }
 
 fn missing_key_prop_for_element_in_iterator(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(r#"eslint-plugin-react(jsx-key): Missing "key" prop for element in iterator."#)
+    OxcDiagnostic::warn(r#"Missing "key" prop for element in iterator."#)
         .with_help(r#"Add a "key" prop to the element in the iterator (https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)."#)
         .with_labels([
             span0.label("Iterator starts here."),
@@ -23,7 +22,7 @@ fn missing_key_prop_for_element_in_iterator(span0: Span, span1: Span) -> OxcDiag
 }
 
 fn key_prop_must_be_placed_before_spread(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(r#"eslint-plugin-react(jsx-key): "key" prop must be placed before any `{...spread}`"#)
+    OxcDiagnostic::warn(r#""key" prop must be placed before any `{...spread}`"#)
         .with_help("To avoid conflicting with React's new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -8,7 +8,8 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn jsx_no_comment_textnodes_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces").with_label(span0)
+    OxcDiagnostic::warn("Comments inside children section of tag should be placed inside braces")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn jsx_no_duplicate_props_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-react(jsx-no-duplicate-props): No duplicate props allowed. The prop \"{x0}\" is duplicated."))
+    OxcDiagnostic::warn(format!("No duplicate props allowed. The prop \"{x0}\" is duplicated."))
         .with_help("Remove one of the props, or rename them so each prop is distinct.")
         .with_labels([span1, span2])
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -14,19 +14,19 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn target_blank_without_noreferrer(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-target-blank): Using target=`_blank` without rel=`noreferrer` (which implies rel=`noopener`) is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
+    OxcDiagnostic::warn("Using target=`_blank` without rel=`noreferrer` (which implies rel=`noopener`) is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
 .with_help("add rel=`noreferrer` to the element")
 .with_label(span0)
 }
 
 fn target_blank_without_noopener(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-target-blank): Using target=`_blank` without rel=`noreferrer` or rel=`noopener` (the former implies the latter and is preferred due to wider support) is a security risk: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
+    OxcDiagnostic::warn("Using target=`_blank` without rel=`noreferrer` or rel=`noopener` (the former implies the latter and is preferred due to wider support) is a security risk: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
 .with_help("add rel=`noreferrer` or rel=`noopener` to the element")
 .with_label(span0)
 }
 
 fn explicit_props_in_spread_attributes(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-target-blank): all spread attributes are treated as if they contain an unsafe combination of props, unless specifically overridden by props after the last spread attribute prop.")
+    OxcDiagnostic::warn("all spread attributes are treated as if they contain an unsafe combination of props, unless specifically overridden by props after the last spread attribute prop.")
 .with_help("add rel=`noreferrer` to the element")
 .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn jsx_no_undef_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-undef): Disallow undeclared variables in JSX")
+    OxcDiagnostic::warn("Disallow undeclared variables in JSX")
         .with_help(format!("'{x0}' is not defined."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -13,11 +13,11 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn needs_more_children(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.").with_label(span0)
+    OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span0)
 }
 
 fn child_of_html_element(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.").with_label(span0)
+    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -9,11 +9,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
 
 fn no_children_prop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-react(no-children-prop): Avoid passing children using a prop.",
-    )
-    .with_help("The canonical way to pass children in React is to use JSX elements")
-    .with_label(span0)
+    OxcDiagnostic::warn("Avoid passing children using a prop.")
+        .with_help("The canonical way to pass children in React is to use JSX elements")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn no_danger_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-danger): Do not use `dangerouslySetInnerHTML` prop")
+    OxcDiagnostic::warn("Do not use `dangerouslySetInnerHTML` prop")
         .with_help("`dangerouslySetInnerHTML` is a way to inject HTML into your React component. This is dangerous because it can easily lead to XSS vulnerabilities.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -14,11 +14,9 @@ use crate::{
 };
 
 fn no_direct_mutation_state_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-react(no-direct-mutation-state): never mutate this.state directly.",
-    )
-    .with_help("calling setState() afterwards may replace the mutation you made.")
-    .with_label(span0)
+    OxcDiagnostic::warn("never mutate this.state directly.")
+        .with_help("calling setState() afterwards may replace the mutation you made.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_find_dom_node_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-find-dom-node): Unexpected call to `findDOMNode`.")
+    OxcDiagnostic::warn("Unexpected call to `findDOMNode`.")
         .with_help("Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_is_mounted_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint(no-is-mounted): Do not use isMounted")
+    OxcDiagnostic::warn("Do not use isMounted")
         .with_help("isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_render_return_value_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-render-return-value): Do not depend on the return value from ReactDOM.render.")
+    OxcDiagnostic::warn("Do not depend on the return value from ReactDOM.render.")
         .with_help("Using the return value is a legacy feature.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn no_set_state_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-set-state): Do not use setState").with_label(span0)
+    OxcDiagnostic::warn("Do not use setState").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -17,13 +17,15 @@ use crate::{
 };
 
 fn this_refs_deprecated(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-string-refs): Using this.refs is deprecated.")
+    OxcDiagnostic::warn("Using this.refs is deprecated.")
         .with_help("Using this.xxx instead of this.refs.xxx")
         .with_label(span0)
 }
 
 fn string_in_ref_deprecated(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-string-refs): Using string literals in ref attributes is deprecated.").with_help("Using reference callback instead").with_label(span0)
+    OxcDiagnostic::warn("Using string literals in ref attributes is deprecated.")
+        .with_help("Using reference callback instead")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -7,10 +7,7 @@ use phf::{phf_map, Map};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unescaped_entities_diagnostic(span0: Span, x1: char, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-react(no-unescaped-entities): `{x1}` can be escaped with {x2}"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("`{x1}` can be escaped with {x2}")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -16,25 +16,27 @@ use serde::Deserialize;
 use crate::{context::LintContext, rule::Rule, utils::get_jsx_attribute_name, AstNode};
 
 fn invalid_prop_on_tag(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-unknown-property): Invalid property found")
+    OxcDiagnostic::warn("Invalid property found")
         .with_help(format!("Property '{x1}' is only allowed on: {x2}"))
         .with_label(span0)
 }
 
 fn data_lowercase_required(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-unknown-property): React does not recognize data-* props with uppercase characters on a DOM element")
-        .with_help(format!("Use '{x1}' instead"))
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "React does not recognize data-* props with uppercase characters on a DOM element",
+    )
+    .with_help(format!("Use '{x1}' instead"))
+    .with_label(span0)
 }
 
 fn unknown_prop_with_standard_name(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-unknown-property): Unknown property found")
+    OxcDiagnostic::warn("Unknown property found")
         .with_help(format!("Use '{x1}' instead"))
         .with_label(span0)
 }
 
 fn unknown_prop(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(no-unknown-property): Unknown property found")
+    OxcDiagnostic::warn("Unknown property found")
         .with_help("Remove unknown property")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -11,13 +11,11 @@ use crate::{
 };
 
 fn unexpected_es6_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(prefer-es6-class): Components should use createClass instead of ES6 class.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Components should use createClass instead of ES6 class.").with_label(span0)
 }
 
 fn expected_es6_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(prefer-es6-class): Components should use es6 class instead of createClass.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Components should use es6 class instead of createClass.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn react_in_jsx_scope_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(react-in-jsx-scope): 'React' must be in scope when using JSX")
+    OxcDiagnostic::warn("'React' must be in scope when using JSX")
         .with_help("When using JSX, `<a />` expands to `React.createElement(\"a\")`. Therefore the `React` variable must be in scope.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn require_render_return_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(require-render-return): Your render method should have a return statement")
+    OxcDiagnostic::warn("Your render method should have a return statement")
         .with_help("When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the return statement is missing.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -21,73 +21,74 @@ use crate::{
 mod diagnostics {
     use oxc_diagnostics::OxcDiagnostic;
     use oxc_span::Span;
+    const SCOPE: &str = "eslint-plugin-react-hooks";
 
     pub(super) fn function_error(span: Span, hook_name: &str, func_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            React Hook {hook_name:?} is called in function {func_name:?} that is neither \
+            "React Hook {hook_name:?} is called in function {func_name:?} that is neither \
             a React function component nor a custom React Hook function. \
             React component names must start with an uppercase letter. \
             React Hook names must start with the word \"use\".",
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 
     pub(super) fn conditional_hook(span: Span, hook_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            React Hook {hook_name:?} is called conditionally. React Hooks must be \
+            "React Hook {hook_name:?} is called conditionally. React Hooks must be \
             called in the exact same order in every component render."
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 
     pub(super) fn loop_hook(span: Span, hook_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            React Hook {hook_name:?} may be executed more than once. Possibly \
+            "React Hook {hook_name:?} may be executed more than once. Possibly \
             because it is called in a loop. React Hooks must be called in the \
             exact same order in every component render."
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 
     pub(super) fn top_level_hook(span: Span, hook_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            React Hook {hook_name:?} cannot be called at the top level. React Hooks \
+            "React Hook {hook_name:?} cannot be called at the top level. React Hooks \
             must be called in a React function component or a custom React \
             Hook function."
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 
     pub(super) fn async_component(span: Span, func_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            message: `React Hook {func_name:?} cannot be called in an async function. "
+            "message: `React Hook {func_name:?} cannot be called in an async function. "
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 
     pub(super) fn class_component(span: Span, hook_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            React Hook {hook_name:?} cannot be called in a class component. React Hooks \
+            "React Hook {hook_name:?} cannot be called in a class component. React Hooks \
             must be called in a React function component or a custom React \
             Hook function."
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 
     pub(super) fn generic_error(span: Span, hook_name: &str) -> OxcDiagnostic {
         OxcDiagnostic::warn(format!(
-            "eslint-plugin-react-hooks(rules-of-hooks): \
-            React Hook {hook_name:?} cannot be called inside a callback. React Hooks \
+            "React Hook {hook_name:?} cannot be called inside a callback. React Hooks \
             must be called in a React function component or a custom React \
             Hook function."
         ))
         .with_label(span)
+        .with_error_code_scope(SCOPE)
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -13,9 +13,11 @@ use phf::phf_set;
 use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
 
 fn void_dom_elements_no_children_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react(void-dom-elements-no-children): Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.")
-        .with_help(format!("Void DOM element <{x0:?} /> cannot receive children."))
-        .with_label(span1)
+    OxcDiagnostic::warn(
+        "Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children.",
+    )
+    .with_help(format!("Void DOM element <{x0:?} /> cannot receive children."))
+    .with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::get_prop_value, AstNode};
 
 fn jsx_no_jsx_as_prop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react-perf(jsx-no-jsx-as-prop): JSX attribute values should not contain other JSX.")
+    OxcDiagnostic::warn("JSX attribute values should not contain other JSX.")
         .with_help(r"simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn jsx_no_new_array_as_prop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react-perf(jsx-no-new-array-as-prop): JSX attribute values should not contain Arrays created in the same scope.")
+    OxcDiagnostic::warn("JSX attribute values should not contain Arrays created in the same scope.")
         .with_help(r"simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn jsx_no_new_function_as_prop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.")
+    OxcDiagnostic::warn("JSX attribute values should not contain functions created in the same scope.")
         .with_help(r"simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 fn jsx_no_new_object_as_prop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.")
+    OxcDiagnostic::warn("JSX attribute values should not contain objects created in the same scope.")
         .with_help(r"simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -14,67 +14,79 @@ use crate::{
 mod listener_map;
 
 fn assignment(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of assignment to `{x0}`")).with_label(span1)
+    OxcDiagnostic::warn(format!("Cannot determine side-effects of assignment to `{x0}`"))
+        .with_label(span1)
 }
 
 fn mutate(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of mutating").with_label(span0)
 }
 
 fn mutate_with_name(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating `{x0}`")).with_label(span1)
+    OxcDiagnostic::warn(format!("Cannot determine side-effects of mutating `{x0}`"))
+        .with_label(span1)
 }
 
 fn mutate_function_return_value(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating function return value").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of mutating function return value")
+        .with_label(span0)
 }
 
 fn mutate_parameter(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating function parameter").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of mutating function parameter")
+        .with_label(span0)
 }
 
 fn mutate_of_this(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating unknown this value").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of mutating unknown this value")
+        .with_label(span0)
 }
 
 fn mutate_import(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of mutating imported variable").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of mutating imported variable")
+        .with_label(span0)
 }
 
 fn call(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of calling").with_label(span0)
 }
 
 fn call_return_value(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling function return value").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of calling function return value")
+        .with_label(span0)
 }
 
 fn call_global(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling global function `{x0}`")).with_label(span1)
+    OxcDiagnostic::warn(format!("Cannot determine side-effects of calling global function `{x0}`"))
+        .with_label(span1)
 }
 
 fn call_parameter(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling function parameter").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of calling function parameter")
+        .with_label(span0)
 }
 
 fn call_import(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling imported function").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of calling imported function")
+        .with_label(span0)
 }
 
 fn call_member(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of calling member function").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of calling member function")
+        .with_label(span0)
 }
 
 fn debugger(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Debugger statements are side-effects").with_label(span0)
+    OxcDiagnostic::warn("Debugger statements are side-effects").with_label(span0)
 }
 
 fn delete(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Cannot determine side-effects of deleting anything but a MemberExpression").with_label(span0)
+    OxcDiagnostic::warn("Cannot determine side-effects of deleting anything but a MemberExpression")
+        .with_label(span0)
 }
 
 fn throw(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-tree-shaking(no-side-effects-in-initialization): Throwing an error is a side-effect").with_label(span0)
+    OxcDiagnostic::warn("Throwing an error is a side-effect").with_label(span0)
 }
 
 /// <https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/master/src/rules/no-side-effects-in-initialization.ts>

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -16,9 +16,7 @@ fn adjacent_overload_signatures_diagnostic(
     span1: Option<Span>,
     span2: Span,
 ) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!(
-        "typescript-eslint(adjacent-overload-signatures): All {x0:?} signatures should be adjacent."
-    ));
+    let mut d = OxcDiagnostic::warn(format!("All {x0:?} signatures should be adjacent."));
     if let Some(span) = span1 {
         d = d.and_label(span);
     }

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -29,19 +29,28 @@ declare_oxc_lint!(
 );
 
 fn generic(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(array-type): Array type using '{x0}{x2}[]' is forbidden. Use '{x1}<{x2}>' instead.")).with_label(span3)
+    OxcDiagnostic::warn(format!(
+        "Array type using '{x0}{x2}[]' is forbidden. Use '{x1}<{x2}>' instead."
+    ))
+    .with_label(span3)
 }
 
 fn generic_simple(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(array-type): Array type using '{x0}{x2}[]' is forbidden for non-simple types. Use '{x1}<{x2}>' instead.")).with_label(span3)
+    OxcDiagnostic::warn(format!("Array type using '{x0}{x2}[]' is forbidden for non-simple types. Use '{x1}<{x2}>' instead.")).with_label(span3)
 }
 
 fn array(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(array-type): Array type using '{x1}<{x2}>' is forbidden. Use '{x0}{x2}[]' instead.")).with_label(span3)
+    OxcDiagnostic::warn(format!(
+        "Array type using '{x1}<{x2}>' is forbidden. Use '{x0}{x2}[]' instead."
+    ))
+    .with_label(span3)
 }
 
 fn array_simple(x0: &str, x1: &str, x2: &str, span3: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(array-type): Array type using '{x1}<{x2}>' is forbidden for simple types. Use '{x0}{x2}[]' instead.")).with_label(span3)
+    OxcDiagnostic::warn(format!(
+        "Array type using '{x1}<{x2}>' is forbidden for simple types. Use '{x0}{x2}[]' instead."
+    ))
+    .with_label(span3)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -7,24 +7,28 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule};
 
 fn comment(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(ban-ts-comment): Do not use @ts-{x0} because it alters compilation errors.")).with_label(span1)
+    OxcDiagnostic::warn(format!("Do not use @ts-{x0} because it alters compilation errors."))
+        .with_label(span1)
 }
 
 fn ignore_instead_of_expect_error(span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(ban-ts-comment): Use \"@ts-expect-error\" instead of @ts-ignore, as \"@ts-ignore\" will do nothing if the following line is error-free.")
+    OxcDiagnostic::warn("Use \"@ts-expect-error\" instead of @ts-ignore, as \"@ts-ignore\" will do nothing if the following line is error-free.")
         .with_help("Replace \"@ts-ignore\" with \"@ts-expect-error\".")
         .with_label(span1)
 }
 
 fn comment_requires_description(x0: &str, x1: u64, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "typescript-eslint(ban-ts-comment): Include a description after the @ts-{x0} directive to explain why the @ts-{x0} is necessary. The description must be {x1} characters or longer."
+        "Include a description after the @ts-{x0} directive to explain why the @ts-{x0} is necessary. The description must be {x1} characters or longer."
     ))
     .with_label(span2)
 }
 
 fn comment_description_not_match_pattern(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(ban-ts-comment): The description for the @ts-{x0} directive must match the {x1} format.")).with_label(span2)
+    OxcDiagnostic::warn(format!(
+        "The description for the @ts-{x0} directive must match the {x1} format."
+    ))
+    .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -7,10 +7,7 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule};
 
 fn ban_tslint_comment_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "typescript-eslint(ban-tslint-comment): tslint comment detected: \"{x0}\""
-    ))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("tslint comment detected: \"{x0}\"")).with_label(span1)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -6,29 +6,25 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn type_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "typescript-eslint(ban-types): Do not use {x0:?} as a type. Use \"{x1}\" instead"
-    ))
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("Do not use {x0:?} as a type. Use \"{x1}\" instead"))
+        .with_label(span2)
 }
 
 fn type_literal(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(ban-types): Prefer explicitly define the object shape")
+    OxcDiagnostic::warn("Prefer explicitly define the object shape")
         .with_help("This type means \"any non-nullish value\", which is slightly better than 'unknown', but it's still a broad type")
         .with_label(span0)
 }
 
 fn function(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(ban-types): Don't use `Function` as a type")
+    OxcDiagnostic::warn("Don't use `Function` as a type")
         .with_help("The `Function` type accepts any function-like value")
         .with_label(span0)
 }
 
 fn object(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(ban-types): 'The `Object` type actually means \"any non-nullish value\"",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("'The `Object` type actually means \"any non-nullish value\"")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -9,11 +9,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn consistent_indexed_object_style_diagnostic(a: &str, b: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "typescript-eslint(consistent-indexed-object-style):A {a} is preferred over an {b}."
-    ))
-    .with_help(format!("A {a} is preferred over an {b}."))
-    .with_label(span)
+    OxcDiagnostic::warn(format!("A {a} is preferred over an {b}."))
+        .with_help(format!("A {a} is preferred over an {b}."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -9,9 +9,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn consistent_type_definitions_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(consistent-type-definitions):")
+    OxcDiagnostic::warn(format!("Use an `{x0}` instead of a `{x1}`"))
         .with_help(format!("Use an `{x0}` instead of a `{x1}`"))
-        .with_label(span2.label(format!("Use an `{x0}` instead of a `{x1}`")))
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -21,29 +21,19 @@ use crate::{
 };
 
 fn no_import_type_annotations_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.",
-    )
-    .with_label(span)
+    OxcDiagnostic::warn("`import()` type annotations are forbidden.").with_label(span)
 }
 
 fn avoid_import_type_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.",
-    )
-    .with_label(span)
+    OxcDiagnostic::warn("Use an `import` instead of an `import type`.").with_label(span)
 }
 fn type_over_value_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn( "typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`."
-    )
-    .with_label(span)
+    OxcDiagnostic::warn("All imports in the declaration are only used as types. Use `import type`.")
+        .with_label(span)
 }
 
 fn some_imports_are_only_types_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "typescript-eslint(consistent-type-imports): Imports {x1} are only used as type."
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Imports {x1} are only used as type.")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -61,11 +61,9 @@ declare_oxc_lint!(
 );
 
 fn explicit_function_return_type_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(explicit-function-return-type): Missing return type on function.",
-    )
-    .with_help("Require explicit return types on functions and class methods.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Missing return type on function.")
+        .with_help("Require explicit return types on functions and class methods.")
+        .with_label(span0)
 }
 
 impl Rule for ExplicitFunctionReturnType {

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 
 fn not_need_no_confusing_non_null_assertion_diagnostic(op_str: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-            "typescript-eslint(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like \"a! {op_str} b\", which looks very similar to not equal \"a !{op_str} b\"."
+            "Confusing combinations of non-null assertion and equal test like \"a! {op_str} b\", which looks very similar to not equal \"a !{op_str} b\"."
     ))
     .with_help("Remove the \"!\", or prefix the \"=\" with it.")
     .with_label(span)
@@ -39,7 +39,7 @@ fn not_need_no_confusing_non_null_assertion_diagnostic(op_str: &str, span: Span)
 
 fn wrap_up_no_confusing_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
-        "typescript-eslint(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like \"a! = b\", which looks very similar to not equal \"a != b\"."
+        "Confusing combinations of non-null assertion and equal test like \"a! = b\", which looks very similar to not equal \"a != b\"."
     )
     .with_help("Wrap left-hand side in parentheses to avoid putting non-null assertion \"!\" and \"=\" together.")
     .with_label(span)

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -7,11 +7,9 @@ use rustc_hash::FxHashMap;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_duplicate_enum_values_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-duplicate-enum-values): Disallow duplicate enum member values",
-    )
-    .with_help("Duplicate values can lead to bugs that are hard to track down")
-    .with_labels([span0, span1])
+    OxcDiagnostic::warn("Disallow duplicate enum member values")
+        .with_help("Duplicate values can lead to bugs that are hard to track down")
+        .with_labels([span0, span1])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -28,11 +28,9 @@ declare_oxc_lint!(
 );
 
 fn no_dynamic_delete_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.",
-    )
-    .with_help("Disallow using the `delete` operator on computed key expressions")
-    .with_label(span0)
+    OxcDiagnostic::warn("Do not delete dynamically computed property keys.")
+        .with_help("Disallow using the `delete` operator on computed key expressions")
+        .with_label(span0)
 }
 
 impl Rule for NoDynamicDelete {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -7,14 +7,12 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_interface_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-empty-interface): an empty interface is equivalent to `{}`",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span0)
 }
 
 fn no_empty_interface_extend_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype").with_label(span0)
+    OxcDiagnostic::warn("an interface declaring no members is equivalent to its supertype")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_explicit_any_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-explicit-any): Unexpected any. Specify a different type.")
+    OxcDiagnostic::warn("Unexpected any. Specify a different type.")
         .with_help("Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -6,8 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_extra_non_null_assertion_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-extra-non-null-assertion): extra non-null assertion")
-        .with_label(span0)
+    OxcDiagnostic::warn("extra non-null assertion").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -63,22 +63,15 @@ declare_oxc_lint!(
 );
 
 fn empty_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-extraneous-class): Unexpected empty class.")
-        .with_label(span)
+    OxcDiagnostic::warn("Unexpected empty class.").with_label(span)
 }
 
 fn only_static_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-extraneous-class): Unexpected class with only static properties.",
-    )
-    .with_label(span)
+    OxcDiagnostic::warn("Unexpected class with only static properties.").with_label(span)
 }
 
 fn only_constructor_no_extraneous_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-extraneous-class): Unexpected class with only a constructor.",
-    )
-    .with_label(span)
+    OxcDiagnostic::warn("Unexpected class with only a constructor.").with_label(span)
 }
 
 impl Rule for NoExtraneousClass {

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
 
 fn no_import_type_side_effects_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-import-type-side-effects): TypeScript will only remove the inline type specifiers which will leave behind a side effect import at runtime.")
+    OxcDiagnostic::warn("TypeScript will only remove the inline type specifiers which will leave behind a side effect import at runtime.")
         .with_help("Convert this to a top-level type qualifier to properly remove the entire import.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -9,15 +9,13 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_misused_new_interface_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-misused-new): Interfaces cannot be constructed, only classes.",
-    )
-    .with_help("Consider removing this method from your interface.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Interfaces cannot be constructed, only classes.")
+        .with_help("Consider removing this method from your interface.")
+        .with_label(span0)
 }
 
 fn no_misused_new_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-misused-new): Class cannot have method named `new`.")
+    OxcDiagnostic::warn("Class cannot have method named `new`.")
         .with_help("This method name is confusing, consider renaming the method to `constructor`")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -9,11 +9,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_namespace_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.",
-    )
-    .with_help("Replace the namespace with an ES2015 module or use `declare module`")
-    .with_label(span0)
+    OxcDiagnostic::warn("ES2015 module syntax is preferred over namespaces.")
+        .with_help("Replace the namespace with an ES2015 module or use `declare module`")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
 );
 
 fn no_non_null_asserted_nullish_coalescing_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator")
+    OxcDiagnostic::warn("'Disallow non-null assertions in the left operand of a nullish coalescing operator")
         .with_help("The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_non_null_asserted_optional_chain_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-non-null-asserted-optional-chain): non-null assertions after an optional chain expression")
+    OxcDiagnostic::warn("non-null assertions after an optional chain expression")
         .with_help("Optional chain expressions can return undefined by design - using a non-null assertion is unsafe and wrong. You should remove the non-null assertion.")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
 );
 
 fn no_non_null_assertion_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.")
+    OxcDiagnostic::warn("Forbidden non-null assertion.")
         .with_help("Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -9,14 +9,16 @@ use oxc_span::{CompactStr, GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_this_alias_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-this-alias): Unexpected aliasing of 'this' to local variable.")
+    OxcDiagnostic::warn("Unexpected aliasing of 'this' to local variable.")
         .with_help("Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.")
         .with_label(span0)
 }
 
 fn no_this_destructure_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-this-alias): Unexpected aliasing of members of 'this' to local variables.")
-        .with_help("Disabling destructuring of this is not a default, consider allowing destructuring")
+    OxcDiagnostic::warn("Unexpected aliasing of members of 'this' to local variables.")
+        .with_help(
+            "Disabling destructuring of this is not a default, consider allowing destructuring",
+        )
         .with_label(span0)
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -11,9 +11,11 @@ fn no_unnecessary_type_constraint_diagnostic(
     span2: Span,
     span3: Span,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(no-unnecessary-type-constraint): constraining the generic type {x0:?} to {x1:?} does nothing and is unnecessary"))
-        .with_help(format!("Remove the unnecessary {x1:?} constraint"))
-        .with_labels([span2, span3])
+    OxcDiagnostic::warn(format!(
+        "constraining the generic type {x0:?} to {x1:?} does nothing and is unnecessary"
+    ))
+    .with_help(format!("Remove the unnecessary {x1:?} constraint"))
+    .with_labels([span2, span3])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unsafe_declaration_merging_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(no-unsafe-declaration-merging): Unsafe declaration merging between classes and interfaces.")
+    OxcDiagnostic::warn("Unsafe declaration merging between classes and interfaces.")
         .with_help("The TypeScript compiler doesn't check whether properties are initialized, which can cause lead to TypeScript not detecting code that will cause runtime errors.")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_empty_export_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-useless-empty-export): Disallow empty exports that don't change anything in a module file",
-    )
-    .with_help("Empty export does nothing and can be removed.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Disallow empty exports that don't change anything in a module file")
+        .with_help("Empty export does nothing and can be removed.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -6,11 +6,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{ast_util::is_global_require_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_var_requires_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "typescript-eslint(no-var-requires): Require statement not part of import statement.",
-    )
-    .with_help("Use ES6 style imports or import instead.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Require statement not part of import statement.")
+        .with_help("Use ES6 style imports or import instead.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_as_const_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(prefer-as-const): Expected a `const` assertion instead of a literal type annotation.")
+    OxcDiagnostic::warn("Expected a `const` assertion instead of a literal type annotation.")
         .with_help("You should use `as const` instead of type annotation.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_enum_initializers_diagnostic(x0: &str, x1: usize, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(prefer-enum-initializers): The value of the member {x0:?} should be explicitly defined."))
+    OxcDiagnostic::warn(format!("The value of the member {x0:?} should be explicitly defined."))
         .with_help(format!("Can be fixed to {x0:?} = {x1:?}."))
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -13,9 +13,11 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator, Up
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_for_of_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(prefer-for-of): Expected a `for-of` loop instead of a `for` loop with this simple iteration.")
-        .with_help("Consider using a for-of loop for this simple iteration.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Expected a `for-of` loop instead of a `for` loop with this simple iteration.",
+    )
+    .with_help("Consider using a for-of loop for this simple iteration.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
 
 fn prefer_function_type_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(prefer-function-type): Enforce using function types instead of interfaces with call signatures.")
+    OxcDiagnostic::warn("Enforce using function types instead of interfaces with call signatures.")
         .with_help(format!("The function type form `{x0}` is generally preferred when possible for being more succinct."))
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -7,9 +7,11 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_literal_enum_member_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).")
-        .with_help("Require all enum members to be literal values.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Explicit enum value must only be a literal value (string, number, boolean, etc).",
+    )
+    .with_help("Require all enum members to be literal values.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn prefer_ts_expect_error_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("typescript-eslint(prefer-ts-expect-error): Enforce using `@ts-expect-error` over `@ts-ignore`")
+    OxcDiagnostic::warn("Enforce using `@ts-expect-error` over `@ts-ignore`")
         .with_help("Use \"@ts-expect-error\" to ensure an error is actually being suppressed.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -11,7 +11,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn triple_slash_reference_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("typescript-eslint(triple-slash-reference): Do not use a triple slash reference for {x0}, use `import` style instead."))
+    OxcDiagnostic::warn(format!("Do not use a triple slash reference for {x0}, use `import` style instead."))
         .with_help("Use of triple-slash reference type directives is generally discouraged in favor of ECMAScript Module imports.")
         .with_label(span1)
 }

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -10,10 +10,8 @@ use oxc_span::{CompactStr, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn catch_error_name_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(catch-error-name): The catch parameter {x0:?} should be named {x1:?}"
-    ))
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("The catch parameter {x0:?} should be named {x1:?}"))
+        .with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn empty_brace_spaces_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(empty-brace-spaces): No spaces inside empty pair of braces allowed")
+    OxcDiagnostic::warn("No spaces inside empty pair of braces allowed")
         .with_help("There should be no spaces or new lines inside a pair of empty braces as it affects the overall readability of the code.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -9,22 +9,15 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn missing_message(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(error-message): Pass a message to the {x0:1} constructor."
-    ))
-    .with_label(span1)
+    OxcDiagnostic::warn(format!("Pass a message to the {x0:1} constructor.")).with_label(span1)
 }
 
 fn empty_message(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(error-message): Error message should not be an empty string.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Error message should not be an empty string.").with_label(span0)
 }
 
 fn not_string(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(error-message): Error message should be a string.")
-        .with_label(span0)
+    OxcDiagnostic::warn("Error message should be a string.").with_label(span0)
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -11,7 +11,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn escape_case_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(escape-case): Use uppercase characters for the value of the escape sequence.").with_label(span0)
+    OxcDiagnostic::warn("Use uppercase characters for the value of the escape sequence.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -17,7 +17,8 @@ use crate::{
 };
 
 fn none_zero(span0: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!("eslint-plugin-unicorn(explicit-length-check): Use `.{x1} {x2}` when checking {x1} is not zero.")).with_label(span0);
+    let mut d = OxcDiagnostic::warn(format!("Use `.{x1} {x2}` when checking {x1} is not zero."))
+        .with_label(span0);
     if let Some(x) = x3 {
         d = d.with_help(x);
     }
@@ -25,9 +26,7 @@ fn none_zero(span0: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnost
 }
 
 fn zero(span0: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(explicit-length-check): Use `.{x1} {x2}` when checking {x1} is zero."
-    ));
+    let mut d = OxcDiagnostic::warn(format!("Use `.{x1} {x2}` when checking {x1} is zero."));
     if let Some(x) = x3 {
         d = d.with_help(x);
     }

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -7,10 +7,7 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule};
 
 fn filename_case_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(filename-case): Filename should not be in {x1} case"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Filename should not be in {x1} case")).with_label(span0)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -11,17 +11,11 @@ use phf::phf_set;
 use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
 
 fn enforce(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(new-for-builtins): Use `new {x1}()` instead of `{x1}()`"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Use `new {x1}()` instead of `{x1}()`")).with_label(span0)
 }
 
 fn disallow(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(new-for-builtins): Use `{x1}()` instead of `new {x1}()`"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Use `{x1}()` instead of `new {x1}()`")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -5,9 +5,11 @@ use oxc_span::Span;
 use crate::{context::LintContext, disable_directives::DisableRuleComment, rule::Rule};
 
 fn no_abusive_eslint_disable_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.")
-        .with_help("Specify the rules you want to disable.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Unexpected `eslint-disable` comment that does not specify any rules to disable.",
+    )
+    .with_help("Specify the rules you want to disable.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_anonymous_default_export_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-anonymous-default-export): Disallow anonymous functions and classes as the default export")
+    OxcDiagnostic::warn("Disallow anonymous functions and classes as the default export")
         .with_help(format!("The {x1} should be named."))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -10,7 +10,7 @@ use phf::phf_set;
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_array_for_each_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-array-for-each): Do not use `Array#forEach`")
+    OxcDiagnostic::warn("Do not use `Array#forEach`")
         .with_help("Replace it with a for` loop. For loop is faster, more readable, and you can use `break` or `return` to exit early.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -12,9 +12,11 @@ use crate::{
 };
 
 fn no_array_reduce_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.")
-        .with_help("Refactor your code to use `for` loops instead.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.",
+    )
+    .with_help("Refactor your code to use `for` loops instead.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_await_expression_member_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-await-expression-member): Disallow member access from await expression")
+    OxcDiagnostic::warn("Disallow member access from await expression")
         .with_help("When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_await_in_promise_methods_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-await-in-promise-methods): Promise in `Promise.{x1}()` should not be awaited."))
+    OxcDiagnostic::warn(format!("Promise in `Promise.{x1}()` should not be awaited."))
         .with_help("Remove the `await`")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 fn no_console_spaces_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-console-spaces): Do not use {x0} spaces with `console.{x1}` parameters"))
+    OxcDiagnostic::warn(format!("Do not use {x0} spaces with `console.{x1}` parameters"))
         .with_help("The `console.log()` method and similar methods join the parameters with a space so adding a leading/trailing space to a parameter, results in two spaces being added.")
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -12,11 +12,9 @@ use crate::{
 };
 
 fn no_document_cookie_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-document-cookie): Do not use `document.cookie` directly",
-    )
-    .with_help("Use the Cookie Store API or a cookie library instead")
-    .with_label(span0)
+    OxcDiagnostic::warn("Do not use `document.cookie` directly")
+        .with_help("Use the Cookie Store API or a cookie library instead")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 fn no_empty_file_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.")
+    OxcDiagnostic::warn("Empty files are not allowed.")
         .with_help("Delete this file or add some code to it.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -9,10 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_hex_escape_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-hex-escape): Use Unicode escapes instead of hexadecimal escapes.",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Use Unicode escapes instead of hexadecimal escapes.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::BinaryOperator;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_instanceof_array_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-instanceof-array): Use `Array.isArray()` instead of `instanceof Array`.")
+    OxcDiagnostic::warn("Use `Array.isArray()` instead of `instanceof Array`.")
         .with_help("The instanceof Array check doesn't work across realms/contexts, for example, frames/windows in browsers or the vm module in Node.js.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_invalid_remove_event_listener_diagnostic(call_span: Span, arg_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-invalid-remove-event-listener): Invalid `removeEventListener` call.")
+    OxcDiagnostic::warn("Invalid `removeEventListener` call.")
         .with_help("The listener argument should be a function reference.")
         .with_labels([
             call_span.label("`removeEventListener` called here."),

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_lonely_if_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-lonely-if): Unexpected `if` as the only statement in a `if` block without `else`.")
+    OxcDiagnostic::warn("Unexpected `if` as the only statement in a `if` block without `else`.")
         .with_help("Move the inner `if` test to the outer `if` test.")
         .with_labels([span0, span1])
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_magic_array_flat_map_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-magic-array-flat-depth): Magic number for `Array.prototype.flat` depth is not allowed.")
+    OxcDiagnostic::warn("Magic number for `Array.prototype.flat` depth is not allowed.")
         .with_help("Add a comment explaining the depth.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -10,11 +10,9 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_negated_condition_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-negated-condition): Unexpected negated condition.",
-    )
-    .with_help("Remove the negation operator and switch the consequent and alternate branches.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected negated condition.")
+        .with_help("Remove the negation operator and switch the consequent and alternate branches.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -11,11 +11,13 @@ fn no_negation_in_equality_check_diagnostic(
     current_operator: BinaryOperator,
     suggested_operator: BinaryOperator,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.",
-    )
-    .with_help(format!("Remove the negation operator and use '{}' instead of '{}'.", suggested_operator.as_str(), current_operator.as_str()))
-    .with_label(span0)
+    OxcDiagnostic::warn("Negated expression is not allowed in equality check.")
+        .with_help(format!(
+            "Remove the negation operator and use '{}' instead of '{}'.",
+            suggested_operator.as_str(),
+            current_operator.as_str()
+        ))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
@@ -6,17 +6,15 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn unparenthesized_nested_ternary(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-nested-ternary): Unexpected nested ternary expression without parentheses.")
+    OxcDiagnostic::warn("Unexpected nested ternary expression without parentheses.")
         .with_help("Add parentheses around the nested ternary expression.")
         .with_label(span0)
 }
 
 fn deeply_nested_ternary(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-nested-ternary): Unexpected deeply nested ternary expression.",
-    )
-    .with_help("Avoid nesting ternary expressions for more than one level.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected deeply nested ternary expression.")
+        .with_help("Avoid nesting ternary expressions for more than one level.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_array_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-new-array): Do not use `new Array(singleArgument)`.").with_help(r"It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.").with_label(span0)
+    OxcDiagnostic::warn("Do not use `new Array(singleArgument)`.").with_help(r"It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_new_buffer_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-new-buffer): Use `Buffer.alloc()` or `Buffer.from()` instead of the deprecated `new Buffer()` constructor.")
+    OxcDiagnostic::warn("Use `Buffer.alloc()` or `Buffer.from()` instead of the deprecated `new Buffer()` constructor.")
         .with_help("`new Buffer()` is deprecated, use `Buffer.alloc()` or `Buffer.from()` instead.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -18,13 +18,13 @@ use crate::{
 };
 
 fn replace_null_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal")
+    OxcDiagnostic::warn("Disallow the use of the `null` literal")
         .with_help("Replace the `null` literal with `undefined`.")
         .with_label(span0)
 }
 
 fn remove_null_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal")
+    OxcDiagnostic::warn("Disallow the use of the `null` literal")
         .with_help("Remove the `null` literal.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -9,11 +9,12 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn identifier(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `{x1}`.")).with_label(span0)
+    OxcDiagnostic::warn(format!("Do not use an object literal as default for parameter `{x1}`."))
+        .with_label(span0)
 }
 
 fn non_identifier(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default").with_label(span0)
+    OxcDiagnostic::warn("Do not use an object literal as default").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_process_exit_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-process-exit): Disallow `process.exit()`.")
+    OxcDiagnostic::warn("Disallow `process.exit()`.")
         .with_help("Only use `process.exit()` in CLI apps. Throw an error instead.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -10,9 +10,11 @@ use oxc_span::{GetSpan, Span};
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn no_single_promise_in_promise_methods_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.{method_name}()` is unnecessary."))
-        .with_help("Either use the value directly, or switch to `Promise.resolve(…)`.")
-        .with_label(span)
+    OxcDiagnostic::warn(format!(
+        "Wrapping single-element array with `Promise.{method_name}()` is unnecessary."
+    ))
+    .with_help("Either use the value directly, or switch to `Promise.resolve(…)`.")
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_static_only_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-static-only-class): Disallow classes that only have static members.")
+    OxcDiagnostic::warn("Disallow classes that only have static members.")
         .with_help("A class with only static members could just be an object instead.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -13,19 +13,19 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn object(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-thenable): Do not add `then` to an object.")
+    OxcDiagnostic::warn("Do not add `then` to an object.")
         .with_help("If an object is defined as 'thenable', once it's accidentally used in an await expression, it may cause problems")
         .with_label(span0)
 }
 
 fn export(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-thenable): Do not export `then`.")
+    OxcDiagnostic::warn("Do not export `then`.")
         .with_help("If an object is defined as 'thenable', once it's accidentally used in an await expression, it may cause problems")
         .with_label(span0)
 }
 
 fn class(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-thenable): Do not add `then` to a class.")
+    OxcDiagnostic::warn("Do not add `then` to a class.")
         .with_help("If an object is defined as 'thenable', once it's accidentally used in an await expression, it may cause problems")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -9,11 +9,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_this_assignment_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(no-this-assignment): Do not assign `this` to `{x1}`"
-    ))
-    .with_help("Reference `this` directly instead of assigning it to a variable.")
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Do not assign `this` to `{x1}`"))
+        .with_help("Reference `this` directly instead of assigning it to a variable.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -7,7 +7,8 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, AstNode};
 
 fn no_typeof_undefined_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.").with_label(span0)
+    OxcDiagnostic::warn("Compare with `undefined` directly instead of using `typeof`.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -6,11 +6,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unnecessary_await_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-unnecessary-await): Disallow awaiting non-promise values",
-    )
-    .with_help("consider to remove the `await`")
-    .with_label(span0)
+    OxcDiagnostic::warn("Disallow awaiting non-promise values")
+        .with_help("consider to remove the `await`")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unreadable_array_destructuring_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-unreadable-array-destructuring): Disallow unreadable array destructuring")
+    OxcDiagnostic::warn("Disallow unreadable array destructuring")
         .with_help("Array destructuring may not contain consecutive ignored values.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unreadable_iife_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-unreadable-iife): IIFE with parenthesized arrow function body is considered unreadable.")
+    OxcDiagnostic::warn("IIFE with parenthesized arrow function body is considered unreadable.")
         .with_help("Rewrite the IIFE to avoid having a parenthesized arrow function body.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::LogicalOperator;
 use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
 
 fn no_useless_fallback_in_spread_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-fallback-in-spread): Disallow useless fallback when spreading in object literals")
+    OxcDiagnostic::warn("Disallow useless fallback when spreading in object literals")
         .with_help("Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -13,7 +13,7 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn some(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-length-check)")
+    OxcDiagnostic::warn("Found a useless array length check")
         .with_help(
             "The non-empty check is useless as `Array#some()` returns `false` for an empty array.",
         )
@@ -21,7 +21,7 @@ fn some(span0: Span) -> OxcDiagnostic {
 }
 
 fn every(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-length-check)")
+    OxcDiagnostic::warn("Found a useless array length check")
         .with_help(
             "The empty check is useless as `Array#every()` returns `true` for an empty array.",
         )

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -15,13 +15,13 @@ use crate::{
 };
 
 fn resolve(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `{x1} value` over `{x1} Promise.resolve(value)`."))
+    OxcDiagnostic::warn(format!("Prefer `{x1} value` over `{x1} Promise.resolve(value)`."))
         .with_help("Wrapping the return value in `Promise.Resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.")
         .with_label(span0)
 }
 
 fn reject(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `{x1} Promise.reject(error)`."))
+    OxcDiagnostic::warn(format!("Prefer `throw error` over `{x1} Promise.reject(error)`."))
         .with_help("Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread.rs
@@ -20,35 +20,37 @@ use crate::{
 };
 
 fn spread_in_list(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new {x1} unnecessarily."))
+    OxcDiagnostic::warn(format!("Using a spread operator here creates a new {x1} unnecessarily."))
         .with_help("Consider removing the spread operator.")
         .with_label(span)
 }
 
 fn spread_in_arguments(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.").with_help("This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.\nFor example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.").with_label(span)
+    OxcDiagnostic::warn("Using a spread operator here creates a new array unnecessarily.").with_help("This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.\nFor example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.").with_label(span)
 }
 
 fn iterable_to_array(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(no-useless-spread): `{x1}` accepts an iterable, so it's unnecessary to convert the iterable to an array."))
-        .with_help("Consider removing the spread operator.")
-        .with_label(span)
+    OxcDiagnostic::warn(format!(
+        "`{x1}` accepts an iterable, so it's unnecessary to convert the iterable to an array."
+    ))
+    .with_help("Consider removing the spread operator.")
+    .with_label(span)
 }
 
 fn iterable_to_array_in_for_of(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.")
+    OxcDiagnostic::warn("Using a spread operator here creates a new array unnecessarily.")
         .with_help("`for…of` can iterate over iterable, it's unnecessary to convert to an array.")
         .with_label(span)
 }
 
 fn iterable_to_array_in_yield_star(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.")
+    OxcDiagnostic::warn("Using a spread operator here creates a new array unnecessarily.")
         .with_help("`yield*` can delegate to another iterable, so it's unnecessary to convert the iterable to an array.")
         .with_label(span)
 }
 
 fn clone_array(span: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.")
+    OxcDiagnostic::warn("Using a spread operator here creates a new array unnecessarily.")
         .with_help(format!("`{x1}` returns a new array. Spreading it into an array expression to create a new array is redundant."))
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::is_empty_stmt, AstNode};
 
 fn no_useless_switch_case_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-useless-switch-case): Useless case in switch statement.",
-    )
-    .with_help("Consider removing this case or removing the `default` case.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Useless case in switch statement.")
+        .with_help("Consider removing this case or removing the `default` case.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -8,10 +8,8 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 fn warn() -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-useless-undefined): Do not use useless `undefined`.",
-    )
-    .with_help("Consider removing `undefined` or using `null` instead.")
+    OxcDiagnostic::warn("Do not use useless `undefined`.")
+        .with_help("Consider removing `undefined` or using `null` instead.")
 }
 fn no_useless_undefined_diagnostic(span0: Span) -> OxcDiagnostic {
     warn().with_label(span0)

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -6,19 +6,15 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn zero_fraction(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-zero-fractions): Don't use a zero fraction in the number.",
-    )
-    .with_help(format!("Replace the number literal with `{x1}`"))
-    .with_label(span0)
+    OxcDiagnostic::warn("Don't use a zero fraction in the number.")
+        .with_help(format!("Replace the number literal with `{x1}`"))
+        .with_label(span0)
 }
 
 fn dangling_dot(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(no-zero-fractions): Don't use a dangling dot in the number.",
-    )
-    .with_help(format!("Replace the number literal with `{x1}`"))
-    .with_label(span0)
+    OxcDiagnostic::warn("Don't use a dangling dot in the number.")
+        .with_help(format!("Replace the number literal with `{x1}`"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -6,31 +6,31 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn uppercase_prefix(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(number-literal-case): Unexpected number literal prefix in uppercase.")
+    OxcDiagnostic::warn("Unexpected number literal prefix in uppercase.")
         .with_help(format!("Use lowercase for the number literal prefix `{x1}`."))
         .with_label(span0)
 }
 
 fn uppercase_exponential_notation(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(number-literal-case): Unexpected exponential notation in uppercase.",
-    )
-    .with_help("Use lowercase for `e` in exponential notations.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected exponential notation in uppercase.")
+        .with_help("Use lowercase for `e` in exponential notations.")
+        .with_label(span0)
 }
 
 fn lowercase_hexadecimal_digits(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(number-literal-case): Unexpected hexadecimal digits in lowercase.",
-    )
-    .with_help("Use uppercase for hexadecimal digits.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Unexpected hexadecimal digits in lowercase.")
+        .with_help("Use uppercase for hexadecimal digits.")
+        .with_label(span0)
 }
 
 fn uppercase_prefix_and_lowercase_hexadecimal_digits(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(number-literal-case): Unexpected number literal prefix in uppercase and hexadecimal digits in lowercase.")
-        .with_help(format!("Use lowercase for the number literal prefix `{x1}` and uppercase for hexadecimal digits."))
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Unexpected number literal prefix in uppercase and hexadecimal digits in lowercase.",
+    )
+    .with_help(format!(
+        "Use lowercase for the number literal prefix `{x1}` and uppercase for hexadecimal digits."
+    ))
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -11,11 +11,9 @@ use regex::Regex;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn numeric_separators_style_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(numeric-separators-style): Invalid group length in numeric value.",
-    )
-    .with_help("Group digits with numeric separators (_) so longer numbers are easier to read.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Invalid group length in numeric value.")
+        .with_help("Group digits with numeric separators (_) so longer numbers are easier to read.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -6,7 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_add_event_listener_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.").with_label(span0)
+    OxcDiagnostic::warn("Prefer `addEventListener()` over their `on`-function counterparts.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 fn prefer_array_flat_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.")
+    OxcDiagnostic::warn("Prefer Array#flat() over legacy techniques to flatten arrays.")
         .with_help(r"Call `.flat()` on the array instead.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn prefer_array_flat_map_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-array-flat-map): `Array.flatMap` performs `Array.map` and `Array.flat` in one step.")
+    OxcDiagnostic::warn("`Array.flatMap` performs `Array.map` and `Array.flat` in one step.")
         .with_help("Prefer `.flatMap(…)` over `.map(…).flat()`.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -16,11 +16,12 @@ use crate::{
 };
 
 fn over_method(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)`or `.findLast(…)`.").with_label(span0)
+    OxcDiagnostic::warn("Prefer `.some(…)` over `.find(…)`or `.findLast(…)`.").with_label(span0)
 }
 
 fn non_zero_filter(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over non-zero length check from `.filter(…)`.").with_label(span0)
+    OxcDiagnostic::warn("Prefer `.some(…)` over non-zero length check from `.filter(…)`.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -6,7 +6,8 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_blob_reading_methods_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(prefer-blob-reading-methods): Prefer `Blob#{x1}()` over `FileReader#{x2}(blob)`.")).with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `Blob#{x1}()` over `FileReader#{x2}(blob)`."))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_code_point_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-code-point): Prefer `{x1}` over `{x2}`"
-    ))
-    .with_help(format!("Unicode is better supported in `{x1}` than `{x2}`"))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`"))
+        .with_help(format!("Unicode is better supported in `{x1}` than `{x2}`"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -10,27 +10,21 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_date_now(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `new Date()`",
-    )
-    .with_help("Change to `Date.now()`.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer `Date.now()` over `new Date()`")
+        .with_help("Change to `Date.now()`.")
+        .with_label(span0)
 }
 
 fn prefer_date_now_over_methods(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `new Date().{x1}()`"
-    ))
-    .with_help("Change to `Date.now()`.")
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `Date.now()` over `new Date().{x1}()`"))
+        .with_help("Change to `Date.now()`.")
+        .with_label(span0)
 }
 
 fn prefer_date_now_over_number_date_object(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(prefer-date-now): Prefer `Date.now()` over `Number(new Date())`",
-    )
-    .with_help("Change to `Date.now()`.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer `Date.now()` over `Number(new Date())`")
+        .with_help("Change to `Date.now()`.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_dom_node_append_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-append): Prefer `Node#append()` over `Node#appendChild()` for DOM nodes.")
+    OxcDiagnostic::warn("Prefer `Node#append()` over `Node#appendChild()` for DOM nodes.")
         .with_help("Replace `Node#appendChild()` with `Node#append()`.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -6,25 +6,27 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn set(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-dataset): Prefer using `dataset` over `setAttribute`.")
+    OxcDiagnostic::warn("Prefer using `dataset` over `setAttribute`.")
         .with_help(format!("Access the `.dataset` object directly: `element.dataset.{x1} = ...;`"))
         .with_label(span0)
 }
 
 fn get(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-dataset): Prefer using `dataset` over `getAttribute`.")
+    OxcDiagnostic::warn("Prefer using `dataset` over `getAttribute`.")
         .with_help(format!("Access the `.dataset` object directly: `element.dataset.{x1}`"))
         .with_label(span0)
 }
 
 fn has(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-dataset): Prefer using `dataset` over `hasAttribute`.")
-        .with_help(format!("Check the `dataset` object directly: `Object.hasOwn(element.dataset, '{x1}')"))
+    OxcDiagnostic::warn("Prefer using `dataset` over `hasAttribute`.")
+        .with_help(format!(
+            "Check the `dataset` object directly: `Object.hasOwn(element.dataset, '{x1}')"
+        ))
         .with_label(span0)
 }
 
 fn remove(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-dataset): Prefer using `dataset` over `removeAttribute`.")
+    OxcDiagnostic::warn("Prefer using `dataset` over `removeAttribute`.")
         .with_help(format!("Access the `.dataset` object directly: `delete element.dataset.{x1};"))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 fn prefer_dom_node_remove_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.")
+    OxcDiagnostic::warn("Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.")
         .with_help("Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_dom_node_text_content_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-dom-node-text-content): Prefer `.textContent` over `.innerText`.")
+    OxcDiagnostic::warn("Prefer `.textContent` over `.innerText`.")
         .with_help("Replace `.innerText` with `.textContent`.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_event_target_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-event-target): Prefer `EventTarget` over `EventEmitter`")
+    OxcDiagnostic::warn("Prefer `EventTarget` over `EventEmitter`")
         .with_help("Change `EventEmitter` to `EventTarget`. EventEmitters are only available in Node.js, while EventTargets are also available in browsers.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 
 fn prefer_includes_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-includes): Prefer `includes()` over `indexOf()` when checking for existence or non-existence.").with_label(span0)
+    OxcDiagnostic::warn(
+        "Prefer `includes()` over `indexOf()` when checking for existence or non-existence.",
+    )
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
 fn prefer_logical_operator_over_ternary_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-logical-operator-over-ternary): Prefer using a logical operator over a ternary.")
+    OxcDiagnostic::warn("Prefer using a logical operator over a ternary.")
         .with_help("Switch to \"||\" or \"??\" operator")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -7,10 +7,8 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_math_trunc_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `{x1} 0`."
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `Math.trunc()` over instead of `{x1} 0`."))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -10,10 +10,7 @@ use phf::phf_map;
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
 fn prefer_modern_dom_apis_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-modern-dom-apis): Prefer using `{x0}` over `{x1}`."
-    ))
-    .with_label(span2)
+    OxcDiagnostic::warn(format!("Prefer using `{x0}` over `{x1}`.")).with_label(span2)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -12,24 +12,15 @@ use crate::{
 };
 
 fn prefer_math_abs(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(prefer-modern-math-apis): Prefer `Math.abs(x)` over alternatives",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer `Math.abs(x)` over alternatives").with_label(span0)
 }
 
 fn prefer_math_hypot(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(prefer-modern-math-apis): Prefer `Math.hypot(…)` over alternatives",
-    )
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer `Math.hypot(…)` over alternatives").with_label(span0)
 }
 
 fn prefer_math_log_n(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-modern-math-apis): Prefer `Math.{x1}(x)` over `{x2}`"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `Math.{x1}(x)` over `{x2}`")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -10,11 +10,12 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::get_first_parameter_name, AstNode};
 
 fn function(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(prefer-native-coercion-functions): The function is equivalent to `{x1}`. Call `{x1}` directly.")).with_label(span0)
+    OxcDiagnostic::warn(format!("The function is equivalent to `{x1}`. Call `{x1}` directly."))
+        .with_label(span0)
 }
 
 fn array_callback(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-native-coercion-functions): The arrow function in the callback of the array is equivalent to `Boolean`. Replace the callback with `Boolean`.")
+    OxcDiagnostic::warn("The arrow function in the callback of the array is equivalent to `Boolean`. Replace the callback with `Boolean`.")
         .with_label(span0)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -10,7 +10,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_node_protocol_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-node-protocol): Prefer using the `node:` protocol when importing Node.js builtin modules.")
+    OxcDiagnostic::warn("Prefer using the `node:` protocol when importing Node.js builtin modules.")
         .with_help(format!("Prefer `node:{x1}` over `{x1}`."))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -9,7 +9,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
 
 fn prefer_number_properties_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(prefer-number-properties): Use `Number.{x1}` instead of the global `{x1}`"))
+    OxcDiagnostic::warn(format!("Use `Number.{x1}` instead of the global `{x1}`"))
         .with_help(format!("Replace it with `Number.{x1}`"))
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -9,7 +9,8 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_optional_catch_binding_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-optional-catch-binding): Prefer omitting the catch binding parameter if it is unused").with_label(span0)
+    OxcDiagnostic::warn("Prefer omitting the catch binding parameter if it is unused")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -12,14 +12,11 @@ use crate::{
 };
 
 fn known_method(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-prototype-methods): Prefer using `{x1}.prototype.{x2}`."
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer using `{x1}.prototype.{x2}`.")).with_label(span0)
 }
 
 fn unknown_method(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(prefer-prototype-methods): Prefer using method from `{x1}.prototype`.")).with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer using method from `{x1}.prototype`.")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -7,7 +7,7 @@ use phf::phf_map;
 use crate::{context::LintContext, rule::Rule, utils::is_node_value_not_dom_node, AstNode};
 
 fn prefer_query_selector_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(prefer-query-selector): Prefer `.{x0}()` over `.{x1}()`."))
+    OxcDiagnostic::warn(format!("Prefer `.{x0}()` over `.{x1}()`."))
         .with_help("It's better to use the same method to query DOM elements. This helps keep consistency and it lends itself to future improvements (e.g. more specific selectors).")
         .with_label(span2)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -9,11 +9,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_reflect_apply_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "eslint-plugin-unicorn(prefer-reflect-apply): Prefer Reflect.apply() over Function#apply()",
-    )
-    .with_help("Reflect.apply() is less verbose and easier to understand.")
-    .with_label(span0)
+    OxcDiagnostic::warn("Prefer Reflect.apply() over Function#apply()")
+        .with_help("Reflect.apply() is less verbose and easier to understand.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
 
 fn prefer_regexp_test_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-regexp-test): Prefer RegExp#test() over String#match() and RegExp#exec()")
+    OxcDiagnostic::warn("Prefer RegExp#test() over String#match() and RegExp#exec()")
         .with_help("RegExp#test() exclusively returns a boolean and therefore is more efficient")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -9,7 +9,10 @@ use oxc_span::Span;
 use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, AstNode};
 
 fn prefer_set_size_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-set-size): Use `Set#size` instead of converting a `Set` to an array and using its `length` property.").with_label(span0)
+    OxcDiagnostic::warn(
+        "Use `Set#size` instead of converting a `Set` to an array and using its `length` property.",
+    )
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -10,11 +10,9 @@ use phf::phf_set;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_spread_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over {x1}"
-    ))
-    .with_help("The spread operator (`...`) is more concise and readable.")
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer the spread operator (`...`) over {x1}"))
+        .with_help("The spread operator (`...`) is more concise and readable.")
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -9,11 +9,11 @@ use oxc_span::{CompactStr, Span};
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
 fn string_literal(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("eslint-plugin-unicorn(prefer-string-replace-all): This pattern can be replaced with `{x1}`.")).with_label(span0)
+    OxcDiagnostic::warn(format!("This pattern can be replaced with `{x1}`.")).with_label(span0)
 }
 
 fn use_replace_all(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-string-replace-all): Prefer `String#replaceAll()` over `String#replace()` when using a regex with the global flag.")
+    OxcDiagnostic::warn("Prefer `String#replaceAll()` over `String#replace()` when using a regex with the global flag.")
         .with_label(span0)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -6,10 +6,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_string_slice_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-string-slice): Prefer String#slice() over String#{x1}()"
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer String#slice() over String#{x1}()")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -9,11 +9,11 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn starts_with(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-string-starts-ends-with): Prefer String#startsWith over a regex with a caret.").with_label(span0)
+    OxcDiagnostic::warn("Prefer String#startsWith over a regex with a caret.").with_label(span0)
 }
 
 fn ends_with(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-string-starts-ends-with): Prefer String#endsWith over a regex with a dollar sign.").with_label(span0)
+    OxcDiagnostic::warn("Prefer String#endsWith over a regex with a dollar sign.").with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -6,11 +6,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_string_trim_start_end_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(prefer-string-trim-start-end): Prefer `{x1}` over `{x2}`"
-    ))
-    .with_help(format!("Replace with `{x1}`"))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`"))
+        .with_help(format!("Replace with `{x1}`"))
+        .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -10,9 +10,11 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn prefer_type_error_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(prefer-type-error): Prefer throwing a `TypeError` over a generic `Error` after a type checking if-statement")
-        .with_help("Change to `throw new TypeError(...)`")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        "Prefer throwing a `TypeError` over a generic `Error` after a type checking if-statement",
+    )
+    .with_help("Change to `throw new TypeError(...)`")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 fn require_array_join_separator_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(require-array-join-separator): Enforce using the separator argument with Array#join()")
+    OxcDiagnostic::warn("Enforce using the separator argument with Array#join()")
         .with_help("Missing the separator argument.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn require_number_to_fixed_digits_argument_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(require-number-to-fixed-digits-argument): Number method .toFixed() should have an argument")
+    OxcDiagnostic::warn("Number method .toFixed() should have an argument")
         .with_help("It's better to make it clear what the value of the digits argument is when calling Number#toFixed(), instead of relying on the default value of 0.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -6,9 +6,11 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn switch_case_braces_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(switch-case-braces):  Empty switch case shouldn't have braces and not-empty case should have braces around it.")
-        .with_help("There is less visual clutter for empty cases and proper scope for non-empty cases.")
-        .with_label(span0)
+    OxcDiagnostic::warn(
+        " Empty switch case shouldn't have braces and not-empty case should have braces around it.",
+    )
+    .with_help("There is less visual clutter for empty cases and proper scope for non-empty cases.")
+    .with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -10,10 +10,7 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn text_encoding_identifier_case_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint-plugin-unicorn(text-encoding-identifier-case): Prefer `{x1}` over `{x2}`."
-    ))
-    .with_label(span0)
+    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`.")).with_label(span0)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 fn throw_new_error_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eslint-plugin-unicorn(throw-new-error): Require `new` when throwing an error.")
+    OxcDiagnostic::warn("Require `new` when throwing an error.")
         .with_help("While it's possible to create a new error without using the `new` keyword, it's better to be explicit.")
         .with_label(span0)
 }

--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -19,7 +19,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     partial_loader::{JavaScriptSource, PartialLoader, LINT_PARTIAL_LOADER_EXT},
-    Fixer, LintContext, Linter, Message,
+    Fixer, Linter, Message,
 };
 
 pub struct LintServiceOptions {
@@ -353,9 +353,7 @@ impl Runtime {
             return semantic_ret.errors.into_iter().map(|err| Message::new(err, None)).collect();
         };
 
-        let lint_ctx =
-            LintContext::new(path.to_path_buf().into_boxed_path(), Rc::new(semantic_ret.semantic));
-        self.linter.run(lint_ctx)
+        self.linter.run(path, Rc::new(semantic_ret.semantic))
     }
 
     fn init_cache_state(&self, path: &Path) -> bool {

--- a/crates/oxc_linter/src/snapshots/bad_bitwise_operator.snap
+++ b/crates/oxc_linter/src/snapshots/bad_bitwise_operator.snap
@@ -71,35 +71,35 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Bitwise operator '|' seems unintended. Did you mean logical operator '||'?
 
-  ⚠ Bad bitwise operator
+  ⚠ oxc(bad-bitwise-operator): Bad bitwise operator
    ╭─[bad_bitwise_operator.tsx:1:1]
  1 │ input |= ''
    · ───────────
    ╰────
   help: Bitwise operator '|=' seems unintended. Consider using non-compound assignment and logical operator '||' instead.
 
-  ⚠ Bad bitwise operator
+  ⚠ oxc(bad-bitwise-operator): Bad bitwise operator
    ╭─[bad_bitwise_operator.tsx:1:1]
  1 │ input |= (1 + '')
    · ─────────────────
    ╰────
   help: Bitwise operator '|=' seems unintended. Consider using non-compound assignment and logical operator '||' instead.
 
-  ⚠ Bad bitwise operator
+  ⚠ oxc(bad-bitwise-operator): Bad bitwise operator
    ╭─[bad_bitwise_operator.tsx:1:1]
  1 │ input |= (1 + (3 + '1'))
    · ────────────────────────
    ╰────
   help: Bitwise operator '|=' seems unintended. Consider using non-compound assignment and logical operator '||' instead.
 
-  ⚠ Bad bitwise operator
+  ⚠ oxc(bad-bitwise-operator): Bad bitwise operator
    ╭─[bad_bitwise_operator.tsx:1:1]
  1 │ input |= !{}
    · ────────────
    ╰────
   help: Bitwise operator '|=' seems unintended. Consider using non-compound assignment and logical operator '||' instead.
 
-  ⚠ Bad bitwise operator
+  ⚠ oxc(bad-bitwise-operator): Bad bitwise operator
    ╭─[bad_bitwise_operator.tsx:1:1]
  1 │ input |= typeof {}
    · ──────────────────

--- a/crates/oxc_linter/src/snapshots/consistent_indexed_object_style.snap
+++ b/crates/oxc_linter/src/snapshots/consistent_indexed_object_style.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo {
  3 │               [key: string]: any;
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo {
  3 │               readonly [key: string]: any;
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo<A> {
  3 │               [key: string]: A;
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo<A = any> {
  3 │               [key: string]: A;
@@ -37,7 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface B extends A {
  3 │               [index: number]: unknown;
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo<A> {
  3 │               readonly [key: string]: A;
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo<A, B> {
  3 │               [key: A]: B;
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo<A, B> {
  3 │               readonly [key: A]: B;
@@ -73,112 +73,112 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: string | Bar };
    ·              ───────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: boolean]: any };
    ·              ───────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { readonly [key: string]: any };
    ·              ───────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:22]
  1 │ type Foo = Generic<{ [key: boolean]: any }>;
    ·                      ───────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:22]
  1 │ type Foo = Generic<{ readonly [key: string]: any }>;
    ·                      ───────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:21]
  1 │ function foo(arg: { [key: string]: any }) {}
    ·                     ──────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:19]
  1 │ function foo(): { [key: string]: any } {}
    ·                   ──────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:21]
  1 │ function foo(arg: { readonly [key: string]: any }) {}
    ·                     ───────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:19]
  1 │ function foo(): { readonly [key: string]: any } {}
    ·                   ───────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
    ╭─[consistent_indexed_object_style.tsx:1:12]
  1 │ type Foo = Record<string, any>;
    ·            ───────────────────
    ╰────
   help: A index signature is preferred over an record.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
    ╭─[consistent_indexed_object_style.tsx:1:15]
  1 │ type Foo<T> = Record<string, T>;
    ·               ─────────────────
    ╰────
   help: A index signature is preferred over an record.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [k: string]: A.Foo };
    ·              ──────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: AnotherFoo };
    ·              ─────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: { [key: string]: Foo } };
    ·              ─────────────────────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:1:14]
  1 │ type Foo = { [key: string]: string } | Foo;
    ·              ─────────────────────
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo<T> {
  3 │               [k: string]: T;
@@ -187,7 +187,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo {
  3 │               [k: string]: A.Foo;
@@ -196,7 +196,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A record is preferred over an index signature.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
    ╭─[consistent_indexed_object_style.tsx:3:12]
  2 │             interface Foo {
  3 │               [k: string]: { [key: string]: Foo };
@@ -205,14 +205,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: A record is preferred over an index signature.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
    ╭─[consistent_indexed_object_style.tsx:1:20]
  1 │ type Foo = Generic<Record<string, any>>;
    ·                    ───────────────────
    ╰────
   help: A index signature is preferred over an record.
 
-  ⚠ typescript-eslint(consistent-indexed-object-style):A index signature is preferred over an record.
+  ⚠ typescript-eslint(consistent-indexed-object-style): A index signature is preferred over an record.
    ╭─[consistent_indexed_object_style.tsx:1:19]
  1 │ function foo(arg: Record<string, any>) {}
    ·                   ───────────────────

--- a/crates/oxc_linter/src/snapshots/consistent_test_it.snap
+++ b/crates/oxc_linter/src/snapshots/consistent_test_it.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:17]
  3 │ 
  4 │                 it("foo")
@@ -18,7 +17,7 @@ assertion_line: 216
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:17]
  3 │ 
  4 │                 testThisThing("foo")
@@ -27,70 +26,70 @@ assertion_line: 216
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ xit("foo")
    · ───
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ fit("foo")
    · ───
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.skip("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.concurrent("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.only("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.each([])("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it.each``("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:32]
  1 │ describe.each``("foo", () => { it.each``("bar") })
    ·                                ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:32]
  1 │ describe.each``("foo", () => { test.each``("bar") })
    ·                                ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:3:21]
  2 │                 describe.each()("%s", () => {
  3 │                     test("is valid, but should not be", () => {});
@@ -99,7 +98,7 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:3:21]
  2 │                 describe.only.each()("%s", () => {
  3 │                     test("is valid, but should not be", () => {});
@@ -108,98 +107,98 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ xtest("foo")
    · ─────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.skip("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.concurrent("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.only("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.each([])("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:32]
  1 │ describe.each``("foo", () => { test.each``("bar") })
    ·                                ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.each``("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.only("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { xtest("foo") })
    ·                           ─────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:43]
  3 │ 
  4 │                 describe("suite", () => { dontTestThis("foo") });
@@ -208,7 +207,7 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:42]
  3 │ 
  4 │                 context("suite", () => { dontTestThis("foo") });
@@ -217,42 +216,42 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.skip("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.concurrent("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.only("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { xtest("foo") })
    ·                           ─────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:43]
  3 │ 
  4 │                 describe("suite", () => { dontTestThis("foo") });
@@ -261,7 +260,7 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:4:38]
  3 │ 
  4 │             context("suite", () => { dontTestThis("foo") });
@@ -270,105 +269,105 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.skip("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test.concurrent("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("shows error", () => {});
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.skip("shows error");
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test.only('shows error');
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:25]
  1 │ describe('foo', () => { it('bar', () => {}); });
    ·                         ──
@@ -383,56 +382,56 @@ assertion_line: 216
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("shows error", () => {});
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──
    ╰────
   help: Prefer using "test" instead of "it" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("foo")
    · ────
    ╰────
   help: Prefer using "it" instead of "test"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { test("foo") })
    ·                           ────
    ╰────
   help: Prefer using "it" instead of "test" within describe
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ it("foo")
    · ──
@@ -447,7 +446,7 @@ assertion_line: 216
    ╰────
   help: Prefer using "test" instead of "it"
 
-  ⚠ eslint-plugin-jest(consistent-test-it): Enforce `test` and `it` usage conventions
+  ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:27]
  1 │ describe("suite", () => { it("foo") })
    ·                           ──

--- a/crates/oxc_linter/src/snapshots/consistent_type_definitions.snap
+++ b/crates/oxc_linter/src/snapshots/consistent_type_definitions.snap
@@ -1,156 +1,139 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ type T = { x: number; };
-   · ──┬─
-   ·   ╰── Use an `interface` instead of a `type`
+   · ────
    ╰────
   help: Use an `interface` instead of a `type`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ type T={ x: number; };
-   · ──┬─
-   ·   ╰── Use an `interface` instead of a `type`
+   · ────
    ╰────
   help: Use an `interface` instead of a `type`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ type T=                         { x: number; };
-   · ──┬─
-   ·   ╰── Use an `interface` instead of a `type`
+   · ────
    ╰────
   help: Use an `interface` instead of a `type`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
    ╭─[consistent_type_definitions.tsx:2:11]
  1 │ 
  2 │             export type W<T> = {
-   ·                    ──┬─
-   ·                      ╰── Use an `interface` instead of a `type`
+   ·                    ────
  3 │               x: T;
    ╰────
   help: Use an `interface` instead of a `type`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ interface T { x: number; }
-   · ────┬────
-   ·     ╰── Use an `type` instead of a `interface`
+   · ─────────
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ interface T{ x: number; }
-   · ────┬────
-   ·     ╰── Use an `type` instead of a `interface`
+   · ─────────
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ interface T                          { x: number; }
-   · ────┬────
-   ·     ╰── Use an `type` instead of a `interface`
+   · ─────────
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ interface A extends B, C { x: number; };
-   · ────┬────
-   ·     ╰── Use an `type` instead of a `interface`
+   · ─────────
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:1:1]
  1 │ interface A extends B<T1>, C<T2> { x: number; };
-   · ────┬────
-   ·     ╰── Use an `type` instead of a `interface`
+   · ─────────
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:2:11]
  1 │ 
  2 │             export interface W<T> {
-   ·                    ────┬────
-   ·                        ╰── Use an `type` instead of a `interface`
+   ·                    ─────────
  3 │               x: T;
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:3:6]
  2 │             namespace JSX {
  3 │               interface Array<T> {
-   ·               ────┬────
-   ·                   ╰── Use an `type` instead of a `interface`
+   ·               ─────────
  4 │                 foo(x: (x: number) => T): T[];
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:3:6]
  2 │             global {
  3 │               interface Array<T> {
-   ·               ────┬────
-   ·                   ╰── Use an `type` instead of a `interface`
+   ·               ─────────
  4 │                 foo(x: (x: number) => T): T[];
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:3:6]
  2 │             declare global {
  3 │               interface Array<T> {
-   ·               ────┬────
-   ·                   ╰── Use an `type` instead of a `interface`
+   ·               ─────────
  4 │                 foo(x: (x: number) => T): T[];
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:4:8]
  3 │               namespace Foo {
  4 │                 interface Bar {}
-   ·                 ────┬────
-   ·                     ╰── Use an `type` instead of a `interface`
+   ·                 ─────────
  5 │               }
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:2:19]
  1 │ 
  2 │             export default interface Test {
-   ·                            ────┬────
-   ·                                ╰── Use an `type` instead of a `interface`
+   ·                            ─────────
  3 │               bar(): string;
    ╰────
   help: Use an `type` instead of a `interface`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
    ╭─[consistent_type_definitions.tsx:2:19]
  1 │ 
  2 │             export declare type Test = {
-   ·                            ──┬─
-   ·                              ╰── Use an `interface` instead of a `type`
+   ·                            ────
  3 │               foo: string;
    ╰────
   help: Use an `interface` instead of a `type`
 
-  ⚠ typescript-eslint(consistent-type-definitions):
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
    ╭─[consistent_type_definitions.tsx:2:19]
  1 │ 
  2 │             export declare interface Test {
-   ·                            ────┬────
-   ·                                ╰── Use an `type` instead of a `interface`
+   ·                            ─────────
  3 │               foo: string;
    ╰────
   help: Use an `type` instead of a `interface`

--- a/crates/oxc_linter/src/snapshots/expect_expect.snap
+++ b/crates/oxc_linter/src/snapshots/expect_expect.snap
@@ -1,99 +1,98 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => {});
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", myTest); function myTest() {}
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => {});
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test.skip("should fail", () => {});
    · ─────────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ afterEach(() => {});
    · ─────────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => { somePromise.then(() => {}); });
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => { foo(true).toBe(true); })
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should also fail",() => expectSaga(mySaga).returns());
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().bar().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => tester.request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:4:10]
  3 │ 
  4 │             checkThat('this passes', () => {
@@ -102,7 +101,7 @@ assertion_line: 216
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:4:10]
  3 │ 
  4 │             checkThat.skip('this passes', () => {
@@ -111,7 +110,7 @@ assertion_line: 216
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:2:13]
  1 │ 
  2 │             it("should warn on non-assert await expression", async () => {
@@ -120,7 +119,7 @@ assertion_line: 216
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:2:13]
  1 │ 
  2 │             test("event emitters bound to CLS context", function(t) {
@@ -129,84 +128,84 @@ assertion_line: 216
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => {});
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", myTest); function myTest() {}
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => {});
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ afterEach(() => {});
    · ─────────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => { somePromise.then(() => {}); });
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test("should fail", () => { foo(true).toBe(true); })
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should also fail",() => expectSaga(mySaga).returns());
    · ──
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request.get().foo().bar().expect(456));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => tester.request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────
    ╰────
   help: Add assertion(s) in this Test
 
-  ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
+  ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => request(123));
    · ────

--- a/crates/oxc_linter/src/snapshots/heading_has_content.snap
+++ b/crates/oxc_linter/src/snapshots/heading_has_content.snap
@@ -1,63 +1,63 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <h1 />
    · ──────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <h1><Bar aria-hidden /></h1>
    · ────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <h1>{undefined}</h1>
    · ────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <h1><></></h1>
    · ────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <h1><input type="hidden" /></h1>
    · ────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <Heading />
    · ───────────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <Heading><Bar aria-hidden /></Heading>
    · ─────────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <Heading>{undefined}</Heading>
    · ─────────
    ╰────
   help: Provide screen reader accessible content when using heading elements.
 
-  ⚠ eslint(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
+  ⚠ eslint-plugin-jsx-a11y(heading-has-content): Headings must have content and the content must be accessible by a screen reader.
    ╭─[heading_has_content.tsx:1:1]
  1 │ <Heading />
    · ───────────

--- a/crates/oxc_linter/src/snapshots/no_alias_methods.snap
+++ b/crates/oxc_linter/src/snapshots/no_alias_methods.snap
@@ -1,127 +1,126 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalled"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalled"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalled()
    ·           ──────────
    ╰────
   help: Replace "toBeCalled" with its canonical name of "toHaveBeenCalled"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalledTimes"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalledTimes"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalledTimes()
    ·           ───────────────
    ╰────
   help: Replace "toBeCalledTimes" with its canonical name of "toHaveBeenCalledTimes"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalledWith"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalledWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalledWith()
    ·           ──────────────
    ╰────
   help: Replace "toBeCalledWith" with its canonical name of "toHaveBeenCalledWith"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "lastCalledWith"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "lastCalledWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).lastCalledWith()
    ·           ──────────────
    ╰────
   help: Replace "lastCalledWith" with its canonical name of "toHaveBeenLastCalledWith"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "nthCalledWith"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "nthCalledWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).nthCalledWith()
    ·           ─────────────
    ╰────
   help: Replace "nthCalledWith" with its canonical name of "toHaveBeenNthCalledWith"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toReturn"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toReturn"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toReturn()
    ·           ────────
    ╰────
   help: Replace "toReturn" with its canonical name of "toHaveReturned"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toReturnTimes"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toReturnTimes"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toReturnTimes()
    ·           ─────────────
    ╰────
   help: Replace "toReturnTimes" with its canonical name of "toHaveReturnedTimes"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toReturnWith"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toReturnWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toReturnWith()
    ·           ────────────
    ╰────
   help: Replace "toReturnWith" with its canonical name of "toHaveReturnedWith"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "lastReturnedWith"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "lastReturnedWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).lastReturnedWith()
    ·           ────────────────
    ╰────
   help: Replace "lastReturnedWith" with its canonical name of "toHaveLastReturnedWith"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "nthReturnedWith"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "nthReturnedWith"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).nthReturnedWith()
    ·           ───────────────
    ╰────
   help: Replace "nthReturnedWith" with its canonical name of "toHaveNthReturnedWith"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toThrowError()
    ·           ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:20]
  1 │ expect(a).resolves.toThrowError()
    ·                    ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:19]
  1 │ expect(a).rejects.toThrowError()
    ·                   ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:15]
  1 │ expect(a).not.toThrowError()
    ·               ────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:15]
  1 │ expect(a).not['toThrowError']()
    ·               ──────────────
    ╰────
   help: Replace "toThrowError" with its canonical name of "toThrow"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalled"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalled"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalled()
    ·           ──────────
    ╰────
   help: Replace "toBeCalled" with its canonical name of "toHaveBeenCalled"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toBeCalledTimes"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toBeCalledTimes"
    ╭─[no_alias_methods.tsx:1:11]
  1 │ expect(a).toBeCalledTimes()
    ·           ───────────────
    ╰────
   help: Replace "toBeCalledTimes" with its canonical name of "toHaveBeenCalledTimes"
 
-  ⚠ eslint-plugin-jest(no-alias-methods): Unexpected alias "toThrowError"
+  ⚠ eslint-plugin-vitest(no-alias-methods): Unexpected alias "toThrowError"
    ╭─[no_alias_methods.tsx:1:15]
  1 │ expect(a).not["toThrowError"]()
    ·               ──────────────

--- a/crates/oxc_linter/src/snapshots/no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/no_confusing_set_timeout.snap
@@ -1,182 +1,164 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
  10 │                 jest.setTimeout(800);
     ·                 ───────────────
  11 │             
     ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
  10 │                 jest.setTimeout(800);
     ·                 ───────────────
  11 │             
     ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
  10 │                 jest.setTimeout(800);
     ·                 ───────────────
  11 │             
     ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
  10 │                 jest.setTimeout(800);
     ·                 ───────────────
  11 │             
     ╰────
-  help: Do not call `jest.setTimeout` multiple times, as only the last call will have an effect
+  help: Only the last call to `jest.setTimeout` will have an effect.
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
  10 │                 jest.setTimeout(800);
     ·                 ───────────────
  11 │             
     ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be call in `global` scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 describe('A', () => {
  3 │                     jest.setTimeout(800);
    ·                     ───────────────
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
    ╰────
-  help: `jest.setTimeout` should be call in `global` scope
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be call in `global` scope
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);
    ·                         ───────────────
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
-  help: `jest.setTimeout` should be call in `global` scope
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be call in `global` scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 test('test-suite', () => {
  3 │                     jest.setTimeout(1000);
    ·                     ───────────────
  4 │                 });
    ╰────
-  help: `jest.setTimeout` should be call in `global` scope
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:7:17]
  6 │                 });
  7 │                 jest.setTimeout(1000);
    ·                 ───────────────
  8 │             
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:7:17]
  6 │                 });
  7 │                 jest.setTimeout(1000);
    ·                 ───────────────
  8 │             
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:7:17]
  6 │                 });
  7 │                 jest.setTimeout(1000);
    ·                 ───────────────
  8 │             
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:7:17]
  6 │                 });
  7 │                 jest.setTimeout(1000);
    ·                 ───────────────
  8 │             
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be call in `global` scope
    ╭─[no_confusing_set_timeout.tsx:4:20]
  3 │                 {
  4 │                    jest.setTimeout(800);
    ·                    ───────────────
  5 │                 }
    ╰────
-  help: `jest.setTimeout` should be call in `global` scope
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
    ╭─[no_confusing_set_timeout.tsx:3:17]
  2 │                 jest.setTimeout(800);
  3 │                 jest.setTimeout(900);
    ·                 ───────────────
  4 │             
    ╰────
-  help: Do not call `jest.setTimeout` multiple times, as only the last call will have an effect
+  help: Only the last call to `jest.setTimeout` will have an effect.
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be call in `global` scope
    ╭─[no_confusing_set_timeout.tsx:4:21]
  3 │                 {
  4 │                     Jest.setTimeout(800);
    ·                     ───────────────
  5 │                 }
    ╰────
-  help: `jest.setTimeout` should be call in `global` scope
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:3:17]
  2 │                 expect(1 + 2).toEqual(3);
  3 │                 jest.setTimeout(1000);
    ·                 ───────────────
  4 │             
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:8:17]
  7 │                 });
  8 │                 Jest.setTimeout(800);
    ·                 ───────────────
  9 │                 setTimeout(800);
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:8:17]
  7 │                 });
  8 │                 Jest.setTimeout(800);
    ·                 ───────────────
  9 │                 setTimeout(800);
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:5:21]
  4 │                     });
  5 │                     jest.setTimeout(1000);
    ·                     ───────────────
  6 │                 
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout)
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods
    ╭─[no_confusing_set_timeout.tsx:5:21]
  4 │                     });
  5 │                     jest.setTimeout(1000);
    ·                     ───────────────
  6 │                 
    ╰────
-  help: `jest.setTimeout` should be placed before any other jest methods

--- a/crates/oxc_linter/src/snapshots/no_disabled_tests.snap
+++ b/crates/oxc_linter/src/snapshots/no_disabled_tests.snap
@@ -1,256 +1,256 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe.skip('foo', function () {})
    · ─────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe.skip.each([1, 2, 3])('%s', (a, b) => {});
    · ─────────────────────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xdescribe.each([1, 2, 3])('%s', (a, b) => {});
    · ─────────────────────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe[`skip`]('foo', function () {})
    · ────────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe['skip']('foo', function () {})
    · ────────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it.skip('foo', function () {})
    · ───────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it['skip']('foo', function () {})
    · ──────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test.skip('foo', function () {})
    · ─────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it.skip.each``('foo', function () {})
    · ──────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test.skip.each``('foo', function () {})
    · ────────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it.skip.each([])('foo', function () {})
    · ────────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test.skip.each([])('foo', function () {})
    · ──────────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test['skip']('foo', function () {})
    · ────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xdescribe('foo', function () {})
    · ─────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit('foo', function () {})
    · ───
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest('foo', function () {})
    · ─────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each``('foo', function () {})
    · ──────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest.each``('foo', function () {})
    · ────────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each([])('foo', function () {})
    · ────────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest.each([])('foo', function () {})
    · ──────────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Test is missing function argument"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it('has title but no callback')
    · ───────────────────────────────
    ╰────
-  help: "Add function argument"
+  help: Add function argument
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Test is missing function argument"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test('has title but no callback')
    · ─────────────────────────────────
    ╰────
-  help: "Add function argument"
+  help: Add function argument
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Call to pending()"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:48]
  1 │ it('contains a call to pending', function () { pending() })
    ·                                                ─────────
    ╰────
-  help: "Remove pending() call"
+  help: Remove pending() call
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Call to pending()"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ pending()
    · ─────────
    ╰────
-  help: "Remove pending() call"
+  help: Remove pending() call
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Call to pending()"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:54]
  1 │ describe('contains a call to pending', function () { pending() })
    ·                                                      ─────────
    ╰────
-  help: "Remove pending() call"
+  help: Remove pending() call
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Test is missing function argument"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:38]
  1 │ import { test } from '@jest/globals';test('something');
    ·                                      ─────────────────
    ╰────
-  help: "Add function argument"
+  help: Add function argument
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ describe.skip("foo", function () {})
    · ─────────────
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest("foo", function () {})
    · ─────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each``("foo", function () {})
    · ──────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xtest.each``("foo", function () {})
    · ────────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Disabled test"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ xit.each([])("foo", function () {})
    · ────────────
    ╰────
-  help: "Remove x prefix"
+  help: Remove x prefix
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Test is missing function argument"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ it("has title but no callback")
    · ───────────────────────────────
    ╰────
-  help: "Add function argument"
+  help: Add function argument
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Test is missing function argument"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Test is missing function argument
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ test("has title but no callback")
    · ─────────────────────────────────
    ╰────
-  help: "Add function argument"
+  help: Add function argument
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Call to pending()"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:48]
  1 │ it("contains a call to pending", function () { pending() })
    ·                                                ─────────
    ╰────
-  help: "Remove pending() call"
+  help: Remove pending() call
 
-  ⚠ eslint-plugin-jest(no-disabled-tests): "Call to pending()"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Call to pending()
    ╭─[no_disabled_tests.tsx:1:1]
  1 │ pending();
    · ─────────
    ╰────
-  help: "Remove pending() call"
+  help: Remove pending() call
 
-  ⚠ eslint-plugin-vitest(no-disabled-tests): "Disabled test suite"
+  ⚠ eslint-plugin-vitest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:3:13]
  2 │             import { describe } from 'vitest'; 
  3 │             describe.skip("foo", function () {})
    ·             ─────────────
  4 │         
    ╰────
-  help: "Remove the appending `.skip`"
+  help: Remove the appending `.skip`

--- a/crates/oxc_linter/src/snapshots/no_focused_tests.snap
+++ b/crates/oxc_linter/src/snapshots/no_focused_tests.snap
@@ -127,14 +127,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove focus from test.
 
-  ⚠ eslint-plugin-vitest(no-focused-tests): Focused tests are not allowed.
+  ⚠ eslint-plugin-jest(no-focused-tests): Unexpected focused test.
    ╭─[no_focused_tests.tsx:3:16]
  2 │             import { it } from 'vitest'; 
  3 │             it.only("test", () => {});
    ·                ────
  4 │             
    ╰────
-  help: Delete this code.
+  help: Remove focus from test.
 
   ⚠ eslint-plugin-jest(no-focused-tests): Unexpected focused test.
    ╭─[no_focused_tests.tsx:1:10]

--- a/crates/oxc_linter/src/snapshots/no_is_mounted.snap
+++ b/crates/oxc_linter/src/snapshots/no_is_mounted.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-is-mounted): Do not use isMounted
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use isMounted
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 componentDidUpdate: function() {
  4 │                   if (!this.isMounted()) {
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.
 
-  ⚠ eslint(no-is-mounted): Do not use isMounted
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use isMounted
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 someMethod: function() {
  4 │                   if (!this.isMounted()) {
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.
 
-  ⚠ eslint(no-is-mounted): Do not use isMounted
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use isMounted
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 someMethod() {
  4 │                   if (!this.isMounted()) {

--- a/crates/oxc_linter/src/snapshots/no_test_prefixes.snap
+++ b/crates/oxc_linter/src/snapshots/no_test_prefixes.snap
@@ -1,77 +1,77 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.only" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Replace `fdescribe` with `describe.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe.each([])('foo', function () {})
    · ──────────────
    ╰────
   help: Replace `xdescribe.each` with `describe.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fit('foo', function () {})
    · ───
    ╰────
   help: Replace `fit` with `it.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe('foo', function () {})
    · ─────────
    ╰────
   help: Replace `xdescribe` with `describe.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit('foo', function () {})
    · ───
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest('foo', function () {})
    · ─────
    ╰────
   help: Replace `xtest` with `test.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each``('foo', function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each``('foo', function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each([])('foo', function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each([])('foo', function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { xit } from '@jest/globals';
  3 │                 xit('foo', function () {})
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { xit as skipThis } from '@jest/globals';
  3 │                 skipThis('foo', function () {})
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `skipThis` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.only" instead.
    ╭─[no_test_prefixes.tsx:3:17]
  2 │                 import { fit as onlyThis } from '@jest/globals';
  3 │                 onlyThis('foo', function () {})
@@ -98,70 +98,70 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `onlyThis` with `it.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.only" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fdescribe("foo", function () {})
    · ─────────
    ╰────
   help: Replace `fdescribe` with `describe.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe.each([])("foo", function () {})
    · ──────────────
    ╰────
   help: Replace `xdescribe.each` with `describe.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.only" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.only" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ fit("foo", function () {})
    · ───
    ╰────
   help: Replace `fit` with `it.only`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "describe.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "describe.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xdescribe("foo", function () {})
    · ─────────
    ╰────
   help: Replace `xdescribe` with `describe.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit("foo", function () {})
    · ───
    ╰────
   help: Replace `xit` with `it.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest("foo", function () {})
    · ─────
    ╰────
   help: Replace `xtest` with `test.skip`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each``("foo", function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each``("foo", function () {})
    · ──────────
    ╰────
   help: Replace `xtest.each` with `test.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "it.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "it.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xit.each([])("foo", function () {})
    · ────────
    ╰────
   help: Replace `xit.each` with `it.skip.each`.
 
-  ⚠ eslint-plugin-jest(no-test-prefixes): Use "test.skip.each" instead.
+  ⚠ eslint-plugin-vitest(no-test-prefixes): Use "test.skip.each" instead.
    ╭─[no_test_prefixes.tsx:1:1]
  1 │ xtest.each([])("foo", function () {})
    · ──────────

--- a/crates/oxc_linter/src/snapshots/no_unsafe_negation.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsafe_negation.snap
@@ -1,77 +1,77 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ Unexpected logical not in the left hand side of 'in' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of 'in' operator
    ╭─[no_unsafe_negation.tsx:1:1]
  1 │ !a in b
    · ──
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than 'in'
 
-  ⚠ Unexpected logical not in the left hand side of 'in' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of 'in' operator
    ╭─[no_unsafe_negation.tsx:1:2]
  1 │ (!a in b)
    ·  ──
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than 'in'
 
-  ⚠ Unexpected logical not in the left hand side of 'in' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of 'in' operator
    ╭─[no_unsafe_negation.tsx:1:1]
  1 │ !(a) in b
    · ────
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than 'in'
 
-  ⚠ Unexpected logical not in the left hand side of 'instanceof' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of 'instanceof' operator
    ╭─[no_unsafe_negation.tsx:1:1]
  1 │ !a instanceof b
    · ──
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than 'instanceof'
 
-  ⚠ Unexpected logical not in the left hand side of 'instanceof' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of 'instanceof' operator
    ╭─[no_unsafe_negation.tsx:1:2]
  1 │ (!a instanceof b)
    ·  ──
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than 'instanceof'
 
-  ⚠ Unexpected logical not in the left hand side of 'instanceof' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of 'instanceof' operator
    ╭─[no_unsafe_negation.tsx:1:1]
  1 │ !(a) instanceof b
    · ────
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than 'instanceof'
 
-  ⚠ Unexpected logical not in the left hand side of '<' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of '<' operator
    ╭─[no_unsafe_negation.tsx:1:5]
  1 │ if (! a < b) {}
    ·     ───
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '<'
 
-  ⚠ Unexpected logical not in the left hand side of '>' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of '>' operator
    ╭─[no_unsafe_negation.tsx:1:8]
  1 │ while (! a > b) {}
    ·        ───
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '>'
 
-  ⚠ Unexpected logical not in the left hand side of '<=' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of '<=' operator
    ╭─[no_unsafe_negation.tsx:1:7]
  1 │ foo = ! a <= b;
    ·       ───
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '<='
 
-  ⚠ Unexpected logical not in the left hand side of '>=' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of '>=' operator
    ╭─[no_unsafe_negation.tsx:1:7]
  1 │ foo = ! a >= b;
    ·       ───
    ╰────
   help: use parenthesis to express the negation of the whole boolean expression, as '!' binds more closely than '>='
 
-  ⚠ Unexpected logical not in the left hand side of '<=' operator
+  ⚠ eslint(no-unsafe-negation): Unexpected logical not in the left hand side of '<=' operator
    ╭─[no_unsafe_negation.tsx:1:1]
  1 │ ! a <= b
    · ───

--- a/crates/oxc_linter/src/snapshots/no_useless_length_check.snap
+++ b/crates/oxc_linter/src/snapshots/no_useless_length_check.snap
@@ -1,189 +1,189 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length === 0 || array.every(Boolean)
    · ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length > 0 && array.some(Boolean)
    · ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length !== 0 && array.some(Boolean)
    · ──────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:8]
  1 │ if ((( array.length > 0 )) && array.some(Boolean));
    ·        ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:2]
  1 │ (array.length === 0 || array.every(Boolean)) || foo
    ·  ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:2]
  1 │ (array.length === 0 || array.every(Boolean)) || foo
    ·  ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:9]
  1 │ foo || (array.length === 0 || array.every(Boolean))
    ·         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:9]
  1 │ foo || (array.length === 0 || array.every(Boolean))
    ·         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:2]
  1 │ (array.length > 0 && array.some(Boolean)) && foo
    ·  ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:2]
  1 │ (array.length > 0 && array.some(Boolean)) && foo
    ·  ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:9]
  1 │ foo && (array.length > 0 && array.some(Boolean))
    ·         ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:9]
  1 │ foo && (array.length > 0 && array.some(Boolean))
    ·         ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:25]
  1 │ array.every(Boolean) || array.length === 0
    ·                         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:24]
  1 │ array.some(Boolean) && array.length !== 0
    ·                        ──────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:24]
  1 │ array.some(Boolean) && array.length > 0
    ·                        ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:8]
  1 │ foo && array.length > 0 && array.some(Boolean)
    ·        ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:8]
  1 │ foo || array.length === 0 || array.every(Boolean)
    ·        ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:9]
  1 │ (foo || array.length === 0) || array.every(Boolean)
    ·         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length === 0 || (array.every(Boolean) || foo)
    · ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:9]
  1 │ (foo && array.length > 0) && array.some(Boolean)
    ·         ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length > 0 && (array.some(Boolean) && foo)
    · ────────────────
    ╰────
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:25]
  1 │ array.every(Boolean) || array.length === 0 || array.every(Boolean)
    ·                         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:25]
  1 │ array.every(Boolean) || array.length === 0 || array.every(Boolean)
    ·                         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:25]
  1 │ array.every(Boolean) || array.length === 0 || array.every(Boolean)
    ·                         ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length === 0 || array.every(Boolean) || array.length === 0
    · ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:47]
  1 │ array.length === 0 || array.every(Boolean) || array.length === 0
    ·                                               ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
 
-  ⚠ eslint-plugin-unicorn(no-useless-length-check)
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:1]
  1 │ array.length === 0 || array.every(Boolean) || array.length === 0
    · ──────────────────

--- a/crates/oxc_linter/src/snapshots/prefer_es6_class.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_es6_class.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use es6 class instead of createClass.
-   ╭─[prefer_es_6_class.tsx:2:25]
+   ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
    ·                         ────────────────
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use es6 class instead of createClass.
-   ╭─[prefer_es_6_class.tsx:2:25]
+   ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
    ·                         ────────────────
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use createClass instead of ES6 class.
-   ╭─[prefer_es_6_class.tsx:2:19]
+   ╭─[prefer_es6_class.tsx:2:19]
  1 │ 
  2 │             class Hello extends React.Component {
    ·                   ─────

--- a/crates/oxc_linter/src/snapshots/prefer_exponentiation_operator.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_exponentiation_operator.snap
@@ -1,74 +1,74 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ globalThis.Math.pow(a, b)
    · ─────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ globalThis.Math['pow'](a, b)
    · ────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b) + Math.pow(c,
    · ──────────────
  2 │              d)
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:18]
  1 │ ╭─▶ Math.pow(a, b) + Math.pow(c,
  2 │ ╰─▶              d)
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(Math.pow(a, b), Math.pow(c, d))
    · ────────────────────────────────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:10]
  1 │ Math.pow(Math.pow(a, b), Math.pow(c, d))
    ·          ──────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:26]
  1 │ Math.pow(Math.pow(a, b), Math.pow(c, d))
    ·                          ──────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b)**Math.pow(c, d)
    · ──────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:17]
  1 │ Math.pow(a, b)**Math.pow(c, d)
    ·                 ──────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b as any)
    · ─────────────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a as any, b)
    · ─────────────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(prefer-exponentian-operator): Prefer `**` over `Math.pow`.
+  ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b) as any
    · ──────────────

--- a/crates/oxc_linter/src/snapshots/prefer_hooks_in_order.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_hooks_in_order.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:6:21]
  5 │                         });
  6 │ ╭─▶                     beforeAll(() => {
@@ -12,7 +11,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:5:17]
  4 │                     });
  5 │ ╭─▶                 beforeAll(() => {
@@ -22,7 +21,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 afterAll(() => {});
  3 │                 beforeAll(() => {});
@@ -31,7 +30,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 afterEach(() => {});
  3 │                 beforeEach(() => {});
@@ -40,7 +39,7 @@ assertion_line: 216
    ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 afterEach(() => {});
  3 │                 beforeAll(() => {});
@@ -49,7 +48,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 beforeEach(() => {});
  3 │                 beforeAll(() => {});
@@ -58,7 +57,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:17]
  2 │                 afterAll(() => {});
  3 │                 afterEach(() => {});
@@ -67,7 +66,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:5:17]
  4 │                 // This comment does not matter for the order
  5 │                 afterEach(() => {});
@@ -76,7 +75,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:17]
  3 │                 afterAll(() => {});
  4 │                 afterEach(() => {});
@@ -85,7 +84,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:21]
  3 │                     afterAll(() => {});
  4 │                     afterEach(() => {});
@@ -94,7 +93,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:21]
  3 │                     afterAll(() => {});
  4 │                     afterEach(() => {});
@@ -103,7 +102,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:9:21]
   8 │                     beforeEach(() => {});
   9 │                     beforeAll(() => {});
@@ -112,7 +111,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:21]
  3 │                     afterAll(() => {});
  4 │                     afterEach(() => {});
@@ -121,7 +120,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:9:21]
   8 │                     beforeEach(() => {});
   9 │                     beforeAll(() => {});
@@ -130,7 +129,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:7:25]
  6 │                         beforeEach(() => {});
  7 │                         beforeAll(() => {});
@@ -139,7 +138,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:10:25]
   9 │                         afterEach(() => {});
  10 │                         beforeEach(() => {});
@@ -148,7 +147,7 @@ assertion_line: 216
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:5:21]
  4 │                     afterAll(() => {});
  5 │                     beforeAll(() => {});
@@ -157,7 +156,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:23:29]
  22 │                             // This comment does nothing
  23 │                             afterEach(() => {});
@@ -166,7 +165,7 @@ assertion_line: 216
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:8:25]
   7 │                             });
   8 │ ╭─▶                         beforeAll(() => {
@@ -176,7 +175,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:19:25]
  18 │                         afterAll(() => {});
  19 │                         afterEach(() => {});
@@ -185,7 +184,7 @@ assertion_line: 216
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:7:21]
   6 │     
   7 │ ╭─▶                     beforeAll(() => {
@@ -195,7 +194,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:38:25]
  37 │     
  38 │ ╭─▶                         beforeEach(() => {
@@ -205,7 +204,7 @@ assertion_line: 216
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:6:17]
  5 │                     });
  6 │ ╭─▶                 beforeAll(() => {
@@ -215,7 +214,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:5:13]
  4 │                 });
  5 │ ╭─▶             beforeAll(() => {
@@ -225,7 +224,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:13]
  2 │             afterAll(() => {});
  3 │             beforeAll(() => {});
@@ -234,7 +233,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:13]
  2 │             afterEach(() => {});
  3 │             beforeEach(() => {});
@@ -243,7 +242,7 @@ assertion_line: 216
    ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:13]
  2 │             afterEach(() => {});
  3 │             beforeAll(() => {});
@@ -252,7 +251,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:13]
  2 │             beforeEach(() => {});
  3 │             beforeAll(() => {});
@@ -261,7 +260,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:3:13]
  2 │             afterAll(() => {});
  3 │             afterEach(() => {});
@@ -270,7 +269,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:5:13]
  4 │             // This comment does not matter for the order
  5 │             afterEach(() => {});
@@ -279,7 +278,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:13]
  3 │             afterAll(() => {});
  4 │             afterEach(() => {});
@@ -288,7 +287,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:17]
  3 │                 afterAll(() => {});
  4 │                 afterEach(() => {});
@@ -297,7 +296,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:17]
  3 │                 afterAll(() => {});
  4 │                 afterEach(() => {});
@@ -306,7 +305,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:9:17]
   8 │                 beforeEach(() => {});
   9 │                 beforeAll(() => {});
@@ -315,7 +314,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:4:17]
  3 │                 afterAll(() => {});
  4 │                 afterEach(() => {});
@@ -324,7 +323,7 @@ assertion_line: 216
    ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:9:17]
   8 │                 beforeEach(() => {});
   9 │                 beforeAll(() => {});
@@ -333,7 +332,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:7:21]
  6 │                     beforeEach(() => {});
  7 │                     beforeAll(() => {});
@@ -342,7 +341,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:10:21]
   9 │                     afterEach(() => {});
  10 │                     beforeEach(() => {});
@@ -351,7 +350,7 @@ assertion_line: 216
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
    ╭─[prefer_hooks_in_order.tsx:5:17]
  4 │                 afterAll(() => {});
  5 │                 beforeAll(() => {});
@@ -360,7 +359,7 @@ assertion_line: 216
    ╰────
   help: "beforeAll" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:23:25]
  22 │                         // This comment does nothing
  23 │                         afterEach(() => {});
@@ -369,7 +368,7 @@ assertion_line: 216
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:8:21]
   7 │                         });
   8 │ ╭─▶                     beforeAll(() => {
@@ -379,7 +378,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:19:21]
  18 │                     afterAll(() => {});
  19 │                     afterEach(() => {});
@@ -388,7 +387,7 @@ assertion_line: 216
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:7:17]
   6 │     
   7 │ ╭─▶                 beforeAll(() => {
@@ -398,7 +397,7 @@ assertion_line: 216
     ╰────
   help: "beforeAll" hooks should be before any "beforeEach" hooks
 
-  ⚠ eslint-plugin-jest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
+  ⚠ eslint-plugin-vitest(prefer-hooks-in-order): Prefer having hooks in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:38:21]
  37 │     
  38 │ ╭─▶                     beforeEach(() => {

--- a/crates/oxc_linter/src/snapshots/valid_describe_callback.snap
+++ b/crates/oxc_linter/src/snapshots/valid_describe_callback.snap
@@ -1,143 +1,142 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each()()
    · ─────────────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe['each']()()
    · ────────────────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each(() => {})()
    · ─────────────────────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:25]
  1 │ describe.each(() => {})('foo')
    ·                         ─────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe.each()(() => {})
    ·                 ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:20]
  1 │ describe['each']()(() => {})
    ·                    ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.each('foo')(() => {})
    ·                      ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:27]
  1 │ describe.only.each('foo')(() => {})
    ·                           ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe(() => {})
    ·          ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe('foo')
    ·          ─────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Second argument must be a function"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Second argument must be a function
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', 'foo2')
    ·                 ──────
    ╰────
-  help: "Replace second argument with a function"
+  help: Replace second argument with a function
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe()
    · ──────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async () => {})
    ·                 ──────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async function () {})
    ·                 ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ xdescribe('foo', async function () {})
    ·                  ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ fdescribe('foo', async function () {})
    ·                  ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:3:30]
  2 │             import { fdescribe } from '@jest/globals';
  3 │             fdescribe('foo', async function () {})
    ·                              ────────────────────
  4 │             
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.only('foo', async function () {})
    ·                      ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.skip('foo', async function () {})
    ·                      ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:6:35]
   5 │                     });
   6 │ ╭─▶                 describe('async', async () => {
@@ -148,9 +147,9 @@ assertion_line: 216
  11 │ ╰─▶                 });
  12 │                 });
     ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:17]
  2 │                 describe('foo', function () {
  3 │ ╭─▶                 return Promise.resolve().then(() => {
@@ -160,9 +159,9 @@ assertion_line: 216
  7 │ ╰─▶                 })
  8 │                 })
    ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:9:21]
   8 │                     describe('nested', () => {
   9 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -172,9 +171,9 @@ assertion_line: 216
  13 │ ╰─▶                     })
  14 │                     })
     ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:17]
  2 │                 describe('foo', () => {
  3 │ ╭─▶                 return Promise.resolve().then(() => {
@@ -184,9 +183,9 @@ assertion_line: 216
  7 │ ╰─▶                 })
  8 │                     describe('nested', () => {
    ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:6:21]
   5 │                     describe('nested', () => {
   6 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -196,9 +195,9 @@ assertion_line: 216
  10 │ ╰─▶                     })
  11 │                     })
     ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:2:29]
   1 │     
   2 │ ╭─▶             describe('foo', async () => {
@@ -214,177 +213,177 @@ assertion_line: 216
  12 │ ╰─▶             })
  13 │                 
     ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:1:23]
  1 │ describe('foo', () => test('bar', () => {})) 
    ·                       ─────────────────────
    ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', done => {})
    ·                 ──────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', function (done) {})
    ·                 ──────────────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', function (one, two, three) {})
    ·                 ─────────────────────────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async function (done) {})
    ·                 ────────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe('foo', async function (done) {})
    ·                 ────────────────────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each()()
    · ─────────────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe["each"]()()
    · ────────────────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe.each(() => {})()
    · ─────────────────────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:25]
  1 │ describe.each(() => {})("foo")
    ·                         ─────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe.each()(() => {})
    ·                 ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:20]
  1 │ describe["each"]()(() => {})
    ·                    ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.each("foo")(() => {})
    ·                      ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:27]
  1 │ describe.only.each("foo")(() => {})
    ·                           ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe(() => {})
    ·          ────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:10]
  1 │ describe("foo")
    ·          ─────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Second argument must be a function"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Second argument must be a function
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", "foo2")
    ·                 ──────
    ╰────
-  help: "Replace second argument with a function"
+  help: Replace second argument with a function
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Describe requires name and callback arguments"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Describe requires name and callback arguments
    ╭─[valid_describe_callback.tsx:1:1]
  1 │ describe()
    · ──────────
    ╰────
-  help: "Add name as first argument and callback as second argument"
+  help: Add name as first argument and callback as second argument
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async () => {})
    ·                 ──────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function () {})
    ·                 ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ xdescribe("foo", async function () {})
    ·                  ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:18]
  1 │ fdescribe("foo", async function () {})
    ·                  ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.only("foo", async function () {})
    ·                      ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:22]
  1 │ describe.skip("foo", async function () {})
    ·                      ────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:6:39]
   5 │                         });
   6 │ ╭─▶                     describe('async', async () => {
@@ -395,9 +394,9 @@ assertion_line: 216
  11 │ ╰─▶                     });
  12 │                     });
     ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                     describe('foo', function () {
  3 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -407,9 +406,9 @@ assertion_line: 216
  7 │ ╰─▶                     })
  8 │                     })
    ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:9:25]
   8 │                         describe('nested', () => {
   9 │ ╭─▶                         return Promise.resolve().then(() => {
@@ -419,9 +418,9 @@ assertion_line: 216
  13 │ ╰─▶                         })
  14 │                         })
     ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                     describe('foo', () => {
  3 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -431,9 +430,9 @@ assertion_line: 216
  7 │ ╰─▶                     })
  8 │                         describe('nested', () => {
    ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:6:25]
   5 │                         describe('nested', () => {
   6 │ ╭─▶                         return Promise.resolve().then(() => {
@@ -443,9 +442,9 @@ assertion_line: 216
  10 │ ╰─▶                         })
  11 │                         })
     ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
     ╭─[valid_describe_callback.tsx:2:33]
   1 │     
   2 │ ╭─▶                 describe('foo', async () => {
@@ -461,48 +460,48 @@ assertion_line: 216
  12 │ ╰─▶                 })
  13 │                 
     ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected return statement in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                 describe('foo', () =>
  3 │                     test('bar', () => {})
    ·                     ─────────────────────
  4 │                 )
    ╰────
-  help: "Remove return statement in your describe callback"
+  help: Remove return statement in your describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", done => {})
    ·                 ──────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", function (done) {})
    ·                 ──────────────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", function (one, two, three) {})
    ·                 ─────────────────────────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "No async describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): No async describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function (done) {})
    ·                 ────────────────────────
    ╰────
-  help: "Remove `async` keyword"
+  help: Remove `async` keyword
 
-  ⚠ eslint-plugin-jest(valid-describe-callback): "Unexpected argument(s) in describe callback"
+  ⚠ eslint-plugin-vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function (done) {})
    ·                 ────────────────────────
    ╰────
-  help: "Remove argument(s) of describe callback"
+  help: Remove argument(s) of describe callback

--- a/crates/oxc_linter/src/snapshots/valid_expect.snap
+++ b/crates/oxc_linter/src/snapshots/valid_expect.snap
@@ -1,395 +1,394 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 216
 ---
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(2);
    · ────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(true);
    · ────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toEqual('something');
    · ────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else').toEqual('something');
    · ───────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else', 'entirely').toEqual('something');
    · ───────────────────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else', 'entirely').toEqual('something');
    · ───────────────────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else', 'entirely').toEqual('something');
    · ───────────────────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something').toEqual('something');
    · ───────────────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 3 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 3 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something', 'else').toEqual('something');
    · ───────────────────────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect must have a corresponding matcher call."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect('something');
    · ───────────────────
    ╰────
-  help: "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)"
+  help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect must have a corresponding matcher call."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect();
    · ────────
    ╰────
-  help: "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)"
+  help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).toBeDefined;
    · ────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.toBeDefined;
    · ────────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined;
    · ─────────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined();
    · ───────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.resolves.toBeDefined();
    · ───────────────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.not.toBeDefined();
    · ──────────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves.not.exactly.toBeDefined();
    · ───────────────────────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves;
    · ─────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).rejects;
    · ────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not;
    · ────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).rejects.toBeDefined();
    · ────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:6:27]
  5 │                         ? expect(obj).toBe(true)
  6 │                         : expect(obj).resolves.not.toThrow();
    ·                           ──────────────────────────────────
  7 │                     }
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:27]
  4 │                         this.isNot
  5 │                         ? expect(obj).resolves.not.toThrow()
    ·                           ──────────────────────────────────
  6 │                         : expect(obj).toBe(true);
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:7:27]
  6 │                         : anotherCondition
  7 │                         ? expect(obj).resolves.not.toThrow()
    ·                           ──────────────────────────────────
  8 │                         : expect(obj).toBe(false)
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).toReject(); });
    ·                              ─────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).not.toReject(); });
    ·                              ─────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });
    ·                              ────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });
    ·                              ────────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test('valid-expect', async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test('valid-expect', async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.reject(2)).toRejectWith(2); });
    ·                              ─────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test('valid-expect', () => { expect(Promise.reject(2)).rejects.toBe(2); });
    ·                              ─────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:17]
  2 │                 test('valid-expect', async () => {
  3 │                 expect(Promise.resolve(2)).resolves.not.toBeDefined();
    ·                 ─────────────────────────────────────────────────────
  4 │                 expect(Promise.resolve(1)).rejects.toBeDefined();
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:17]
  3 │                 expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                 expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                 ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                     await expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                     ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
    ·                     ─────────────────────────────────────────────────────
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                            ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
    ·                     ─────────────────────────────────────────────────────
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     await expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                            ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     await expect(Promise.resolve(2)).toResolve();
  4 │                     return expect(Promise.resolve(1)).toReject();
    ·                            ─────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
    ·                     ──────────────────────────────────────────────────────────────────────
  4 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.reject(expect(Promise.resolve(2)).resolves.not.toBeDefined());
    ·                     ─────────────────────────────────────────────────────────────────────
  4 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
    ·                     ────────────────────────────────────────────────────────────────
  4 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test('valid-expect', () => {
  3 │                     Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
    ·                     ──────────────────────────────────────────────────────────────────────
  4 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:17]
  2 │                     test('valid-expect', () => {
  3 │ ╭─▶                 Promise.all([
@@ -398,9 +397,9 @@ assertion_line: 216
  6 │ ╰─▶                 ]);
  7 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:17]
  2 │                     test('valid-expect', () => {
  3 │ ╭─▶                 Promise.x([
@@ -409,439 +408,439 @@ assertion_line: 216
  6 │ ╰─▶                 ]);
  7 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                 const assertions = [
  4 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined(),
    ·                     ─────────────────────────────────────────────────────
  5 │                     expect(Promise.resolve(3)).resolves.not.toBeDefined(),
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:21]
  4 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined(),
  5 │                     expect(Promise.resolve(3)).resolves.not.toBeDefined(),
    ·                     ─────────────────────────────────────────────────────
  6 │                 ]
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                 const assertions = [
  4 │                     expect(Promise.resolve(2)).toResolve(),
    ·                     ──────────────────────────────────────
  5 │                     expect(Promise.resolve(3)).toReject(),
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:21]
  4 │                     expect(Promise.resolve(2)).toResolve(),
  5 │                     expect(Promise.resolve(3)).toReject(),
    ·                     ─────────────────────────────────────
  6 │                 ]
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                 const assertions = [
  4 │                     expect(Promise.resolve(2)).not.toResolve(),
    ·                     ──────────────────────────────────────────
  5 │                     expect(Promise.resolve(3)).resolves.toReject(),
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:21]
  4 │                     expect(Promise.resolve(2)).not.toResolve(),
  5 │                     expect(Promise.resolve(3)).resolves.toReject(),
    ·                     ──────────────────────────────────────────────
  6 │                 ]
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBe;
    · ────────────────────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
  4 │                         expect(Promise.resolve(2)).resolves.toBe(1);
    ·                         ───────────────────────────────────────────
  5 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         await expect(Promise.resolve(2)).resolves.toBe(1);
  5 │                         expect(Promise.resolve(4)).resolves.toBe(4);
    ·                         ───────────────────────────────────────────
  6 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect must have a corresponding matcher call."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:3:27]
  2 │                 test('valid-expect', async () => {
  3 │                     await expect(Promise.resolve(1));
    ·                           ──────────────────────────
  4 │                 });
    ╰────
-  help: "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)"
+  help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(2);
    · ────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toBe(true);
    · ────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect().toEqual("something");
    · ────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 1 argument "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 1 argument
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else").toEqual("something");
    · ───────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
    · ───────────────────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
    · ───────────────────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect requires at least 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
    · ───────────────────────────────────────
    ╰────
-  help: "Add the missing arguments."
+  help: Add the missing arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 2 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something").toEqual("something");
    · ───────────────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect takes at most 3 arguments "
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 3 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else").toEqual("something");
    · ───────────────────────────
    ╰────
-  help: "Remove the extra arguments."
+  help: Remove the extra arguments.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect must have a corresponding matcher call."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something");
    · ───────────────────
    ╰────
-  help: "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)"
+  help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect must have a corresponding matcher call."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect();
    · ────────
    ╰────
-  help: "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)"
+  help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).toBeDefined;
    · ────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.toBeDefined;
    · ────────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined;
    · ─────────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined();
    · ───────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.resolves.toBeDefined();
    · ───────────────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.not.toBeDefined();
    · ──────────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect has an unknown modifier."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves.not.exactly.toBeDefined();
    · ───────────────────────────────────────────────
    ╰────
-  help: "Is it a spelling mistake?"
+  help: Is it a spelling mistake?
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).resolves;
    · ─────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).rejects;
    · ────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not;
    · ────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).rejects.toBeDefined();
    · ────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBeDefined();
    · ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:6:31]
  5 │                             ? expect(obj).toBe(true)
  6 │                             : expect(obj).resolves.not.toThrow();
    ·                               ──────────────────────────────────
  7 │                     }
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:31]
  4 │                         this.isNot
  5 │                             ? expect(obj).resolves.not.toThrow()
    ·                               ──────────────────────────────────
  6 │                             : expect(obj).toBe(true);
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });
    ·                              ──────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).toReject(); });
    ·                              ─────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).not.toReject(); });
    ·                              ─────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                              ─────────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });
    ·                              ────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });
    ·                              ────────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:36]
  1 │ test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });
    ·                                    ─────────────────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });
    ·                              ─────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:30]
  1 │ test("valid-expect", () => { expect(Promise.reject(2)).rejects.toBe(2); });
    ·                              ─────────────────────────────────────────
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
    ·                     ─────────────────────────────────────────────────────
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                     ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:21]
  3 │                     await expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                     ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
    ·                     ─────────────────────────────────────────────────────
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:28]
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ·                            ────────────────────────────────────────────────
  5 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", async () => {
  3 │                     expect(Promise.resolve(2)).resolves.not.toBeDefined();
    ·                     ─────────────────────────────────────────────────────
  4 │                     return expect(Promise.resolve(1)).rejects.toBeDefined();
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", () => {
  3 │                     Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
    ·                     ────────────────────────────────────────────────────────────────
  4 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                 test("valid-expect", () => {
  3 │                     Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
    ·                     ──────────────────────────────────────────────────────────────────────
  4 │                 });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                     test("valid-expect", () => {
  3 │ ╭─▶                     Promise.all([
@@ -850,9 +849,9 @@ assertion_line: 216
  6 │ ╰─▶                     ]);
  7 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Promises which return async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Promises which return async assertions must be awaited.
    ╭─[valid_expect.tsx:3:21]
  2 │                     test("valid-expect", () => {
  3 │ ╭─▶                     Promise.x([
@@ -861,92 +860,92 @@ assertion_line: 216
  6 │ ╰─▶                     ]);
  7 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     const assertions = [
  4 │                         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
    ·                         ─────────────────────────────────────────────────────
  5 │                         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
  5 │                         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
    ·                         ─────────────────────────────────────────────────────
  6 │                     ]
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     const assertions = [
  4 │                         expect(Promise.resolve(2)).toResolve(),
    ·                         ──────────────────────────────────────
  5 │                         expect(Promise.resolve(3)).toReject(),
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         expect(Promise.resolve(2)).toResolve(),
  5 │                         expect(Promise.resolve(3)).toReject(),
    ·                         ─────────────────────────────────────
  6 │                     ]
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     const assertions = [
  4 │                         expect(Promise.resolve(2)).not.toResolve(),
    ·                         ──────────────────────────────────────────
  5 │                         expect(Promise.resolve(3)).resolves.toReject(),
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         expect(Promise.resolve(2)).not.toResolve(),
  5 │                         expect(Promise.resolve(3)).resolves.toReject(),
    ·                         ──────────────────────────────────────────────
  6 │                     ]
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Matchers must be called to assert."
+  ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(Promise.resolve(2)).resolves.toBe;
    · ────────────────────────────────────────
    ╰────
-  help: "You need call your matcher, e.g. `expect(true).toBe(true)`."
+  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
  3 │                     return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
  4 │                         expect(Promise.resolve(2)).resolves.toBe(1);
    ·                         ───────────────────────────────────────────
  5 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Async assertions must be awaited."
+  ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:5:25]
  4 │                         await expect(Promise.resolve(2)).resolves.toBe(1);
  5 │                         expect(Promise.resolve(4)).resolves.toBe(4);
    ·                         ───────────────────────────────────────────
  6 │                     });
    ╰────
-  help: "Add `await` to your assertion."
+  help: Add `await` to your assertion.
 
-  ⚠ eslint-plugin-jest(valid-expect): "Expect must have a corresponding matcher call."
+  ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:3:27]
  2 │                 test("valid-expect", async () => {
  3 │                     await expect(Promise.resolve(1));
    ·                           ──────────────────────────
  4 │                 });
    ╰────
-  help: "Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)"
+  help: Did you forget add a matcher(e.g. `toBe`, `toBeDefined`)

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -6,8 +6,6 @@ mod react_perf;
 mod tree_shaking;
 mod unicorn;
 
-use crate::LintContext;
-
 pub use self::{
     jest::*, jsdoc::*, nextjs::*, react::*, react_perf::*, tree_shaking::*, unicorn::*,
 };
@@ -29,43 +27,4 @@ pub fn is_jest_rule_adapted_to_vitest(rule_name: &str) -> bool {
     ];
 
     jest_rules.contains(&rule_name)
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum TestPluginName {
-    Jest,
-    Vitest,
-}
-
-impl std::fmt::Display for TestPluginName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TestPluginName::Jest => write!(f, "eslint-plugin-jest"),
-            TestPluginName::Vitest => write!(f, "eslint-plugin-vitest"),
-        }
-    }
-}
-
-pub fn get_test_plugin_name(ctx: &LintContext) -> TestPluginName {
-    if is_using_vitest(ctx) {
-        TestPluginName::Vitest
-    } else {
-        TestPluginName::Jest
-    }
-}
-
-fn is_using_vitest(ctx: &LintContext) -> bool {
-    // If import 'vitest' is found, we assume the user is using vitest.
-    if ctx
-        .semantic()
-        .module_record()
-        .import_entries
-        .iter()
-        .any(|entry| entry.module_request.name().as_str() == "vitest")
-    {
-        return true;
-    }
-
-    // Or, find the eslint config file
-    ctx.rules().iter().any(|rule| rule.plugin_name == "vitest")
 }

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -87,7 +87,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub fn plugin_name(&self) -> &str {
+            pub fn plugin_name(&self) -> &'static str {
                 match self {
                     #(Self::#struct_names(_) => #plugin_names),*
                 }

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -1,4 +1,4 @@
-use convert_case::{Case, Casing};
+use convert_case::{Boundary, Case, Converter};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
@@ -39,9 +39,14 @@ impl Parse for LintRuleMeta {
     }
 }
 
+fn rule_name_converter() -> Converter {
+    Converter::new().remove_boundary(Boundary::LowerDigit).to_case(Case::Kebab)
+}
+
 pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
     let LintRuleMeta { name, category, documentation, used_in_test } = metadata;
-    let canonical_name = name.to_string().to_case(Case::Kebab);
+
+    let canonical_name = rule_name_converter().convert(name.to_string());
     let category = match category.to_string().as_str() {
         "correctness" => quote! { RuleCategory::Correctness },
         "suspicious" => quote! { RuleCategory::Suspicious },

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -16,7 +16,7 @@ use oxc::{
     span::SourceType,
     transformer::{TransformOptions, Transformer},
 };
-use oxc_linter::{LintContext, Linter};
+use oxc_linter::Linter;
 use oxc_prettier::{Prettier, PrettierOptions};
 use serde::Serialize;
 use tsify::Tsify;
@@ -194,8 +194,7 @@ impl Oxc {
         let semantic = Rc::new(semantic_ret.semantic);
         // Only lint if there are not syntax errors
         if run_options.lint() && self.diagnostics.borrow().is_empty() {
-            let lint_ctx = LintContext::new(path.clone().into_boxed_path(), Rc::clone(&semantic));
-            let linter_ret = Linter::default().run(lint_ctx);
+            let linter_ret = Linter::default().run(&path, Rc::clone(&semantic));
             let diagnostics = linter_ret.into_iter().map(|e| Error::from(e.error)).collect();
             self.save_diagnostics(diagnostics);
         }

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -1,8 +1,12 @@
-use std::{env, path::PathBuf, rc::Rc};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, LintContext, LintOptions, Linter};
+use oxc_linter::{AllowWarnDeny, LintOptions, Linter};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -47,12 +51,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     .with_react_perf_plugin(true);
                 let linter = Linter::from_options(lint_options).unwrap();
                 let semantic = Rc::new(semantic_ret.semantic);
-                b.iter(|| {
-                    linter.run(LintContext::new(
-                        PathBuf::from("").into_boxed_path(),
-                        Rc::clone(&semantic),
-                    ))
-                });
+                b.iter(|| linter.run(Path::new(std::ffi::OsStr::new("")), Rc::clone(&semantic)));
             },
         );
     }


### PR DESCRIPTION
> This PR is (unfortunately) quite large, but all changes are needed in tandem for this to work properly.

## What This PR Does

Updates the linter to populate diagnostics reported by rules with error codes statically derived from `RuleMeta` + `RuleEnum`.

Doing so required changing how we handle vitest rules. I know @mysterven was hoping to refactor that part of the code, and I think this approach is an improvement (but could probably be cleaned up further).

## Changes

### 1. Auto-Populate Error Codes
`LintContext` now sets an error code scope + error code number for diagnostics reported by lint rules. `LintContext` will not clobber existing codes set by rules, allowing for rule-specific override behavior (e.g. to use `eslint-plugin-react-hooks` as an error scope).

In order to accomplish this, I had to update every diagnostic factory for every rule. While doing this I found some incorrect error messages, or messages that could be easily improved. This is where a large majority of the snapshot diffs come from. Additionally, I was able to reduce string allocations from `format!` usages in diagnostic factories, especially within jest rules.

### 2. Framework and Library Detection
This PR adds `FrameworkFlags`, which specify what (if any) set of libraries and frameworks are being used by a project and/or file. They are passed in two ways:

1. `LintOptions` can specify a set of `framework_hints` that apply to the entire target codebase. Right now these are always empty, but I'm thinking in the future we could sniff `package.json`. It may be helpful for enabling/disabling default rules.
2. When `Linter` gets run on a file, framework information is sniffed from the `LintContext`. Right now, we are only checking for `vitest` imports in `ModuleRecord` and test path prefixes from `source_path`. It may be useful to do something similar for React/NextJS rules in the future. I know that [next/no-html-link-for-pages](https://nextjs.org/docs/messages/no-html-link-for-pages) could benefit greatly from this.

