### PR TITLE
example(semantic): examples print parser errors

### DIFF
--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -37,15 +37,26 @@ fn main() -> std::io::Result<()> {
     let source_text = Arc::new(std::fs::read_to_string(test_file_path)?);
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(test_file_path).unwrap();
-    let ret = Parser::new(&allocator, &source_text, source_type).parse();
+    let parser_ret = Parser::new(&allocator, &source_text, source_type).parse();
 
-    let program = allocator.alloc(ret.program);
+    if !parser_ret.errors.is_empty() {
+        let error_message: String = parser_ret
+            .errors
+            .into_iter()
+            .map(|error| error.with_source_code(Arc::clone(&source_text)).to_string())
+            .join("\n\n");
+
+        println!("Parsing failed:\n\n{error_message}",);
+        return Ok(());
+    }
+
+    let program = allocator.alloc(parser_ret.program);
     std::fs::write(ast_file_path, format!("{:#?}", &program))?;
     println!("Wrote AST to: {}", &ast_file_name);
 
     let semantic = SemanticBuilder::new(&source_text, source_type)
         .with_check_syntax_error(true)
-        .with_trivias(ret.trivias)
+        .with_trivias(parser_ret.trivias)
         .with_cfg(true)
         .build(program);
 

--- a/crates/oxc_semantic/examples/simple.rs
+++ b/crates/oxc_semantic/examples/simple.rs
@@ -18,13 +18,24 @@ fn main() -> std::io::Result<()> {
     let source_text = Arc::new(std::fs::read_to_string(path)?);
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
-    let ret = Parser::new(&allocator, &source_text, source_type).parse();
+    let parser_ret = Parser::new(&allocator, &source_text, source_type).parse();
 
-    let program = allocator.alloc(ret.program);
+    if !parser_ret.errors.is_empty() {
+        let error_message: String = parser_ret
+            .errors
+            .into_iter()
+            .map(|error| error.with_source_code(Arc::clone(&source_text)).to_string())
+            .join("\n\n");
+
+        println!("Parsing failed:\n\n{error_message}",);
+        return Ok(());
+    }
+
+    let program = allocator.alloc(parser_ret.program);
 
     let semantic = SemanticBuilder::new(&source_text, source_type)
         .with_check_syntax_error(true)
-        .with_trivias(ret.trivias)
+        .with_trivias(parser_ret.trivias)
         .build(program);
 
     if !semantic.errors.is_empty() {


### PR DESCRIPTION
Examples for `Semantic` print parser errors if parsing fails.