### PR TITLE
refactor(semantic): change initial size of unresolved references stack to 4

### DIFF
--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -16,12 +16,9 @@ pub(crate) struct UnresolvedReferencesStack {
 }
 
 impl UnresolvedReferencesStack {
-    // Most programs will have at least 1 place where scope depth reaches 16,
-    // so initialize `stack` with this length, to reduce reallocations as it grows.
-    // This is just an estimate of a good initial size, but certainly better than
-    // `Vec`'s default initial capacity of 4.
+    // This is just an estimate of a good initial size.
     // SAFETY: Must be >= 2 to ensure soundness of `current_and_parent_mut`.
-    const INITIAL_SIZE: usize = 16;
+    const INITIAL_SIZE: usize = 4;
     // Initial scope depth.
     // Start on 1 (`Program` scope depth).
     // SAFETY: Must be >= 1 to ensure soundness of `current_and_parent_mut`.


### PR DESCRIPTION
Reduce initial size of `UnresolvedReferencesStack` to 4 (rather than 16).

Our [RadixUIAdoptionSection.jsx](https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx) benchmark only contains a single function. Stack has 3 levels in this case:

1. Root (unbound references e.g. `window`)
2. Program
3. Function

I think this will be quite a common pattern for e.g. React apps:

```js
import React from 'react';
export function Greeting() {
  return <>
    <div>Hello {name}</div>
    {
      name === 'Greg'
      && <div>But I can't say I'm pleased to see you.</div>
    }
  </>;
}
```

Even if the component is quite complex, often it will not introduce any scopes beyond a single function.

Files with much deeper scope nesting will also tend to be larger files, in which case growing the stack a few times will be a drop in the ocean.