### PR TITLE
ci: run conformance with debug assertions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 ck        = "check --workspace --all-features --all-targets --locked"
 lint      = "clippy --workspace --all-targets --all-features"
 codecov   = "llvm-cov --workspace --ignore-filename-regex tasks"
-coverage  = "run -p oxc_coverage --profile release-thin --"
+coverage  = "run -p oxc_coverage --profile coverage --"
 benchmark = "run -p oxc_benchmark --release --"
 minsize   = "run -p oxc_minsize --release --"
 rule      = "run -p rulegen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,8 @@ strip         = "symbols" # set to `false` for debug information
 debug         = false # set to `true` for debug information
 panic         = "abort" # Let it crash and force ourselves to write safe Rust.
 
-# Faster compile time with thin lto
-[profile.release-thin]
-inherits = "release"
-lto      = "thin"
+# Profile for `cargo coverage`
+[profile.coverage]
+inherits         = "release"
+lto              = "thin" # Faster compile time with thin lto
+debug-assertions = true # Make sure `debug_assert!`s pass


### PR DESCRIPTION
Run conformance with debug assertions enabled to ensure `debug_assert!`s pass.