### PR TITLE
refactor(allocator): make `Box::new_in` code more explicit

### DIFF
--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -37,7 +37,7 @@ impl<'alloc, T> Box<'alloc, T> {
 
 impl<'alloc, T> Box<'alloc, T> {
     pub fn new_in(value: T, allocator: &Allocator) -> Self {
-        Self(allocator.alloc(value).into(), PhantomData)
+        Self(NonNull::from(allocator.alloc(value)), PhantomData)
     }
 
     /// Create a fake `Box` with a dangling pointer.


### PR DESCRIPTION
Replace `.into` with `NonNull::from`. I feel this is a bit clearer.