### PR TITLE
perf(semantic): remove a branch from `add_scope`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -189,7 +189,7 @@ impl<'a> SemanticBuilder<'a> {
     /// # Panics
     pub fn build(mut self, program: &Program<'a>) -> SemanticBuilderReturn<'a> {
         if self.source_type.is_typescript_definition() {
-            let scope_id = self.scope.add_scope(None, AstNodeId::DUMMY, ScopeFlags::Top);
+            let scope_id = self.scope.add_root_scope(AstNodeId::DUMMY, ScopeFlags::Top);
             program.scope_id.set(Some(scope_id));
         } else {
             self.visit_program(program);
@@ -471,8 +471,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         };
         flags = self.scope.get_new_scope_flags(flags, parent_scope_id);
 
-        self.current_scope_id =
-            self.scope.add_scope(Some(parent_scope_id), self.current_node_id, flags);
+        self.current_scope_id = self.scope.add_scope(parent_scope_id, self.current_node_id, flags);
         scope_id.set(Some(self.current_scope_id));
 
         if self.scope.get_flags(parent_scope_id).is_catch_clause() {
@@ -553,7 +552,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if program.is_strict() {
             flags |= ScopeFlags::StrictMode;
         }
-        self.current_scope_id = self.scope.add_scope(None, self.current_node_id, flags);
+        self.current_scope_id = self.scope.add_root_scope(self.current_node_id, flags);
         program.scope_id.set(Some(self.current_scope_id));
 
         if let Some(hashbang) = &program.hashbang {

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -121,7 +121,7 @@ impl TraverseScoping {
     /// `flags` provided are amended to inherit from parent scope's flags.
     pub fn create_scope_child_of_current(&mut self, flags: ScopeFlags) -> ScopeId {
         let flags = self.scopes.get_new_scope_flags(flags, self.current_scope_id);
-        self.scopes.add_scope(Some(self.current_scope_id), AstNodeId::DUMMY, flags)
+        self.scopes.add_scope(self.current_scope_id, AstNodeId::DUMMY, flags)
     }
 
     /// Insert a scope into scope tree below a statement.


### PR DESCRIPTION
Similar to #4361.

`ScopeTree::add_scope` had a branch specifically to handle `Program`. Remove that by inlining the special logic for `Program` into `visit_program`.

Probably won't have much effect on benchmarks as the branch is easy to predict, but still removes a few instructions and makes `add_scope` easier for compiler to inline.