### PR TITLE
perf(semantic): calculate number of nodes, scopes, symbols, references before visiting AST

### DIFF
--- a/crates/oxc_semantic/src/counter.rs
+++ b/crates/oxc_semantic/src/counter.rs
@@ -1,0 +1,90 @@
+//! Visitor to count nodes, scopes, symbols and references in AST.
+//! These counts can be used to pre-allocate sufficient capacity in `AstNodes`,
+//! `ScopeTree`, and `SymbolTable` to store info for all these items.
+
+use std::cell::Cell;
+
+use oxc_ast::{
+    ast::{
+        BindingIdentifier, IdentifierReference, JSXElementName, JSXMemberExpressionObject,
+        TSEnumMemberName, TSModuleDeclarationName,
+    },
+    visit::walk::{walk_ts_enum_member_name, walk_ts_module_declaration_name},
+    AstKind, Visit,
+};
+use oxc_syntax::scope::{ScopeFlags, ScopeId};
+
+#[allow(clippy::struct_field_names)]
+#[derive(Default, Debug)]
+pub struct Counter {
+    pub nodes_count: usize,
+    pub scopes_count: usize,
+    pub symbols_count: usize,
+    pub references_count: usize,
+}
+
+impl<'a> Visit<'a> for Counter {
+    #[inline]
+    fn enter_node(&mut self, _: AstKind<'a>) {
+        self.nodes_count += 1;
+    }
+    #[inline]
+    fn enter_scope(&mut self, _: ScopeFlags, _: &Cell<Option<ScopeId>>) {
+        self.scopes_count += 1;
+    }
+
+    #[inline]
+    fn visit_binding_identifier(&mut self, _: &BindingIdentifier<'a>) {
+        self.nodes_count += 1;
+        self.symbols_count += 1;
+    }
+
+    #[inline]
+    fn visit_identifier_reference(&mut self, _: &IdentifierReference<'a>) {
+        self.nodes_count += 1;
+        self.references_count += 1;
+    }
+
+    #[inline]
+    fn visit_jsx_member_expression_object(&mut self, it: &JSXMemberExpressionObject<'a>) {
+        self.nodes_count += 1;
+        match it {
+            JSXMemberExpressionObject::MemberExpression(expr) => {
+                self.visit_jsx_member_expression(expr);
+            }
+            JSXMemberExpressionObject::Identifier(_) => {
+                self.nodes_count += 1;
+                self.references_count += 1;
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_jsx_element_name(&mut self, it: &JSXElementName<'a>) {
+        self.nodes_count += 1;
+        match it {
+            JSXElementName::Identifier(ident) => {
+                self.nodes_count += 1;
+                if ident.name.chars().next().is_some_and(char::is_uppercase) {
+                    self.references_count += 1;
+                }
+            }
+            JSXElementName::NamespacedName(name) => self.visit_jsx_namespaced_name(name),
+            JSXElementName::MemberExpression(expr) => self.visit_jsx_member_expression(expr),
+        }
+    }
+
+    #[inline]
+    fn visit_ts_enum_member_name(&mut self, it: &TSEnumMemberName<'a>) {
+        if !it.is_expression() {
+            self.symbols_count += 1;
+        }
+        walk_ts_enum_member_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_module_declaration_name(&mut self, it: &TSModuleDeclarationName<'a>) {
+        self.symbols_count += 1;
+        walk_ts_module_declaration_name(self, it);
+    }
+}

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -2,6 +2,7 @@ mod binder;
 mod builder;
 mod checker;
 mod class;
+mod counter;
 mod diagnostics;
 mod jsdoc;
 mod label;

--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -171,6 +171,11 @@ impl<'a> AstNodes<'a> {
         self.nodes.push(node);
         ast_node_id
     }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.nodes.reserve(additional);
+        self.parent_ids.reserve(additional);
+    }
 }
 
 #[derive(Debug)]

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -236,4 +236,12 @@ impl ScopeTree {
     pub fn remove_binding(&mut self, scope_id: ScopeId, name: &CompactStr) {
         self.bindings[scope_id].shift_remove(name);
     }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.parent_ids.reserve(additional);
+        self.child_ids.reserve(additional);
+        self.flags.reserve(additional);
+        self.bindings.reserve(additional);
+        self.node_ids.reserve(additional);
+    }
 }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -193,4 +193,16 @@ impl SymbolTable {
             _ => false,
         }
     }
+
+    pub fn reserve(&mut self, additional_symbols: usize, additional_references: usize) {
+        self.spans.reserve(additional_symbols);
+        self.names.reserve(additional_symbols);
+        self.flags.reserve(additional_symbols);
+        self.scope_ids.reserve(additional_symbols);
+        self.declarations.reserve(additional_symbols);
+        self.resolved_references.reserve(additional_symbols);
+        self.redeclare_variables.reserve(additional_symbols);
+
+        self.references.reserve(additional_references);
+    }
 }


### PR DESCRIPTION
context: #4328 