### PR TITLE
fix(semantic): align `visit_arrow_function_expression` field visit order with ast

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1571,6 +1571,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_node(kind);
         self.enter_scope(ScopeFlags::Function | ScopeFlags::Arrow, &expr.scope_id);
 
+        if let Some(parameters) = &expr.type_parameters {
+            self.visit_ts_type_parameter_declaration(parameters);
+        }
+
         self.visit_formal_parameters(&expr.params);
 
         /* cfg */
@@ -1580,6 +1584,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             EdgeType::NewFunction
         ));
         /* cfg */
+
+        if let Some(return_type) = &expr.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
 
         self.visit_function_body(&expr.body);
 
@@ -1592,9 +1600,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         });
         /* cfg */
 
-        if let Some(parameters) = &expr.type_parameters {
-            self.visit_ts_type_parameter_declaration(parameters);
-        }
         self.leave_node(kind);
         self.leave_scope();
     }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -12,15 +12,8 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
-            "id": 1,
-            "name": "x",
-            "node": "VariableDeclarator",
-            "references": []
-          },
-          {
             "flag": "SymbolFlags(TypeParameter)",
-            "id": 2,
+            "id": 1,
             "name": "T",
             "node": "TSTypeParameter",
             "references": [
@@ -28,9 +21,16 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flag": "ReferenceFlag(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 13
+                "node_id": 16
               }
             ]
+          },
+          {
+            "flag": "SymbolFlags(BlockScopedVariable)",
+            "id": 2,
+            "name": "x",
+            "node": "VariableDeclarator",
+            "references": []
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -12,17 +12,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
-            "id": 1,
-            "name": "a",
-            "node": "FormalParameter",
-            "references": []
-          },
-          {
             "flag": "SymbolFlags(TypeParameter)",
-            "id": 2,
+            "id": 1,
             "name": "T",
             "node": "TSTypeParameter",
+            "references": [
+              {
+                "flag": "ReferenceFlag(Type)",
+                "id": 0,
+                "name": "T",
+                "node_id": 14
+              }
+            ]
+          },
+          {
+            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "id": 2,
+            "name": "a",
+            "node": "FormalParameter",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -16,7 +16,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter",
-            "references": []
+            "references": [
+              {
+                "flag": "ReferenceFlag(Type)",
+                "id": 0,
+                "name": "T",
+                "node_id": 12
+              }
+            ]
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flag": "ReferenceFlag(Type)",
                 "id": 0,
                 "name": "T",
-                "node_id": 14
+                "node_id": 12
               }
             ]
           },

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -37,7 +37,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Type)",
+            "id": 0,
+            "name": "T",
+            "node_id": 18
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flag": "ReferenceFlag(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 14
+                "node_id": 18
               }
             ]
           }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
                 "flag": "ReferenceFlag(Read)",
                 "id": 0,
                 "name": "arg",
-                "node_id": 17
+                "node_id": 23
               }
             ]
           }
@@ -44,7 +44,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
-        "references": []
+        "references": [
+          {
+            "flag": "ReferenceFlag(Type)",
+            "id": 0,
+            "name": "T",
+            "node_id": 18
+          }
+        ]
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",


### PR DESCRIPTION
related: #4364 