### PR TITLE
refactor(semantic): methods take `Span` as param, not `&Span`

### DIFF
--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -99,7 +99,7 @@ impl Rule for Namespace {
             }
 
             let Some(symbol_id) =
-                ctx.semantic().symbols().get_symbol_id_from_span(&entry.local_name.span())
+                ctx.semantic().symbols().get_symbol_id_from_span(entry.local_name.span())
             else {
                 return;
             };

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -71,7 +71,7 @@ impl Rule for NoNamedAsDefaultMember {
 
             if !remote_module_record_ref.exported_bindings.is_empty() {
                 has_members_map.insert(
-                    ctx.symbols().get_symbol_id_from_span(&import_entry.local_name.span()).unwrap(),
+                    ctx.symbols().get_symbol_id_from_span(import_entry.local_name.span()).unwrap(),
                     (remote_module_record_ref, import_entry.module_request.name().clone()),
                 );
             }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -64,10 +64,10 @@ impl SymbolTable {
         self.spans.iter_enumerated().rev().map(|(symbol_id, _)| symbol_id)
     }
 
-    pub fn get_symbol_id_from_span(&self, span: &Span) -> Option<SymbolId> {
+    pub fn get_symbol_id_from_span(&self, span: Span) -> Option<SymbolId> {
         self.spans
             .iter_enumerated()
-            .find_map(|(symbol, inner_span)| if inner_span == span { Some(symbol) } else { None })
+            .find_map(|(symbol, &inner_span)| if inner_span == span { Some(symbol) } else { None })
     }
 
     pub fn get_symbol_id_from_name(&self, name: &str) -> Option<SymbolId> {
@@ -113,7 +113,7 @@ impl SymbolTable {
         self.scope_ids[symbol_id]
     }
 
-    pub fn get_scope_id_from_span(&self, span: &Span) -> Option<ScopeId> {
+    pub fn get_scope_id_from_span(&self, span: Span) -> Option<ScopeId> {
         self.get_symbol_id_from_span(span).map(|symbol_id| self.get_scope_id(symbol_id))
     }
 


### PR DESCRIPTION
`Span` is `Copy` and 8 bytes. So better to pass `Span` to functions, rather than `&Span` (which is also 8 bytes, but involves the indirection of a reference).