### PR TITLE
fix(transformer): add to `SymbolTable::declarations` for all symbols

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -4,6 +4,7 @@ use oxc_allocator::Vec;
 use oxc_ast::{ast::*, visit::walk_mut, VisitMut};
 use oxc_span::{Atom, Span, SPAN};
 use oxc_syntax::{
+    node::AstNodeId,
     number::{NumberBase, ToJsInt32, ToJsString},
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
     reference::ReferenceFlag,
@@ -80,6 +81,7 @@ impl<'a> TypeScriptEnum<'a> {
             SymbolFlags::FunctionScopedVariable,
             func_scope_id,
         );
+        ctx.symbols_mut().add_declaration(AstNodeId::DUMMY);
         let ident = BindingIdentifier {
             span: decl.id.span,
             name: decl.id.name.clone(),

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -246,6 +246,7 @@ impl TraverseScoping {
 
         // Add binding to scope
         let symbol_id = self.symbols.create_symbol(SPAN, name.clone(), flags, scope_id);
+        self.symbols.add_declaration(AstNodeId::DUMMY);
         self.scopes.add_binding(scope_id, name, symbol_id);
         symbol_id
     }


### PR DESCRIPTION
`declarations` field of `SymbolTable` is part of the SoA group field. For it to be valid to index into with `SymbolId`, an entry must be added for every new symbol which is created.