### PR TITLE
fix(semantic): use correct span for namespace symbols

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
     syntax_directed_operations::{BoundNames, IsSimpleParameterList},
     AstKind,
 };
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 
 use crate::{scope::ScopeFlags, symbol::SymbolFlags, SemanticBuilder};
 
@@ -368,7 +368,7 @@ impl<'a> Binder for TSModuleDeclaration<'a> {
         // is made inside a the scope of a module that the symbol is modified
         let ambient = if self.declare { SymbolFlags::Ambient } else { SymbolFlags::None };
         builder.declare_symbol(
-            self.span,
+            self.id.span(),
             self.id.name().as_str(),
             SymbolFlags::NameSpaceModule | ambient,
             SymbolFlags::None,

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -5378,11 +5378,11 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
     ╰────
 
   × Identifier `m1a` has already been declared
-   ╭─[compiler/augmentedTypesModules.ts:5:1]
+   ╭─[compiler/augmentedTypesModules.ts:5:8]
  4 │ 
  5 │ module m1a { var y = 2; } // error
-   · ────────────┬────────────
-   ·             ╰── `m1a` has already been declared here
+   ·        ─┬─
+   ·         ╰── `m1a` has already been declared here
  6 │ var m1a = 1; // error
    ·     ─┬─
    ·      ╰── It can not be redeclared here
@@ -5390,11 +5390,11 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
    ╰────
 
   × Identifier `m1b` has already been declared
-    ╭─[compiler/augmentedTypesModules.ts:8:1]
+    ╭─[compiler/augmentedTypesModules.ts:8:8]
   7 │ 
   8 │ module m1b { export var y = 2; } // error
-    · ────────────────┬───────────────
-    ·                 ╰── `m1b` has already been declared here
+    ·        ─┬─
+    ·         ╰── `m1b` has already been declared here
   9 │ var m1b = 1; // error
     ·     ─┬─
     ·      ╰── It can not be redeclared here
@@ -5402,24 +5402,25 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
     ╰────
 
   × Identifier `m1d` has already been declared
-    ╭─[compiler/augmentedTypesModules.ts:16:1]
- 15 │     
- 16 │ ╭─▶ module m1d { // error
- 17 │ │       export class I { foo() { } }
- 18 │ ├─▶ }
-    · ╰──── `m1d` has already been declared here
- 19 │     var m1d = 1; // error
-    ·         ─┬─
-    ·          ╰── It can not be redeclared here
- 20 │     
+    ╭─[compiler/augmentedTypesModules.ts:16:8]
+ 15 │ 
+ 16 │ module m1d { // error
+    ·        ─┬─
+    ·         ╰── `m1d` has already been declared here
+ 17 │     export class I { foo() { } }
+ 18 │ }
+ 19 │ var m1d = 1; // error
+    ·     ─┬─
+    ·      ╰── It can not be redeclared here
+ 20 │ 
     ╰────
 
   × Identifier `m2a` has already been declared
-    ╭─[compiler/augmentedTypesModules.ts:25:1]
+    ╭─[compiler/augmentedTypesModules.ts:25:8]
  24 │ 
  25 │ module m2a { var y = 2; }
-    · ────────────┬────────────
-    ·             ╰── `m2a` has already been declared here
+    ·        ─┬─
+    ·         ╰── `m2a` has already been declared here
  26 │ function m2a() { }; // error since the module is instantiated
     ·          ─┬─
     ·           ╰── It can not be redeclared here
@@ -5427,11 +5428,11 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
     ╰────
 
   × Identifier `m2b` has already been declared
-    ╭─[compiler/augmentedTypesModules.ts:28:1]
+    ╭─[compiler/augmentedTypesModules.ts:28:8]
  27 │ 
  28 │ module m2b { export var y = 2; }
-    · ────────────────┬───────────────
-    ·                 ╰── `m2b` has already been declared here
+    ·        ─┬─
+    ·         ╰── `m2b` has already been declared here
  29 │ function m2b() { };  // error since the module is instantiated
     ·          ─┬─
     ·           ╰── It can not be redeclared here
@@ -5439,11 +5440,11 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
     ╰────
 
   × Identifier `m2a` has already been declared
-   ╭─[compiler/augmentedTypesModules2.ts:5:1]
+   ╭─[compiler/augmentedTypesModules2.ts:5:8]
  4 │ 
  5 │ module m2a { var y = 2; }
-   · ────────────┬────────────
-   ·             ╰── `m2a` has already been declared here
+   ·        ─┬─
+   ·         ╰── `m2a` has already been declared here
  6 │ function m2a() { }; // error since the module is instantiated
    ·          ─┬─
    ·           ╰── It can not be redeclared here
@@ -5451,11 +5452,11 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
    ╰────
 
   × Identifier `m2b` has already been declared
-    ╭─[compiler/augmentedTypesModules2.ts:8:1]
+    ╭─[compiler/augmentedTypesModules2.ts:8:8]
   7 │ 
   8 │ module m2b { export var y = 2; }
-    · ────────────────┬───────────────
-    ·                 ╰── `m2b` has already been declared here
+    ·        ─┬─
+    ·         ╰── `m2b` has already been declared here
   9 │ function m2b() { };  // error since the module is instantiated
     ·          ─┬─
     ·           ╰── It can not be redeclared here
@@ -5463,11 +5464,11 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
     ╰────
 
   × Identifier `m2cc` has already been declared
-    ╭─[compiler/augmentedTypesModules2.ts:14:1]
+    ╭─[compiler/augmentedTypesModules2.ts:14:8]
  13 │ 
  14 │ module m2cc { export var y = 2; }
-    · ────────────────┬────────────────
-    ·                 ╰── `m2cc` has already been declared here
+    ·        ──┬─
+    ·          ╰── `m2cc` has already been declared here
  15 │ function m2cc() { }; // error to have module first
     ·          ──┬─
     ·            ╰── It can not be redeclared here
@@ -7319,16 +7320,17 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
    ╰────
 
   × Identifier `F` has already been declared
-    ╭─[compiler/duplicateSymbolsExportMatching.ts:49:5]
- 48 │     module M {
- 49 │ ╭─▶     module F {
- 50 │ │           var t;
- 51 │ ├─▶     }
-    · ╰──── `F` has already been declared here
- 52 │         export function F() { } // Only one error for duplicate identifier (don't consider visibility)
-    ·                         ┬
-    ·                         ╰── It can not be redeclared here
- 53 │     }
+    ╭─[compiler/duplicateSymbolsExportMatching.ts:49:12]
+ 48 │ module M {
+ 49 │     module F {
+    ·            ┬
+    ·            ╰── `F` has already been declared here
+ 50 │         var t;
+ 51 │     }
+ 52 │     export function F() { } // Only one error for duplicate identifier (don't consider visibility)
+    ·                     ┬
+    ·                     ╰── It can not be redeclared here
+ 53 │ }
     ╰────
 
   × Empty parenthesized expression
@@ -9308,16 +9310,17 @@ Expect to Parse: "conformance/salsa/typeFromPropertyAssignmentWithExport.ts"
   help: Remove the duplicate modifier.
 
   × Identifier `z` has already been declared
-    ╭─[compiler/nameCollisions.ts:10:5]
-  9 │     
- 10 │ ╭─▶     module z {
- 11 │ │           var t;
- 12 │ ├─▶     }
-    · ╰──── `z` has already been declared here
- 13 │         var z; // error
-    ·             ┬
-    ·             ╰── It can not be redeclared here
- 14 │     
+    ╭─[compiler/nameCollisions.ts:10:12]
+  9 │ 
+ 10 │     module z {
+    ·            ┬
+    ·            ╰── `z` has already been declared here
+ 11 │         var t;
+ 12 │     }
+ 13 │     var z; // error
+    ·         ┬
+    ·         ╰── It can not be redeclared here
+ 14 │ 
     ╰────
 
   × Identifier `C` has already been declared


### PR DESCRIPTION
Before:
```ts
    namespace N {}
// ---------------
```

After:
```ts
    namespace N {}
//            -
```

Found while working on #4427 