### PR TITLE
refactor(semantic): populate `declarations` field in `SymbolTable::create_symbol`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -343,8 +343,13 @@ impl<'a> SemanticBuilder<'a> {
 
         let includes = includes | self.current_symbol_flags;
         let name = CompactStr::new(name);
-        let symbol_id = self.symbols.create_symbol(span, name.clone(), includes, scope_id);
-        self.symbols.add_declaration(self.current_node_id);
+        let symbol_id = self.symbols.create_symbol(
+            span,
+            name.clone(),
+            includes,
+            scope_id,
+            self.current_node_id,
+        );
         self.scope.add_binding(scope_id, name, symbol_id);
         symbol_id
     }
@@ -402,9 +407,13 @@ impl<'a> SemanticBuilder<'a> {
     ) -> SymbolId {
         let includes = includes | self.current_symbol_flags;
         let name = CompactStr::new(name);
-        let symbol_id =
-            self.symbols.create_symbol(span, name.clone(), includes, self.current_scope_id);
-        self.symbols.add_declaration(self.current_node_id);
+        let symbol_id = self.symbols.create_symbol(
+            span,
+            name.clone(),
+            includes,
+            self.current_scope_id,
+            self.current_node_id,
+        );
         self.scope.get_bindings_mut(scope_id).insert(name, symbol_id);
         symbol_id
     }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -120,17 +120,15 @@ impl SymbolTable {
         name: CompactStr,
         flag: SymbolFlags,
         scope_id: ScopeId,
+        node_id: AstNodeId,
     ) -> SymbolId {
         self.spans.push(span);
         self.names.push(name);
         self.flags.push(flag);
         self.scope_ids.push(scope_id);
+        self.declarations.push(node_id);
         self.resolved_references.push(vec![]);
         self.redeclare_variables.push(vec![])
-    }
-
-    pub fn add_declaration(&mut self, node_id: AstNodeId) {
-        self.declarations.push(node_id);
     }
 
     pub fn add_redeclare_variable(&mut self, symbol_id: SymbolId, span: Span) {

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -80,8 +80,8 @@ impl<'a> TypeScriptEnum<'a> {
             enum_name.to_compact_str(),
             SymbolFlags::FunctionScopedVariable,
             func_scope_id,
+            AstNodeId::DUMMY,
         );
-        ctx.symbols_mut().add_declaration(AstNodeId::DUMMY);
         let ident = BindingIdentifier {
             span: decl.id.span,
             name: decl.id.name.clone(),

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -245,8 +245,8 @@ impl TraverseScoping {
         let name = CompactStr::new(&self.find_uid_name(name));
 
         // Add binding to scope
-        let symbol_id = self.symbols.create_symbol(SPAN, name.clone(), flags, scope_id);
-        self.symbols.add_declaration(AstNodeId::DUMMY);
+        let symbol_id =
+            self.symbols.create_symbol(SPAN, name.clone(), flags, scope_id, AstNodeId::DUMMY);
         self.scopes.add_binding(scope_id, name, symbol_id);
         symbol_id
     }


### PR DESCRIPTION
`declarations` field of `SymbolTable` is part of SoA group, where all `Vec`s in the group are indexed by `SymbolId`. Populate `declarations` field along with the rest in `create_symbol`, to prevent them getting out of sync. This will prevent bugs like the one fixed in #4460.