### PR TITLE
refactor(ast_codegen): use `stringify` for generators names.

### DIFF
--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -23,7 +23,7 @@ pub struct AstBuilderGenerator;
 
 impl Generator for AstBuilderGenerator {
     fn name(&self) -> &'static str {
-        "AstBuilderGenerator"
+        stringify!(AstBuilderGenerator)
     }
 
     fn generate(&mut self, ctx: &CodegenCtx) -> GeneratorOutput {

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -133,7 +133,7 @@ pub fn process_types(ty: &TypeRef) -> Vec<(Ident, Type)> {
 
 impl Generator for AstKindGenerator {
     fn name(&self) -> &'static str {
-        "AstKindGenerator"
+        stringify!(AstKindGenerator)
     }
 
     fn generate(&mut self, ctx: &CodegenCtx) -> GeneratorOutput {

--- a/tasks/ast_codegen/src/generators/impl_get_span.rs
+++ b/tasks/ast_codegen/src/generators/impl_get_span.rs
@@ -17,7 +17,7 @@ pub struct ImplGetSpanGenerator;
 
 impl Generator for ImplGetSpanGenerator {
     fn name(&self) -> &'static str {
-        "ImplGetSpanGenerator"
+        stringify!(ImplGetSpanGenerator)
     }
 
     fn generate(&mut self, ctx: &CodegenCtx) -> GeneratorOutput {

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -37,7 +37,7 @@ pub struct VisitMutGenerator;
 
 impl Generator for VisitGenerator {
     fn name(&self) -> &'static str {
-        "VisitGenerator"
+        stringify!(VisitGenerator)
     }
 
     fn generate(&mut self, ctx: &CodegenCtx) -> GeneratorOutput {
@@ -47,7 +47,7 @@ impl Generator for VisitGenerator {
 
 impl Generator for VisitMutGenerator {
     fn name(&self) -> &'static str {
-        "VisitMutGenerator"
+        stringify!(VisitMutGenerator)
     }
 
     fn generate(&mut self, ctx: &CodegenCtx) -> GeneratorOutput {


### PR DESCRIPTION
The generator name is always the same as its identifier so this PR changes all `"<generator_ident>"` to `stringify!(<generator_ident>)`