### PR TITLE
chore: format `.cargo/config.toml`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,12 @@
 [alias]
 # Do not append `--` or it will break IDEs
-ck = "check --workspace --all-features --all-targets --locked"
-lint = "clippy --workspace --all-targets --all-features"
-codecov = "llvm-cov --workspace --ignore-filename-regex tasks"
-coverage = "run -p oxc_coverage --profile release-thin --"
+ck        = "check --workspace --all-features --all-targets --locked"
+lint      = "clippy --workspace --all-targets --all-features"
+codecov   = "llvm-cov --workspace --ignore-filename-regex tasks"
+coverage  = "run -p oxc_coverage --profile release-thin --"
 benchmark = "run -p oxc_benchmark --release --"
-minsize = "run -p oxc_minsize --release --"
-rule = "run -p rulegen"
+minsize   = "run -p oxc_minsize --release --"
+rule      = "run -p rulegen"
 
 # Build oxlint in release mode
 oxlint = "build --release --bin oxlint --features allocator"


### PR DESCRIPTION
Fix indentation in `.cargo/config.toml`.