### PR TITLE
perf(linter): disable lint rules by file type

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -116,10 +116,10 @@ impl Linter {
         let ctx = self.create_ctx(path, semantic);
         let semantic = Rc::clone(ctx.semantic());
 
-        let ctx = ctx.with_fix(self.options.fix).with_eslint_config(&self.eslint_config);
         let rules = self
             .rules
             .iter()
+            .filter(|rule| rule.should_run(&ctx))
             .map(|rule| {
                 let rule_name = rule.name();
                 let plugin_name = self.map_jest(rule.plugin_name(), rule_name);

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -22,6 +22,17 @@ pub trait Rule: Sized + Default + fmt::Debug {
 
     /// Run only once. Useful for inspecting scopes and trivias etc.
     fn run_once(&self, _ctx: &LintContext) {}
+
+    /// Check if a rule should be run at all.
+    ///
+    /// You usually do not need to implement this function. If you do, use it to
+    /// enable rules on a file-by-file basis. Do not check if plugins are
+    /// enabled/disabled; this is handled by the [`linter`].
+    ///
+    /// [`linter`]: crate::Linter
+    fn should_run(&self, _ctx: &LintContext) -> bool {
+        true
+    }
 }
 
 pub trait RuleMeta {

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -146,6 +146,10 @@ impl Rule for ButtonHasType {
                 .unwrap_or(true),
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 impl ButtonHasType {

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -63,6 +63,10 @@ impl Rule for JsxKey {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 enum InsideArrayOrIterator {

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -60,6 +60,10 @@ impl Rule for JsxNoCommentTextnodes {
             ctx.diagnostic(jsx_no_comment_textnodes_diagnostic(jsx_text.span));
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 fn control_patterns(pattern: &str) -> bool {

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -69,6 +69,10 @@ impl Rule for JsxNoDuplicateProps {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -243,6 +243,10 @@ impl Rule for JsxNoTargetBlank {
                 .unwrap_or(false),
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 fn check_is_external_link(link: &str) -> bool {

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -72,6 +72,10 @@ impl Rule for JsxNoUndef {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -74,6 +74,10 @@ impl Rule for JsxNoUselessFragment {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 impl JsxNoUselessFragment {

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -85,6 +85,10 @@ impl Rule for NoChildrenProp {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -74,6 +74,10 @@ impl Rule for NoDanger {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -117,6 +117,10 @@ impl Rule for NoDirectMutationState {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 // check current node is this.state.xx

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -66,6 +66,10 @@ impl Rule for NoFindDomNode {
         };
         ctx.diagnostic(no_find_dom_node_diagnostic(span));
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -66,6 +66,10 @@ impl Rule for NoIsMounted {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -78,6 +78,10 @@ impl Rule for NoRenderReturnValue {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -71,6 +71,10 @@ impl Rule for NoSetState {
 
         ctx.diagnostic(no_set_state_diagnostic(call_expr.callee.span()));
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -127,6 +127,10 @@ impl Rule for NoStringRefs {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -61,6 +61,10 @@ impl Rule for NoUnescapedEntities {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 pub const DEFAULTS: Map<char, &'static [&'static str]> = phf_map! {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -529,6 +529,10 @@ impl Rule for NoUnknownProperty {
                     );
             });
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -74,6 +74,10 @@ impl Rule for PreferEs6Class {
             ));
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -54,6 +54,10 @@ impl Rule for ReactInJsxScope {
             ctx.diagnostic(react_in_jsx_scope_diagnostic(node_span));
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -78,6 +78,10 @@ impl Rule for RequireRenderReturn {
             };
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -137,6 +137,10 @@ impl Rule for VoidDomElementsNoChildren {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -42,6 +42,10 @@ impl Rule for JsxNoJsxAsProp {
             check_jsx_element(jsx_elem, ctx);
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 fn check_jsx_element<'a>(jsx_elem: &JSXElement<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -50,6 +50,10 @@ impl Rule for JsxNoNewArrayAsProp {
             check_jsx_element(jsx_elem, ctx);
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 fn check_jsx_element<'a>(jsx_elem: &JSXElement<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -45,6 +45,10 @@ impl Rule for JsxNoNewFunctionAsProp {
             check_jsx_element(jsx_elem, ctx);
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 fn check_jsx_element<'a>(jsx_elem: &JSXElement<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -49,6 +49,10 @@ impl Rule for JsxNoNewObjectAsProp {
             check_jsx_element(jsx_elem, ctx);
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_jsx()
+    }
 }
 
 fn check_jsx_element<'a>(jsx_elem: &JSXElement<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -319,6 +319,10 @@ impl Rule for AdjacentOverloadSignatures {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -126,6 +126,10 @@ impl Rule for ArrayType {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn check(

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -204,6 +204,10 @@ impl Rule for BanTsComment {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 impl BanTsComment {

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -83,6 +83,10 @@ impl Rule for BanTypes {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -244,6 +244,10 @@ impl Rule for ConsistentIndexedObjectStyle {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -214,6 +214,10 @@ impl Rule for ConsistentTypeDefinitions {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -266,6 +266,10 @@ impl Rule for ConsistentTypeImports {
             );
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 // Given an array of words, returns an English-friendly concatenation, separated with commas, with

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -249,6 +249,10 @@ impl Rule for ExplicitFunctionReturnType {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 impl ExplicitFunctionReturnType {

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -92,6 +92,10 @@ impl Rule for NoConfusingNonNullAssertion {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -64,6 +64,10 @@ impl Rule for NoDuplicateEnumValues {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -68,6 +68,10 @@ impl Rule for NoEmptyInterface {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -112,6 +112,10 @@ impl Rule for NoExplicitAny {
 
         Self { fix_to_unknown, ignore_rest_args }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 impl NoExplicitAny {

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -64,6 +64,10 @@ impl Rule for NoExtraNonNullAssertion {
             ctx.diagnostic(no_extra_non_null_assertion_diagnostic(Span::new(end, end)));
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -109,6 +109,10 @@ impl Rule for NoImportTypeSideEffects {
             },
         );
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -98,6 +98,10 @@ impl Rule for NoNamespace {
             ctx.diagnostic(no_namespace_diagnostic(span));
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn is_declaration(node: &AstNode, ctx: &LintContext) -> bool {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -47,6 +47,10 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
 
         ctx.diagnostic(no_non_null_asserted_nullish_coalescing_diagnostic(ts_non_null_expr.span));
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 fn has_assignment_before_node(
     symbol_id: SymbolId,

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -88,6 +88,10 @@ impl Rule for NoNonNullAssertedOptionalChain {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn is_parent_member_or_call(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -36,6 +36,10 @@ impl Rule for NoNonNullAssertion {
         let AstKind::TSNonNullExpression(expr) = node.kind() else { return };
         ctx.diagnostic(no_non_null_assertion_diagnostic(expr.span));
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -87,9 +87,6 @@ impl Rule for NoThisAlias {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !ctx.source_type().is_typescript() {
-            return;
-        }
         match node.kind() {
             AstKind::VariableDeclarator(decl) => {
                 let Some(init) = &decl.init else { return };
@@ -145,6 +142,9 @@ impl Rule for NoThisAlias {
             }
             _ => {}
         }
+    }
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -67,6 +67,10 @@ impl Rule for NoUnnecessaryTypeConstraint {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -36,10 +36,6 @@ declare_oxc_lint!(
 
 impl Rule for NoUnsafeDeclarationMerging {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !ctx.source_type().is_typescript() {
-            return;
-        }
-
         match node.kind() {
             AstKind::Class(decl) => {
                 if let Some(ident) = decl.id.as_ref() {
@@ -63,6 +59,10 @@ impl Rule for NoUnsafeDeclarationMerging {
             }
             _ => {}
         }
+    }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -34,9 +34,6 @@ declare_oxc_lint!(
 
 impl Rule for NoVarRequires {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !ctx.source_type().is_typescript() {
-            return;
-        }
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };
@@ -67,6 +64,10 @@ impl Rule for NoVarRequires {
                 ctx.diagnostic(no_var_requires_diagnostic(node.kind().span()));
             }
         }
+    }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -80,6 +80,10 @@ impl Rule for PreferAsConst {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn check_and_report(

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -51,6 +51,10 @@ impl Rule for PreferEnumInitializers {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -392,6 +392,10 @@ impl Rule for PreferFunctionType {
             _ => {}
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -108,6 +108,10 @@ impl Rule for PreferLiteralEnumMember {
 
         ctx.diagnostic(prefer_literal_enum_member_diagnostic(decl.span));
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -71,6 +71,10 @@ impl Rule for PreferTsExpectError {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn get_last_comment_line(comment: CommentKind, raw: &str) -> String {

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -162,6 +162,10 @@ impl Rule for TripleSlashReference {
             }
         }
     }
+
+    fn should_run(&self, ctx: &LintContext) -> bool {
+        ctx.source_type().is_typescript()
+    }
 }
 
 fn get_attr_key_and_value(raw: &str) -> Option<(String, String)> {

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -118,6 +118,12 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                     #(Self::#struct_names(rule) => rule.run_once(ctx)),*
                 }
             }
+
+            pub(super) fn should_run(&self, ctx: &LintContext) -> bool {
+                match self {
+                    #(Self::#struct_names(rule) => rule.should_run(ctx)),*
+                }
+            }
         }
 
         impl std::hash::Hash for RuleEnum {


### PR DESCRIPTION
### TL;DR

Added a `should_run` function to multiple lint rules to determine if a rule should be executed based on the source type. This change optimizes the linting process by avoiding unnecessary rule checks.

### What changed?

1. **New Method**: Introduced the `should_run` method in the `Rule` trait.
2. **Implementation**: Implemented the `should_run` method for various lint rules, particularly those related to React and TypeScript.
3. **Usage**: Updated the `Linter` to use the `should_run` method to filter rules before execution.
4. **Macro Update**: Modified the `declare_all_lint_rules` macro to incorporate the `should_run` method.

### How to test?

1. Run the linter on a project containing React and TypeScript files.
2. Verify that only relevant rules are executed based on the file type (e.g., JSX rules for React files).

### Why make this change?

This change improves the performance of the linter by ensuring that only applicable rules are run for a given file type, reducing unnecessary computation and potential false positives.

---

