### PR TITLE
refactor(ast)!: reorder fields of `ArrowFunctionExpression`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1558,12 +1558,11 @@ pub struct ArrowFunctionExpression<'a> {
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
     pub expression: bool,
     pub r#async: bool,
+    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
+    pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// See `expression` for whether this arrow expression returns an expression.
     pub body: Box<'a, FunctionBody<'a>>,
-
-    pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-    pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub scope_id: Cell<Option<ScopeId>>,
 }
 

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -351,25 +351,25 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: bool,
         r#async: bool,
-        params: T1,
-        body: T2,
-        type_parameters: T3,
-        return_type: T4,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
+        body: T4,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
     {
         Expression::ArrowFunctionExpression(self.alloc(self.arrow_function_expression(
             span,
             expression,
             r#async,
-            params,
-            body,
             type_parameters,
+            params,
             return_type,
+            body,
         )))
     }
 
@@ -3863,25 +3863,25 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: bool,
         r#async: bool,
-        params: T1,
-        body: T2,
-        type_parameters: T3,
-        return_type: T4,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
+        body: T4,
     ) -> ArrowFunctionExpression<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
     {
         ArrowFunctionExpression {
             span,
             expression,
             r#async,
-            params: params.into_in(self.allocator),
-            body: body.into_in(self.allocator),
             type_parameters: type_parameters.into_in(self.allocator),
+            params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
+            body: body.into_in(self.allocator),
             scope_id: Default::default(),
         }
     }
@@ -3892,25 +3892,25 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: bool,
         r#async: bool,
-        params: T1,
-        body: T2,
-        type_parameters: T3,
-        return_type: T4,
+        type_parameters: T1,
+        params: T2,
+        return_type: T3,
+        body: T4,
     ) -> Box<'a, ArrowFunctionExpression<'a>>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
     {
         self.arrow_function_expression(
             span,
             expression,
             r#async,
-            params,
-            body,
             type_parameters,
+            params,
             return_type,
+            body,
         )
         .into_in(self.allocator)
     }

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -216,88 +216,23 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_formal_parameters(&mut self, it: &FormalParameters<'a>) {
-        walk_formal_parameters(self, it);
+    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
+        walk_ts_type_parameter_declaration(self, it);
     }
 
     #[inline]
-    fn visit_formal_parameter_list(&mut self, it: &Vec<'a, FormalParameter<'a>>) {
-        walk_formal_parameter_list(self, it);
+    fn visit_ts_type_parameters(&mut self, it: &Vec<'a, TSTypeParameter<'a>>) {
+        walk_ts_type_parameters(self, it);
     }
 
     #[inline]
-    fn visit_formal_parameter(&mut self, it: &FormalParameter<'a>) {
-        walk_formal_parameter(self, it);
-    }
-
-    #[inline]
-    fn visit_decorators(&mut self, it: &Vec<'a, Decorator<'a>>) {
-        walk_decorators(self, it);
-    }
-
-    #[inline]
-    fn visit_decorator(&mut self, it: &Decorator<'a>) {
-        walk_decorator(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern(&mut self, it: &BindingPattern<'a>) {
-        walk_binding_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern_kind(&mut self, it: &BindingPatternKind<'a>) {
-        walk_binding_pattern_kind(self, it);
+    fn visit_ts_type_parameter(&mut self, it: &TSTypeParameter<'a>) {
+        walk_ts_type_parameter(self, it);
     }
 
     #[inline]
     fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
         walk_binding_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_object_pattern(&mut self, it: &ObjectPattern<'a>) {
-        walk_object_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_properties(&mut self, it: &Vec<'a, BindingProperty<'a>>) {
-        walk_binding_properties(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_property(&mut self, it: &BindingProperty<'a>) {
-        walk_binding_property(self, it);
-    }
-
-    #[inline]
-    fn visit_property_key(&mut self, it: &PropertyKey<'a>) {
-        walk_property_key(self, it);
-    }
-
-    #[inline]
-    fn visit_private_identifier(&mut self, it: &PrivateIdentifier<'a>) {
-        walk_private_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_rest_element(&mut self, it: &BindingRestElement<'a>) {
-        walk_binding_rest_element(self, it);
-    }
-
-    #[inline]
-    fn visit_array_pattern(&mut self, it: &ArrayPattern<'a>) {
-        walk_array_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_pattern(&mut self, it: &AssignmentPattern<'a>) {
-        walk_assignment_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
-        walk_ts_type_annotation(self, it);
     }
 
     #[inline]
@@ -386,18 +321,83 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
-        walk_ts_type_parameter_declaration(self, it);
+    fn visit_formal_parameters(&mut self, it: &FormalParameters<'a>) {
+        walk_formal_parameters(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_parameters(&mut self, it: &Vec<'a, TSTypeParameter<'a>>) {
-        walk_ts_type_parameters(self, it);
+    fn visit_formal_parameter_list(&mut self, it: &Vec<'a, FormalParameter<'a>>) {
+        walk_formal_parameter_list(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_parameter(&mut self, it: &TSTypeParameter<'a>) {
-        walk_ts_type_parameter(self, it);
+    fn visit_formal_parameter(&mut self, it: &FormalParameter<'a>) {
+        walk_formal_parameter(self, it);
+    }
+
+    #[inline]
+    fn visit_decorators(&mut self, it: &Vec<'a, Decorator<'a>>) {
+        walk_decorators(self, it);
+    }
+
+    #[inline]
+    fn visit_decorator(&mut self, it: &Decorator<'a>) {
+        walk_decorator(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_pattern(&mut self, it: &BindingPattern<'a>) {
+        walk_binding_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_pattern_kind(&mut self, it: &BindingPatternKind<'a>) {
+        walk_binding_pattern_kind(self, it);
+    }
+
+    #[inline]
+    fn visit_object_pattern(&mut self, it: &ObjectPattern<'a>) {
+        walk_object_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_properties(&mut self, it: &Vec<'a, BindingProperty<'a>>) {
+        walk_binding_properties(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_property(&mut self, it: &BindingProperty<'a>) {
+        walk_binding_property(self, it);
+    }
+
+    #[inline]
+    fn visit_property_key(&mut self, it: &PropertyKey<'a>) {
+        walk_property_key(self, it);
+    }
+
+    #[inline]
+    fn visit_private_identifier(&mut self, it: &PrivateIdentifier<'a>) {
+        walk_private_identifier(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_rest_element(&mut self, it: &BindingRestElement<'a>) {
+        walk_binding_rest_element(self, it);
+    }
+
+    #[inline]
+    fn visit_array_pattern(&mut self, it: &ArrayPattern<'a>) {
+        walk_array_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_pattern(&mut self, it: &AssignmentPattern<'a>) {
+        walk_assignment_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
+        walk_ts_type_annotation(self, it);
     }
 
     #[inline]
@@ -1718,177 +1718,57 @@ pub mod walk {
             },
             &it.scope_id,
         );
-        visitor.visit_formal_parameters(&it.params);
-        visitor.visit_function_body(&it.body);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
+        visitor.visit_formal_parameters(&it.params);
         if let Some(return_type) = &it.return_type {
             visitor.visit_ts_type_annotation(return_type);
         }
+        visitor.visit_function_body(&it.body);
         visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_formal_parameters<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameters<'a>) {
-        let kind = AstKind::FormalParameters(visitor.alloc(it));
+    pub fn walk_ts_type_parameter_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeParameterDeclaration<'a>,
+    ) {
+        let kind = AstKind::TSTypeParameterDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_formal_parameter_list(&it.items);
-        if let Some(rest) = &it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
+        visitor.visit_ts_type_parameters(&it.params);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_formal_parameter_list<'a, V: Visit<'a>>(
+    pub fn walk_ts_type_parameters<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, FormalParameter<'a>>,
+        it: &Vec<'a, TSTypeParameter<'a>>,
     ) {
         for el in it.iter() {
-            visitor.visit_formal_parameter(el);
+            visitor.visit_ts_type_parameter(el);
         }
     }
 
     #[inline]
-    pub fn walk_formal_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameter<'a>) {
-        let kind = AstKind::FormalParameter(visitor.alloc(it));
+    pub fn walk_ts_type_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeParameter<'a>) {
+        let kind = AstKind::TSTypeParameter(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_decorators(&it.decorators);
-        visitor.visit_binding_pattern(&it.pattern);
+        visitor.visit_binding_identifier(&it.name);
+        if let Some(constraint) = &it.constraint {
+            visitor.visit_ts_type(constraint);
+        }
+        if let Some(default) = &it.default {
+            visitor.visit_ts_type(default);
+        }
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
-        for el in it.iter() {
-            visitor.visit_decorator(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
-        let kind = AstKind::Decorator(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingPattern<'a>) {
-        // NOTE: AstKind doesn't exists!
-        visitor.visit_binding_pattern_kind(&it.kind);
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern_kind<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &BindingPatternKind<'a>,
-    ) {
-        match it {
-            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
-            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
-            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
-            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
-        }
     }
 
     #[inline]
     pub fn walk_binding_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingIdentifier<'a>) {
         let kind = AstKind::BindingIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
-        let kind = AstKind::ObjectPattern(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_binding_properties(&it.properties);
-        if let Some(rest) = &it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_properties<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, BindingProperty<'a>>,
-    ) {
-        for el in it.iter() {
-            visitor.visit_binding_property(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_property<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingProperty<'a>) {
-        // NOTE: AstKind doesn't exists!
-        visitor.visit_property_key(&it.key);
-        visitor.visit_binding_pattern(&it.value);
-    }
-
-    #[inline]
-    pub fn walk_property_key<'a, V: Visit<'a>>(visitor: &mut V, it: &PropertyKey<'a>) {
-        let kind = AstKind::PropertyKey(visitor.alloc(it));
-        visitor.enter_node(kind);
-        match it {
-            PropertyKey::StaticIdentifier(it) => visitor.visit_identifier_name(it),
-            PropertyKey::PrivateIdentifier(it) => visitor.visit_private_identifier(it),
-            match_expression!(PropertyKey) => visitor.visit_expression(it.to_expression()),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_private_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &PrivateIdentifier<'a>) {
-        let kind = AstKind::PrivateIdentifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_rest_element<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &BindingRestElement<'a>,
-    ) {
-        let kind = AstKind::BindingRestElement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_binding_pattern(&it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
-        let kind = AstKind::ArrayPattern(visitor.alloc(it));
-        visitor.enter_node(kind);
-        for elements in it.elements.iter().flatten() {
-            visitor.visit_binding_pattern(elements);
-        }
-        if let Some(rest) = &it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentPattern<'a>) {
-        let kind = AstKind::AssignmentPattern(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_binding_pattern(&it.left);
-        visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_annotation<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAnnotation<'a>) {
-        let kind = AstKind::TSTypeAnnotation(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_ts_type(&it.type_annotation);
         visitor.leave_node(kind);
     }
 
@@ -2056,37 +1936,157 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_type_parameter_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSTypeParameterDeclaration<'a>,
-    ) {
-        let kind = AstKind::TSTypeParameterDeclaration(visitor.alloc(it));
+    pub fn walk_formal_parameters<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameters<'a>) {
+        let kind = AstKind::FormalParameters(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_ts_type_parameters(&it.params);
+        visitor.visit_formal_parameter_list(&it.items);
+        if let Some(rest) = &it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_type_parameters<'a, V: Visit<'a>>(
+    pub fn walk_formal_parameter_list<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSTypeParameter<'a>>,
+        it: &Vec<'a, FormalParameter<'a>>,
     ) {
         for el in it.iter() {
-            visitor.visit_ts_type_parameter(el);
+            visitor.visit_formal_parameter(el);
         }
     }
 
     #[inline]
-    pub fn walk_ts_type_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeParameter<'a>) {
-        let kind = AstKind::TSTypeParameter(visitor.alloc(it));
+    pub fn walk_formal_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameter<'a>) {
+        let kind = AstKind::FormalParameter(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_binding_identifier(&it.name);
-        if let Some(constraint) = &it.constraint {
-            visitor.visit_ts_type(constraint);
+        visitor.visit_decorators(&it.decorators);
+        visitor.visit_binding_pattern(&it.pattern);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
+        for el in it.iter() {
+            visitor.visit_decorator(el);
         }
-        if let Some(default) = &it.default {
-            visitor.visit_ts_type(default);
+    }
+
+    #[inline]
+    pub fn walk_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
+        let kind = AstKind::Decorator(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_expression(&it.expression);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingPattern<'a>) {
+        // NOTE: AstKind doesn't exists!
+        visitor.visit_binding_pattern_kind(&it.kind);
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
         }
+    }
+
+    #[inline]
+    pub fn walk_binding_pattern_kind<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingPatternKind<'a>,
+    ) {
+        match it {
+            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
+            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
+            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
+            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
+        let kind = AstKind::ObjectPattern(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_binding_properties(&it.properties);
+        if let Some(rest) = &it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_properties<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, BindingProperty<'a>>,
+    ) {
+        for el in it.iter() {
+            visitor.visit_binding_property(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_binding_property<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingProperty<'a>) {
+        // NOTE: AstKind doesn't exists!
+        visitor.visit_property_key(&it.key);
+        visitor.visit_binding_pattern(&it.value);
+    }
+
+    #[inline]
+    pub fn walk_property_key<'a, V: Visit<'a>>(visitor: &mut V, it: &PropertyKey<'a>) {
+        let kind = AstKind::PropertyKey(visitor.alloc(it));
+        visitor.enter_node(kind);
+        match it {
+            PropertyKey::StaticIdentifier(it) => visitor.visit_identifier_name(it),
+            PropertyKey::PrivateIdentifier(it) => visitor.visit_private_identifier(it),
+            match_expression!(PropertyKey) => visitor.visit_expression(it.to_expression()),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_private_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &PrivateIdentifier<'a>) {
+        let kind = AstKind::PrivateIdentifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_rest_element<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingRestElement<'a>,
+    ) {
+        let kind = AstKind::BindingRestElement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_binding_pattern(&it.argument);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
+        let kind = AstKind::ArrayPattern(visitor.alloc(it));
+        visitor.enter_node(kind);
+        for elements in it.elements.iter().flatten() {
+            visitor.visit_binding_pattern(elements);
+        }
+        if let Some(rest) = &it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_assignment_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentPattern<'a>) {
+        let kind = AstKind::AssignmentPattern(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_binding_pattern(&it.left);
+        visitor.visit_expression(&it.right);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_annotation<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAnnotation<'a>) {
+        let kind = AstKind::TSTypeAnnotation(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_ts_type(&it.type_annotation);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -208,88 +208,23 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_formal_parameters(&mut self, it: &mut FormalParameters<'a>) {
-        walk_formal_parameters(self, it);
+    fn visit_ts_type_parameter_declaration(&mut self, it: &mut TSTypeParameterDeclaration<'a>) {
+        walk_ts_type_parameter_declaration(self, it);
     }
 
     #[inline]
-    fn visit_formal_parameter_list(&mut self, it: &mut Vec<'a, FormalParameter<'a>>) {
-        walk_formal_parameter_list(self, it);
+    fn visit_ts_type_parameters(&mut self, it: &mut Vec<'a, TSTypeParameter<'a>>) {
+        walk_ts_type_parameters(self, it);
     }
 
     #[inline]
-    fn visit_formal_parameter(&mut self, it: &mut FormalParameter<'a>) {
-        walk_formal_parameter(self, it);
-    }
-
-    #[inline]
-    fn visit_decorators(&mut self, it: &mut Vec<'a, Decorator<'a>>) {
-        walk_decorators(self, it);
-    }
-
-    #[inline]
-    fn visit_decorator(&mut self, it: &mut Decorator<'a>) {
-        walk_decorator(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern(&mut self, it: &mut BindingPattern<'a>) {
-        walk_binding_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern_kind(&mut self, it: &mut BindingPatternKind<'a>) {
-        walk_binding_pattern_kind(self, it);
+    fn visit_ts_type_parameter(&mut self, it: &mut TSTypeParameter<'a>) {
+        walk_ts_type_parameter(self, it);
     }
 
     #[inline]
     fn visit_binding_identifier(&mut self, it: &mut BindingIdentifier<'a>) {
         walk_binding_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_object_pattern(&mut self, it: &mut ObjectPattern<'a>) {
-        walk_object_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_properties(&mut self, it: &mut Vec<'a, BindingProperty<'a>>) {
-        walk_binding_properties(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_property(&mut self, it: &mut BindingProperty<'a>) {
-        walk_binding_property(self, it);
-    }
-
-    #[inline]
-    fn visit_property_key(&mut self, it: &mut PropertyKey<'a>) {
-        walk_property_key(self, it);
-    }
-
-    #[inline]
-    fn visit_private_identifier(&mut self, it: &mut PrivateIdentifier<'a>) {
-        walk_private_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_rest_element(&mut self, it: &mut BindingRestElement<'a>) {
-        walk_binding_rest_element(self, it);
-    }
-
-    #[inline]
-    fn visit_array_pattern(&mut self, it: &mut ArrayPattern<'a>) {
-        walk_array_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_pattern(&mut self, it: &mut AssignmentPattern<'a>) {
-        walk_assignment_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_annotation(&mut self, it: &mut TSTypeAnnotation<'a>) {
-        walk_ts_type_annotation(self, it);
     }
 
     #[inline]
@@ -378,18 +313,83 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_type_parameter_declaration(&mut self, it: &mut TSTypeParameterDeclaration<'a>) {
-        walk_ts_type_parameter_declaration(self, it);
+    fn visit_formal_parameters(&mut self, it: &mut FormalParameters<'a>) {
+        walk_formal_parameters(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_parameters(&mut self, it: &mut Vec<'a, TSTypeParameter<'a>>) {
-        walk_ts_type_parameters(self, it);
+    fn visit_formal_parameter_list(&mut self, it: &mut Vec<'a, FormalParameter<'a>>) {
+        walk_formal_parameter_list(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_parameter(&mut self, it: &mut TSTypeParameter<'a>) {
-        walk_ts_type_parameter(self, it);
+    fn visit_formal_parameter(&mut self, it: &mut FormalParameter<'a>) {
+        walk_formal_parameter(self, it);
+    }
+
+    #[inline]
+    fn visit_decorators(&mut self, it: &mut Vec<'a, Decorator<'a>>) {
+        walk_decorators(self, it);
+    }
+
+    #[inline]
+    fn visit_decorator(&mut self, it: &mut Decorator<'a>) {
+        walk_decorator(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_pattern(&mut self, it: &mut BindingPattern<'a>) {
+        walk_binding_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_pattern_kind(&mut self, it: &mut BindingPatternKind<'a>) {
+        walk_binding_pattern_kind(self, it);
+    }
+
+    #[inline]
+    fn visit_object_pattern(&mut self, it: &mut ObjectPattern<'a>) {
+        walk_object_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_properties(&mut self, it: &mut Vec<'a, BindingProperty<'a>>) {
+        walk_binding_properties(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_property(&mut self, it: &mut BindingProperty<'a>) {
+        walk_binding_property(self, it);
+    }
+
+    #[inline]
+    fn visit_property_key(&mut self, it: &mut PropertyKey<'a>) {
+        walk_property_key(self, it);
+    }
+
+    #[inline]
+    fn visit_private_identifier(&mut self, it: &mut PrivateIdentifier<'a>) {
+        walk_private_identifier(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_rest_element(&mut self, it: &mut BindingRestElement<'a>) {
+        walk_binding_rest_element(self, it);
+    }
+
+    #[inline]
+    fn visit_array_pattern(&mut self, it: &mut ArrayPattern<'a>) {
+        walk_array_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_pattern(&mut self, it: &mut AssignmentPattern<'a>) {
+        walk_assignment_pattern(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_annotation(&mut self, it: &mut TSTypeAnnotation<'a>) {
+        walk_ts_type_annotation(self, it);
     }
 
     #[inline]
@@ -1740,89 +1740,54 @@ pub mod walk_mut {
             },
             &it.scope_id,
         );
-        visitor.visit_formal_parameters(&mut it.params);
-        visitor.visit_function_body(&mut it.body);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
+        visitor.visit_formal_parameters(&mut it.params);
         if let Some(return_type) = &mut it.return_type {
             visitor.visit_ts_type_annotation(return_type);
         }
+        visitor.visit_function_body(&mut it.body);
         visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_formal_parameters<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_type_parameter_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut FormalParameters<'a>,
+        it: &mut TSTypeParameterDeclaration<'a>,
     ) {
-        let kind = AstType::FormalParameters;
+        let kind = AstType::TSTypeParameterDeclaration;
         visitor.enter_node(kind);
-        visitor.visit_formal_parameter_list(&mut it.items);
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
+        visitor.visit_ts_type_parameters(&mut it.params);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_formal_parameter_list<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_type_parameters<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, FormalParameter<'a>>,
+        it: &mut Vec<'a, TSTypeParameter<'a>>,
     ) {
         for el in it.iter_mut() {
-            visitor.visit_formal_parameter(el);
+            visitor.visit_ts_type_parameter(el);
         }
     }
 
     #[inline]
-    pub fn walk_formal_parameter<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_type_parameter<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut FormalParameter<'a>,
+        it: &mut TSTypeParameter<'a>,
     ) {
-        let kind = AstType::FormalParameter;
+        let kind = AstType::TSTypeParameter;
         visitor.enter_node(kind);
-        visitor.visit_decorators(&mut it.decorators);
-        visitor.visit_binding_pattern(&mut it.pattern);
+        visitor.visit_binding_identifier(&mut it.name);
+        if let Some(constraint) = &mut it.constraint {
+            visitor.visit_ts_type(constraint);
+        }
+        if let Some(default) = &mut it.default {
+            visitor.visit_ts_type(default);
+        }
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_decorators<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Decorator<'a>>) {
-        for el in it.iter_mut() {
-            visitor.visit_decorator(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
-        let kind = AstType::Decorator;
-        visitor.enter_node(kind);
-        visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BindingPattern<'a>) {
-        // NOTE: AstType doesn't exists!
-        visitor.visit_binding_pattern_kind(&mut it.kind);
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern_kind<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut BindingPatternKind<'a>,
-    ) {
-        match it {
-            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
-            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
-            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
-            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
-        }
     }
 
     #[inline]
@@ -1832,106 +1797,6 @@ pub mod walk_mut {
     ) {
         let kind = AstType::BindingIdentifier;
         visitor.enter_node(kind);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_object_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectPattern<'a>) {
-        let kind = AstType::ObjectPattern;
-        visitor.enter_node(kind);
-        visitor.visit_binding_properties(&mut it.properties);
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_properties<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, BindingProperty<'a>>,
-    ) {
-        for el in it.iter_mut() {
-            visitor.visit_binding_property(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_property<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut BindingProperty<'a>,
-    ) {
-        // NOTE: AstType doesn't exists!
-        visitor.visit_property_key(&mut it.key);
-        visitor.visit_binding_pattern(&mut it.value);
-    }
-
-    #[inline]
-    pub fn walk_property_key<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut PropertyKey<'a>) {
-        let kind = AstType::PropertyKey;
-        visitor.enter_node(kind);
-        match it {
-            PropertyKey::StaticIdentifier(it) => visitor.visit_identifier_name(it),
-            PropertyKey::PrivateIdentifier(it) => visitor.visit_private_identifier(it),
-            match_expression!(PropertyKey) => visitor.visit_expression(it.to_expression_mut()),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_private_identifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut PrivateIdentifier<'a>,
-    ) {
-        let kind = AstType::PrivateIdentifier;
-        visitor.enter_node(kind);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_rest_element<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut BindingRestElement<'a>,
-    ) {
-        let kind = AstType::BindingRestElement;
-        visitor.enter_node(kind);
-        visitor.visit_binding_pattern(&mut it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_array_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArrayPattern<'a>) {
-        let kind = AstType::ArrayPattern;
-        visitor.enter_node(kind);
-        for elements in it.elements.iter_mut().flatten() {
-            visitor.visit_binding_pattern(elements);
-        }
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_pattern<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut AssignmentPattern<'a>,
-    ) {
-        let kind = AstType::AssignmentPattern;
-        visitor.enter_node(kind);
-        visitor.visit_binding_pattern(&mut it.left);
-        visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_annotation<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeAnnotation<'a>,
-    ) {
-        let kind = AstType::TSTypeAnnotation;
-        visitor.enter_node(kind);
-        visitor.visit_ts_type(&mut it.type_annotation);
         visitor.leave_node(kind);
     }
 
@@ -2117,40 +1982,175 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_type_parameter_declaration<'a, V: VisitMut<'a>>(
+    pub fn walk_formal_parameters<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSTypeParameterDeclaration<'a>,
+        it: &mut FormalParameters<'a>,
     ) {
-        let kind = AstType::TSTypeParameterDeclaration;
+        let kind = AstType::FormalParameters;
         visitor.enter_node(kind);
-        visitor.visit_ts_type_parameters(&mut it.params);
+        visitor.visit_formal_parameter_list(&mut it.items);
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_type_parameters<'a, V: VisitMut<'a>>(
+    pub fn walk_formal_parameter_list<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSTypeParameter<'a>>,
+        it: &mut Vec<'a, FormalParameter<'a>>,
     ) {
         for el in it.iter_mut() {
-            visitor.visit_ts_type_parameter(el);
+            visitor.visit_formal_parameter(el);
         }
     }
 
     #[inline]
-    pub fn walk_ts_type_parameter<'a, V: VisitMut<'a>>(
+    pub fn walk_formal_parameter<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSTypeParameter<'a>,
+        it: &mut FormalParameter<'a>,
     ) {
-        let kind = AstType::TSTypeParameter;
+        let kind = AstType::FormalParameter;
         visitor.enter_node(kind);
-        visitor.visit_binding_identifier(&mut it.name);
-        if let Some(constraint) = &mut it.constraint {
-            visitor.visit_ts_type(constraint);
+        visitor.visit_decorators(&mut it.decorators);
+        visitor.visit_binding_pattern(&mut it.pattern);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_decorators<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Decorator<'a>>) {
+        for el in it.iter_mut() {
+            visitor.visit_decorator(el);
         }
-        if let Some(default) = &mut it.default {
-            visitor.visit_ts_type(default);
+    }
+
+    #[inline]
+    pub fn walk_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
+        let kind = AstType::Decorator;
+        visitor.enter_node(kind);
+        visitor.visit_expression(&mut it.expression);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BindingPattern<'a>) {
+        // NOTE: AstType doesn't exists!
+        visitor.visit_binding_pattern_kind(&mut it.kind);
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
         }
+    }
+
+    #[inline]
+    pub fn walk_binding_pattern_kind<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingPatternKind<'a>,
+    ) {
+        match it {
+            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
+            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
+            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
+            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_object_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectPattern<'a>) {
+        let kind = AstType::ObjectPattern;
+        visitor.enter_node(kind);
+        visitor.visit_binding_properties(&mut it.properties);
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_properties<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, BindingProperty<'a>>,
+    ) {
+        for el in it.iter_mut() {
+            visitor.visit_binding_property(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_binding_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingProperty<'a>,
+    ) {
+        // NOTE: AstType doesn't exists!
+        visitor.visit_property_key(&mut it.key);
+        visitor.visit_binding_pattern(&mut it.value);
+    }
+
+    #[inline]
+    pub fn walk_property_key<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut PropertyKey<'a>) {
+        let kind = AstType::PropertyKey;
+        visitor.enter_node(kind);
+        match it {
+            PropertyKey::StaticIdentifier(it) => visitor.visit_identifier_name(it),
+            PropertyKey::PrivateIdentifier(it) => visitor.visit_private_identifier(it),
+            match_expression!(PropertyKey) => visitor.visit_expression(it.to_expression_mut()),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_private_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PrivateIdentifier<'a>,
+    ) {
+        let kind = AstType::PrivateIdentifier;
+        visitor.enter_node(kind);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_rest_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingRestElement<'a>,
+    ) {
+        let kind = AstType::BindingRestElement;
+        visitor.enter_node(kind);
+        visitor.visit_binding_pattern(&mut it.argument);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_array_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArrayPattern<'a>) {
+        let kind = AstType::ArrayPattern;
+        visitor.enter_node(kind);
+        for elements in it.elements.iter_mut().flatten() {
+            visitor.visit_binding_pattern(elements);
+        }
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_assignment_pattern<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentPattern<'a>,
+    ) {
+        let kind = AstType::AssignmentPattern;
+        visitor.enter_node(kind);
+        visitor.visit_binding_pattern(&mut it.left);
+        visitor.visit_expression(&mut it.right);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_annotation<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeAnnotation<'a>,
+    ) {
+        let kind = AstType::TSTypeAnnotation;
+        visitor.enter_node(kind);
+        visitor.visit_ts_type(&mut it.type_annotation);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -304,10 +304,10 @@ impl<'a> ParserImpl<'a> {
             self.end_span(span),
             expression,
             r#async,
-            params,
-            body,
             type_parameters,
+            params,
             return_type,
+            body,
         ))
     }
 

--- a/crates/oxc_traverse/src/ancestor.rs
+++ b/crates/oxc_traverse/src/ancestor.rs
@@ -151,10 +151,10 @@ pub(crate) enum AncestorType {
     FormalParameterPattern = 119,
     FunctionBodyDirectives = 120,
     FunctionBodyStatements = 121,
-    ArrowFunctionExpressionParams = 122,
-    ArrowFunctionExpressionBody = 123,
-    ArrowFunctionExpressionTypeParameters = 124,
-    ArrowFunctionExpressionReturnType = 125,
+    ArrowFunctionExpressionTypeParameters = 122,
+    ArrowFunctionExpressionParams = 123,
+    ArrowFunctionExpressionReturnType = 124,
+    ArrowFunctionExpressionBody = 125,
     YieldExpressionArgument = 126,
     ClassDecorators = 127,
     ClassId = 128,
@@ -545,14 +545,14 @@ pub enum Ancestor<'a> {
         AncestorType::FunctionBodyDirectives as u16,
     FunctionBodyStatements(FunctionBodyWithoutStatements<'a>) =
         AncestorType::FunctionBodyStatements as u16,
-    ArrowFunctionExpressionParams(ArrowFunctionExpressionWithoutParams<'a>) =
-        AncestorType::ArrowFunctionExpressionParams as u16,
-    ArrowFunctionExpressionBody(ArrowFunctionExpressionWithoutBody<'a>) =
-        AncestorType::ArrowFunctionExpressionBody as u16,
     ArrowFunctionExpressionTypeParameters(ArrowFunctionExpressionWithoutTypeParameters<'a>) =
         AncestorType::ArrowFunctionExpressionTypeParameters as u16,
+    ArrowFunctionExpressionParams(ArrowFunctionExpressionWithoutParams<'a>) =
+        AncestorType::ArrowFunctionExpressionParams as u16,
     ArrowFunctionExpressionReturnType(ArrowFunctionExpressionWithoutReturnType<'a>) =
         AncestorType::ArrowFunctionExpressionReturnType as u16,
+    ArrowFunctionExpressionBody(ArrowFunctionExpressionWithoutBody<'a>) =
+        AncestorType::ArrowFunctionExpressionBody as u16,
     YieldExpressionArgument(YieldExpressionWithoutArgument<'a>) =
         AncestorType::YieldExpressionArgument as u16,
     ClassDecorators(ClassWithoutDecorators<'a>) = AncestorType::ClassDecorators as u16,
@@ -1266,10 +1266,10 @@ impl<'a> Ancestor<'a> {
     pub fn is_arrow_function_expression(&self) -> bool {
         matches!(
             self,
-            Self::ArrowFunctionExpressionParams(_)
-                | Self::ArrowFunctionExpressionBody(_)
-                | Self::ArrowFunctionExpressionTypeParameters(_)
+            Self::ArrowFunctionExpressionTypeParameters(_)
+                | Self::ArrowFunctionExpressionParams(_)
                 | Self::ArrowFunctionExpressionReturnType(_)
+                | Self::ArrowFunctionExpressionBody(_)
         )
     }
 
@@ -5856,136 +5856,16 @@ pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_EXPRESSION: usize =
     offset_of!(ArrowFunctionExpression, expression);
 pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_ASYNC: usize =
     offset_of!(ArrowFunctionExpression, r#async);
-pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS: usize =
-    offset_of!(ArrowFunctionExpression, params);
-pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_BODY: usize =
-    offset_of!(ArrowFunctionExpression, body);
 pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS: usize =
     offset_of!(ArrowFunctionExpression, type_parameters);
+pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS: usize =
+    offset_of!(ArrowFunctionExpression, params);
 pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE: usize =
     offset_of!(ArrowFunctionExpression, return_type);
+pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_BODY: usize =
+    offset_of!(ArrowFunctionExpression, body);
 pub(crate) const OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID: usize =
     offset_of!(ArrowFunctionExpression, scope_id);
-
-#[repr(transparent)]
-#[derive(Debug)]
-pub struct ArrowFunctionExpressionWithoutParams<'a>(pub(crate) *const ArrowFunctionExpression<'a>);
-
-impl<'a> ArrowFunctionExpressionWithoutParams<'a> {
-    #[inline]
-    pub fn span(&self) -> &Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn expression(&self) -> &bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_EXPRESSION)
-                as *const bool)
-        }
-    }
-
-    #[inline]
-    pub fn r#async(&self) -> &bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_ASYNC) as *const bool)
-        }
-    }
-
-    #[inline]
-    pub fn body(&self) -> &Box<'a, FunctionBody<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(&self) -> &Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Debug)]
-pub struct ArrowFunctionExpressionWithoutBody<'a>(pub(crate) *const ArrowFunctionExpression<'a>);
-
-impl<'a> ArrowFunctionExpressionWithoutBody<'a> {
-    #[inline]
-    pub fn span(&self) -> &Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn expression(&self) -> &bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_EXPRESSION)
-                as *const bool)
-        }
-    }
-
-    #[inline]
-    pub fn r#async(&self) -> &bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_ASYNC) as *const bool)
-        }
-    }
-
-    #[inline]
-    pub fn params(&self) -> &Box<'a, FormalParameters<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(&self) -> &Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
 
 #[repr(transparent)]
 #[derive(Debug)]
@@ -6025,6 +5905,14 @@ impl<'a> ArrowFunctionExpressionWithoutTypeParameters<'a> {
     }
 
     #[inline]
+    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
     pub fn body(&self) -> &Box<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
@@ -6033,10 +5921,62 @@ impl<'a> ArrowFunctionExpressionWithoutTypeParameters<'a> {
     }
 
     #[inline]
+    pub fn scope_id(&self) -> &Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct ArrowFunctionExpressionWithoutParams<'a>(pub(crate) *const ArrowFunctionExpression<'a>);
+
+impl<'a> ArrowFunctionExpressionWithoutParams<'a> {
+    #[inline]
+    pub fn span(&self) -> &Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn expression(&self) -> &bool {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_EXPRESSION)
+                as *const bool)
+        }
+    }
+
+    #[inline]
+    pub fn r#async(&self) -> &bool {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_ASYNC) as *const bool)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
     pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
                 as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(&self) -> &Box<'a, FunctionBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
+                as *const Box<'a, FunctionBody<'a>>)
         }
     }
 
@@ -6079,6 +6019,14 @@ impl<'a> ArrowFunctionExpressionWithoutReturnType<'a> {
     }
 
     #[inline]
+    pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
     pub fn params(&self) -> &Box<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
@@ -6095,10 +6043,62 @@ impl<'a> ArrowFunctionExpressionWithoutReturnType<'a> {
     }
 
     #[inline]
+    pub fn scope_id(&self) -> &Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct ArrowFunctionExpressionWithoutBody<'a>(pub(crate) *const ArrowFunctionExpression<'a>);
+
+impl<'a> ArrowFunctionExpressionWithoutBody<'a> {
+    #[inline]
+    pub fn span(&self) -> &Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn expression(&self) -> &bool {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_EXPRESSION)
+                as *const bool)
+        }
+    }
+
+    #[inline]
+    pub fn r#async(&self) -> &bool {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_ASYNC) as *const bool)
+        }
+    }
+
+    #[inline]
     pub fn type_parameters(&self) -> &Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn params(&self) -> &Box<'a, FormalParameters<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
+                as *const Box<'a, FormalParameters<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn return_type(&self) -> &Option<Box<'a, TSTypeAnnotation<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
+                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
         }
     }
 

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -2392,29 +2392,22 @@ pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
         ctx.set_current_scope_id(scope_id);
     }
     traverser.enter_arrow_function_expression(&mut *node, ctx);
-    ctx.push_stack(Ancestor::ArrowFunctionExpressionParams(
-        ancestor::ArrowFunctionExpressionWithoutParams(node),
+    ctx.push_stack(Ancestor::ArrowFunctionExpressionTypeParameters(
+        ancestor::ArrowFunctionExpressionWithoutTypeParameters(node),
     ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ArrowFunctionExpressionParams);
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
             as *mut Box<FormalParameters>)) as *mut _,
         ctx,
     );
-    ctx.retag_stack(AncestorType::ArrowFunctionExpressionBody);
-    walk_function_body(
-        traverser,
-        (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-            as *mut Box<FunctionBody>)) as *mut _,
-        ctx,
-    );
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
-    {
-        ctx.retag_stack(AncestorType::ArrowFunctionExpressionTypeParameters);
-        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
-    }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
         as *mut Option<Box<TSTypeAnnotation>>)
@@ -2422,6 +2415,13 @@ pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::ArrowFunctionExpressionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
+    ctx.retag_stack(AncestorType::ArrowFunctionExpressionBody);
+    walk_function_body(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
+            as *mut Box<FunctionBody>)) as *mut _,
+        ctx,
+    );
     ctx.pop_stack();
     traverser.exit_arrow_function_expression(&mut *node, ctx);
     if let Some(previous_scope_id) = previous_scope_id {


### PR DESCRIPTION
Found in #4328
Same as #4248
