### PR TITLE
fix(transformer/typescript): unexpectedly removed class binding from ExportNamedDeclaration

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -399,12 +399,12 @@ impl<'a> SemanticBuilder<'a> {
                 resolved_references.reserve(references.len());
 
                 references.retain(|(id, flag)| {
-                    if flag.is_type() && symbol_flag.is_can_be_referenced_by_type()
-                        || flag.is_value() && symbol_flag.is_value()
+                    if flag.is_type() && symbol_flag.can_be_referenced_by_type()
+                        || flag.is_value() && symbol_flag.can_be_referenced_by_value()
                     {
-                        // The non type-only ExportSpecifier can reference a type,
-                        // If the reference is not a type, remove the type flag from the reference
-                        if !symbol_flag.is_type() && !flag.is_type_only() {
+                        // The non type-only ExportSpecifier can reference a type/value symbol,
+                        // If the symbol is a value symbol and reference flag is not type-only, remove the type flag.
+                        if symbol_flag.is_value() && !flag.is_type_only() {
                             *self.symbols.references[*id].flag_mut() -= ReferenceFlag::Type;
                         }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
         "node": "VariableDeclarator",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Type)",
+            "flag": "ReferenceFlag(Read)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -94,14 +94,12 @@ impl SymbolFlags {
         self.intersects(Self::Variable)
     }
 
+    /// If true, then the symbol is a type, such as a TypeAlias, Interface, or Enum
     pub fn is_type(&self) -> bool {
-        self.intersects(Self::Type | Self::TypeImport)
+        self.intersects((Self::TypeImport | Self::Type) - Self::Value)
     }
 
-    pub fn is_can_be_referenced_by_type(&self) -> bool {
-        self.is_type() || self.contains(Self::Import)
-    }
-
+    /// If true, then the symbol is a value, such as a Variable, Function, or Class
     pub fn is_value(&self) -> bool {
         self.intersects(Self::Value | Self::Import | Self::Function)
     }
@@ -132,5 +130,15 @@ impl SymbolFlags {
 
     pub fn is_import(&self) -> bool {
         self.intersects(Self::Import | Self::TypeImport)
+    }
+
+    /// If true, then the symbol can be referenced by a type
+    pub fn can_be_referenced_by_type(&self) -> bool {
+        self.intersects(Self::Type | Self::TypeImport | Self::Import)
+    }
+
+    /// If true, then the symbol can be referenced by a value
+    pub fn can_be_referenced_by_value(&self) -> bool {
+        self.intersects(Self::Value | Self::Import | Self::Function)
     }
 }

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 6/6
+Passed: 7/7
 
 # All Passed:
 * babel-plugin-transform-typescript

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-export/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-export/input.ts
@@ -1,0 +1,11 @@
+import Im, {Ok} from 'a';
+class Foo {}
+const Bar = 0;
+function Func() {}
+type Baz = any;
+interface Baq {}
+namespace Name {
+  export const Q = 0;
+}
+
+export { Im, Ok, Foo, Bar, Func, Baz, Baq, Name };

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-export/output.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-export/output.ts
@@ -1,0 +1,9 @@
+import Im, { Ok } from "a";
+class Foo {}
+const Bar = 0;
+function Func() {}
+let Name;
+(function(_Name) {
+	const Q = _Name.Q = 0;
+})(Name || (Name = {}));
+export { Im, Ok, Foo, Bar, Func, Name };


### PR DESCRIPTION
The original `SymbolFlags` methods were a bit confusing I renamed and re-implemented them.