### PR TITLE
Revert "chore: fix failed publish caused by cyclic dev dependencies "

### DIFF
--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -28,9 +28,7 @@ oxc_index    = { workspace = true }
 itertools    = { workspace = true }
 
 [dev-dependencies]
-# Using `path` instead of `workspace = true` Workaround for https://github.com/rust-lang/cargo/issues/4242
-# ref: https://github.com/rust-lang/futures-rs/pull/2305
-oxc_codegen   = { path = "../oxc_codegen" }
+oxc_codegen   = { workspace = true }
 oxc_parser    = { workspace = true }
 oxc_span      = { workspace = true }
 oxc_allocator = { workspace = true }


### PR DESCRIPTION
Reverts oxc-project/oxc#4416

This trick doesn't work for crates that have circular dependencies on each other that all need to be published!