### PR TITLE
perf(semantic): grow `unresolved_references` by doubling

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -495,6 +495,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             }
             grow(self);
         }
+
+        // Dummy comment to re-run benchmarks
     }
 
     // NB: Not called for `Program`

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -495,8 +495,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             }
             grow(self);
         }
-
-        // Dummy comment to re-run benchmarks
     }
 
     // NB: Not called for `Program`


### PR DESCRIPTION
Grow stack of unresolved references by doubling rather than incrementing. This will initialize more entries than required in some cases, but in return it makes the branch on when to grow more predictable.