### PR TITLE
feat(semantic): add `Symbol`

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -32,7 +32,7 @@ use rustc_hash::FxHashSet;
 pub use crate::{
     reference::{Reference, ReferenceFlag, ReferenceId},
     scope::ScopeTree,
-    symbol::SymbolTable,
+    symbol::{Symbol, SymbolTable},
 };
 
 pub struct Semantic<'a> {
@@ -60,6 +60,10 @@ pub struct Semantic<'a> {
 }
 
 impl<'a> Semantic<'a> {
+    pub fn get_symbol(&self, symbol_id: SymbolId) -> Symbol<'_, 'a> {
+        Symbol::new(self, symbol_id)
+    }
+
     pub fn into_symbol_table_and_scope_tree(self) -> (SymbolTable, ScopeTree) {
         (self.symbols, self.scopes)
     }


### PR DESCRIPTION
# What This PR Does

Adds `Symbol`, which is a thin abstraction over `Semantic` for interacting with a specific symbol. It basically just wraps a `SymbolId`, making it a little nicer to interact with the symbol table.