### PR TITLE
chore: fix failed publish caused by cyclic dev dependencies 

### DIFF
--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -28,7 +28,7 @@ oxc_index    = { workspace = true }
 itertools    = { workspace = true }
 
 [dev-dependencies]
-oxc_codegen   = { workspace = true }
+oxc_codegen   = { path = "../oxc_codegen" }
 oxc_parser    = { workspace = true }
 oxc_span      = { workspace = true }
 oxc_allocator = { workspace = true }

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -28,6 +28,8 @@ oxc_index    = { workspace = true }
 itertools    = { workspace = true }
 
 [dev-dependencies]
+# Workaround for https://github.com/rust-lang/cargo/issues/4242
+# ref: https://github.com/rust-lang/futures-rs/pull/2305
 oxc_codegen   = { path = "../oxc_codegen" }
 oxc_parser    = { workspace = true }
 oxc_span      = { workspace = true }

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -28,7 +28,7 @@ oxc_index    = { workspace = true }
 itertools    = { workspace = true }
 
 [dev-dependencies]
-# Workaround for https://github.com/rust-lang/cargo/issues/4242
+# Using `path` instead of `workspace = true` Workaround for https://github.com/rust-lang/cargo/issues/4242
 # ref: https://github.com/rust-lang/futures-rs/pull/2305
 oxc_codegen   = { path = "../oxc_codegen" }
 oxc_parser    = { workspace = true }


### PR DESCRIPTION
1. This looks like caused by https://github.com/rust-lang/cargo/issues/4242

## Ref
1. https://github.com/rust-lang/futures-rs/pull/2305