### PR TITLE
fix(semantic): `visit_program` visit `hashbang` field

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -553,6 +553,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             &program.scope_id,
         );
 
+        if let Some(hashbang) = &program.hashbang {
+            self.visit_hashbang(hashbang);
+        }
+
         for directive in &program.directives {
             self.visit_directive(directive);
         }


### PR DESCRIPTION
The visit was missing previously, though it didn't matter, because semantic doesn't do anything with `Hashbang` anyway. But is needed for #4367.

Edit: It also should have an entry in `AstNodes`, which it didn't previously.