### PR TITLE
fix(semantic): incorrect symbol’s scope_id after var hoisting

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -71,6 +71,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                     // avoid same symbols appear in multi-scopes
                     builder.scope.remove_binding(*scope_id, &name);
                     builder.scope.add_binding(target_scope_id, name, symbol_id);
+                    builder.symbols.scope_ids[symbol_id] = target_scope_id;
                     break;
                 }
             }

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -138,3 +138,18 @@ fn test_catch_clause_parameters() {
     .has_number_of_references(1)
     .test();
 }
+
+#[test]
+fn var_hoisting() {
+    SemanticTester::js(
+        "
+            try {} catch (e) {
+                var e = 0;
+            }
+        ",
+    )
+    .has_root_symbol("e")
+    // `e` was hoisted to the top scope so the symbol's scope is also the top scope
+    .is_in_scope(ScopeFlags::Top)
+    .test();
+}


### PR DESCRIPTION
Bug found in https://github.com/rolldown/rolldown/pull/1726