### PR TITLE
chore: git ignore `.DS_Store` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.DS_Store
 **/*.rs.bk
 
 /node_modules/


### PR DESCRIPTION
Git ignore Mac OS metadata `.DS_Store` files.