### PR TITLE
refactor(allocator): rename fn params for `Box::new_in`

### DIFF
--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -36,8 +36,8 @@ impl<'alloc, T> Box<'alloc, T> {
 }
 
 impl<'alloc, T> Box<'alloc, T> {
-    pub fn new_in(x: T, alloc: &Allocator) -> Self {
-        Self(alloc.alloc(x).into(), PhantomData)
+    pub fn new_in(value: T, allocator: &Allocator) -> Self {
+        Self(allocator.alloc(value).into(), PhantomData)
     }
 
     /// Create a fake `Box` with a dangling pointer.


### PR DESCRIPTION
Rename function params for `Box::new_in` to be more descriptive and match our naming conventions.