### PR TITLE
docs(ast): auto-generate doc comments for AstBuilder methods

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -26,26 +26,61 @@ pub struct AstBuilder<'a> {
 }
 
 impl<'a> AstBuilder<'a> {
+    /// Builds a [`BooleanLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_boolean_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
         BooleanLiteral { span, value }
     }
 
+    /// Builds a [`BooleanLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::boolean_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn alloc_boolean_literal(self, span: Span, value: bool) -> Box<'a, BooleanLiteral> {
         Box::new_in(self.boolean_literal(span, value), self.allocator)
     }
 
+    /// Builds a [`NullLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_null_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn null_literal(self, span: Span) -> NullLiteral {
         NullLiteral { span }
     }
 
+    /// Builds a [`NullLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::null_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_null_literal(self, span: Span) -> Box<'a, NullLiteral> {
         Box::new_in(self.null_literal(span), self.allocator)
     }
 
+    /// Builds a [`NumericLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_numeric_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - raw
+    /// - base
     #[inline]
     pub fn numeric_literal<S>(
         self,
@@ -60,6 +95,15 @@ impl<'a> AstBuilder<'a> {
         NumericLiteral { span, value, raw: raw.into_in(self.allocator), base }
     }
 
+    /// Builds a [`NumericLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::numeric_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - raw
+    /// - base
     #[inline]
     pub fn alloc_numeric_literal<S>(
         self,
@@ -74,6 +118,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
     }
 
+    /// Builds a [`BigIntLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_big_int_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - raw
+    /// - base
     #[inline]
     pub fn big_int_literal<A>(self, span: Span, raw: A, base: BigintBase) -> BigIntLiteral<'a>
     where
@@ -82,6 +134,14 @@ impl<'a> AstBuilder<'a> {
         BigIntLiteral { span, raw: raw.into_in(self.allocator), base }
     }
 
+    /// Builds a [`BigIntLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::big_int_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - raw
+    /// - base
     #[inline]
     pub fn alloc_big_int_literal<A>(
         self,
@@ -95,6 +155,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.big_int_literal(span, raw, base), self.allocator)
     }
 
+    /// Builds a [`RegExpLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_reg_exp_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - regex
     #[inline]
     pub fn reg_exp_literal(
         self,
@@ -105,6 +173,14 @@ impl<'a> AstBuilder<'a> {
         RegExpLiteral { span, value, regex }
     }
 
+    /// Builds a [`RegExpLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::reg_exp_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - regex
     #[inline]
     pub fn alloc_reg_exp_literal(
         self,
@@ -115,6 +191,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.reg_exp_literal(span, value, regex), self.allocator)
     }
 
+    /// Builds a [`StringLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn string_literal<A>(self, span: Span, value: A) -> StringLiteral<'a>
     where
@@ -123,6 +206,13 @@ impl<'a> AstBuilder<'a> {
         StringLiteral { span, value: value.into_in(self.allocator) }
     }
 
+    /// Builds a [`StringLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn alloc_string_literal<A>(self, span: Span, value: A) -> Box<'a, StringLiteral<'a>>
     where
@@ -131,6 +221,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.string_literal(span, value), self.allocator)
     }
 
+    /// Builds a [`Program`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_program`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - source_type
+    /// - hashbang
+    /// - directives
+    /// - body
     #[inline]
     pub fn program(
         self,
@@ -143,6 +243,16 @@ impl<'a> AstBuilder<'a> {
         Program { span, source_type, hashbang, directives, body, scope_id: Default::default() }
     }
 
+    /// Builds a [`Program`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::program`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - source_type
+    /// - hashbang
+    /// - directives
+    /// - body
     #[inline]
     pub fn alloc_program(
         self,
@@ -155,11 +265,19 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.program(span, source_type, hashbang, directives, body), self.allocator)
     }
 
+    /// Build a [`Expression::BooleanLiteral`]
+    ///
+    /// This node contains a [`BooleanLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn expression_boolean_literal(self, span: Span, value: bool) -> Expression<'a> {
         Expression::BooleanLiteral(self.alloc(self.boolean_literal(span, value)))
     }
 
+    /// Convert a [`BooleanLiteral`] into a [`Expression::BooleanLiteral`]
     #[inline]
     pub fn expression_from_boolean_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -168,11 +286,18 @@ impl<'a> AstBuilder<'a> {
         Expression::BooleanLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::NullLiteral`]
+    ///
+    /// This node contains a [`NullLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn expression_null_literal(self, span: Span) -> Expression<'a> {
         Expression::NullLiteral(self.alloc(self.null_literal(span)))
     }
 
+    /// Convert a [`NullLiteral`] into a [`Expression::NullLiteral`]
     #[inline]
     pub fn expression_from_null_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -181,6 +306,15 @@ impl<'a> AstBuilder<'a> {
         Expression::NullLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::NumericLiteral`]
+    ///
+    /// This node contains a [`NumericLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - raw
+    /// - base
     #[inline]
     pub fn expression_numeric_literal<S>(
         self,
@@ -195,6 +329,7 @@ impl<'a> AstBuilder<'a> {
         Expression::NumericLiteral(self.alloc(self.numeric_literal(span, value, raw, base)))
     }
 
+    /// Convert a [`NumericLiteral`] into a [`Expression::NumericLiteral`]
     #[inline]
     pub fn expression_from_numeric_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -203,6 +338,14 @@ impl<'a> AstBuilder<'a> {
         Expression::NumericLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::BigIntLiteral`]
+    ///
+    /// This node contains a [`BigIntLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - raw
+    /// - base
     #[inline]
     pub fn expression_big_int_literal<A>(
         self,
@@ -216,6 +359,7 @@ impl<'a> AstBuilder<'a> {
         Expression::BigIntLiteral(self.alloc(self.big_int_literal(span, raw, base)))
     }
 
+    /// Convert a [`BigIntLiteral`] into a [`Expression::BigIntLiteral`]
     #[inline]
     pub fn expression_from_big_int_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -224,6 +368,14 @@ impl<'a> AstBuilder<'a> {
         Expression::BigIntLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::RegExpLiteral`]
+    ///
+    /// This node contains a [`RegExpLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - regex
     #[inline]
     pub fn expression_reg_exp_literal(
         self,
@@ -234,6 +386,7 @@ impl<'a> AstBuilder<'a> {
         Expression::RegExpLiteral(self.alloc(self.reg_exp_literal(span, value, regex)))
     }
 
+    /// Convert a [`RegExpLiteral`] into a [`Expression::RegExpLiteral`]
     #[inline]
     pub fn expression_from_reg_exp_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -242,6 +395,13 @@ impl<'a> AstBuilder<'a> {
         Expression::RegExpLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::StringLiteral`]
+    ///
+    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn expression_string_literal<A>(self, span: Span, value: A) -> Expression<'a>
     where
@@ -250,6 +410,7 @@ impl<'a> AstBuilder<'a> {
         Expression::StringLiteral(self.alloc(self.string_literal(span, value)))
     }
 
+    /// Convert a [`StringLiteral`] into a [`Expression::StringLiteral`]
     #[inline]
     pub fn expression_from_string_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -258,6 +419,14 @@ impl<'a> AstBuilder<'a> {
         Expression::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TemplateLiteral`]
+    ///
+    /// This node contains a [`TemplateLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - expressions
     #[inline]
     pub fn expression_template_literal(
         self,
@@ -268,6 +437,7 @@ impl<'a> AstBuilder<'a> {
         Expression::TemplateLiteral(self.alloc(self.template_literal(span, quasis, expressions)))
     }
 
+    /// Convert a [`TemplateLiteral`] into a [`Expression::TemplateLiteral`]
     #[inline]
     pub fn expression_from_template_literal<T>(self, inner: T) -> Expression<'a>
     where
@@ -276,6 +446,13 @@ impl<'a> AstBuilder<'a> {
         Expression::TemplateLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::Identifier`]
+    ///
+    /// This node contains a [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The name of the identifier being referenced.
     #[inline]
     pub fn expression_identifier_reference<A>(self, span: Span, name: A) -> Expression<'a>
     where
@@ -284,6 +461,7 @@ impl<'a> AstBuilder<'a> {
         Expression::Identifier(self.alloc(self.identifier_reference(span, name)))
     }
 
+    /// Convert a [`IdentifierReference`] into a [`Expression::Identifier`]
     #[inline]
     pub fn expression_from_identifier_reference<T>(self, inner: T) -> Expression<'a>
     where
@@ -292,6 +470,14 @@ impl<'a> AstBuilder<'a> {
         Expression::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::MetaProperty`]
+    ///
+    /// This node contains a [`MetaProperty`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - meta
+    /// - property
     #[inline]
     pub fn expression_meta_property(
         self,
@@ -302,6 +488,7 @@ impl<'a> AstBuilder<'a> {
         Expression::MetaProperty(self.alloc(self.meta_property(span, meta, property)))
     }
 
+    /// Convert a [`MetaProperty`] into a [`Expression::MetaProperty`]
     #[inline]
     pub fn expression_from_meta_property<T>(self, inner: T) -> Expression<'a>
     where
@@ -310,11 +497,18 @@ impl<'a> AstBuilder<'a> {
         Expression::MetaProperty(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::Super`]
+    ///
+    /// This node contains a [`Super`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn expression_super(self, span: Span) -> Expression<'a> {
         Expression::Super(self.alloc(self.super_(span)))
     }
 
+    /// Convert a [`Super`] into a [`Expression::Super`]
     #[inline]
     pub fn expression_from_super<T>(self, inner: T) -> Expression<'a>
     where
@@ -323,6 +517,14 @@ impl<'a> AstBuilder<'a> {
         Expression::Super(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ArrayExpression`]
+    ///
+    /// This node contains a [`ArrayExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - trailing_comma: Array trailing comma
     #[inline]
     pub fn expression_array(
         self,
@@ -337,6 +539,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ArrayExpression`] into a [`Expression::ArrayExpression`]
     #[inline]
     pub fn expression_from_array<T>(self, inner: T) -> Expression<'a>
     where
@@ -345,6 +548,18 @@ impl<'a> AstBuilder<'a> {
         Expression::ArrayExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ArrowFunctionExpression`]
+    ///
+    /// This node contains a [`ArrowFunctionExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression: Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
+    /// - r#async
+    /// - type_parameters
+    /// - params
+    /// - return_type
+    /// - body: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn expression_arrow_function<T1, T2, T3, T4>(
         self,
@@ -373,6 +588,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ArrowFunctionExpression`] into a [`Expression::ArrowFunctionExpression`]
     #[inline]
     pub fn expression_from_arrow_function<T>(self, inner: T) -> Expression<'a>
     where
@@ -381,6 +597,15 @@ impl<'a> AstBuilder<'a> {
         Expression::ArrowFunctionExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::AssignmentExpression`]
+    ///
+    /// This node contains a [`AssignmentExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - left
+    /// - right
     #[inline]
     pub fn expression_assignment(
         self,
@@ -394,6 +619,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`AssignmentExpression`] into a [`Expression::AssignmentExpression`]
     #[inline]
     pub fn expression_from_assignment<T>(self, inner: T) -> Expression<'a>
     where
@@ -402,11 +628,19 @@ impl<'a> AstBuilder<'a> {
         Expression::AssignmentExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::AwaitExpression`]
+    ///
+    /// This node contains a [`AwaitExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn expression_await(self, span: Span, argument: Expression<'a>) -> Expression<'a> {
         Expression::AwaitExpression(self.alloc(self.await_expression(span, argument)))
     }
 
+    /// Convert a [`AwaitExpression`] into a [`Expression::AwaitExpression`]
     #[inline]
     pub fn expression_from_await<T>(self, inner: T) -> Expression<'a>
     where
@@ -415,6 +649,15 @@ impl<'a> AstBuilder<'a> {
         Expression::AwaitExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::BinaryExpression`]
+    ///
+    /// This node contains a [`BinaryExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn expression_binary(
         self,
@@ -428,6 +671,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`BinaryExpression`] into a [`Expression::BinaryExpression`]
     #[inline]
     pub fn expression_from_binary<T>(self, inner: T) -> Expression<'a>
     where
@@ -436,6 +680,16 @@ impl<'a> AstBuilder<'a> {
         Expression::BinaryExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::CallExpression`]
+    ///
+    /// This node contains a [`CallExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - arguments
+    /// - callee
+    /// - type_parameters
+    /// - optional
     #[inline]
     pub fn expression_call<T1>(
         self,
@@ -457,6 +711,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`CallExpression`] into a [`Expression::CallExpression`]
     #[inline]
     pub fn expression_from_call<T>(self, inner: T) -> Expression<'a>
     where
@@ -465,11 +720,19 @@ impl<'a> AstBuilder<'a> {
         Expression::CallExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ChainExpression`]
+    ///
+    /// This node contains a [`ChainExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn expression_chain(self, span: Span, expression: ChainElement<'a>) -> Expression<'a> {
         Expression::ChainExpression(self.alloc(self.chain_expression(span, expression)))
     }
 
+    /// Convert a [`ChainExpression`] into a [`Expression::ChainExpression`]
     #[inline]
     pub fn expression_from_chain<T>(self, inner: T) -> Expression<'a>
     where
@@ -478,6 +741,22 @@ impl<'a> AstBuilder<'a> {
         Expression::ChainExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ClassExpression`]
+    ///
+    /// This node contains a [`Class`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the class.
+    /// - id: Class identifier, AKA the name
+    /// - type_parameters
+    /// - super_class: Super class. When present, this will usually be an [`IdentifierReference`].
+    /// - super_type_parameters: Type parameters passed to super class.
+    /// - implements: Interface implementation clause for TypeScript classes.
+    /// - body
+    /// - r#abstract: Whether the class is abstract
+    /// - declare: Whether the class was `declare`ed
     #[inline]
     pub fn expression_class<T1, T2, T3>(
         self,
@@ -513,6 +792,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`Class`] into a [`Expression::ClassExpression`]
     #[inline]
     pub fn expression_from_class<T>(self, inner: T) -> Expression<'a>
     where
@@ -521,6 +801,15 @@ impl<'a> AstBuilder<'a> {
         Expression::ClassExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ConditionalExpression`]
+    ///
+    /// This node contains a [`ConditionalExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
+    /// - alternate
     #[inline]
     pub fn expression_conditional(
         self,
@@ -534,6 +823,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ConditionalExpression`] into a [`Expression::ConditionalExpression`]
     #[inline]
     pub fn expression_from_conditional<T>(self, inner: T) -> Expression<'a>
     where
@@ -542,6 +832,22 @@ impl<'a> AstBuilder<'a> {
         Expression::ConditionalExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::FunctionExpression`]
+    ///
+    /// This node contains a [`Function`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - generator
+    /// - r#async
+    /// - declare
+    /// - type_parameters
+    /// - this_param: Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
+    /// - params
+    /// - return_type
+    /// - body
     #[inline]
     pub fn expression_function<T1, T2, T3, T4>(
         self,
@@ -578,6 +884,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`Function`] into a [`Expression::FunctionExpression`]
     #[inline]
     pub fn expression_from_function<T>(self, inner: T) -> Expression<'a>
     where
@@ -586,6 +893,14 @@ impl<'a> AstBuilder<'a> {
         Expression::FunctionExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ImportExpression`]
+    ///
+    /// This node contains a [`ImportExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - source
+    /// - arguments
     #[inline]
     pub fn expression_import(
         self,
@@ -596,6 +911,7 @@ impl<'a> AstBuilder<'a> {
         Expression::ImportExpression(self.alloc(self.import_expression(span, source, arguments)))
     }
 
+    /// Convert a [`ImportExpression`] into a [`Expression::ImportExpression`]
     #[inline]
     pub fn expression_from_import<T>(self, inner: T) -> Expression<'a>
     where
@@ -604,6 +920,15 @@ impl<'a> AstBuilder<'a> {
         Expression::ImportExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::LogicalExpression`]
+    ///
+    /// This node contains a [`LogicalExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn expression_logical(
         self,
@@ -617,6 +942,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`LogicalExpression`] into a [`Expression::LogicalExpression`]
     #[inline]
     pub fn expression_from_logical<T>(self, inner: T) -> Expression<'a>
     where
@@ -625,6 +951,15 @@ impl<'a> AstBuilder<'a> {
         Expression::LogicalExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::NewExpression`]
+    ///
+    /// This node contains a [`NewExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - callee
+    /// - arguments
+    /// - type_parameters
     #[inline]
     pub fn expression_new<T1>(
         self,
@@ -644,6 +979,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`NewExpression`] into a [`Expression::NewExpression`]
     #[inline]
     pub fn expression_from_new<T>(self, inner: T) -> Expression<'a>
     where
@@ -652,6 +988,14 @@ impl<'a> AstBuilder<'a> {
         Expression::NewExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ObjectExpression`]
+    ///
+    /// This node contains a [`ObjectExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties: Properties declared in the object
+    /// - trailing_comma
     #[inline]
     pub fn expression_object(
         self,
@@ -666,6 +1010,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ObjectExpression`] into a [`Expression::ObjectExpression`]
     #[inline]
     pub fn expression_from_object<T>(self, inner: T) -> Expression<'a>
     where
@@ -674,6 +1019,13 @@ impl<'a> AstBuilder<'a> {
         Expression::ObjectExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ParenthesizedExpression`]
+    ///
+    /// This node contains a [`ParenthesizedExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn expression_parenthesized(
         self,
@@ -685,6 +1037,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ParenthesizedExpression`] into a [`Expression::ParenthesizedExpression`]
     #[inline]
     pub fn expression_from_parenthesized<T>(self, inner: T) -> Expression<'a>
     where
@@ -693,6 +1046,13 @@ impl<'a> AstBuilder<'a> {
         Expression::ParenthesizedExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::SequenceExpression`]
+    ///
+    /// This node contains a [`SequenceExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expressions
     #[inline]
     pub fn expression_sequence(
         self,
@@ -702,6 +1062,7 @@ impl<'a> AstBuilder<'a> {
         Expression::SequenceExpression(self.alloc(self.sequence_expression(span, expressions)))
     }
 
+    /// Convert a [`SequenceExpression`] into a [`Expression::SequenceExpression`]
     #[inline]
     pub fn expression_from_sequence<T>(self, inner: T) -> Expression<'a>
     where
@@ -710,6 +1071,15 @@ impl<'a> AstBuilder<'a> {
         Expression::SequenceExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TaggedTemplateExpression`]
+    ///
+    /// This node contains a [`TaggedTemplateExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - tag
+    /// - quasi
+    /// - type_parameters
     #[inline]
     pub fn expression_tagged_template<T1>(
         self,
@@ -729,6 +1099,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TaggedTemplateExpression`] into a [`Expression::TaggedTemplateExpression`]
     #[inline]
     pub fn expression_from_tagged_template<T>(self, inner: T) -> Expression<'a>
     where
@@ -737,11 +1108,18 @@ impl<'a> AstBuilder<'a> {
         Expression::TaggedTemplateExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::ThisExpression`]
+    ///
+    /// This node contains a [`ThisExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn expression_this(self, span: Span) -> Expression<'a> {
         Expression::ThisExpression(self.alloc(self.this_expression(span)))
     }
 
+    /// Convert a [`ThisExpression`] into a [`Expression::ThisExpression`]
     #[inline]
     pub fn expression_from_this<T>(self, inner: T) -> Expression<'a>
     where
@@ -750,6 +1128,14 @@ impl<'a> AstBuilder<'a> {
         Expression::ThisExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::UnaryExpression`]
+    ///
+    /// This node contains a [`UnaryExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - argument
     #[inline]
     pub fn expression_unary(
         self,
@@ -760,6 +1146,7 @@ impl<'a> AstBuilder<'a> {
         Expression::UnaryExpression(self.alloc(self.unary_expression(span, operator, argument)))
     }
 
+    /// Convert a [`UnaryExpression`] into a [`Expression::UnaryExpression`]
     #[inline]
     pub fn expression_from_unary<T>(self, inner: T) -> Expression<'a>
     where
@@ -768,6 +1155,15 @@ impl<'a> AstBuilder<'a> {
         Expression::UnaryExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::UpdateExpression`]
+    ///
+    /// This node contains a [`UpdateExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - prefix
+    /// - argument
     #[inline]
     pub fn expression_update(
         self,
@@ -781,6 +1177,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`UpdateExpression`] into a [`Expression::UpdateExpression`]
     #[inline]
     pub fn expression_from_update<T>(self, inner: T) -> Expression<'a>
     where
@@ -789,6 +1186,14 @@ impl<'a> AstBuilder<'a> {
         Expression::UpdateExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::YieldExpression`]
+    ///
+    /// This node contains a [`YieldExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - delegate
+    /// - argument
     #[inline]
     pub fn expression_yield(
         self,
@@ -799,6 +1204,7 @@ impl<'a> AstBuilder<'a> {
         Expression::YieldExpression(self.alloc(self.yield_expression(span, delegate, argument)))
     }
 
+    /// Convert a [`YieldExpression`] into a [`Expression::YieldExpression`]
     #[inline]
     pub fn expression_from_yield<T>(self, inner: T) -> Expression<'a>
     where
@@ -807,6 +1213,15 @@ impl<'a> AstBuilder<'a> {
         Expression::YieldExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::PrivateInExpression`]
+    ///
+    /// This node contains a [`PrivateInExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn expression_private_in(
         self,
@@ -820,6 +1235,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`PrivateInExpression`] into a [`Expression::PrivateInExpression`]
     #[inline]
     pub fn expression_from_private_in<T>(self, inner: T) -> Expression<'a>
     where
@@ -828,6 +1244,15 @@ impl<'a> AstBuilder<'a> {
         Expression::PrivateInExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::JSXElement`]
+    ///
+    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_element
+    /// - closing_element
+    /// - children
     #[inline]
     pub fn expression_jsx_element<T1, T2>(
         self,
@@ -848,6 +1273,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSXElement`] into a [`Expression::JSXElement`]
     #[inline]
     pub fn expression_from_jsx_element<T>(self, inner: T) -> Expression<'a>
     where
@@ -856,6 +1282,15 @@ impl<'a> AstBuilder<'a> {
         Expression::JSXElement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::JSXFragment`]
+    ///
+    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_fragment
+    /// - closing_fragment
+    /// - children
     #[inline]
     pub fn expression_jsx_fragment(
         self,
@@ -872,6 +1307,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSXFragment`] into a [`Expression::JSXFragment`]
     #[inline]
     pub fn expression_from_jsx_fragment<T>(self, inner: T) -> Expression<'a>
     where
@@ -880,6 +1316,14 @@ impl<'a> AstBuilder<'a> {
         Expression::JSXFragment(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TSAsExpression`]
+    ///
+    /// This node contains a [`TSAsExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn expression_ts_as(
         self,
@@ -894,6 +1338,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSAsExpression`] into a [`Expression::TSAsExpression`]
     #[inline]
     pub fn expression_from_ts_as<T>(self, inner: T) -> Expression<'a>
     where
@@ -902,6 +1347,14 @@ impl<'a> AstBuilder<'a> {
         Expression::TSAsExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TSSatisfiesExpression`]
+    ///
+    /// This node contains a [`TSSatisfiesExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn expression_ts_satisfies(
         self,
@@ -916,6 +1369,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSSatisfiesExpression`] into a [`Expression::TSSatisfiesExpression`]
     #[inline]
     pub fn expression_from_ts_satisfies<T>(self, inner: T) -> Expression<'a>
     where
@@ -924,6 +1378,14 @@ impl<'a> AstBuilder<'a> {
         Expression::TSSatisfiesExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TSTypeAssertion`]
+    ///
+    /// This node contains a [`TSTypeAssertion`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn expression_ts_type_assertion(
         self,
@@ -938,6 +1400,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSTypeAssertion`] into a [`Expression::TSTypeAssertion`]
     #[inline]
     pub fn expression_from_ts_type_assertion<T>(self, inner: T) -> Expression<'a>
     where
@@ -946,11 +1409,19 @@ impl<'a> AstBuilder<'a> {
         Expression::TSTypeAssertion(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TSNonNullExpression`]
+    ///
+    /// This node contains a [`TSNonNullExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn expression_ts_non_null(self, span: Span, expression: Expression<'a>) -> Expression<'a> {
         Expression::TSNonNullExpression(self.alloc(self.ts_non_null_expression(span, expression)))
     }
 
+    /// Convert a [`TSNonNullExpression`] into a [`Expression::TSNonNullExpression`]
     #[inline]
     pub fn expression_from_ts_non_null<T>(self, inner: T) -> Expression<'a>
     where
@@ -959,6 +1430,14 @@ impl<'a> AstBuilder<'a> {
         Expression::TSNonNullExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Expression::TSInstantiationExpression`]
+    ///
+    /// This node contains a [`TSInstantiationExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn expression_ts_instantiation<T1>(
         self,
@@ -976,6 +1455,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSInstantiationExpression`] into a [`Expression::TSInstantiationExpression`]
     #[inline]
     pub fn expression_from_ts_instantiation<T>(self, inner: T) -> Expression<'a>
     where
@@ -989,6 +1469,13 @@ impl<'a> AstBuilder<'a> {
         Expression::from(inner)
     }
 
+    /// Builds a [`IdentifierName`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_identifier_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn identifier_name<A>(self, span: Span, name: A) -> IdentifierName<'a>
     where
@@ -997,6 +1484,13 @@ impl<'a> AstBuilder<'a> {
         IdentifierName { span, name: name.into_in(self.allocator) }
     }
 
+    /// Builds a [`IdentifierName`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::identifier_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn alloc_identifier_name<A>(self, span: Span, name: A) -> Box<'a, IdentifierName<'a>>
     where
@@ -1005,6 +1499,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.identifier_name(span, name), self.allocator)
     }
 
+    /// Builds a [`IdentifierReference`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_identifier_reference`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The name of the identifier being referenced.
     #[inline]
     pub fn identifier_reference<A>(self, span: Span, name: A) -> IdentifierReference<'a>
     where
@@ -1018,6 +1519,13 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`IdentifierReference`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::identifier_reference`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The name of the identifier being referenced.
     #[inline]
     pub fn alloc_identifier_reference<A>(
         self,
@@ -1030,6 +1538,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.identifier_reference(span, name), self.allocator)
     }
 
+    /// Builds a [`BindingIdentifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The identifier name being bound.
     #[inline]
     pub fn binding_identifier<A>(self, span: Span, name: A) -> BindingIdentifier<'a>
     where
@@ -1042,6 +1557,13 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`BindingIdentifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The identifier name being bound.
     #[inline]
     pub fn alloc_binding_identifier<A>(self, span: Span, name: A) -> Box<'a, BindingIdentifier<'a>>
     where
@@ -1050,6 +1572,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.binding_identifier(span, name), self.allocator)
     }
 
+    /// Builds a [`LabelIdentifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_label_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn label_identifier<A>(self, span: Span, name: A) -> LabelIdentifier<'a>
     where
@@ -1058,6 +1587,13 @@ impl<'a> AstBuilder<'a> {
         LabelIdentifier { span, name: name.into_in(self.allocator) }
     }
 
+    /// Builds a [`LabelIdentifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::label_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn alloc_label_identifier<A>(self, span: Span, name: A) -> Box<'a, LabelIdentifier<'a>>
     where
@@ -1066,16 +1602,36 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.label_identifier(span, name), self.allocator)
     }
 
+    /// Builds a [`ThisExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_this_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn this_expression(self, span: Span) -> ThisExpression {
         ThisExpression { span }
     }
 
+    /// Builds a [`ThisExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::this_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_this_expression(self, span: Span) -> Box<'a, ThisExpression> {
         Box::new_in(self.this_expression(span), self.allocator)
     }
 
+    /// Builds a [`ArrayExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_array_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - trailing_comma: Array trailing comma
     #[inline]
     pub fn array_expression(
         self,
@@ -1086,6 +1642,14 @@ impl<'a> AstBuilder<'a> {
         ArrayExpression { span, elements, trailing_comma }
     }
 
+    /// Builds a [`ArrayExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::array_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - trailing_comma: Array trailing comma
     #[inline]
     pub fn alloc_array_expression(
         self,
@@ -1096,6 +1660,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.array_expression(span, elements, trailing_comma), self.allocator)
     }
 
+    /// Build a [`ArrayExpressionElement::SpreadElement`]
+    ///
+    /// This node contains a [`SpreadElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument: The expression being spread.
     #[inline]
     pub fn array_expression_element_spread_element(
         self,
@@ -1105,6 +1676,7 @@ impl<'a> AstBuilder<'a> {
         ArrayExpressionElement::SpreadElement(self.alloc(self.spread_element(span, argument)))
     }
 
+    /// Convert a [`SpreadElement`] into a [`ArrayExpressionElement::SpreadElement`]
     #[inline]
     pub fn array_expression_element_from_spread_element<T>(
         self,
@@ -1116,11 +1688,16 @@ impl<'a> AstBuilder<'a> {
         ArrayExpressionElement::SpreadElement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ArrayExpressionElement::Elision`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn array_expression_element_elision(self, span: Span) -> ArrayExpressionElement<'a> {
         ArrayExpressionElement::Elision(self.elision(span))
     }
 
+    /// Convert a [`Elision`] into a [`ArrayExpressionElement::Elision`]
     #[inline]
     pub fn array_expression_element_from_elision<T>(self, inner: T) -> ArrayExpressionElement<'a>
     where
@@ -1137,16 +1714,36 @@ impl<'a> AstBuilder<'a> {
         ArrayExpressionElement::from(inner)
     }
 
+    /// Builds a [`Elision`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_elision`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn elision(self, span: Span) -> Elision {
         Elision { span }
     }
 
+    /// Builds a [`Elision`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::elision`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_elision(self, span: Span) -> Box<'a, Elision> {
         Box::new_in(self.elision(span), self.allocator)
     }
 
+    /// Builds a [`ObjectExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties: Properties declared in the object
+    /// - trailing_comma
     #[inline]
     pub fn object_expression(
         self,
@@ -1157,6 +1754,14 @@ impl<'a> AstBuilder<'a> {
         ObjectExpression { span, properties, trailing_comma }
     }
 
+    /// Builds a [`ObjectExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties: Properties declared in the object
+    /// - trailing_comma
     #[inline]
     pub fn alloc_object_expression(
         self,
@@ -1167,6 +1772,19 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.object_expression(span, properties, trailing_comma), self.allocator)
     }
 
+    /// Build a [`ObjectPropertyKind::ObjectProperty`]
+    ///
+    /// This node contains a [`ObjectProperty`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - key
+    /// - value
+    /// - init
+    /// - method
+    /// - shorthand
+    /// - computed
     #[inline]
     pub fn object_property_kind_object_property(
         self,
@@ -1186,6 +1804,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ObjectProperty`] into a [`ObjectPropertyKind::ObjectProperty`]
     #[inline]
     pub fn object_property_kind_from_object_property<T>(self, inner: T) -> ObjectPropertyKind<'a>
     where
@@ -1194,6 +1813,13 @@ impl<'a> AstBuilder<'a> {
         ObjectPropertyKind::ObjectProperty(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ObjectPropertyKind::SpreadProperty`]
+    ///
+    /// This node contains a [`SpreadElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument: The expression being spread.
     #[inline]
     pub fn object_property_kind_spread_element(
         self,
@@ -1203,6 +1829,7 @@ impl<'a> AstBuilder<'a> {
         ObjectPropertyKind::SpreadProperty(self.alloc(self.spread_element(span, argument)))
     }
 
+    /// Convert a [`SpreadElement`] into a [`ObjectPropertyKind::SpreadProperty`]
     #[inline]
     pub fn object_property_kind_from_spread_element<T>(self, inner: T) -> ObjectPropertyKind<'a>
     where
@@ -1211,6 +1838,19 @@ impl<'a> AstBuilder<'a> {
         ObjectPropertyKind::SpreadProperty(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`ObjectProperty`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - key
+    /// - value
+    /// - init
+    /// - method
+    /// - shorthand
+    /// - computed
     #[inline]
     pub fn object_property(
         self,
@@ -1226,6 +1866,19 @@ impl<'a> AstBuilder<'a> {
         ObjectProperty { span, kind, key, value, init, method, shorthand, computed }
     }
 
+    /// Builds a [`ObjectProperty`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - key
+    /// - value
+    /// - init
+    /// - method
+    /// - shorthand
+    /// - computed
     #[inline]
     pub fn alloc_object_property(
         self,
@@ -1244,6 +1897,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`PropertyKey::StaticIdentifier`]
+    ///
+    /// This node contains a [`IdentifierName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn property_key_identifier_name<A>(self, span: Span, name: A) -> PropertyKey<'a>
     where
@@ -1252,6 +1912,7 @@ impl<'a> AstBuilder<'a> {
         PropertyKey::StaticIdentifier(self.alloc(self.identifier_name(span, name)))
     }
 
+    /// Convert a [`IdentifierName`] into a [`PropertyKey::StaticIdentifier`]
     #[inline]
     pub fn property_key_from_identifier_name<T>(self, inner: T) -> PropertyKey<'a>
     where
@@ -1260,6 +1921,13 @@ impl<'a> AstBuilder<'a> {
         PropertyKey::StaticIdentifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`PropertyKey::PrivateIdentifier`]
+    ///
+    /// This node contains a [`PrivateIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn property_key_private_identifier<A>(self, span: Span, name: A) -> PropertyKey<'a>
     where
@@ -1268,6 +1936,7 @@ impl<'a> AstBuilder<'a> {
         PropertyKey::PrivateIdentifier(self.alloc(self.private_identifier(span, name)))
     }
 
+    /// Convert a [`PrivateIdentifier`] into a [`PropertyKey::PrivateIdentifier`]
     #[inline]
     pub fn property_key_from_private_identifier<T>(self, inner: T) -> PropertyKey<'a>
     where
@@ -1281,6 +1950,14 @@ impl<'a> AstBuilder<'a> {
         PropertyKey::from(inner)
     }
 
+    /// Builds a [`TemplateLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_template_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - expressions
     #[inline]
     pub fn template_literal(
         self,
@@ -1291,6 +1968,14 @@ impl<'a> AstBuilder<'a> {
         TemplateLiteral { span, quasis, expressions }
     }
 
+    /// Builds a [`TemplateLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::template_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - expressions
     #[inline]
     pub fn alloc_template_literal(
         self,
@@ -1301,6 +1986,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.template_literal(span, quasis, expressions), self.allocator)
     }
 
+    /// Builds a [`TaggedTemplateExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_tagged_template_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - tag
+    /// - quasi
+    /// - type_parameters
     #[inline]
     pub fn tagged_template_expression<T1>(
         self,
@@ -1320,6 +2014,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TaggedTemplateExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::tagged_template_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - tag
+    /// - quasi
+    /// - type_parameters
     #[inline]
     pub fn alloc_tagged_template_expression<T1>(
         self,
@@ -1337,6 +2040,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TemplateElement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_template_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - tail
+    /// - value
     #[inline]
     pub fn template_element(
         self,
@@ -1347,6 +2058,14 @@ impl<'a> AstBuilder<'a> {
         TemplateElement { span, tail, value }
     }
 
+    /// Builds a [`TemplateElement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::template_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - tail
+    /// - value
     #[inline]
     pub fn alloc_template_element(
         self,
@@ -1357,6 +2076,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.template_element(span, tail, value), self.allocator)
     }
 
+    /// Build a [`MemberExpression::ComputedMemberExpression`]
+    ///
+    /// This node contains a [`ComputedMemberExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - expression
+    /// - optional
     #[inline]
     pub fn member_expression_computed(
         self,
@@ -1370,6 +2098,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ComputedMemberExpression`] into a [`MemberExpression::ComputedMemberExpression`]
     #[inline]
     pub fn member_expression_from_computed<T>(self, inner: T) -> MemberExpression<'a>
     where
@@ -1378,6 +2107,15 @@ impl<'a> AstBuilder<'a> {
         MemberExpression::ComputedMemberExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`MemberExpression::StaticMemberExpression`]
+    ///
+    /// This node contains a [`StaticMemberExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - property
+    /// - optional
     #[inline]
     pub fn member_expression_static(
         self,
@@ -1391,6 +2129,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`StaticMemberExpression`] into a [`MemberExpression::StaticMemberExpression`]
     #[inline]
     pub fn member_expression_from_static<T>(self, inner: T) -> MemberExpression<'a>
     where
@@ -1399,6 +2138,15 @@ impl<'a> AstBuilder<'a> {
         MemberExpression::StaticMemberExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`MemberExpression::PrivateFieldExpression`]
+    ///
+    /// This node contains a [`PrivateFieldExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - field
+    /// - optional
     #[inline]
     pub fn member_expression_private_field_expression(
         self,
@@ -1412,6 +2160,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`PrivateFieldExpression`] into a [`MemberExpression::PrivateFieldExpression`]
     #[inline]
     pub fn member_expression_from_private_field_expression<T>(
         self,
@@ -1423,6 +2172,15 @@ impl<'a> AstBuilder<'a> {
         MemberExpression::PrivateFieldExpression(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`ComputedMemberExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_computed_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - expression
+    /// - optional
     #[inline]
     pub fn computed_member_expression(
         self,
@@ -1434,6 +2192,15 @@ impl<'a> AstBuilder<'a> {
         ComputedMemberExpression { span, object, expression, optional }
     }
 
+    /// Builds a [`ComputedMemberExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::computed_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - expression
+    /// - optional
     #[inline]
     pub fn alloc_computed_member_expression(
         self,
@@ -1448,6 +2215,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`StaticMemberExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_static_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - property
+    /// - optional
     #[inline]
     pub fn static_member_expression(
         self,
@@ -1459,6 +2235,15 @@ impl<'a> AstBuilder<'a> {
         StaticMemberExpression { span, object, property, optional }
     }
 
+    /// Builds a [`StaticMemberExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::static_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - property
+    /// - optional
     #[inline]
     pub fn alloc_static_member_expression(
         self,
@@ -1470,6 +2255,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.static_member_expression(span, object, property, optional), self.allocator)
     }
 
+    /// Builds a [`PrivateFieldExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_private_field_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - field
+    /// - optional
     #[inline]
     pub fn private_field_expression(
         self,
@@ -1481,6 +2275,15 @@ impl<'a> AstBuilder<'a> {
         PrivateFieldExpression { span, object, field, optional }
     }
 
+    /// Builds a [`PrivateFieldExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::private_field_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - field
+    /// - optional
     #[inline]
     pub fn alloc_private_field_expression(
         self,
@@ -1492,6 +2295,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.private_field_expression(span, object, field, optional), self.allocator)
     }
 
+    /// Builds a [`CallExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_call_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - arguments
+    /// - callee
+    /// - type_parameters
+    /// - optional
     #[inline]
     pub fn call_expression<T1>(
         self,
@@ -1513,6 +2326,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`CallExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::call_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - arguments
+    /// - callee
+    /// - type_parameters
+    /// - optional
     #[inline]
     pub fn alloc_call_expression<T1>(
         self,
@@ -1531,6 +2354,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`NewExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_new_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - callee
+    /// - arguments
+    /// - type_parameters
     #[inline]
     pub fn new_expression<T1>(
         self,
@@ -1550,6 +2382,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`NewExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::new_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - callee
+    /// - arguments
+    /// - type_parameters
     #[inline]
     pub fn alloc_new_expression<T1>(
         self,
@@ -1564,6 +2405,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.new_expression(span, callee, arguments, type_parameters), self.allocator)
     }
 
+    /// Builds a [`MetaProperty`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_meta_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - meta
+    /// - property
     #[inline]
     pub fn meta_property(
         self,
@@ -1574,6 +2423,14 @@ impl<'a> AstBuilder<'a> {
         MetaProperty { span, meta, property }
     }
 
+    /// Builds a [`MetaProperty`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::meta_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - meta
+    /// - property
     #[inline]
     pub fn alloc_meta_property(
         self,
@@ -1584,11 +2441,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.meta_property(span, meta, property), self.allocator)
     }
 
+    /// Builds a [`SpreadElement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_spread_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument: The expression being spread.
     #[inline]
     pub fn spread_element(self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
         SpreadElement { span, argument }
     }
 
+    /// Builds a [`SpreadElement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::spread_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument: The expression being spread.
     #[inline]
     pub fn alloc_spread_element(
         self,
@@ -1598,11 +2469,19 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.spread_element(span, argument), self.allocator)
     }
 
+    /// Build a [`Argument::SpreadElement`]
+    ///
+    /// This node contains a [`SpreadElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument: The expression being spread.
     #[inline]
     pub fn argument_spread_element(self, span: Span, argument: Expression<'a>) -> Argument<'a> {
         Argument::SpreadElement(self.alloc(self.spread_element(span, argument)))
     }
 
+    /// Convert a [`SpreadElement`] into a [`Argument::SpreadElement`]
     #[inline]
     pub fn argument_from_spread_element<T>(self, inner: T) -> Argument<'a>
     where
@@ -1616,6 +2495,15 @@ impl<'a> AstBuilder<'a> {
         Argument::from(inner)
     }
 
+    /// Builds a [`UpdateExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_update_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - prefix
+    /// - argument
     #[inline]
     pub fn update_expression(
         self,
@@ -1627,6 +2515,15 @@ impl<'a> AstBuilder<'a> {
         UpdateExpression { span, operator, prefix, argument }
     }
 
+    /// Builds a [`UpdateExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::update_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - prefix
+    /// - argument
     #[inline]
     pub fn alloc_update_expression(
         self,
@@ -1638,6 +2535,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.update_expression(span, operator, prefix, argument), self.allocator)
     }
 
+    /// Builds a [`UnaryExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_unary_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - argument
     #[inline]
     pub fn unary_expression(
         self,
@@ -1648,6 +2553,14 @@ impl<'a> AstBuilder<'a> {
         UnaryExpression { span, operator, argument }
     }
 
+    /// Builds a [`UnaryExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::unary_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - argument
     #[inline]
     pub fn alloc_unary_expression(
         self,
@@ -1658,6 +2571,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.unary_expression(span, operator, argument), self.allocator)
     }
 
+    /// Builds a [`BinaryExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binary_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn binary_expression(
         self,
@@ -1669,6 +2591,15 @@ impl<'a> AstBuilder<'a> {
         BinaryExpression { span, left, operator, right }
     }
 
+    /// Builds a [`BinaryExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binary_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn alloc_binary_expression(
         self,
@@ -1680,6 +2611,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.binary_expression(span, left, operator, right), self.allocator)
     }
 
+    /// Builds a [`PrivateInExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_private_in_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn private_in_expression(
         self,
@@ -1691,6 +2631,15 @@ impl<'a> AstBuilder<'a> {
         PrivateInExpression { span, left, operator, right }
     }
 
+    /// Builds a [`PrivateInExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::private_in_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn alloc_private_in_expression(
         self,
@@ -1702,6 +2651,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.private_in_expression(span, left, operator, right), self.allocator)
     }
 
+    /// Builds a [`LogicalExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_logical_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn logical_expression(
         self,
@@ -1713,6 +2671,15 @@ impl<'a> AstBuilder<'a> {
         LogicalExpression { span, left, operator, right }
     }
 
+    /// Builds a [`LogicalExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::logical_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - operator
+    /// - right
     #[inline]
     pub fn alloc_logical_expression(
         self,
@@ -1724,6 +2691,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.logical_expression(span, left, operator, right), self.allocator)
     }
 
+    /// Builds a [`ConditionalExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_conditional_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
+    /// - alternate
     #[inline]
     pub fn conditional_expression(
         self,
@@ -1735,6 +2711,15 @@ impl<'a> AstBuilder<'a> {
         ConditionalExpression { span, test, consequent, alternate }
     }
 
+    /// Builds a [`ConditionalExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::conditional_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
+    /// - alternate
     #[inline]
     pub fn alloc_conditional_expression(
         self,
@@ -1746,6 +2731,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.conditional_expression(span, test, consequent, alternate), self.allocator)
     }
 
+    /// Builds a [`AssignmentExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - left
+    /// - right
     #[inline]
     pub fn assignment_expression(
         self,
@@ -1757,6 +2751,15 @@ impl<'a> AstBuilder<'a> {
         AssignmentExpression { span, operator, left, right }
     }
 
+    /// Builds a [`AssignmentExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - left
+    /// - right
     #[inline]
     pub fn alloc_assignment_expression(
         self,
@@ -1784,6 +2787,13 @@ impl<'a> AstBuilder<'a> {
         AssignmentTarget::from(inner)
     }
 
+    /// Build a [`SimpleAssignmentTarget::AssignmentTargetIdentifier`]
+    ///
+    /// This node contains a [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The name of the identifier being referenced.
     #[inline]
     pub fn simple_assignment_target_identifier_reference<A>(
         self,
@@ -1798,6 +2808,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`IdentifierReference`] into a [`SimpleAssignmentTarget::AssignmentTargetIdentifier`]
     #[inline]
     pub fn simple_assignment_target_from_identifier_reference<T>(
         self,
@@ -1809,6 +2820,14 @@ impl<'a> AstBuilder<'a> {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`SimpleAssignmentTarget::TSAsExpression`]
+    ///
+    /// This node contains a [`TSAsExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn simple_assignment_target_ts_as_expression(
         self,
@@ -1823,6 +2842,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSAsExpression`] into a [`SimpleAssignmentTarget::TSAsExpression`]
     #[inline]
     pub fn simple_assignment_target_from_ts_as_expression<T>(
         self,
@@ -1834,6 +2854,14 @@ impl<'a> AstBuilder<'a> {
         SimpleAssignmentTarget::TSAsExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`SimpleAssignmentTarget::TSSatisfiesExpression`]
+    ///
+    /// This node contains a [`TSSatisfiesExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn simple_assignment_target_ts_satisfies_expression(
         self,
@@ -1848,6 +2876,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSSatisfiesExpression`] into a [`SimpleAssignmentTarget::TSSatisfiesExpression`]
     #[inline]
     pub fn simple_assignment_target_from_ts_satisfies_expression<T>(
         self,
@@ -1859,6 +2888,13 @@ impl<'a> AstBuilder<'a> {
         SimpleAssignmentTarget::TSSatisfiesExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`SimpleAssignmentTarget::TSNonNullExpression`]
+    ///
+    /// This node contains a [`TSNonNullExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn simple_assignment_target_ts_non_null_expression(
         self,
@@ -1870,6 +2906,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSNonNullExpression`] into a [`SimpleAssignmentTarget::TSNonNullExpression`]
     #[inline]
     pub fn simple_assignment_target_from_ts_non_null_expression<T>(
         self,
@@ -1881,6 +2918,14 @@ impl<'a> AstBuilder<'a> {
         SimpleAssignmentTarget::TSNonNullExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`SimpleAssignmentTarget::TSTypeAssertion`]
+    ///
+    /// This node contains a [`TSTypeAssertion`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn simple_assignment_target_ts_type_assertion(
         self,
@@ -1895,6 +2940,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSTypeAssertion`] into a [`SimpleAssignmentTarget::TSTypeAssertion`]
     #[inline]
     pub fn simple_assignment_target_from_ts_type_assertion<T>(
         self,
@@ -1906,6 +2952,14 @@ impl<'a> AstBuilder<'a> {
         SimpleAssignmentTarget::TSTypeAssertion(inner.into_in(self.allocator))
     }
 
+    /// Build a [`SimpleAssignmentTarget::TSInstantiationExpression`]
+    ///
+    /// This node contains a [`TSInstantiationExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn simple_assignment_target_ts_instantiation_expression<T1>(
         self,
@@ -1921,6 +2975,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSInstantiationExpression`] into a [`SimpleAssignmentTarget::TSInstantiationExpression`]
     #[inline]
     pub fn simple_assignment_target_from_ts_instantiation_expression<T>(
         self,
@@ -1940,6 +2995,15 @@ impl<'a> AstBuilder<'a> {
         SimpleAssignmentTarget::from(inner)
     }
 
+    /// Build a [`AssignmentTargetPattern::ArrayAssignmentTarget`]
+    ///
+    /// This node contains a [`ArrayAssignmentTarget`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - rest
+    /// - trailing_comma
     #[inline]
     pub fn assignment_target_pattern_array_assignment_target(
         self,
@@ -1956,6 +3020,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ArrayAssignmentTarget`] into a [`AssignmentTargetPattern::ArrayAssignmentTarget`]
     #[inline]
     pub fn assignment_target_pattern_from_array_assignment_target<T>(
         self,
@@ -1967,6 +3032,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetPattern::ArrayAssignmentTarget(inner.into_in(self.allocator))
     }
 
+    /// Build a [`AssignmentTargetPattern::ObjectAssignmentTarget`]
+    ///
+    /// This node contains a [`ObjectAssignmentTarget`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties
+    /// - rest
     #[inline]
     pub fn assignment_target_pattern_object_assignment_target(
         self,
@@ -1979,6 +3052,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ObjectAssignmentTarget`] into a [`AssignmentTargetPattern::ObjectAssignmentTarget`]
     #[inline]
     pub fn assignment_target_pattern_from_object_assignment_target<T>(
         self,
@@ -1990,6 +3064,15 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetPattern::ObjectAssignmentTarget(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`ArrayAssignmentTarget`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_array_assignment_target`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - rest
+    /// - trailing_comma
     #[inline]
     pub fn array_assignment_target(
         self,
@@ -2001,6 +3084,15 @@ impl<'a> AstBuilder<'a> {
         ArrayAssignmentTarget { span, elements, rest, trailing_comma }
     }
 
+    /// Builds a [`ArrayAssignmentTarget`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::array_assignment_target`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - rest
+    /// - trailing_comma
     #[inline]
     pub fn alloc_array_assignment_target(
         self,
@@ -2015,6 +3107,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`ObjectAssignmentTarget`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_assignment_target`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties
+    /// - rest
     #[inline]
     pub fn object_assignment_target(
         self,
@@ -2025,6 +3125,14 @@ impl<'a> AstBuilder<'a> {
         ObjectAssignmentTarget { span, properties, rest }
     }
 
+    /// Builds a [`ObjectAssignmentTarget`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_assignment_target`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties
+    /// - rest
     #[inline]
     pub fn alloc_object_assignment_target(
         self,
@@ -2035,6 +3143,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.object_assignment_target(span, properties, rest), self.allocator)
     }
 
+    /// Builds a [`AssignmentTargetRest`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_rest`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - target
     #[inline]
     pub fn assignment_target_rest(
         self,
@@ -2044,6 +3159,13 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetRest { span, target }
     }
 
+    /// Builds a [`AssignmentTargetRest`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_rest`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - target
     #[inline]
     pub fn alloc_assignment_target_rest(
         self,
@@ -2053,6 +3175,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.assignment_target_rest(span, target), self.allocator)
     }
 
+    /// Build a [`AssignmentTargetMaybeDefault::AssignmentTargetWithDefault`]
+    ///
+    /// This node contains a [`AssignmentTargetWithDefault`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - binding
+    /// - init
     #[inline]
     pub fn assignment_target_maybe_default_assignment_target_with_default(
         self,
@@ -2065,6 +3195,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`AssignmentTargetWithDefault`] into a [`AssignmentTargetMaybeDefault::AssignmentTargetWithDefault`]
     #[inline]
     pub fn assignment_target_maybe_default_from_assignment_target_with_default<T>(
         self,
@@ -2084,6 +3215,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetMaybeDefault::from(inner)
     }
 
+    /// Builds a [`AssignmentTargetWithDefault`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_with_default`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - binding
+    /// - init
     #[inline]
     pub fn assignment_target_with_default(
         self,
@@ -2094,6 +3233,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetWithDefault { span, binding, init }
     }
 
+    /// Builds a [`AssignmentTargetWithDefault`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_with_default`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - binding
+    /// - init
     #[inline]
     pub fn alloc_assignment_target_with_default(
         self,
@@ -2104,6 +3251,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.assignment_target_with_default(span, binding, init), self.allocator)
     }
 
+    /// Build a [`AssignmentTargetProperty::AssignmentTargetPropertyIdentifier`]
+    ///
+    /// This node contains a [`AssignmentTargetPropertyIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - binding
+    /// - init
     #[inline]
     pub fn assignment_target_property_assignment_target_property_identifier(
         self,
@@ -2116,6 +3271,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`AssignmentTargetPropertyIdentifier`] into a [`AssignmentTargetProperty::AssignmentTargetPropertyIdentifier`]
     #[inline]
     pub fn assignment_target_property_from_assignment_target_property_identifier<T>(
         self,
@@ -2127,6 +3283,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`AssignmentTargetProperty::AssignmentTargetPropertyProperty`]
+    ///
+    /// This node contains a [`AssignmentTargetPropertyProperty`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - binding
     #[inline]
     pub fn assignment_target_property_assignment_target_property_property(
         self,
@@ -2139,6 +3303,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`AssignmentTargetPropertyProperty`] into a [`AssignmentTargetProperty::AssignmentTargetPropertyProperty`]
     #[inline]
     pub fn assignment_target_property_from_assignment_target_property_property<T>(
         self,
@@ -2150,6 +3315,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetProperty::AssignmentTargetPropertyProperty(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`AssignmentTargetPropertyIdentifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_property_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - binding
+    /// - init
     #[inline]
     pub fn assignment_target_property_identifier(
         self,
@@ -2160,6 +3333,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetPropertyIdentifier { span, binding, init }
     }
 
+    /// Builds a [`AssignmentTargetPropertyIdentifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - binding
+    /// - init
     #[inline]
     pub fn alloc_assignment_target_property_identifier(
         self,
@@ -2170,6 +3351,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.assignment_target_property_identifier(span, binding, init), self.allocator)
     }
 
+    /// Builds a [`AssignmentTargetPropertyProperty`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_property_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - binding
     #[inline]
     pub fn assignment_target_property_property(
         self,
@@ -2180,6 +3369,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentTargetPropertyProperty { span, name, binding }
     }
 
+    /// Builds a [`AssignmentTargetPropertyProperty`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - binding
     #[inline]
     pub fn alloc_assignment_target_property_property(
         self,
@@ -2190,6 +3387,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.assignment_target_property_property(span, name, binding), self.allocator)
     }
 
+    /// Builds a [`SequenceExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_sequence_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expressions
     #[inline]
     pub fn sequence_expression(
         self,
@@ -2199,6 +3403,13 @@ impl<'a> AstBuilder<'a> {
         SequenceExpression { span, expressions }
     }
 
+    /// Builds a [`SequenceExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::sequence_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expressions
     #[inline]
     pub fn alloc_sequence_expression(
         self,
@@ -2208,21 +3419,47 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.sequence_expression(span, expressions), self.allocator)
     }
 
+    /// Builds a [`Super`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_super_`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn super_(self, span: Span) -> Super {
         Super { span }
     }
 
+    /// Builds a [`Super`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::super_`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_super_(self, span: Span) -> Box<'a, Super> {
         Box::new_in(self.super_(span), self.allocator)
     }
 
+    /// Builds a [`AwaitExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_await_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn await_expression(self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
         AwaitExpression { span, argument }
     }
 
+    /// Builds a [`AwaitExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::await_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn alloc_await_expression(
         self,
@@ -2232,11 +3469,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.await_expression(span, argument), self.allocator)
     }
 
+    /// Builds a [`ChainExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_chain_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn chain_expression(self, span: Span, expression: ChainElement<'a>) -> ChainExpression<'a> {
         ChainExpression { span, expression }
     }
 
+    /// Builds a [`ChainExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::chain_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_chain_expression(
         self,
@@ -2246,6 +3497,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.chain_expression(span, expression), self.allocator)
     }
 
+    /// Build a [`ChainElement::CallExpression`]
+    ///
+    /// This node contains a [`CallExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - arguments
+    /// - callee
+    /// - type_parameters
+    /// - optional
     #[inline]
     pub fn chain_element_call_expression<T1>(
         self,
@@ -2267,6 +3528,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`CallExpression`] into a [`ChainElement::CallExpression`]
     #[inline]
     pub fn chain_element_from_call_expression<T>(self, inner: T) -> ChainElement<'a>
     where
@@ -2280,6 +3542,13 @@ impl<'a> AstBuilder<'a> {
         ChainElement::from(inner)
     }
 
+    /// Builds a [`ParenthesizedExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_parenthesized_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn parenthesized_expression(
         self,
@@ -2289,6 +3558,13 @@ impl<'a> AstBuilder<'a> {
         ParenthesizedExpression { span, expression }
     }
 
+    /// Builds a [`ParenthesizedExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::parenthesized_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_parenthesized_expression(
         self,
@@ -2298,11 +3574,19 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.parenthesized_expression(span, expression), self.allocator)
     }
 
+    /// Build a [`Statement::BlockStatement`]
+    ///
+    /// This node contains a [`BlockStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn statement_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> Statement<'a> {
         Statement::BlockStatement(self.alloc(self.block_statement(span, body)))
     }
 
+    /// Convert a [`BlockStatement`] into a [`Statement::BlockStatement`]
     #[inline]
     pub fn statement_from_block<T>(self, inner: T) -> Statement<'a>
     where
@@ -2311,11 +3595,19 @@ impl<'a> AstBuilder<'a> {
         Statement::BlockStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::BreakStatement`]
+    ///
+    /// This node contains a [`BreakStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
     #[inline]
     pub fn statement_break(self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
         Statement::BreakStatement(self.alloc(self.break_statement(span, label)))
     }
 
+    /// Convert a [`BreakStatement`] into a [`Statement::BreakStatement`]
     #[inline]
     pub fn statement_from_break<T>(self, inner: T) -> Statement<'a>
     where
@@ -2324,6 +3616,13 @@ impl<'a> AstBuilder<'a> {
         Statement::BreakStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ContinueStatement`]
+    ///
+    /// This node contains a [`ContinueStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
     #[inline]
     pub fn statement_continue(
         self,
@@ -2333,6 +3632,7 @@ impl<'a> AstBuilder<'a> {
         Statement::ContinueStatement(self.alloc(self.continue_statement(span, label)))
     }
 
+    /// Convert a [`ContinueStatement`] into a [`Statement::ContinueStatement`]
     #[inline]
     pub fn statement_from_continue<T>(self, inner: T) -> Statement<'a>
     where
@@ -2341,11 +3641,18 @@ impl<'a> AstBuilder<'a> {
         Statement::ContinueStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::DebuggerStatement`]
+    ///
+    /// This node contains a [`DebuggerStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn statement_debugger(self, span: Span) -> Statement<'a> {
         Statement::DebuggerStatement(self.alloc(self.debugger_statement(span)))
     }
 
+    /// Convert a [`DebuggerStatement`] into a [`Statement::DebuggerStatement`]
     #[inline]
     pub fn statement_from_debugger<T>(self, inner: T) -> Statement<'a>
     where
@@ -2354,6 +3661,14 @@ impl<'a> AstBuilder<'a> {
         Statement::DebuggerStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::DoWhileStatement`]
+    ///
+    /// This node contains a [`DoWhileStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
+    /// - test
     #[inline]
     pub fn statement_do_while(
         self,
@@ -2364,6 +3679,7 @@ impl<'a> AstBuilder<'a> {
         Statement::DoWhileStatement(self.alloc(self.do_while_statement(span, body, test)))
     }
 
+    /// Convert a [`DoWhileStatement`] into a [`Statement::DoWhileStatement`]
     #[inline]
     pub fn statement_from_do_while<T>(self, inner: T) -> Statement<'a>
     where
@@ -2372,11 +3688,18 @@ impl<'a> AstBuilder<'a> {
         Statement::DoWhileStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::EmptyStatement`]
+    ///
+    /// This node contains a [`EmptyStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn statement_empty(self, span: Span) -> Statement<'a> {
         Statement::EmptyStatement(self.alloc(self.empty_statement(span)))
     }
 
+    /// Convert a [`EmptyStatement`] into a [`Statement::EmptyStatement`]
     #[inline]
     pub fn statement_from_empty<T>(self, inner: T) -> Statement<'a>
     where
@@ -2385,11 +3708,19 @@ impl<'a> AstBuilder<'a> {
         Statement::EmptyStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ExpressionStatement`]
+    ///
+    /// This node contains a [`ExpressionStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn statement_expression(self, span: Span, expression: Expression<'a>) -> Statement<'a> {
         Statement::ExpressionStatement(self.alloc(self.expression_statement(span, expression)))
     }
 
+    /// Convert a [`ExpressionStatement`] into a [`Statement::ExpressionStatement`]
     #[inline]
     pub fn statement_from_expression<T>(self, inner: T) -> Statement<'a>
     where
@@ -2398,6 +3729,15 @@ impl<'a> AstBuilder<'a> {
         Statement::ExpressionStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ForInStatement`]
+    ///
+    /// This node contains a [`ForInStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
+    /// - body
     #[inline]
     pub fn statement_for_in(
         self,
@@ -2409,6 +3749,7 @@ impl<'a> AstBuilder<'a> {
         Statement::ForInStatement(self.alloc(self.for_in_statement(span, left, right, body)))
     }
 
+    /// Convert a [`ForInStatement`] into a [`Statement::ForInStatement`]
     #[inline]
     pub fn statement_from_for_in<T>(self, inner: T) -> Statement<'a>
     where
@@ -2417,6 +3758,16 @@ impl<'a> AstBuilder<'a> {
         Statement::ForInStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ForOfStatement`]
+    ///
+    /// This node contains a [`ForOfStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - r#await
+    /// - left
+    /// - right
+    /// - body
     #[inline]
     pub fn statement_for_of(
         self,
@@ -2431,6 +3782,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ForOfStatement`] into a [`Statement::ForOfStatement`]
     #[inline]
     pub fn statement_from_for_of<T>(self, inner: T) -> Statement<'a>
     where
@@ -2439,6 +3791,16 @@ impl<'a> AstBuilder<'a> {
         Statement::ForOfStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ForStatement`]
+    ///
+    /// This node contains a [`ForStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - init
+    /// - test
+    /// - update
+    /// - body
     #[inline]
     pub fn statement_for(
         self,
@@ -2451,6 +3813,7 @@ impl<'a> AstBuilder<'a> {
         Statement::ForStatement(self.alloc(self.for_statement(span, init, test, update, body)))
     }
 
+    /// Convert a [`ForStatement`] into a [`Statement::ForStatement`]
     #[inline]
     pub fn statement_from_for<T>(self, inner: T) -> Statement<'a>
     where
@@ -2459,6 +3822,15 @@ impl<'a> AstBuilder<'a> {
         Statement::ForStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::IfStatement`]
+    ///
+    /// This node contains a [`IfStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
+    /// - alternate
     #[inline]
     pub fn statement_if(
         self,
@@ -2470,6 +3842,7 @@ impl<'a> AstBuilder<'a> {
         Statement::IfStatement(self.alloc(self.if_statement(span, test, consequent, alternate)))
     }
 
+    /// Convert a [`IfStatement`] into a [`Statement::IfStatement`]
     #[inline]
     pub fn statement_from_if<T>(self, inner: T) -> Statement<'a>
     where
@@ -2478,6 +3851,14 @@ impl<'a> AstBuilder<'a> {
         Statement::IfStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::LabeledStatement`]
+    ///
+    /// This node contains a [`LabeledStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
+    /// - body
     #[inline]
     pub fn statement_labeled(
         self,
@@ -2488,6 +3869,7 @@ impl<'a> AstBuilder<'a> {
         Statement::LabeledStatement(self.alloc(self.labeled_statement(span, label, body)))
     }
 
+    /// Convert a [`LabeledStatement`] into a [`Statement::LabeledStatement`]
     #[inline]
     pub fn statement_from_labeled<T>(self, inner: T) -> Statement<'a>
     where
@@ -2496,11 +3878,19 @@ impl<'a> AstBuilder<'a> {
         Statement::LabeledStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ReturnStatement`]
+    ///
+    /// This node contains a [`ReturnStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn statement_return(self, span: Span, argument: Option<Expression<'a>>) -> Statement<'a> {
         Statement::ReturnStatement(self.alloc(self.return_statement(span, argument)))
     }
 
+    /// Convert a [`ReturnStatement`] into a [`Statement::ReturnStatement`]
     #[inline]
     pub fn statement_from_return<T>(self, inner: T) -> Statement<'a>
     where
@@ -2509,6 +3899,14 @@ impl<'a> AstBuilder<'a> {
         Statement::ReturnStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::SwitchStatement`]
+    ///
+    /// This node contains a [`SwitchStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - discriminant
+    /// - cases
     #[inline]
     pub fn statement_switch(
         self,
@@ -2519,6 +3917,7 @@ impl<'a> AstBuilder<'a> {
         Statement::SwitchStatement(self.alloc(self.switch_statement(span, discriminant, cases)))
     }
 
+    /// Convert a [`SwitchStatement`] into a [`Statement::SwitchStatement`]
     #[inline]
     pub fn statement_from_switch<T>(self, inner: T) -> Statement<'a>
     where
@@ -2527,11 +3926,19 @@ impl<'a> AstBuilder<'a> {
         Statement::SwitchStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::ThrowStatement`]
+    ///
+    /// This node contains a [`ThrowStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn statement_throw(self, span: Span, argument: Expression<'a>) -> Statement<'a> {
         Statement::ThrowStatement(self.alloc(self.throw_statement(span, argument)))
     }
 
+    /// Convert a [`ThrowStatement`] into a [`Statement::ThrowStatement`]
     #[inline]
     pub fn statement_from_throw<T>(self, inner: T) -> Statement<'a>
     where
@@ -2540,6 +3947,15 @@ impl<'a> AstBuilder<'a> {
         Statement::ThrowStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::TryStatement`]
+    ///
+    /// This node contains a [`TryStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - block
+    /// - handler
+    /// - finalizer
     #[inline]
     pub fn statement_try<T1, T2, T3>(
         self,
@@ -2556,6 +3972,7 @@ impl<'a> AstBuilder<'a> {
         Statement::TryStatement(self.alloc(self.try_statement(span, block, handler, finalizer)))
     }
 
+    /// Convert a [`TryStatement`] into a [`Statement::TryStatement`]
     #[inline]
     pub fn statement_from_try<T>(self, inner: T) -> Statement<'a>
     where
@@ -2564,6 +3981,14 @@ impl<'a> AstBuilder<'a> {
         Statement::TryStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::WhileStatement`]
+    ///
+    /// This node contains a [`WhileStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - body
     #[inline]
     pub fn statement_while(
         self,
@@ -2574,6 +3999,7 @@ impl<'a> AstBuilder<'a> {
         Statement::WhileStatement(self.alloc(self.while_statement(span, test, body)))
     }
 
+    /// Convert a [`WhileStatement`] into a [`Statement::WhileStatement`]
     #[inline]
     pub fn statement_from_while<T>(self, inner: T) -> Statement<'a>
     where
@@ -2582,6 +4008,14 @@ impl<'a> AstBuilder<'a> {
         Statement::WhileStatement(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Statement::WithStatement`]
+    ///
+    /// This node contains a [`WithStatement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - body
     #[inline]
     pub fn statement_with(
         self,
@@ -2592,6 +4026,7 @@ impl<'a> AstBuilder<'a> {
         Statement::WithStatement(self.alloc(self.with_statement(span, object, body)))
     }
 
+    /// Convert a [`WithStatement`] into a [`Statement::WithStatement`]
     #[inline]
     pub fn statement_from_with<T>(self, inner: T) -> Statement<'a>
     where
@@ -2610,6 +4045,14 @@ impl<'a> AstBuilder<'a> {
         Statement::from(inner)
     }
 
+    /// Builds a [`Directive`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_directive`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression: Directive with any escapes unescaped
+    /// - directive: Raw content of directive as it appears in source, any escapes left as is
     #[inline]
     pub fn directive<A>(
         self,
@@ -2623,6 +4066,14 @@ impl<'a> AstBuilder<'a> {
         Directive { span, expression, directive: directive.into_in(self.allocator) }
     }
 
+    /// Builds a [`Directive`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::directive`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression: Directive with any escapes unescaped
+    /// - directive: Raw content of directive as it appears in source, any escapes left as is
     #[inline]
     pub fn alloc_directive<A>(
         self,
@@ -2636,6 +4087,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.directive(span, expression, directive), self.allocator)
     }
 
+    /// Builds a [`Hashbang`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_hashbang`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn hashbang<A>(self, span: Span, value: A) -> Hashbang<'a>
     where
@@ -2644,6 +4102,13 @@ impl<'a> AstBuilder<'a> {
         Hashbang { span, value: value.into_in(self.allocator) }
     }
 
+    /// Builds a [`Hashbang`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::hashbang`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn alloc_hashbang<A>(self, span: Span, value: A) -> Box<'a, Hashbang<'a>>
     where
@@ -2652,11 +4117,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.hashbang(span, value), self.allocator)
     }
 
+    /// Builds a [`BlockStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_block_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn block_statement(self, span: Span, body: Vec<'a, Statement<'a>>) -> BlockStatement<'a> {
         BlockStatement { span, body, scope_id: Default::default() }
     }
 
+    /// Builds a [`BlockStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::block_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn alloc_block_statement(
         self,
@@ -2666,6 +4145,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.block_statement(span, body), self.allocator)
     }
 
+    /// Build a [`Declaration::VariableDeclaration`]
+    ///
+    /// This node contains a [`VariableDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - declarations
+    /// - declare
     #[inline]
     pub fn declaration_variable(
         self,
@@ -2682,6 +4170,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`VariableDeclaration`] into a [`Declaration::VariableDeclaration`]
     #[inline]
     pub fn declaration_from_variable<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2690,6 +4179,22 @@ impl<'a> AstBuilder<'a> {
         Declaration::VariableDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::FunctionDeclaration`]
+    ///
+    /// This node contains a [`Function`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - generator
+    /// - r#async
+    /// - declare
+    /// - type_parameters
+    /// - this_param: Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
+    /// - params
+    /// - return_type
+    /// - body
     #[inline]
     pub fn declaration_function<T1, T2, T3, T4>(
         self,
@@ -2726,6 +4231,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`Function`] into a [`Declaration::FunctionDeclaration`]
     #[inline]
     pub fn declaration_from_function<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2734,6 +4240,22 @@ impl<'a> AstBuilder<'a> {
         Declaration::FunctionDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::ClassDeclaration`]
+    ///
+    /// This node contains a [`Class`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the class.
+    /// - id: Class identifier, AKA the name
+    /// - type_parameters
+    /// - super_class: Super class. When present, this will usually be an [`IdentifierReference`].
+    /// - super_type_parameters: Type parameters passed to super class.
+    /// - implements: Interface implementation clause for TypeScript classes.
+    /// - body
+    /// - r#abstract: Whether the class is abstract
+    /// - declare: Whether the class was `declare`ed
     #[inline]
     pub fn declaration_class<T1, T2, T3>(
         self,
@@ -2769,6 +4291,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`Class`] into a [`Declaration::ClassDeclaration`]
     #[inline]
     pub fn declaration_from_class<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2777,6 +4300,14 @@ impl<'a> AstBuilder<'a> {
         Declaration::ClassDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::UsingDeclaration`]
+    ///
+    /// This node contains a [`UsingDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_await
+    /// - declarations
     #[inline]
     pub fn declaration_using(
         self,
@@ -2791,6 +4322,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`UsingDeclaration`] into a [`Declaration::UsingDeclaration`]
     #[inline]
     pub fn declaration_from_using<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2799,6 +4331,16 @@ impl<'a> AstBuilder<'a> {
         Declaration::UsingDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::TSTypeAliasDeclaration`]
+    ///
+    /// This node contains a [`TSTypeAliasDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - type_parameters
+    /// - type_annotation
+    /// - declare
     #[inline]
     pub fn declaration_ts_type_alias<T1>(
         self,
@@ -2820,6 +4362,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSTypeAliasDeclaration`] into a [`Declaration::TSTypeAliasDeclaration`]
     #[inline]
     pub fn declaration_from_ts_type_alias<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2828,6 +4371,17 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSTypeAliasDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::TSInterfaceDeclaration`]
+    ///
+    /// This node contains a [`TSInterfaceDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id: The identifier (name) of the interface.
+    /// - extends
+    /// - type_parameters
+    /// - body
+    /// - declare
     #[inline]
     pub fn declaration_ts_interface<T1, T2>(
         self,
@@ -2852,6 +4406,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSInterfaceDeclaration`] into a [`Declaration::TSInterfaceDeclaration`]
     #[inline]
     pub fn declaration_from_ts_interface<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2860,6 +4415,16 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSInterfaceDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::TSEnumDeclaration`]
+    ///
+    /// This node contains a [`TSEnumDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - members
+    /// - r#const
+    /// - declare
     #[inline]
     pub fn declaration_ts_enum(
         self,
@@ -2874,6 +4439,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSEnumDeclaration`] into a [`Declaration::TSEnumDeclaration`]
     #[inline]
     pub fn declaration_from_ts_enum<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2882,6 +4448,16 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSEnumDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::TSModuleDeclaration`]
+    ///
+    /// This node contains a [`TSModuleDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - body
+    /// - kind: The keyword used to define this module declaration
+    /// - declare
     #[inline]
     pub fn declaration_ts_module(
         self,
@@ -2896,6 +4472,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSModuleDeclaration`] into a [`Declaration::TSModuleDeclaration`]
     #[inline]
     pub fn declaration_from_ts_module<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2904,6 +4481,15 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSModuleDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`Declaration::TSImportEqualsDeclaration`]
+    ///
+    /// This node contains a [`TSImportEqualsDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - module_reference
+    /// - import_kind
     #[inline]
     pub fn declaration_ts_import_equals(
         self,
@@ -2920,6 +4506,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSImportEqualsDeclaration`] into a [`Declaration::TSImportEqualsDeclaration`]
     #[inline]
     pub fn declaration_from_ts_import_equals<T>(self, inner: T) -> Declaration<'a>
     where
@@ -2928,6 +4515,15 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSImportEqualsDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`VariableDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_variable_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - declarations
+    /// - declare
     #[inline]
     pub fn variable_declaration(
         self,
@@ -2939,6 +4535,15 @@ impl<'a> AstBuilder<'a> {
         VariableDeclaration { span, kind, declarations, declare }
     }
 
+    /// Builds a [`VariableDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::variable_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - declarations
+    /// - declare
     #[inline]
     pub fn alloc_variable_declaration(
         self,
@@ -2950,6 +4555,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.variable_declaration(span, kind, declarations, declare), self.allocator)
     }
 
+    /// Builds a [`VariableDeclarator`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_variable_declarator`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - id
+    /// - init
+    /// - definite
     #[inline]
     pub fn variable_declarator(
         self,
@@ -2962,6 +4577,16 @@ impl<'a> AstBuilder<'a> {
         VariableDeclarator { span, kind, id, init, definite }
     }
 
+    /// Builds a [`VariableDeclarator`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::variable_declarator`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - id
+    /// - init
+    /// - definite
     #[inline]
     pub fn alloc_variable_declarator(
         self,
@@ -2974,6 +4599,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.variable_declarator(span, kind, id, init, definite), self.allocator)
     }
 
+    /// Builds a [`UsingDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_using_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_await
+    /// - declarations
     #[inline]
     pub fn using_declaration(
         self,
@@ -2984,6 +4617,14 @@ impl<'a> AstBuilder<'a> {
         UsingDeclaration { span, is_await, declarations }
     }
 
+    /// Builds a [`UsingDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::using_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_await
+    /// - declarations
     #[inline]
     pub fn alloc_using_declaration(
         self,
@@ -2994,16 +4635,35 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.using_declaration(span, is_await, declarations), self.allocator)
     }
 
+    /// Builds a [`EmptyStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_empty_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn empty_statement(self, span: Span) -> EmptyStatement {
         EmptyStatement { span }
     }
 
+    /// Builds a [`EmptyStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::empty_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_empty_statement(self, span: Span) -> Box<'a, EmptyStatement> {
         Box::new_in(self.empty_statement(span), self.allocator)
     }
 
+    /// Builds a [`ExpressionStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_expression_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn expression_statement(
         self,
@@ -3013,6 +4673,13 @@ impl<'a> AstBuilder<'a> {
         ExpressionStatement { span, expression }
     }
 
+    /// Builds a [`ExpressionStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::expression_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_expression_statement(
         self,
@@ -3022,6 +4689,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.expression_statement(span, expression), self.allocator)
     }
 
+    /// Builds a [`IfStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_if_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
+    /// - alternate
     #[inline]
     pub fn if_statement(
         self,
@@ -3033,6 +4709,15 @@ impl<'a> AstBuilder<'a> {
         IfStatement { span, test, consequent, alternate }
     }
 
+    /// Builds a [`IfStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::if_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
+    /// - alternate
     #[inline]
     pub fn alloc_if_statement(
         self,
@@ -3044,6 +4729,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.if_statement(span, test, consequent, alternate), self.allocator)
     }
 
+    /// Builds a [`DoWhileStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_do_while_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
+    /// - test
     #[inline]
     pub fn do_while_statement(
         self,
@@ -3054,6 +4747,14 @@ impl<'a> AstBuilder<'a> {
         DoWhileStatement { span, body, test }
     }
 
+    /// Builds a [`DoWhileStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::do_while_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
+    /// - test
     #[inline]
     pub fn alloc_do_while_statement(
         self,
@@ -3064,6 +4765,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.do_while_statement(span, body, test), self.allocator)
     }
 
+    /// Builds a [`WhileStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_while_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - body
     #[inline]
     pub fn while_statement(
         self,
@@ -3074,6 +4783,14 @@ impl<'a> AstBuilder<'a> {
         WhileStatement { span, test, body }
     }
 
+    /// Builds a [`WhileStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::while_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - body
     #[inline]
     pub fn alloc_while_statement(
         self,
@@ -3084,6 +4801,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.while_statement(span, test, body), self.allocator)
     }
 
+    /// Builds a [`ForStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - init
+    /// - test
+    /// - update
+    /// - body
     #[inline]
     pub fn for_statement(
         self,
@@ -3096,6 +4823,16 @@ impl<'a> AstBuilder<'a> {
         ForStatement { span, init, test, update, body, scope_id: Default::default() }
     }
 
+    /// Builds a [`ForStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - init
+    /// - test
+    /// - update
+    /// - body
     #[inline]
     pub fn alloc_for_statement(
         self,
@@ -3108,6 +4845,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.for_statement(span, init, test, update, body), self.allocator)
     }
 
+    /// Build a [`ForStatementInit::VariableDeclaration`]
+    ///
+    /// This node contains a [`VariableDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - declarations
+    /// - declare
     #[inline]
     pub fn for_statement_init_variable_declaration(
         self,
@@ -3124,6 +4870,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`VariableDeclaration`] into a [`ForStatementInit::VariableDeclaration`]
     #[inline]
     pub fn for_statement_init_from_variable_declaration<T>(self, inner: T) -> ForStatementInit<'a>
     where
@@ -3132,6 +4879,14 @@ impl<'a> AstBuilder<'a> {
         ForStatementInit::VariableDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ForStatementInit::UsingDeclaration`]
+    ///
+    /// This node contains a [`UsingDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_await
+    /// - declarations
     #[inline]
     pub fn for_statement_init_using_declaration(
         self,
@@ -3146,6 +4901,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`UsingDeclaration`] into a [`ForStatementInit::UsingDeclaration`]
     #[inline]
     pub fn for_statement_init_from_using_declaration<T>(self, inner: T) -> ForStatementInit<'a>
     where
@@ -3159,6 +4915,15 @@ impl<'a> AstBuilder<'a> {
         ForStatementInit::from(inner)
     }
 
+    /// Builds a [`ForInStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_in_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
+    /// - body
     #[inline]
     pub fn for_in_statement(
         self,
@@ -3170,6 +4935,15 @@ impl<'a> AstBuilder<'a> {
         ForInStatement { span, left, right, body, scope_id: Default::default() }
     }
 
+    /// Builds a [`ForInStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_in_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
+    /// - body
     #[inline]
     pub fn alloc_for_in_statement(
         self,
@@ -3181,6 +4955,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.for_in_statement(span, left, right, body), self.allocator)
     }
 
+    /// Build a [`ForStatementLeft::VariableDeclaration`]
+    ///
+    /// This node contains a [`VariableDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - declarations
+    /// - declare
     #[inline]
     pub fn for_statement_left_variable_declaration(
         self,
@@ -3197,6 +4980,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`VariableDeclaration`] into a [`ForStatementLeft::VariableDeclaration`]
     #[inline]
     pub fn for_statement_left_from_variable_declaration<T>(self, inner: T) -> ForStatementLeft<'a>
     where
@@ -3205,6 +4989,14 @@ impl<'a> AstBuilder<'a> {
         ForStatementLeft::VariableDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ForStatementLeft::UsingDeclaration`]
+    ///
+    /// This node contains a [`UsingDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_await
+    /// - declarations
     #[inline]
     pub fn for_statement_left_using_declaration(
         self,
@@ -3219,6 +5011,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`UsingDeclaration`] into a [`ForStatementLeft::UsingDeclaration`]
     #[inline]
     pub fn for_statement_left_from_using_declaration<T>(self, inner: T) -> ForStatementLeft<'a>
     where
@@ -3235,6 +5028,16 @@ impl<'a> AstBuilder<'a> {
         ForStatementLeft::from(inner)
     }
 
+    /// Builds a [`ForOfStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_of_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - r#await
+    /// - left
+    /// - right
+    /// - body
     #[inline]
     pub fn for_of_statement(
         self,
@@ -3247,6 +5050,16 @@ impl<'a> AstBuilder<'a> {
         ForOfStatement { span, r#await, left, right, body, scope_id: Default::default() }
     }
 
+    /// Builds a [`ForOfStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_of_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - r#await
+    /// - left
+    /// - right
+    /// - body
     #[inline]
     pub fn alloc_for_of_statement(
         self,
@@ -3259,6 +5072,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.for_of_statement(span, r#await, left, right, body), self.allocator)
     }
 
+    /// Builds a [`ContinueStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_continue_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
     #[inline]
     pub fn continue_statement(
         self,
@@ -3268,6 +5088,13 @@ impl<'a> AstBuilder<'a> {
         ContinueStatement { span, label }
     }
 
+    /// Builds a [`ContinueStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::continue_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
     #[inline]
     pub fn alloc_continue_statement(
         self,
@@ -3277,6 +5104,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.continue_statement(span, label), self.allocator)
     }
 
+    /// Builds a [`BreakStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_break_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
     #[inline]
     pub fn break_statement(
         self,
@@ -3286,6 +5120,13 @@ impl<'a> AstBuilder<'a> {
         BreakStatement { span, label }
     }
 
+    /// Builds a [`BreakStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::break_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
     #[inline]
     pub fn alloc_break_statement(
         self,
@@ -3295,6 +5136,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.break_statement(span, label), self.allocator)
     }
 
+    /// Builds a [`ReturnStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_return_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn return_statement(
         self,
@@ -3304,6 +5152,13 @@ impl<'a> AstBuilder<'a> {
         ReturnStatement { span, argument }
     }
 
+    /// Builds a [`ReturnStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::return_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn alloc_return_statement(
         self,
@@ -3313,6 +5168,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.return_statement(span, argument), self.allocator)
     }
 
+    /// Builds a [`WithStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_with_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - body
     #[inline]
     pub fn with_statement(
         self,
@@ -3323,6 +5186,14 @@ impl<'a> AstBuilder<'a> {
         WithStatement { span, object, body }
     }
 
+    /// Builds a [`WithStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::with_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object
+    /// - body
     #[inline]
     pub fn alloc_with_statement(
         self,
@@ -3333,6 +5204,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.with_statement(span, object, body), self.allocator)
     }
 
+    /// Builds a [`SwitchStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_switch_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - discriminant
+    /// - cases
     #[inline]
     pub fn switch_statement(
         self,
@@ -3343,6 +5222,14 @@ impl<'a> AstBuilder<'a> {
         SwitchStatement { span, discriminant, cases, scope_id: Default::default() }
     }
 
+    /// Builds a [`SwitchStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::switch_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - discriminant
+    /// - cases
     #[inline]
     pub fn alloc_switch_statement(
         self,
@@ -3353,6 +5240,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.switch_statement(span, discriminant, cases), self.allocator)
     }
 
+    /// Builds a [`SwitchCase`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_switch_case`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
     #[inline]
     pub fn switch_case(
         self,
@@ -3363,6 +5258,14 @@ impl<'a> AstBuilder<'a> {
         SwitchCase { span, test, consequent }
     }
 
+    /// Builds a [`SwitchCase`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::switch_case`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - test
+    /// - consequent
     #[inline]
     pub fn alloc_switch_case(
         self,
@@ -3373,6 +5276,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.switch_case(span, test, consequent), self.allocator)
     }
 
+    /// Builds a [`LabeledStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_labeled_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
+    /// - body
     #[inline]
     pub fn labeled_statement(
         self,
@@ -3383,6 +5294,14 @@ impl<'a> AstBuilder<'a> {
         LabeledStatement { span, label, body }
     }
 
+    /// Builds a [`LabeledStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::labeled_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - label
+    /// - body
     #[inline]
     pub fn alloc_labeled_statement(
         self,
@@ -3393,11 +5312,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.labeled_statement(span, label, body), self.allocator)
     }
 
+    /// Builds a [`ThrowStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_throw_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn throw_statement(self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
         ThrowStatement { span, argument }
     }
 
+    /// Builds a [`ThrowStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::throw_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn alloc_throw_statement(
         self,
@@ -3407,6 +5340,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.throw_statement(span, argument), self.allocator)
     }
 
+    /// Builds a [`TryStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_try_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - block
+    /// - handler
+    /// - finalizer
     #[inline]
     pub fn try_statement<T1, T2, T3>(
         self,
@@ -3428,6 +5370,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TryStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::try_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - block
+    /// - handler
+    /// - finalizer
     #[inline]
     pub fn alloc_try_statement<T1, T2, T3>(
         self,
@@ -3444,6 +5395,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.try_statement(span, block, handler, finalizer), self.allocator)
     }
 
+    /// Builds a [`CatchClause`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_catch_clause`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - param
+    /// - body
     #[inline]
     pub fn catch_clause<T1>(
         self,
@@ -3462,6 +5421,14 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`CatchClause`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::catch_clause`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - param
+    /// - body
     #[inline]
     pub fn alloc_catch_clause<T1>(
         self,
@@ -3475,11 +5442,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.catch_clause(span, param, body), self.allocator)
     }
 
+    /// Builds a [`CatchParameter`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_catch_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - pattern
     #[inline]
     pub fn catch_parameter(self, span: Span, pattern: BindingPattern<'a>) -> CatchParameter<'a> {
         CatchParameter { span, pattern }
     }
 
+    /// Builds a [`CatchParameter`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::catch_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - pattern
     #[inline]
     pub fn alloc_catch_parameter(
         self,
@@ -3489,16 +5470,36 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.catch_parameter(span, pattern), self.allocator)
     }
 
+    /// Builds a [`DebuggerStatement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_debugger_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn debugger_statement(self, span: Span) -> DebuggerStatement {
         DebuggerStatement { span }
     }
 
+    /// Builds a [`DebuggerStatement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::debugger_statement`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_debugger_statement(self, span: Span) -> Box<'a, DebuggerStatement> {
         Box::new_in(self.debugger_statement(span), self.allocator)
     }
 
+    /// Builds a [`BindingPattern`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - kind
+    /// - type_annotation
+    /// - optional
     #[inline]
     pub fn binding_pattern<T1>(
         self,
@@ -3512,6 +5513,14 @@ impl<'a> AstBuilder<'a> {
         BindingPattern { kind, type_annotation: type_annotation.into_in(self.allocator), optional }
     }
 
+    /// Builds a [`BindingPattern`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - kind
+    /// - type_annotation
+    /// - optional
     #[inline]
     pub fn alloc_binding_pattern<T1>(
         self,
@@ -3525,6 +5534,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.binding_pattern(kind, type_annotation, optional), self.allocator)
     }
 
+    /// Build a [`BindingPatternKind::BindingIdentifier`]
+    ///
+    /// This node contains a [`BindingIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The identifier name being bound.
     #[inline]
     pub fn binding_pattern_kind_binding_identifier<A>(
         self,
@@ -3537,6 +5553,7 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::BindingIdentifier(self.alloc(self.binding_identifier(span, name)))
     }
 
+    /// Convert a [`BindingIdentifier`] into a [`BindingPatternKind::BindingIdentifier`]
     #[inline]
     pub fn binding_pattern_kind_from_binding_identifier<T>(self, inner: T) -> BindingPatternKind<'a>
     where
@@ -3545,6 +5562,14 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::BindingIdentifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`BindingPatternKind::ObjectPattern`]
+    ///
+    /// This node contains a [`ObjectPattern`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties
+    /// - rest
     #[inline]
     pub fn binding_pattern_kind_object_pattern<T1>(
         self,
@@ -3558,6 +5583,7 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::ObjectPattern(self.alloc(self.object_pattern(span, properties, rest)))
     }
 
+    /// Convert a [`ObjectPattern`] into a [`BindingPatternKind::ObjectPattern`]
     #[inline]
     pub fn binding_pattern_kind_from_object_pattern<T>(self, inner: T) -> BindingPatternKind<'a>
     where
@@ -3566,6 +5592,14 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::ObjectPattern(inner.into_in(self.allocator))
     }
 
+    /// Build a [`BindingPatternKind::ArrayPattern`]
+    ///
+    /// This node contains a [`ArrayPattern`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - rest
     #[inline]
     pub fn binding_pattern_kind_array_pattern<T1>(
         self,
@@ -3579,6 +5613,7 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::ArrayPattern(self.alloc(self.array_pattern(span, elements, rest)))
     }
 
+    /// Convert a [`ArrayPattern`] into a [`BindingPatternKind::ArrayPattern`]
     #[inline]
     pub fn binding_pattern_kind_from_array_pattern<T>(self, inner: T) -> BindingPatternKind<'a>
     where
@@ -3587,6 +5622,14 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::ArrayPattern(inner.into_in(self.allocator))
     }
 
+    /// Build a [`BindingPatternKind::AssignmentPattern`]
+    ///
+    /// This node contains a [`AssignmentPattern`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn binding_pattern_kind_assignment_pattern(
         self,
@@ -3599,6 +5642,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`AssignmentPattern`] into a [`BindingPatternKind::AssignmentPattern`]
     #[inline]
     pub fn binding_pattern_kind_from_assignment_pattern<T>(self, inner: T) -> BindingPatternKind<'a>
     where
@@ -3607,6 +5651,14 @@ impl<'a> AstBuilder<'a> {
         BindingPatternKind::AssignmentPattern(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`AssignmentPattern`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn assignment_pattern(
         self,
@@ -3617,6 +5669,14 @@ impl<'a> AstBuilder<'a> {
         AssignmentPattern { span, left, right }
     }
 
+    /// Builds a [`AssignmentPattern`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn alloc_assignment_pattern(
         self,
@@ -3627,6 +5687,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.assignment_pattern(span, left, right), self.allocator)
     }
 
+    /// Builds a [`ObjectPattern`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties
+    /// - rest
     #[inline]
     pub fn object_pattern<T1>(
         self,
@@ -3640,6 +5708,14 @@ impl<'a> AstBuilder<'a> {
         ObjectPattern { span, properties, rest: rest.into_in(self.allocator) }
     }
 
+    /// Builds a [`ObjectPattern`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - properties
+    /// - rest
     #[inline]
     pub fn alloc_object_pattern<T1>(
         self,
@@ -3653,6 +5729,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.object_pattern(span, properties, rest), self.allocator)
     }
 
+    /// Builds a [`BindingProperty`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - value
+    /// - shorthand
+    /// - computed
     #[inline]
     pub fn binding_property(
         self,
@@ -3665,6 +5751,16 @@ impl<'a> AstBuilder<'a> {
         BindingProperty { span, key, value, shorthand, computed }
     }
 
+    /// Builds a [`BindingProperty`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_property`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - value
+    /// - shorthand
+    /// - computed
     #[inline]
     pub fn alloc_binding_property(
         self,
@@ -3677,6 +5773,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.binding_property(span, key, value, shorthand, computed), self.allocator)
     }
 
+    /// Builds a [`ArrayPattern`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_array_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - rest
     #[inline]
     pub fn array_pattern<T1>(
         self,
@@ -3690,6 +5794,14 @@ impl<'a> AstBuilder<'a> {
         ArrayPattern { span, elements, rest: rest.into_in(self.allocator) }
     }
 
+    /// Builds a [`ArrayPattern`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::array_pattern`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
+    /// - rest
     #[inline]
     pub fn alloc_array_pattern<T1>(
         self,
@@ -3703,6 +5815,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.array_pattern(span, elements, rest), self.allocator)
     }
 
+    /// Builds a [`BindingRestElement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_rest_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn binding_rest_element(
         self,
@@ -3712,6 +5831,13 @@ impl<'a> AstBuilder<'a> {
         BindingRestElement { span, argument }
     }
 
+    /// Builds a [`BindingRestElement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_rest_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn alloc_binding_rest_element(
         self,
@@ -3721,6 +5847,22 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.binding_rest_element(span, argument), self.allocator)
     }
 
+    /// Builds a [`Function`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - generator
+    /// - r#async
+    /// - declare
+    /// - type_parameters
+    /// - this_param: Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
+    /// - params
+    /// - return_type
+    /// - body
     #[inline]
     pub fn function<T1, T2, T3, T4>(
         self,
@@ -3758,6 +5900,22 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`Function`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - generator
+    /// - r#async
+    /// - declare
+    /// - type_parameters
+    /// - this_param: Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
+    /// - params
+    /// - return_type
+    /// - body
     #[inline]
     pub fn alloc_function<T1, T2, T3, T4>(
         self,
@@ -3797,6 +5955,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`FormalParameters`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_formal_parameters`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - items
+    /// - rest
     #[inline]
     pub fn formal_parameters<T1>(
         self,
@@ -3811,6 +5978,15 @@ impl<'a> AstBuilder<'a> {
         FormalParameters { span, kind, items, rest: rest.into_in(self.allocator) }
     }
 
+    /// Builds a [`FormalParameters`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::formal_parameters`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - kind
+    /// - items
+    /// - rest
     #[inline]
     pub fn alloc_formal_parameters<T1>(
         self,
@@ -3825,6 +6001,17 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.formal_parameters(span, kind, items, rest), self.allocator)
     }
 
+    /// Builds a [`FormalParameter`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_formal_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - decorators
+    /// - pattern
+    /// - accessibility
+    /// - readonly
+    /// - r#override
     #[inline]
     pub fn formal_parameter(
         self,
@@ -3838,6 +6025,17 @@ impl<'a> AstBuilder<'a> {
         FormalParameter { span, decorators, pattern, accessibility, readonly, r#override }
     }
 
+    /// Builds a [`FormalParameter`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::formal_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - decorators
+    /// - pattern
+    /// - accessibility
+    /// - readonly
+    /// - r#override
     #[inline]
     pub fn alloc_formal_parameter(
         self,
@@ -3854,6 +6052,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`FunctionBody`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function_body`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - directives
+    /// - statements
     #[inline]
     pub fn function_body(
         self,
@@ -3864,6 +6070,14 @@ impl<'a> AstBuilder<'a> {
         FunctionBody { span, directives, statements }
     }
 
+    /// Builds a [`FunctionBody`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function_body`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - directives
+    /// - statements
     #[inline]
     pub fn alloc_function_body(
         self,
@@ -3874,6 +6088,18 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.function_body(span, directives, statements), self.allocator)
     }
 
+    /// Builds a [`ArrowFunctionExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_arrow_function_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression: Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
+    /// - r#async
+    /// - type_parameters
+    /// - params
+    /// - return_type
+    /// - body: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn arrow_function_expression<T1, T2, T3, T4>(
         self,
@@ -3903,6 +6129,18 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`ArrowFunctionExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression: Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
+    /// - r#async
+    /// - type_parameters
+    /// - params
+    /// - return_type
+    /// - body: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn alloc_arrow_function_expression<T1, T2, T3, T4>(
         self,
@@ -3934,6 +6172,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`YieldExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_yield_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - delegate
+    /// - argument
     #[inline]
     pub fn yield_expression(
         self,
@@ -3944,6 +6190,14 @@ impl<'a> AstBuilder<'a> {
         YieldExpression { span, delegate, argument }
     }
 
+    /// Builds a [`YieldExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::yield_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - delegate
+    /// - argument
     #[inline]
     pub fn alloc_yield_expression(
         self,
@@ -3954,6 +6208,22 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.yield_expression(span, delegate, argument), self.allocator)
     }
 
+    /// Builds a [`Class`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the class.
+    /// - id: Class identifier, AKA the name
+    /// - type_parameters
+    /// - super_class: Super class. When present, this will usually be an [`IdentifierReference`].
+    /// - super_type_parameters: Type parameters passed to super class.
+    /// - implements: Interface implementation clause for TypeScript classes.
+    /// - body
+    /// - r#abstract: Whether the class is abstract
+    /// - declare: Whether the class was `declare`ed
     #[inline]
     pub fn class<T1, T2, T3>(
         self,
@@ -3990,6 +6260,22 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`Class`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the class.
+    /// - id: Class identifier, AKA the name
+    /// - type_parameters
+    /// - super_class: Super class. When present, this will usually be an [`IdentifierReference`].
+    /// - super_type_parameters: Type parameters passed to super class.
+    /// - implements: Interface implementation clause for TypeScript classes.
+    /// - body
+    /// - r#abstract: Whether the class is abstract
+    /// - declare: Whether the class was `declare`ed
     #[inline]
     pub fn alloc_class<T1, T2, T3>(
         self,
@@ -4028,11 +6314,25 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`ClassBody`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class_body`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn class_body(self, span: Span, body: Vec<'a, ClassElement<'a>>) -> ClassBody<'a> {
         ClassBody { span, body }
     }
 
+    /// Builds a [`ClassBody`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class_body`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn alloc_class_body(
         self,
@@ -4042,6 +6342,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.class_body(span, body), self.allocator)
     }
 
+    /// Build a [`ClassElement::StaticBlock`]
+    ///
+    /// This node contains a [`StaticBlock`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn class_element_static_block(
         self,
@@ -4051,6 +6358,7 @@ impl<'a> AstBuilder<'a> {
         ClassElement::StaticBlock(self.alloc(self.static_block(span, body)))
     }
 
+    /// Convert a [`StaticBlock`] into a [`ClassElement::StaticBlock`]
     #[inline]
     pub fn class_element_from_static_block<T>(self, inner: T) -> ClassElement<'a>
     where
@@ -4059,6 +6367,22 @@ impl<'a> AstBuilder<'a> {
         ClassElement::StaticBlock(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ClassElement::MethodDefinition`]
+    ///
+    /// This node contains a [`MethodDefinition`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type: Method definition type
+    /// - span: The [`Span`] covering this node
+    /// - decorators
+    /// - key
+    /// - value
+    /// - kind
+    /// - computed
+    /// - r#static
+    /// - r#override
+    /// - optional
+    /// - accessibility
     #[inline]
     pub fn class_element_method_definition<T1>(
         self,
@@ -4092,6 +6416,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`MethodDefinition`] into a [`ClassElement::MethodDefinition`]
     #[inline]
     pub fn class_element_from_method_definition<T>(self, inner: T) -> ClassElement<'a>
     where
@@ -4100,6 +6425,25 @@ impl<'a> AstBuilder<'a> {
         ClassElement::MethodDefinition(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ClassElement::PropertyDefinition`]
+    ///
+    /// This node contains a [`PropertyDefinition`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the property.
+    /// - key: The expression used to declare the property.
+    /// - value: Initialized value in the declaration.
+    /// - computed: Property was declared with a computed key
+    /// - r#static: Property was declared with a `static` modifier
+    /// - declare: Property is declared with a `declare` modifier.
+    /// - r#override
+    /// - optional: `true` when created with an optional modifier (`?`)
+    /// - definite
+    /// - readonly: `true` when declared with a `readonly` modifier
+    /// - type_annotation: Type annotation on the property.
+    /// - accessibility: Accessibility modifier.
     #[inline]
     pub fn class_element_property_definition<T1>(
         self,
@@ -4139,6 +6483,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`PropertyDefinition`] into a [`ClassElement::PropertyDefinition`]
     #[inline]
     pub fn class_element_from_property_definition<T>(self, inner: T) -> ClassElement<'a>
     where
@@ -4147,6 +6492,18 @@ impl<'a> AstBuilder<'a> {
         ClassElement::PropertyDefinition(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ClassElement::AccessorProperty`]
+    ///
+    /// This node contains a [`AccessorProperty`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the accessor property.
+    /// - key: The expression used to declare the property.
+    /// - value: Initialized value in the declaration, if present.
+    /// - computed
+    /// - r#static
     #[inline]
     pub fn class_element_accessor_property(
         self,
@@ -4163,6 +6520,7 @@ impl<'a> AstBuilder<'a> {
         ))
     }
 
+    /// Convert a [`AccessorProperty`] into a [`ClassElement::AccessorProperty`]
     #[inline]
     pub fn class_element_from_accessor_property<T>(self, inner: T) -> ClassElement<'a>
     where
@@ -4171,6 +6529,15 @@ impl<'a> AstBuilder<'a> {
         ClassElement::AccessorProperty(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ClassElement::TSIndexSignature`]
+    ///
+    /// This node contains a [`TSIndexSignature`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameters
+    /// - type_annotation
+    /// - readonly
     #[inline]
     pub fn class_element_ts_index_signature<T1>(
         self,
@@ -4190,6 +6557,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSIndexSignature`] into a [`ClassElement::TSIndexSignature`]
     #[inline]
     pub fn class_element_from_ts_index_signature<T>(self, inner: T) -> ClassElement<'a>
     where
@@ -4198,6 +6566,22 @@ impl<'a> AstBuilder<'a> {
         ClassElement::TSIndexSignature(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`MethodDefinition`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_method_definition`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type: Method definition type
+    /// - span: The [`Span`] covering this node
+    /// - decorators
+    /// - key
+    /// - value
+    /// - kind
+    /// - computed
+    /// - r#static
+    /// - r#override
+    /// - optional
+    /// - accessibility
     #[inline]
     pub fn method_definition<T1>(
         self,
@@ -4231,6 +6615,22 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`MethodDefinition`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::method_definition`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type: Method definition type
+    /// - span: The [`Span`] covering this node
+    /// - decorators
+    /// - key
+    /// - value
+    /// - kind
+    /// - computed
+    /// - r#static
+    /// - r#override
+    /// - optional
+    /// - accessibility
     #[inline]
     pub fn alloc_method_definition<T1>(
         self,
@@ -4267,6 +6667,25 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`PropertyDefinition`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_property_definition`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the property.
+    /// - key: The expression used to declare the property.
+    /// - value: Initialized value in the declaration.
+    /// - computed: Property was declared with a computed key
+    /// - r#static: Property was declared with a `static` modifier
+    /// - declare: Property is declared with a `declare` modifier.
+    /// - r#override
+    /// - optional: `true` when created with an optional modifier (`?`)
+    /// - definite
+    /// - readonly: `true` when declared with a `readonly` modifier
+    /// - type_annotation: Type annotation on the property.
+    /// - accessibility: Accessibility modifier.
     #[inline]
     pub fn property_definition<T1>(
         self,
@@ -4306,6 +6725,25 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`PropertyDefinition`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::property_definition`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the property.
+    /// - key: The expression used to declare the property.
+    /// - value: Initialized value in the declaration.
+    /// - computed: Property was declared with a computed key
+    /// - r#static: Property was declared with a `static` modifier
+    /// - declare: Property is declared with a `declare` modifier.
+    /// - r#override
+    /// - optional: `true` when created with an optional modifier (`?`)
+    /// - definite
+    /// - readonly: `true` when declared with a `readonly` modifier
+    /// - type_annotation: Type annotation on the property.
+    /// - accessibility: Accessibility modifier.
     #[inline]
     pub fn alloc_property_definition<T1>(
         self,
@@ -4348,6 +6786,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`PrivateIdentifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_private_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn private_identifier<A>(self, span: Span, name: A) -> PrivateIdentifier<'a>
     where
@@ -4356,6 +6801,13 @@ impl<'a> AstBuilder<'a> {
         PrivateIdentifier { span, name: name.into_in(self.allocator) }
     }
 
+    /// Builds a [`PrivateIdentifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::private_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn alloc_private_identifier<A>(self, span: Span, name: A) -> Box<'a, PrivateIdentifier<'a>>
     where
@@ -4364,11 +6816,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.private_identifier(span, name), self.allocator)
     }
 
+    /// Builds a [`StaticBlock`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_static_block`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn static_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> StaticBlock<'a> {
         StaticBlock { span, body, scope_id: Default::default() }
     }
 
+    /// Builds a [`StaticBlock`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::static_block`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn alloc_static_block(
         self,
@@ -4378,6 +6844,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.static_block(span, body), self.allocator)
     }
 
+    /// Build a [`ModuleDeclaration::ImportDeclaration`]
+    ///
+    /// This node contains a [`ImportDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - specifiers: `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
+    /// - source
+    /// - with_clause: Some(vec![]) for empty assertion
+    /// - import_kind: `import type { foo } from 'bar'`
     #[inline]
     pub fn module_declaration_import_declaration(
         self,
@@ -4396,6 +6872,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ImportDeclaration`] into a [`ModuleDeclaration::ImportDeclaration`]
     #[inline]
     pub fn module_declaration_from_import_declaration<T>(self, inner: T) -> ModuleDeclaration<'a>
     where
@@ -4404,6 +6881,16 @@ impl<'a> AstBuilder<'a> {
         ModuleDeclaration::ImportDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleDeclaration::ExportAllDeclaration`]
+    ///
+    /// This node contains a [`ExportAllDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - exported: If this declaration is re-named
+    /// - source
+    /// - with_clause: Will be `Some(vec![])` for empty assertion
+    /// - export_kind
     #[inline]
     pub fn module_declaration_export_all_declaration(
         self,
@@ -4422,6 +6909,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ExportAllDeclaration`] into a [`ModuleDeclaration::ExportAllDeclaration`]
     #[inline]
     pub fn module_declaration_from_export_all_declaration<T>(
         self,
@@ -4433,6 +6921,14 @@ impl<'a> AstBuilder<'a> {
         ModuleDeclaration::ExportAllDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleDeclaration::ExportDefaultDeclaration`]
+    ///
+    /// This node contains a [`ExportDefaultDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - declaration
+    /// - exported
     #[inline]
     pub fn module_declaration_export_default_declaration(
         self,
@@ -4447,6 +6943,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ExportDefaultDeclaration`] into a [`ModuleDeclaration::ExportDefaultDeclaration`]
     #[inline]
     pub fn module_declaration_from_export_default_declaration<T>(
         self,
@@ -4458,6 +6955,17 @@ impl<'a> AstBuilder<'a> {
         ModuleDeclaration::ExportDefaultDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleDeclaration::ExportNamedDeclaration`]
+    ///
+    /// This node contains a [`ExportNamedDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - declaration
+    /// - specifiers
+    /// - source
+    /// - export_kind: `export type { foo }`
+    /// - with_clause: Some(vec![]) for empty assertion
     #[inline]
     pub fn module_declaration_export_named_declaration(
         self,
@@ -4478,6 +6986,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ExportNamedDeclaration`] into a [`ModuleDeclaration::ExportNamedDeclaration`]
     #[inline]
     pub fn module_declaration_from_export_named_declaration<T>(
         self,
@@ -4489,6 +6998,13 @@ impl<'a> AstBuilder<'a> {
         ModuleDeclaration::ExportNamedDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleDeclaration::TSExportAssignment`]
+    ///
+    /// This node contains a [`TSExportAssignment`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn module_declaration_ts_export_assignment(
         self,
@@ -4500,6 +7016,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSExportAssignment`] into a [`ModuleDeclaration::TSExportAssignment`]
     #[inline]
     pub fn module_declaration_from_ts_export_assignment<T>(self, inner: T) -> ModuleDeclaration<'a>
     where
@@ -4508,6 +7025,13 @@ impl<'a> AstBuilder<'a> {
         ModuleDeclaration::TSExportAssignment(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleDeclaration::TSNamespaceExportDeclaration`]
+    ///
+    /// This node contains a [`TSNamespaceExportDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
     #[inline]
     pub fn module_declaration_ts_namespace_export_declaration(
         self,
@@ -4519,6 +7043,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSNamespaceExportDeclaration`] into a [`ModuleDeclaration::TSNamespaceExportDeclaration`]
     #[inline]
     pub fn module_declaration_from_ts_namespace_export_declaration<T>(
         self,
@@ -4530,6 +7055,18 @@ impl<'a> AstBuilder<'a> {
         ModuleDeclaration::TSNamespaceExportDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`AccessorProperty`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_accessor_property`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the accessor property.
+    /// - key: The expression used to declare the property.
+    /// - value: Initialized value in the declaration, if present.
+    /// - computed
+    /// - r#static
     #[inline]
     pub fn accessor_property(
         self,
@@ -4544,6 +7081,18 @@ impl<'a> AstBuilder<'a> {
         AccessorProperty { r#type, span, decorators, key, value, computed, r#static }
     }
 
+    /// Builds a [`AccessorProperty`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::accessor_property`] instead.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the accessor property.
+    /// - key: The expression used to declare the property.
+    /// - value: Initialized value in the declaration, if present.
+    /// - computed
+    /// - r#static
     #[inline]
     pub fn alloc_accessor_property(
         self,
@@ -4561,6 +7110,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`ImportExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - source
+    /// - arguments
     #[inline]
     pub fn import_expression(
         self,
@@ -4571,6 +7128,14 @@ impl<'a> AstBuilder<'a> {
         ImportExpression { span, source, arguments }
     }
 
+    /// Builds a [`ImportExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - source
+    /// - arguments
     #[inline]
     pub fn alloc_import_expression(
         self,
@@ -4581,6 +7146,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.import_expression(span, source, arguments), self.allocator)
     }
 
+    /// Builds a [`ImportDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - specifiers: `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
+    /// - source
+    /// - with_clause: Some(vec![]) for empty assertion
+    /// - import_kind: `import type { foo } from 'bar'`
     #[inline]
     pub fn import_declaration(
         self,
@@ -4593,6 +7168,16 @@ impl<'a> AstBuilder<'a> {
         ImportDeclaration { span, specifiers, source, with_clause, import_kind }
     }
 
+    /// Builds a [`ImportDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - specifiers: `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
+    /// - source
+    /// - with_clause: Some(vec![]) for empty assertion
+    /// - import_kind: `import type { foo } from 'bar'`
     #[inline]
     pub fn alloc_import_declaration(
         self,
@@ -4608,6 +7193,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`ImportDeclarationSpecifier::ImportSpecifier`]
+    ///
+    /// This node contains a [`ImportSpecifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - imported
+    /// - local: The name of the imported symbol.
+    /// - import_kind
     #[inline]
     pub fn import_declaration_specifier_import_specifier(
         self,
@@ -4624,6 +7218,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`ImportSpecifier`] into a [`ImportDeclarationSpecifier::ImportSpecifier`]
     #[inline]
     pub fn import_declaration_specifier_from_import_specifier<T>(
         self,
@@ -4635,6 +7230,13 @@ impl<'a> AstBuilder<'a> {
         ImportDeclarationSpecifier::ImportSpecifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ImportDeclarationSpecifier::ImportDefaultSpecifier`]
+    ///
+    /// This node contains a [`ImportDefaultSpecifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local: The name of the imported symbol.
     #[inline]
     pub fn import_declaration_specifier_import_default_specifier(
         self,
@@ -4646,6 +7248,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ImportDefaultSpecifier`] into a [`ImportDeclarationSpecifier::ImportDefaultSpecifier`]
     #[inline]
     pub fn import_declaration_specifier_from_import_default_specifier<T>(
         self,
@@ -4657,6 +7260,13 @@ impl<'a> AstBuilder<'a> {
         ImportDeclarationSpecifier::ImportDefaultSpecifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ImportDeclarationSpecifier::ImportNamespaceSpecifier`]
+    ///
+    /// This node contains a [`ImportNamespaceSpecifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local
     #[inline]
     pub fn import_declaration_specifier_import_namespace_specifier(
         self,
@@ -4668,6 +7278,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`ImportNamespaceSpecifier`] into a [`ImportDeclarationSpecifier::ImportNamespaceSpecifier`]
     #[inline]
     pub fn import_declaration_specifier_from_import_namespace_specifier<T>(
         self,
@@ -4679,6 +7290,15 @@ impl<'a> AstBuilder<'a> {
         ImportDeclarationSpecifier::ImportNamespaceSpecifier(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`ImportSpecifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - imported
+    /// - local: The name of the imported symbol.
+    /// - import_kind
     #[inline]
     pub fn import_specifier(
         self,
@@ -4690,6 +7310,15 @@ impl<'a> AstBuilder<'a> {
         ImportSpecifier { span, imported, local, import_kind }
     }
 
+    /// Builds a [`ImportSpecifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - imported
+    /// - local: The name of the imported symbol.
+    /// - import_kind
     #[inline]
     pub fn alloc_import_specifier(
         self,
@@ -4701,6 +7330,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.import_specifier(span, imported, local, import_kind), self.allocator)
     }
 
+    /// Builds a [`ImportDefaultSpecifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_default_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local: The name of the imported symbol.
     #[inline]
     pub fn import_default_specifier(
         self,
@@ -4710,6 +7346,13 @@ impl<'a> AstBuilder<'a> {
         ImportDefaultSpecifier { span, local }
     }
 
+    /// Builds a [`ImportDefaultSpecifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_default_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local: The name of the imported symbol.
     #[inline]
     pub fn alloc_import_default_specifier(
         self,
@@ -4719,6 +7362,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.import_default_specifier(span, local), self.allocator)
     }
 
+    /// Builds a [`ImportNamespaceSpecifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_namespace_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local
     #[inline]
     pub fn import_namespace_specifier(
         self,
@@ -4728,6 +7378,13 @@ impl<'a> AstBuilder<'a> {
         ImportNamespaceSpecifier { span, local }
     }
 
+    /// Builds a [`ImportNamespaceSpecifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_namespace_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local
     #[inline]
     pub fn alloc_import_namespace_specifier(
         self,
@@ -4737,6 +7394,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.import_namespace_specifier(span, local), self.allocator)
     }
 
+    /// Builds a [`WithClause`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_with_clause`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - attributes_keyword
+    /// - with_entries
     #[inline]
     pub fn with_clause(
         self,
@@ -4747,6 +7412,14 @@ impl<'a> AstBuilder<'a> {
         WithClause { span, attributes_keyword, with_entries }
     }
 
+    /// Builds a [`WithClause`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::with_clause`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - attributes_keyword
+    /// - with_entries
     #[inline]
     pub fn alloc_with_clause(
         self,
@@ -4757,6 +7430,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.with_clause(span, attributes_keyword, with_entries), self.allocator)
     }
 
+    /// Builds a [`ImportAttribute`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - value
     #[inline]
     pub fn import_attribute(
         self,
@@ -4767,6 +7448,14 @@ impl<'a> AstBuilder<'a> {
         ImportAttribute { span, key, value }
     }
 
+    /// Builds a [`ImportAttribute`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - value
     #[inline]
     pub fn alloc_import_attribute(
         self,
@@ -4777,6 +7466,11 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.import_attribute(span, key, value), self.allocator)
     }
 
+    /// Build a [`ImportAttributeKey::Identifier`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn import_attribute_key_identifier_name<A>(
         self,
@@ -4789,6 +7483,7 @@ impl<'a> AstBuilder<'a> {
         ImportAttributeKey::Identifier(self.identifier_name(span, name))
     }
 
+    /// Convert a [`IdentifierName`] into a [`ImportAttributeKey::Identifier`]
     #[inline]
     pub fn import_attribute_key_from_identifier_name<T>(self, inner: T) -> ImportAttributeKey<'a>
     where
@@ -4797,6 +7492,11 @@ impl<'a> AstBuilder<'a> {
         ImportAttributeKey::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ImportAttributeKey::StringLiteral`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn import_attribute_key_string_literal<A>(
         self,
@@ -4809,6 +7509,7 @@ impl<'a> AstBuilder<'a> {
         ImportAttributeKey::StringLiteral(self.string_literal(span, value))
     }
 
+    /// Convert a [`StringLiteral`] into a [`ImportAttributeKey::StringLiteral`]
     #[inline]
     pub fn import_attribute_key_from_string_literal<T>(self, inner: T) -> ImportAttributeKey<'a>
     where
@@ -4817,6 +7518,17 @@ impl<'a> AstBuilder<'a> {
         ImportAttributeKey::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`ExportNamedDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_named_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - declaration
+    /// - specifiers
+    /// - source
+    /// - export_kind: `export type { foo }`
+    /// - with_clause: Some(vec![]) for empty assertion
     #[inline]
     pub fn export_named_declaration(
         self,
@@ -4830,6 +7542,17 @@ impl<'a> AstBuilder<'a> {
         ExportNamedDeclaration { span, declaration, specifiers, source, export_kind, with_clause }
     }
 
+    /// Builds a [`ExportNamedDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_named_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - declaration
+    /// - specifiers
+    /// - source
+    /// - export_kind: `export type { foo }`
+    /// - with_clause: Some(vec![]) for empty assertion
     #[inline]
     pub fn alloc_export_named_declaration(
         self,
@@ -4853,6 +7576,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`ExportDefaultDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_default_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - declaration
+    /// - exported
     #[inline]
     pub fn export_default_declaration(
         self,
@@ -4863,6 +7594,14 @@ impl<'a> AstBuilder<'a> {
         ExportDefaultDeclaration { span, declaration, exported }
     }
 
+    /// Builds a [`ExportDefaultDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_default_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - declaration
+    /// - exported
     #[inline]
     pub fn alloc_export_default_declaration(
         self,
@@ -4873,6 +7612,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.export_default_declaration(span, declaration, exported), self.allocator)
     }
 
+    /// Builds a [`ExportAllDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_all_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - exported: If this declaration is re-named
+    /// - source
+    /// - with_clause: Will be `Some(vec![])` for empty assertion
+    /// - export_kind
     #[inline]
     pub fn export_all_declaration(
         self,
@@ -4885,6 +7634,16 @@ impl<'a> AstBuilder<'a> {
         ExportAllDeclaration { span, exported, source, with_clause, export_kind }
     }
 
+    /// Builds a [`ExportAllDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_all_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - exported: If this declaration is re-named
+    /// - source
+    /// - with_clause: Will be `Some(vec![])` for empty assertion
+    /// - export_kind
     #[inline]
     pub fn alloc_export_all_declaration(
         self,
@@ -4900,6 +7659,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`ExportSpecifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local
+    /// - exported
+    /// - export_kind
     #[inline]
     pub fn export_specifier(
         self,
@@ -4911,6 +7679,15 @@ impl<'a> AstBuilder<'a> {
         ExportSpecifier { span, local, exported, export_kind }
     }
 
+    /// Builds a [`ExportSpecifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_specifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - local
+    /// - exported
+    /// - export_kind
     #[inline]
     pub fn alloc_export_specifier(
         self,
@@ -4922,6 +7699,22 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.export_specifier(span, local, exported, export_kind), self.allocator)
     }
 
+    /// Build a [`ExportDefaultDeclarationKind::FunctionDeclaration`]
+    ///
+    /// This node contains a [`Function`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - generator
+    /// - r#async
+    /// - declare
+    /// - type_parameters
+    /// - this_param: Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
+    /// - params
+    /// - return_type
+    /// - body
     #[inline]
     pub fn export_default_declaration_kind_function<T1, T2, T3, T4>(
         self,
@@ -4958,6 +7751,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`Function`] into a [`ExportDefaultDeclarationKind::FunctionDeclaration`]
     #[inline]
     pub fn export_default_declaration_kind_from_function<T>(
         self,
@@ -4969,6 +7763,22 @@ impl<'a> AstBuilder<'a> {
         ExportDefaultDeclarationKind::FunctionDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ExportDefaultDeclarationKind::ClassDeclaration`]
+    ///
+    /// This node contains a [`Class`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - r#type
+    /// - span: The [`Span`] covering this node
+    /// - decorators: Decorators applied to the class.
+    /// - id: Class identifier, AKA the name
+    /// - type_parameters
+    /// - super_class: Super class. When present, this will usually be an [`IdentifierReference`].
+    /// - super_type_parameters: Type parameters passed to super class.
+    /// - implements: Interface implementation clause for TypeScript classes.
+    /// - body
+    /// - r#abstract: Whether the class is abstract
+    /// - declare: Whether the class was `declare`ed
     #[inline]
     pub fn export_default_declaration_kind_class<T1, T2, T3>(
         self,
@@ -5004,6 +7814,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`Class`] into a [`ExportDefaultDeclarationKind::ClassDeclaration`]
     #[inline]
     pub fn export_default_declaration_kind_from_class<T>(
         self,
@@ -5015,6 +7826,17 @@ impl<'a> AstBuilder<'a> {
         ExportDefaultDeclarationKind::ClassDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ExportDefaultDeclarationKind::TSInterfaceDeclaration`]
+    ///
+    /// This node contains a [`TSInterfaceDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id: The identifier (name) of the interface.
+    /// - extends
+    /// - type_parameters
+    /// - body
+    /// - declare
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration<T1, T2>(
         self,
@@ -5034,6 +7856,7 @@ impl<'a> AstBuilder<'a> {
         ))
     }
 
+    /// Convert a [`TSInterfaceDeclaration`] into a [`ExportDefaultDeclarationKind::TSInterfaceDeclaration`]
     #[inline]
     pub fn export_default_declaration_kind_from_ts_interface_declaration<T>(
         self,
@@ -5053,6 +7876,11 @@ impl<'a> AstBuilder<'a> {
         ExportDefaultDeclarationKind::from(inner)
     }
 
+    /// Build a [`ModuleExportName::IdentifierName`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn module_export_name_identifier_name<A>(self, span: Span, name: A) -> ModuleExportName<'a>
     where
@@ -5061,6 +7889,7 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::IdentifierName(self.identifier_name(span, name))
     }
 
+    /// Convert a [`IdentifierName`] into a [`ModuleExportName::IdentifierName`]
     #[inline]
     pub fn module_export_name_from_identifier_name<T>(self, inner: T) -> ModuleExportName<'a>
     where
@@ -5069,6 +7898,11 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::IdentifierName(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleExportName::IdentifierReference`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The name of the identifier being referenced.
     #[inline]
     pub fn module_export_name_identifier_reference<A>(
         self,
@@ -5081,6 +7915,7 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::IdentifierReference(self.identifier_reference(span, name))
     }
 
+    /// Convert a [`IdentifierReference`] into a [`ModuleExportName::IdentifierReference`]
     #[inline]
     pub fn module_export_name_from_identifier_reference<T>(self, inner: T) -> ModuleExportName<'a>
     where
@@ -5089,6 +7924,11 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::IdentifierReference(inner.into_in(self.allocator))
     }
 
+    /// Build a [`ModuleExportName::StringLiteral`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn module_export_name_string_literal<A>(self, span: Span, value: A) -> ModuleExportName<'a>
     where
@@ -5097,6 +7937,7 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::StringLiteral(self.string_literal(span, value))
     }
 
+    /// Convert a [`StringLiteral`] into a [`ModuleExportName::StringLiteral`]
     #[inline]
     pub fn module_export_name_from_string_literal<T>(self, inner: T) -> ModuleExportName<'a>
     where
@@ -5105,6 +7946,14 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSThisParameter`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_this_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this
+    /// - type_annotation
     #[inline]
     pub fn ts_this_parameter<T1>(
         self,
@@ -5118,6 +7967,14 @@ impl<'a> AstBuilder<'a> {
         TSThisParameter { span, this, type_annotation: type_annotation.into_in(self.allocator) }
     }
 
+    /// Builds a [`TSThisParameter`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_this_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_this_parameter<T1>(
         self,
@@ -5131,6 +7988,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_this_parameter(span, this, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSEnumDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_enum_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - members
+    /// - r#const
+    /// - declare
     #[inline]
     pub fn ts_enum_declaration(
         self,
@@ -5143,6 +8010,16 @@ impl<'a> AstBuilder<'a> {
         TSEnumDeclaration { span, id, members, r#const, declare, scope_id: Default::default() }
     }
 
+    /// Builds a [`TSEnumDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - members
+    /// - r#const
+    /// - declare
     #[inline]
     pub fn alloc_ts_enum_declaration(
         self,
@@ -5155,6 +8032,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_enum_declaration(span, id, members, r#const, declare), self.allocator)
     }
 
+    /// Builds a [`TSEnumMember`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_enum_member`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - initializer
     #[inline]
     pub fn ts_enum_member(
         self,
@@ -5165,6 +8050,14 @@ impl<'a> AstBuilder<'a> {
         TSEnumMember { span, id, initializer }
     }
 
+    /// Builds a [`TSEnumMember`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_enum_member`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - initializer
     #[inline]
     pub fn alloc_ts_enum_member(
         self,
@@ -5175,6 +8068,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_enum_member(span, id, initializer), self.allocator)
     }
 
+    /// Build a [`TSEnumMemberName::StaticIdentifier`]
+    ///
+    /// This node contains a [`IdentifierName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn ts_enum_member_name_identifier_name<A>(self, span: Span, name: A) -> TSEnumMemberName<'a>
     where
@@ -5183,6 +8083,7 @@ impl<'a> AstBuilder<'a> {
         TSEnumMemberName::StaticIdentifier(self.alloc(self.identifier_name(span, name)))
     }
 
+    /// Convert a [`IdentifierName`] into a [`TSEnumMemberName::StaticIdentifier`]
     #[inline]
     pub fn ts_enum_member_name_from_identifier_name<T>(self, inner: T) -> TSEnumMemberName<'a>
     where
@@ -5191,6 +8092,13 @@ impl<'a> AstBuilder<'a> {
         TSEnumMemberName::StaticIdentifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSEnumMemberName::StaticStringLiteral`]
+    ///
+    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn ts_enum_member_name_string_literal<A>(self, span: Span, value: A) -> TSEnumMemberName<'a>
     where
@@ -5199,6 +8107,7 @@ impl<'a> AstBuilder<'a> {
         TSEnumMemberName::StaticStringLiteral(self.alloc(self.string_literal(span, value)))
     }
 
+    /// Convert a [`StringLiteral`] into a [`TSEnumMemberName::StaticStringLiteral`]
     #[inline]
     pub fn ts_enum_member_name_from_string_literal<T>(self, inner: T) -> TSEnumMemberName<'a>
     where
@@ -5207,6 +8116,15 @@ impl<'a> AstBuilder<'a> {
         TSEnumMemberName::StaticStringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSEnumMemberName::StaticNumericLiteral`]
+    ///
+    /// This node contains a [`NumericLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - raw
+    /// - base
     #[inline]
     pub fn ts_enum_member_name_numeric_literal<S>(
         self,
@@ -5223,6 +8141,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`NumericLiteral`] into a [`TSEnumMemberName::StaticNumericLiteral`]
     #[inline]
     pub fn ts_enum_member_name_from_numeric_literal<T>(self, inner: T) -> TSEnumMemberName<'a>
     where
@@ -5236,6 +8155,13 @@ impl<'a> AstBuilder<'a> {
         TSEnumMemberName::from(inner)
     }
 
+    /// Builds a [`TSTypeAnnotation`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_annotation`] instead.
+    ///
+    /// ## Parameters
+    /// - span: starts at the `:` token and ends at the end of the type annotation
+    /// - type_annotation
     #[inline]
     pub fn ts_type_annotation(
         self,
@@ -5245,6 +8171,13 @@ impl<'a> AstBuilder<'a> {
         TSTypeAnnotation { span, type_annotation }
     }
 
+    /// Builds a [`TSTypeAnnotation`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_annotation`] instead.
+    ///
+    /// ## Parameters
+    /// - span: starts at the `:` token and ends at the end of the type annotation
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_type_annotation(
         self,
@@ -5254,11 +8187,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_annotation(span, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSLiteralType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_literal_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - literal
     #[inline]
     pub fn ts_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
         TSLiteralType { span, literal }
     }
 
+    /// Builds a [`TSLiteralType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_literal_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - literal
     #[inline]
     pub fn alloc_ts_literal_type(
         self,
@@ -5268,11 +8215,19 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_literal_type(span, literal), self.allocator)
     }
 
+    /// Build a [`TSLiteral::BooleanLiteral`]
+    ///
+    /// This node contains a [`BooleanLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn ts_literal_boolean_literal(self, span: Span, value: bool) -> TSLiteral<'a> {
         TSLiteral::BooleanLiteral(self.alloc(self.boolean_literal(span, value)))
     }
 
+    /// Convert a [`BooleanLiteral`] into a [`TSLiteral::BooleanLiteral`]
     #[inline]
     pub fn ts_literal_from_boolean_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5281,11 +8236,18 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::BooleanLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::NullLiteral`]
+    ///
+    /// This node contains a [`NullLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_literal_null_literal(self, span: Span) -> TSLiteral<'a> {
         TSLiteral::NullLiteral(self.alloc(self.null_literal(span)))
     }
 
+    /// Convert a [`NullLiteral`] into a [`TSLiteral::NullLiteral`]
     #[inline]
     pub fn ts_literal_from_null_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5294,6 +8256,15 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::NullLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::NumericLiteral`]
+    ///
+    /// This node contains a [`NumericLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - raw
+    /// - base
     #[inline]
     pub fn ts_literal_numeric_literal<S>(
         self,
@@ -5308,6 +8279,7 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::NumericLiteral(self.alloc(self.numeric_literal(span, value, raw, base)))
     }
 
+    /// Convert a [`NumericLiteral`] into a [`TSLiteral::NumericLiteral`]
     #[inline]
     pub fn ts_literal_from_numeric_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5316,6 +8288,14 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::NumericLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::BigIntLiteral`]
+    ///
+    /// This node contains a [`BigIntLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - raw
+    /// - base
     #[inline]
     pub fn ts_literal_big_int_literal<A>(
         self,
@@ -5329,6 +8309,7 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::BigIntLiteral(self.alloc(self.big_int_literal(span, raw, base)))
     }
 
+    /// Convert a [`BigIntLiteral`] into a [`TSLiteral::BigIntLiteral`]
     #[inline]
     pub fn ts_literal_from_big_int_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5337,6 +8318,14 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::BigIntLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::RegExpLiteral`]
+    ///
+    /// This node contains a [`RegExpLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
+    /// - regex
     #[inline]
     pub fn ts_literal_reg_exp_literal(
         self,
@@ -5347,6 +8336,7 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::RegExpLiteral(self.alloc(self.reg_exp_literal(span, value, regex)))
     }
 
+    /// Convert a [`RegExpLiteral`] into a [`TSLiteral::RegExpLiteral`]
     #[inline]
     pub fn ts_literal_from_reg_exp_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5355,6 +8345,13 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::RegExpLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::StringLiteral`]
+    ///
+    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn ts_literal_string_literal<A>(self, span: Span, value: A) -> TSLiteral<'a>
     where
@@ -5363,6 +8360,7 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::StringLiteral(self.alloc(self.string_literal(span, value)))
     }
 
+    /// Convert a [`StringLiteral`] into a [`TSLiteral::StringLiteral`]
     #[inline]
     pub fn ts_literal_from_string_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5371,6 +8369,14 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::TemplateLiteral`]
+    ///
+    /// This node contains a [`TemplateLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - expressions
     #[inline]
     pub fn ts_literal_template_literal(
         self,
@@ -5381,6 +8387,7 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::TemplateLiteral(self.alloc(self.template_literal(span, quasis, expressions)))
     }
 
+    /// Convert a [`TemplateLiteral`] into a [`TSLiteral::TemplateLiteral`]
     #[inline]
     pub fn ts_literal_from_template_literal<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5389,6 +8396,14 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::TemplateLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSLiteral::UnaryExpression`]
+    ///
+    /// This node contains a [`UnaryExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - argument
     #[inline]
     pub fn ts_literal_unary_expression(
         self,
@@ -5399,6 +8414,7 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::UnaryExpression(self.alloc(self.unary_expression(span, operator, argument)))
     }
 
+    /// Convert a [`UnaryExpression`] into a [`TSLiteral::UnaryExpression`]
     #[inline]
     pub fn ts_literal_from_unary_expression<T>(self, inner: T) -> TSLiteral<'a>
     where
@@ -5407,11 +8423,18 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::UnaryExpression(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSAnyKeyword`]
+    ///
+    /// This node contains a [`TSAnyKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_any_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSAnyKeyword(self.alloc(self.ts_any_keyword(span)))
     }
 
+    /// Convert a [`TSAnyKeyword`] into a [`TSType::TSAnyKeyword`]
     #[inline]
     pub fn ts_type_from_ts_any_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5420,11 +8443,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSAnyKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSBigIntKeyword`]
+    ///
+    /// This node contains a [`TSBigIntKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_big_int_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSBigIntKeyword(self.alloc(self.ts_big_int_keyword(span)))
     }
 
+    /// Convert a [`TSBigIntKeyword`] into a [`TSType::TSBigIntKeyword`]
     #[inline]
     pub fn ts_type_from_ts_big_int_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5433,11 +8463,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSBigIntKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSBooleanKeyword`]
+    ///
+    /// This node contains a [`TSBooleanKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_boolean_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSBooleanKeyword(self.alloc(self.ts_boolean_keyword(span)))
     }
 
+    /// Convert a [`TSBooleanKeyword`] into a [`TSType::TSBooleanKeyword`]
     #[inline]
     pub fn ts_type_from_ts_boolean_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5446,11 +8483,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSBooleanKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSIntrinsicKeyword`]
+    ///
+    /// This node contains a [`TSIntrinsicKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_intrinsic_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSIntrinsicKeyword(self.alloc(self.ts_intrinsic_keyword(span)))
     }
 
+    /// Convert a [`TSIntrinsicKeyword`] into a [`TSType::TSIntrinsicKeyword`]
     #[inline]
     pub fn ts_type_from_ts_intrinsic_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5459,11 +8503,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSIntrinsicKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSNeverKeyword`]
+    ///
+    /// This node contains a [`TSNeverKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_never_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSNeverKeyword(self.alloc(self.ts_never_keyword(span)))
     }
 
+    /// Convert a [`TSNeverKeyword`] into a [`TSType::TSNeverKeyword`]
     #[inline]
     pub fn ts_type_from_ts_never_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5472,11 +8523,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSNeverKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSNullKeyword`]
+    ///
+    /// This node contains a [`TSNullKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_null_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSNullKeyword(self.alloc(self.ts_null_keyword(span)))
     }
 
+    /// Convert a [`TSNullKeyword`] into a [`TSType::TSNullKeyword`]
     #[inline]
     pub fn ts_type_from_ts_null_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5485,11 +8543,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSNullKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSNumberKeyword`]
+    ///
+    /// This node contains a [`TSNumberKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_number_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSNumberKeyword(self.alloc(self.ts_number_keyword(span)))
     }
 
+    /// Convert a [`TSNumberKeyword`] into a [`TSType::TSNumberKeyword`]
     #[inline]
     pub fn ts_type_from_ts_number_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5498,11 +8563,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSNumberKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSObjectKeyword`]
+    ///
+    /// This node contains a [`TSObjectKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_object_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSObjectKeyword(self.alloc(self.ts_object_keyword(span)))
     }
 
+    /// Convert a [`TSObjectKeyword`] into a [`TSType::TSObjectKeyword`]
     #[inline]
     pub fn ts_type_from_ts_object_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5511,11 +8583,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSObjectKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSStringKeyword`]
+    ///
+    /// This node contains a [`TSStringKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_string_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSStringKeyword(self.alloc(self.ts_string_keyword(span)))
     }
 
+    /// Convert a [`TSStringKeyword`] into a [`TSType::TSStringKeyword`]
     #[inline]
     pub fn ts_type_from_ts_string_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5524,11 +8603,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSStringKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSSymbolKeyword`]
+    ///
+    /// This node contains a [`TSSymbolKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_symbol_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSSymbolKeyword(self.alloc(self.ts_symbol_keyword(span)))
     }
 
+    /// Convert a [`TSSymbolKeyword`] into a [`TSType::TSSymbolKeyword`]
     #[inline]
     pub fn ts_type_from_ts_symbol_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5537,11 +8623,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSSymbolKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSUndefinedKeyword`]
+    ///
+    /// This node contains a [`TSUndefinedKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_undefined_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSUndefinedKeyword(self.alloc(self.ts_undefined_keyword(span)))
     }
 
+    /// Convert a [`TSUndefinedKeyword`] into a [`TSType::TSUndefinedKeyword`]
     #[inline]
     pub fn ts_type_from_ts_undefined_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5550,11 +8643,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSUndefinedKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSUnknownKeyword`]
+    ///
+    /// This node contains a [`TSUnknownKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_unknown_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSUnknownKeyword(self.alloc(self.ts_unknown_keyword(span)))
     }
 
+    /// Convert a [`TSUnknownKeyword`] into a [`TSType::TSUnknownKeyword`]
     #[inline]
     pub fn ts_type_from_ts_unknown_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5563,11 +8663,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSUnknownKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSVoidKeyword`]
+    ///
+    /// This node contains a [`TSVoidKeyword`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_void_keyword(self, span: Span) -> TSType<'a> {
         TSType::TSVoidKeyword(self.alloc(self.ts_void_keyword(span)))
     }
 
+    /// Convert a [`TSVoidKeyword`] into a [`TSType::TSVoidKeyword`]
     #[inline]
     pub fn ts_type_from_ts_void_keyword<T>(self, inner: T) -> TSType<'a>
     where
@@ -5576,11 +8683,19 @@ impl<'a> AstBuilder<'a> {
         TSType::TSVoidKeyword(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSArrayType`]
+    ///
+    /// This node contains a [`TSArrayType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_type
     #[inline]
     pub fn ts_type_array_type(self, span: Span, element_type: TSType<'a>) -> TSType<'a> {
         TSType::TSArrayType(self.alloc(self.ts_array_type(span, element_type)))
     }
 
+    /// Convert a [`TSArrayType`] into a [`TSType::TSArrayType`]
     #[inline]
     pub fn ts_type_from_ts_array_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5589,6 +8704,16 @@ impl<'a> AstBuilder<'a> {
         TSType::TSArrayType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSConditionalType`]
+    ///
+    /// This node contains a [`TSConditionalType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - check_type
+    /// - extends_type
+    /// - true_type
+    /// - false_type
     #[inline]
     pub fn ts_type_conditional_type(
         self,
@@ -5607,6 +8732,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSConditionalType`] into a [`TSType::TSConditionalType`]
     #[inline]
     pub fn ts_type_from_ts_conditional_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5615,6 +8741,16 @@ impl<'a> AstBuilder<'a> {
         TSType::TSConditionalType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSConstructorType`]
+    ///
+    /// This node contains a [`TSConstructorType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - r#abstract
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_type_constructor_type<T1, T2, T3>(
         self,
@@ -5638,6 +8774,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSConstructorType`] into a [`TSType::TSConstructorType`]
     #[inline]
     pub fn ts_type_from_ts_constructor_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5646,6 +8783,16 @@ impl<'a> AstBuilder<'a> {
         TSType::TSConstructorType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSFunctionType`]
+    ///
+    /// This node contains a [`TSFunctionType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_type_function_type<T1, T2, T3>(
         self,
@@ -5669,6 +8816,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSFunctionType`] into a [`TSType::TSFunctionType`]
     #[inline]
     pub fn ts_type_from_ts_function_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5677,6 +8825,17 @@ impl<'a> AstBuilder<'a> {
         TSType::TSFunctionType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSImportType`]
+    ///
+    /// This node contains a [`TSImportType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_type_of
+    /// - parameter
+    /// - qualifier
+    /// - attributes
+    /// - type_parameters
     #[inline]
     pub fn ts_type_import_type<T1>(
         self,
@@ -5700,6 +8859,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSImportType`] into a [`TSType::TSImportType`]
     #[inline]
     pub fn ts_type_from_ts_import_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5708,6 +8868,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSImportType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSIndexedAccessType`]
+    ///
+    /// This node contains a [`TSIndexedAccessType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object_type
+    /// - index_type
     #[inline]
     pub fn ts_type_indexed_access_type(
         self,
@@ -5722,6 +8890,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSIndexedAccessType`] into a [`TSType::TSIndexedAccessType`]
     #[inline]
     pub fn ts_type_from_ts_indexed_access_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5730,6 +8899,13 @@ impl<'a> AstBuilder<'a> {
         TSType::TSIndexedAccessType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSInferType`]
+    ///
+    /// This node contains a [`TSInferType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_parameter
     #[inline]
     pub fn ts_type_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSType<'a>
     where
@@ -5738,6 +8914,7 @@ impl<'a> AstBuilder<'a> {
         TSType::TSInferType(self.alloc(self.ts_infer_type(span, type_parameter)))
     }
 
+    /// Convert a [`TSInferType`] into a [`TSType::TSInferType`]
     #[inline]
     pub fn ts_type_from_ts_infer_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5746,11 +8923,19 @@ impl<'a> AstBuilder<'a> {
         TSType::TSInferType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSIntersectionType`]
+    ///
+    /// This node contains a [`TSIntersectionType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - types
     #[inline]
     pub fn ts_type_intersection_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSIntersectionType(self.alloc(self.ts_intersection_type(span, types)))
     }
 
+    /// Convert a [`TSIntersectionType`] into a [`TSType::TSIntersectionType`]
     #[inline]
     pub fn ts_type_from_ts_intersection_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5759,11 +8944,19 @@ impl<'a> AstBuilder<'a> {
         TSType::TSIntersectionType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSLiteralType`]
+    ///
+    /// This node contains a [`TSLiteralType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - literal
     #[inline]
     pub fn ts_type_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSType<'a> {
         TSType::TSLiteralType(self.alloc(self.ts_literal_type(span, literal)))
     }
 
+    /// Convert a [`TSLiteralType`] into a [`TSType::TSLiteralType`]
     #[inline]
     pub fn ts_type_from_ts_literal_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5772,6 +8965,17 @@ impl<'a> AstBuilder<'a> {
         TSType::TSLiteralType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSMappedType`]
+    ///
+    /// This node contains a [`TSMappedType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_parameter
+    /// - name_type
+    /// - type_annotation
+    /// - optional
+    /// - readonly
     #[inline]
     pub fn ts_type_mapped_type<T1>(
         self,
@@ -5795,6 +8999,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSMappedType`] into a [`TSType::TSMappedType`]
     #[inline]
     pub fn ts_type_from_ts_mapped_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5803,6 +9008,15 @@ impl<'a> AstBuilder<'a> {
         TSType::TSMappedType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSNamedTupleMember`]
+    ///
+    /// This node contains a [`TSNamedTupleMember`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_type
+    /// - label
+    /// - optional
     #[inline]
     pub fn ts_type_named_tuple_member(
         self,
@@ -5819,6 +9033,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSNamedTupleMember`] into a [`TSType::TSNamedTupleMember`]
     #[inline]
     pub fn ts_type_from_ts_named_tuple_member<T>(self, inner: T) -> TSType<'a>
     where
@@ -5827,6 +9042,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSNamedTupleMember(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSQualifiedName`]
+    ///
+    /// This node contains a [`TSQualifiedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn ts_type_qualified_name(
         self,
@@ -5837,6 +9060,7 @@ impl<'a> AstBuilder<'a> {
         TSType::TSQualifiedName(self.alloc(self.ts_qualified_name(span, left, right)))
     }
 
+    /// Convert a [`TSQualifiedName`] into a [`TSType::TSQualifiedName`]
     #[inline]
     pub fn ts_type_from_ts_qualified_name<T>(self, inner: T) -> TSType<'a>
     where
@@ -5845,6 +9069,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSQualifiedName(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTemplateLiteralType`]
+    ///
+    /// This node contains a [`TSTemplateLiteralType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - types
     #[inline]
     pub fn ts_type_template_literal_type(
         self,
@@ -5857,6 +9089,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSTemplateLiteralType`] into a [`TSType::TSTemplateLiteralType`]
     #[inline]
     pub fn ts_type_from_ts_template_literal_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5865,11 +9098,18 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTemplateLiteralType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSThisType`]
+    ///
+    /// This node contains a [`TSThisType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_this_type(self, span: Span) -> TSType<'a> {
         TSType::TSThisType(self.alloc(self.ts_this_type(span)))
     }
 
+    /// Convert a [`TSThisType`] into a [`TSType::TSThisType`]
     #[inline]
     pub fn ts_type_from_ts_this_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5878,6 +9118,13 @@ impl<'a> AstBuilder<'a> {
         TSType::TSThisType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTupleType`]
+    ///
+    /// This node contains a [`TSTupleType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_types
     #[inline]
     pub fn ts_type_tuple_type(
         self,
@@ -5887,6 +9134,7 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTupleType(self.alloc(self.ts_tuple_type(span, element_types)))
     }
 
+    /// Convert a [`TSTupleType`] into a [`TSType::TSTupleType`]
     #[inline]
     pub fn ts_type_from_ts_tuple_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -5895,11 +9143,19 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTupleType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTypeLiteral`]
+    ///
+    /// This node contains a [`TSTypeLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - members
     #[inline]
     pub fn ts_type_type_literal(self, span: Span, members: Vec<'a, TSSignature<'a>>) -> TSType<'a> {
         TSType::TSTypeLiteral(self.alloc(self.ts_type_literal(span, members)))
     }
 
+    /// Convert a [`TSTypeLiteral`] into a [`TSType::TSTypeLiteral`]
     #[inline]
     pub fn ts_type_from_ts_type_literal<T>(self, inner: T) -> TSType<'a>
     where
@@ -5908,6 +9164,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTypeLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTypeOperatorType`]
+    ///
+    /// This node contains a [`TSTypeOperator`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - type_annotation
     #[inline]
     pub fn ts_type_type_operator(
         self,
@@ -5922,6 +9186,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSTypeOperator`] into a [`TSType::TSTypeOperatorType`]
     #[inline]
     pub fn ts_type_from_ts_type_operator<T>(self, inner: T) -> TSType<'a>
     where
@@ -5930,6 +9195,15 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTypeOperatorType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTypePredicate`]
+    ///
+    /// This node contains a [`TSTypePredicate`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameter_name
+    /// - asserts
+    /// - type_annotation
     #[inline]
     pub fn ts_type_type_predicate<T1>(
         self,
@@ -5949,6 +9223,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSTypePredicate`] into a [`TSType::TSTypePredicate`]
     #[inline]
     pub fn ts_type_from_ts_type_predicate<T>(self, inner: T) -> TSType<'a>
     where
@@ -5957,6 +9232,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTypePredicate(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTypeQuery`]
+    ///
+    /// This node contains a [`TSTypeQuery`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expr_name
+    /// - type_parameters
     #[inline]
     pub fn ts_type_type_query<T1>(
         self,
@@ -5970,6 +9253,7 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTypeQuery(self.alloc(self.ts_type_query(span, expr_name, type_parameters)))
     }
 
+    /// Convert a [`TSTypeQuery`] into a [`TSType::TSTypeQuery`]
     #[inline]
     pub fn ts_type_from_ts_type_query<T>(self, inner: T) -> TSType<'a>
     where
@@ -5978,6 +9262,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTypeQuery(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSTypeReference`]
+    ///
+    /// This node contains a [`TSTypeReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_name
+    /// - type_parameters
     #[inline]
     pub fn ts_type_type_reference<T1>(
         self,
@@ -5995,6 +9287,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSTypeReference`] into a [`TSType::TSTypeReference`]
     #[inline]
     pub fn ts_type_from_ts_type_reference<T>(self, inner: T) -> TSType<'a>
     where
@@ -6003,11 +9296,19 @@ impl<'a> AstBuilder<'a> {
         TSType::TSTypeReference(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSUnionType`]
+    ///
+    /// This node contains a [`TSUnionType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - types
     #[inline]
     pub fn ts_type_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSUnionType(self.alloc(self.ts_union_type(span, types)))
     }
 
+    /// Convert a [`TSUnionType`] into a [`TSType::TSUnionType`]
     #[inline]
     pub fn ts_type_from_ts_union_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -6016,11 +9317,19 @@ impl<'a> AstBuilder<'a> {
         TSType::TSUnionType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::TSParenthesizedType`]
+    ///
+    /// This node contains a [`TSParenthesizedType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn ts_type_parenthesized_type(self, span: Span, type_annotation: TSType<'a>) -> TSType<'a> {
         TSType::TSParenthesizedType(self.alloc(self.ts_parenthesized_type(span, type_annotation)))
     }
 
+    /// Convert a [`TSParenthesizedType`] into a [`TSType::TSParenthesizedType`]
     #[inline]
     pub fn ts_type_from_ts_parenthesized_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -6029,6 +9338,14 @@ impl<'a> AstBuilder<'a> {
         TSType::TSParenthesizedType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::JSDocNullableType`]
+    ///
+    /// This node contains a [`JSDocNullableType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
+    /// - postfix: Was `?` after the type annotation?
     #[inline]
     pub fn ts_type_js_doc_nullable_type(
         self,
@@ -6043,6 +9360,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSDocNullableType`] into a [`TSType::JSDocNullableType`]
     #[inline]
     pub fn ts_type_from_js_doc_nullable_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -6051,6 +9369,14 @@ impl<'a> AstBuilder<'a> {
         TSType::JSDocNullableType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::JSDocNonNullableType`]
+    ///
+    /// This node contains a [`JSDocNonNullableType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
+    /// - postfix
     #[inline]
     pub fn ts_type_js_doc_non_nullable_type(
         self,
@@ -6065,6 +9391,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSDocNonNullableType`] into a [`TSType::JSDocNonNullableType`]
     #[inline]
     pub fn ts_type_from_js_doc_non_nullable_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -6073,11 +9400,18 @@ impl<'a> AstBuilder<'a> {
         TSType::JSDocNonNullableType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSType::JSDocUnknownType`]
+    ///
+    /// This node contains a [`JSDocUnknownType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_js_doc_unknown_type(self, span: Span) -> TSType<'a> {
         TSType::JSDocUnknownType(self.alloc(self.js_doc_unknown_type(span)))
     }
 
+    /// Convert a [`JSDocUnknownType`] into a [`TSType::JSDocUnknownType`]
     #[inline]
     pub fn ts_type_from_js_doc_unknown_type<T>(self, inner: T) -> TSType<'a>
     where
@@ -6086,6 +9420,16 @@ impl<'a> AstBuilder<'a> {
         TSType::JSDocUnknownType(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSConditionalType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_conditional_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - check_type
+    /// - extends_type
+    /// - true_type
+    /// - false_type
     #[inline]
     pub fn ts_conditional_type(
         self,
@@ -6105,6 +9449,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSConditionalType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - check_type
+    /// - extends_type
+    /// - true_type
+    /// - false_type
     #[inline]
     pub fn alloc_ts_conditional_type(
         self,
@@ -6120,11 +9474,25 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSUnionType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_union_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - types
     #[inline]
     pub fn ts_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSUnionType<'a> {
         TSUnionType { span, types }
     }
 
+    /// Builds a [`TSUnionType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_union_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - types
     #[inline]
     pub fn alloc_ts_union_type(
         self,
@@ -6134,6 +9502,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_union_type(span, types), self.allocator)
     }
 
+    /// Builds a [`TSIntersectionType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_intersection_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - types
     #[inline]
     pub fn ts_intersection_type(
         self,
@@ -6143,6 +9518,13 @@ impl<'a> AstBuilder<'a> {
         TSIntersectionType { span, types }
     }
 
+    /// Builds a [`TSIntersectionType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_intersection_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - types
     #[inline]
     pub fn alloc_ts_intersection_type(
         self,
@@ -6152,6 +9534,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_intersection_type(span, types), self.allocator)
     }
 
+    /// Builds a [`TSParenthesizedType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_parenthesized_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn ts_parenthesized_type(
         self,
@@ -6161,6 +9550,13 @@ impl<'a> AstBuilder<'a> {
         TSParenthesizedType { span, type_annotation }
     }
 
+    /// Builds a [`TSParenthesizedType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_parenthesized_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_parenthesized_type(
         self,
@@ -6170,6 +9566,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_parenthesized_type(span, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSTypeOperator`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_operator`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - type_annotation
     #[inline]
     pub fn ts_type_operator(
         self,
@@ -6180,6 +9584,14 @@ impl<'a> AstBuilder<'a> {
         TSTypeOperator { span, operator, type_annotation }
     }
 
+    /// Builds a [`TSTypeOperator`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_operator`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - operator
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_type_operator(
         self,
@@ -6190,11 +9602,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_operator(span, operator, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSArrayType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_array_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_type
     #[inline]
     pub fn ts_array_type(self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
         TSArrayType { span, element_type }
     }
 
+    /// Builds a [`TSArrayType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_array_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_type
     #[inline]
     pub fn alloc_ts_array_type(
         self,
@@ -6204,6 +9630,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_array_type(span, element_type), self.allocator)
     }
 
+    /// Builds a [`TSIndexedAccessType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_indexed_access_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object_type
+    /// - index_type
     #[inline]
     pub fn ts_indexed_access_type(
         self,
@@ -6214,6 +9648,14 @@ impl<'a> AstBuilder<'a> {
         TSIndexedAccessType { span, object_type, index_type }
     }
 
+    /// Builds a [`TSIndexedAccessType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_indexed_access_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object_type
+    /// - index_type
     #[inline]
     pub fn alloc_ts_indexed_access_type(
         self,
@@ -6224,6 +9666,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_indexed_access_type(span, object_type, index_type), self.allocator)
     }
 
+    /// Builds a [`TSTupleType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_tuple_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_types
     #[inline]
     pub fn ts_tuple_type(
         self,
@@ -6233,6 +9682,13 @@ impl<'a> AstBuilder<'a> {
         TSTupleType { span, element_types }
     }
 
+    /// Builds a [`TSTupleType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_tuple_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_types
     #[inline]
     pub fn alloc_ts_tuple_type(
         self,
@@ -6242,6 +9698,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_tuple_type(span, element_types), self.allocator)
     }
 
+    /// Builds a [`TSNamedTupleMember`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_named_tuple_member`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_type
+    /// - label
+    /// - optional
     #[inline]
     pub fn ts_named_tuple_member(
         self,
@@ -6253,6 +9718,15 @@ impl<'a> AstBuilder<'a> {
         TSNamedTupleMember { span, element_type, label, optional }
     }
 
+    /// Builds a [`TSNamedTupleMember`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_named_tuple_member`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - element_type
+    /// - label
+    /// - optional
     #[inline]
     pub fn alloc_ts_named_tuple_member(
         self,
@@ -6264,11 +9738,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_named_tuple_member(span, element_type, label, optional), self.allocator)
     }
 
+    /// Builds a [`TSOptionalType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_optional_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn ts_optional_type(self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
         TSOptionalType { span, type_annotation }
     }
 
+    /// Builds a [`TSOptionalType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_optional_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_optional_type(
         self,
@@ -6278,11 +9766,25 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_optional_type(span, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSRestType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_rest_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn ts_rest_type(self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
         TSRestType { span, type_annotation }
     }
 
+    /// Builds a [`TSRestType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_rest_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_rest_type(
         self,
@@ -6292,6 +9794,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_rest_type(span, type_annotation), self.allocator)
     }
 
+    /// Build a [`TSTupleElement::TSOptionalType`]
+    ///
+    /// This node contains a [`TSOptionalType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn ts_tuple_element_optional_type(
         self,
@@ -6301,6 +9810,7 @@ impl<'a> AstBuilder<'a> {
         TSTupleElement::TSOptionalType(self.alloc(self.ts_optional_type(span, type_annotation)))
     }
 
+    /// Convert a [`TSOptionalType`] into a [`TSTupleElement::TSOptionalType`]
     #[inline]
     pub fn ts_tuple_element_from_ts_optional_type<T>(self, inner: T) -> TSTupleElement<'a>
     where
@@ -6309,6 +9819,13 @@ impl<'a> AstBuilder<'a> {
         TSTupleElement::TSOptionalType(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSTupleElement::TSRestType`]
+    ///
+    /// This node contains a [`TSRestType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
     #[inline]
     pub fn ts_tuple_element_rest_type(
         self,
@@ -6318,6 +9835,7 @@ impl<'a> AstBuilder<'a> {
         TSTupleElement::TSRestType(self.alloc(self.ts_rest_type(span, type_annotation)))
     }
 
+    /// Convert a [`TSRestType`] into a [`TSTupleElement::TSRestType`]
     #[inline]
     pub fn ts_tuple_element_from_ts_rest_type<T>(self, inner: T) -> TSTupleElement<'a>
     where
@@ -6331,146 +9849,322 @@ impl<'a> AstBuilder<'a> {
         TSTupleElement::from(inner)
     }
 
+    /// Builds a [`TSAnyKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_any_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_any_keyword(self, span: Span) -> TSAnyKeyword {
         TSAnyKeyword { span }
     }
 
+    /// Builds a [`TSAnyKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_any_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_any_keyword(self, span: Span) -> Box<'a, TSAnyKeyword> {
         Box::new_in(self.ts_any_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSStringKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_string_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_string_keyword(self, span: Span) -> TSStringKeyword {
         TSStringKeyword { span }
     }
 
+    /// Builds a [`TSStringKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_string_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_string_keyword(self, span: Span) -> Box<'a, TSStringKeyword> {
         Box::new_in(self.ts_string_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSBooleanKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_boolean_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_boolean_keyword(self, span: Span) -> TSBooleanKeyword {
         TSBooleanKeyword { span }
     }
 
+    /// Builds a [`TSBooleanKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_boolean_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_boolean_keyword(self, span: Span) -> Box<'a, TSBooleanKeyword> {
         Box::new_in(self.ts_boolean_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSNumberKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_number_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_number_keyword(self, span: Span) -> TSNumberKeyword {
         TSNumberKeyword { span }
     }
 
+    /// Builds a [`TSNumberKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_number_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_number_keyword(self, span: Span) -> Box<'a, TSNumberKeyword> {
         Box::new_in(self.ts_number_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSNeverKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_never_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_never_keyword(self, span: Span) -> TSNeverKeyword {
         TSNeverKeyword { span }
     }
 
+    /// Builds a [`TSNeverKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_never_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_never_keyword(self, span: Span) -> Box<'a, TSNeverKeyword> {
         Box::new_in(self.ts_never_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSIntrinsicKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_intrinsic_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_intrinsic_keyword(self, span: Span) -> TSIntrinsicKeyword {
         TSIntrinsicKeyword { span }
     }
 
+    /// Builds a [`TSIntrinsicKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_intrinsic_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_intrinsic_keyword(self, span: Span) -> Box<'a, TSIntrinsicKeyword> {
         Box::new_in(self.ts_intrinsic_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSUnknownKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_unknown_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_unknown_keyword(self, span: Span) -> TSUnknownKeyword {
         TSUnknownKeyword { span }
     }
 
+    /// Builds a [`TSUnknownKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_unknown_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_unknown_keyword(self, span: Span) -> Box<'a, TSUnknownKeyword> {
         Box::new_in(self.ts_unknown_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSNullKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_null_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_null_keyword(self, span: Span) -> TSNullKeyword {
         TSNullKeyword { span }
     }
 
+    /// Builds a [`TSNullKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_null_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_null_keyword(self, span: Span) -> Box<'a, TSNullKeyword> {
         Box::new_in(self.ts_null_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSUndefinedKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_undefined_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_undefined_keyword(self, span: Span) -> TSUndefinedKeyword {
         TSUndefinedKeyword { span }
     }
 
+    /// Builds a [`TSUndefinedKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_undefined_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_undefined_keyword(self, span: Span) -> Box<'a, TSUndefinedKeyword> {
         Box::new_in(self.ts_undefined_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSVoidKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_void_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_void_keyword(self, span: Span) -> TSVoidKeyword {
         TSVoidKeyword { span }
     }
 
+    /// Builds a [`TSVoidKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_void_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_void_keyword(self, span: Span) -> Box<'a, TSVoidKeyword> {
         Box::new_in(self.ts_void_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSSymbolKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_symbol_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_symbol_keyword(self, span: Span) -> TSSymbolKeyword {
         TSSymbolKeyword { span }
     }
 
+    /// Builds a [`TSSymbolKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_symbol_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_symbol_keyword(self, span: Span) -> Box<'a, TSSymbolKeyword> {
         Box::new_in(self.ts_symbol_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSThisType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_this_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_this_type(self, span: Span) -> TSThisType {
         TSThisType { span }
     }
 
+    /// Builds a [`TSThisType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_this_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_this_type(self, span: Span) -> Box<'a, TSThisType> {
         Box::new_in(self.ts_this_type(span), self.allocator)
     }
 
+    /// Builds a [`TSObjectKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_object_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_object_keyword(self, span: Span) -> TSObjectKeyword {
         TSObjectKeyword { span }
     }
 
+    /// Builds a [`TSObjectKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_object_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_object_keyword(self, span: Span) -> Box<'a, TSObjectKeyword> {
         Box::new_in(self.ts_object_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSBigIntKeyword`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_big_int_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_big_int_keyword(self, span: Span) -> TSBigIntKeyword {
         TSBigIntKeyword { span }
     }
 
+    /// Builds a [`TSBigIntKeyword`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_big_int_keyword`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_ts_big_int_keyword(self, span: Span) -> Box<'a, TSBigIntKeyword> {
         Box::new_in(self.ts_big_int_keyword(span), self.allocator)
     }
 
+    /// Builds a [`TSTypeReference`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_reference`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_name
+    /// - type_parameters
     #[inline]
     pub fn ts_type_reference<T1>(
         self,
@@ -6488,6 +10182,14 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSTypeReference`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_reference`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_name
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_type_reference<T1>(
         self,
@@ -6501,6 +10203,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_reference(span, type_name, type_parameters), self.allocator)
     }
 
+    /// Build a [`TSTypeName::IdentifierReference`]
+    ///
+    /// This node contains a [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name: The name of the identifier being referenced.
     #[inline]
     pub fn ts_type_name_identifier_reference<A>(self, span: Span, name: A) -> TSTypeName<'a>
     where
@@ -6509,6 +10218,7 @@ impl<'a> AstBuilder<'a> {
         TSTypeName::IdentifierReference(self.alloc(self.identifier_reference(span, name)))
     }
 
+    /// Convert a [`IdentifierReference`] into a [`TSTypeName::IdentifierReference`]
     #[inline]
     pub fn ts_type_name_from_identifier_reference<T>(self, inner: T) -> TSTypeName<'a>
     where
@@ -6517,6 +10227,14 @@ impl<'a> AstBuilder<'a> {
         TSTypeName::IdentifierReference(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSTypeName::QualifiedName`]
+    ///
+    /// This node contains a [`TSQualifiedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn ts_type_name_qualified_name(
         self,
@@ -6527,6 +10245,7 @@ impl<'a> AstBuilder<'a> {
         TSTypeName::QualifiedName(self.alloc(self.ts_qualified_name(span, left, right)))
     }
 
+    /// Convert a [`TSQualifiedName`] into a [`TSTypeName::QualifiedName`]
     #[inline]
     pub fn ts_type_name_from_ts_qualified_name<T>(self, inner: T) -> TSTypeName<'a>
     where
@@ -6535,6 +10254,14 @@ impl<'a> AstBuilder<'a> {
         TSTypeName::QualifiedName(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSQualifiedName`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_qualified_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn ts_qualified_name(
         self,
@@ -6545,6 +10272,14 @@ impl<'a> AstBuilder<'a> {
         TSQualifiedName { span, left, right }
     }
 
+    /// Builds a [`TSQualifiedName`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_qualified_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - left
+    /// - right
     #[inline]
     pub fn alloc_ts_qualified_name(
         self,
@@ -6555,6 +10290,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_qualified_name(span, left, right), self.allocator)
     }
 
+    /// Builds a [`TSTypeParameterInstantiation`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_parameter_instantiation`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
     #[inline]
     pub fn ts_type_parameter_instantiation(
         self,
@@ -6564,6 +10306,13 @@ impl<'a> AstBuilder<'a> {
         TSTypeParameterInstantiation { span, params }
     }
 
+    /// Builds a [`TSTypeParameterInstantiation`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_instantiation`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
     #[inline]
     pub fn alloc_ts_type_parameter_instantiation(
         self,
@@ -6573,6 +10322,18 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_parameter_instantiation(span, params), self.allocator)
     }
 
+    /// Builds a [`TSTypeParameter`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - constraint
+    /// - default
+    /// - r#in
+    /// - out
+    /// - r#const
     #[inline]
     pub fn ts_type_parameter(
         self,
@@ -6587,6 +10348,18 @@ impl<'a> AstBuilder<'a> {
         TSTypeParameter { span, name, constraint, default, r#in, out, r#const }
     }
 
+    /// Builds a [`TSTypeParameter`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - constraint
+    /// - default
+    /// - r#in
+    /// - out
+    /// - r#const
     #[inline]
     pub fn alloc_ts_type_parameter(
         self,
@@ -6604,6 +10377,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSTypeParameterDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_parameter_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
     #[inline]
     pub fn ts_type_parameter_declaration(
         self,
@@ -6613,6 +10393,13 @@ impl<'a> AstBuilder<'a> {
         TSTypeParameterDeclaration { span, params }
     }
 
+    /// Builds a [`TSTypeParameterDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
     #[inline]
     pub fn alloc_ts_type_parameter_declaration(
         self,
@@ -6622,6 +10409,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_parameter_declaration(span, params), self.allocator)
     }
 
+    /// Builds a [`TSTypeAliasDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_alias_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - type_parameters
+    /// - type_annotation
+    /// - declare
     #[inline]
     pub fn ts_type_alias_declaration<T1>(
         self,
@@ -6644,6 +10441,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSTypeAliasDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - type_parameters
+    /// - type_annotation
+    /// - declare
     #[inline]
     pub fn alloc_ts_type_alias_declaration<T1>(
         self,
@@ -6662,6 +10469,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSClassImplements`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_class_implements`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn ts_class_implements<T1>(
         self,
@@ -6679,6 +10494,14 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSClassImplements`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_class_implements`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_class_implements<T1>(
         self,
@@ -6692,6 +10515,17 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_class_implements(span, expression, type_parameters), self.allocator)
     }
 
+    /// Builds a [`TSInterfaceDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id: The identifier (name) of the interface.
+    /// - extends
+    /// - type_parameters
+    /// - body
+    /// - declare
     #[inline]
     pub fn ts_interface_declaration<T1, T2>(
         self,
@@ -6717,6 +10551,17 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSInterfaceDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id: The identifier (name) of the interface.
+    /// - extends
+    /// - type_parameters
+    /// - body
+    /// - declare
     #[inline]
     pub fn alloc_ts_interface_declaration<T1, T2>(
         self,
@@ -6737,6 +10582,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSInterfaceBody`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_body`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn ts_interface_body(
         self,
@@ -6746,6 +10598,13 @@ impl<'a> AstBuilder<'a> {
         TSInterfaceBody { span, body }
     }
 
+    /// Builds a [`TSInterfaceBody`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_body`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - body
     #[inline]
     pub fn alloc_ts_interface_body(
         self,
@@ -6755,6 +10614,17 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_interface_body(span, body), self.allocator)
     }
 
+    /// Builds a [`TSPropertySignature`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_property_signature`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - computed
+    /// - optional
+    /// - readonly
+    /// - key
+    /// - type_annotation
     #[inline]
     pub fn ts_property_signature<T1>(
         self,
@@ -6778,6 +10648,17 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSPropertySignature`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_property_signature`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - computed
+    /// - optional
+    /// - readonly
+    /// - key
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_property_signature<T1>(
         self,
@@ -6797,6 +10678,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`TSSignature::TSIndexSignature`]
+    ///
+    /// This node contains a [`TSIndexSignature`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameters
+    /// - type_annotation
+    /// - readonly
     #[inline]
     pub fn ts_signature_index_signature<T1>(
         self,
@@ -6816,6 +10706,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSIndexSignature`] into a [`TSSignature::TSIndexSignature`]
     #[inline]
     pub fn ts_signature_from_ts_index_signature<T>(self, inner: T) -> TSSignature<'a>
     where
@@ -6824,6 +10715,17 @@ impl<'a> AstBuilder<'a> {
         TSSignature::TSIndexSignature(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSSignature::TSPropertySignature`]
+    ///
+    /// This node contains a [`TSPropertySignature`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - computed
+    /// - optional
+    /// - readonly
+    /// - key
+    /// - type_annotation
     #[inline]
     pub fn ts_signature_property_signature<T1>(
         self,
@@ -6847,6 +10749,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSPropertySignature`] into a [`TSSignature::TSPropertySignature`]
     #[inline]
     pub fn ts_signature_from_ts_property_signature<T>(self, inner: T) -> TSSignature<'a>
     where
@@ -6855,6 +10758,16 @@ impl<'a> AstBuilder<'a> {
         TSSignature::TSPropertySignature(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSSignature::TSCallSignatureDeclaration`]
+    ///
+    /// This node contains a [`TSCallSignatureDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_signature_call_signature_declaration<T1, T2, T3>(
         self,
@@ -6878,6 +10791,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSCallSignatureDeclaration`] into a [`TSSignature::TSCallSignatureDeclaration`]
     #[inline]
     pub fn ts_signature_from_ts_call_signature_declaration<T>(self, inner: T) -> TSSignature<'a>
     where
@@ -6886,6 +10800,15 @@ impl<'a> AstBuilder<'a> {
         TSSignature::TSCallSignatureDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSSignature::TSConstructSignatureDeclaration`]
+    ///
+    /// This node contains a [`TSConstructSignatureDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_signature_construct_signature_declaration<T1, T2, T3>(
         self,
@@ -6904,6 +10827,7 @@ impl<'a> AstBuilder<'a> {
         ))
     }
 
+    /// Convert a [`TSConstructSignatureDeclaration`] into a [`TSSignature::TSConstructSignatureDeclaration`]
     #[inline]
     pub fn ts_signature_from_ts_construct_signature_declaration<T>(
         self,
@@ -6915,6 +10839,20 @@ impl<'a> AstBuilder<'a> {
         TSSignature::TSConstructSignatureDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSSignature::TSMethodSignature`]
+    ///
+    /// This node contains a [`TSMethodSignature`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - computed
+    /// - optional
+    /// - kind
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_signature_method_signature<T1, T2, T3>(
         self,
@@ -6946,6 +10884,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSMethodSignature`] into a [`TSSignature::TSMethodSignature`]
     #[inline]
     pub fn ts_signature_from_ts_method_signature<T>(self, inner: T) -> TSSignature<'a>
     where
@@ -6954,6 +10893,15 @@ impl<'a> AstBuilder<'a> {
         TSSignature::TSMethodSignature(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSIndexSignature`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_index_signature`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameters
+    /// - type_annotation
+    /// - readonly
     #[inline]
     pub fn ts_index_signature<T1>(
         self,
@@ -6973,6 +10921,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSIndexSignature`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_index_signature`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameters
+    /// - type_annotation
+    /// - readonly
     #[inline]
     pub fn alloc_ts_index_signature<T1>(
         self,
@@ -6990,6 +10947,16 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSCallSignatureDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_call_signature_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_call_signature_declaration<T1, T2, T3>(
         self,
@@ -7013,6 +10980,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSCallSignatureDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_call_signature_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_call_signature_declaration<T1, T2, T3>(
         self,
@@ -7039,6 +11016,20 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSMethodSignature`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_method_signature`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - computed
+    /// - optional
+    /// - kind
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_method_signature<T1, T2, T3>(
         self,
@@ -7071,6 +11062,20 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSMethodSignature`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_method_signature`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - key
+    /// - computed
+    /// - optional
+    /// - kind
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_method_signature<T1, T2, T3>(
         self,
@@ -7105,6 +11110,15 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSConstructSignatureDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_construct_signature_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_construct_signature_declaration<T1, T2, T3>(
         self,
@@ -7127,6 +11141,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSConstructSignatureDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_construct_signature_declaration<T1, T2, T3>(
         self,
@@ -7146,6 +11169,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSIndexSignatureName`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_index_signature_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - type_annotation
     #[inline]
     pub fn ts_index_signature_name<A, T1>(
         self,
@@ -7164,6 +11195,14 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSIndexSignatureName`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_index_signature_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_index_signature_name<A, T1>(
         self,
@@ -7178,6 +11217,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_index_signature_name(span, name, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSInterfaceHeritage`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_heritage`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn ts_interface_heritage<T1>(
         self,
@@ -7195,6 +11242,14 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSInterfaceHeritage`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_heritage`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_interface_heritage<T1>(
         self,
@@ -7208,6 +11263,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_interface_heritage(span, expression, type_parameters), self.allocator)
     }
 
+    /// Builds a [`TSTypePredicate`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_predicate`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameter_name
+    /// - asserts
+    /// - type_annotation
     #[inline]
     pub fn ts_type_predicate<T1>(
         self,
@@ -7227,6 +11291,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSTypePredicate`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_predicate`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - parameter_name
+    /// - asserts
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_type_predicate<T1>(
         self,
@@ -7244,6 +11317,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`TSTypePredicateName::Identifier`]
+    ///
+    /// This node contains a [`IdentifierName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn ts_type_predicate_name_identifier_name<A>(
         self,
@@ -7256,6 +11336,7 @@ impl<'a> AstBuilder<'a> {
         TSTypePredicateName::Identifier(self.alloc(self.identifier_name(span, name)))
     }
 
+    /// Convert a [`IdentifierName`] into a [`TSTypePredicateName::Identifier`]
     #[inline]
     pub fn ts_type_predicate_name_from_identifier_name<T>(self, inner: T) -> TSTypePredicateName<'a>
     where
@@ -7264,11 +11345,16 @@ impl<'a> AstBuilder<'a> {
         TSTypePredicateName::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSTypePredicateName::This`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_predicate_name_this_type(self, span: Span) -> TSTypePredicateName<'a> {
         TSTypePredicateName::This(self.ts_this_type(span))
     }
 
+    /// Convert a [`TSThisType`] into a [`TSTypePredicateName::This`]
     #[inline]
     pub fn ts_type_predicate_name_from_ts_this_type<T>(self, inner: T) -> TSTypePredicateName<'a>
     where
@@ -7277,6 +11363,16 @@ impl<'a> AstBuilder<'a> {
         TSTypePredicateName::This(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSModuleDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_module_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - body
+    /// - kind: The keyword used to define this module declaration
+    /// - declare
     #[inline]
     pub fn ts_module_declaration(
         self,
@@ -7289,6 +11385,16 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclaration { span, id, body, kind, declare, scope_id: Default::default() }
     }
 
+    /// Builds a [`TSModuleDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - body
+    /// - kind: The keyword used to define this module declaration
+    /// - declare
     #[inline]
     pub fn alloc_ts_module_declaration(
         self,
@@ -7301,6 +11407,11 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_module_declaration(span, id, body, kind, declare), self.allocator)
     }
 
+    /// Build a [`TSModuleDeclarationName::Identifier`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn ts_module_declaration_name_identifier_name<A>(
         self,
@@ -7313,6 +11424,7 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclarationName::Identifier(self.identifier_name(span, name))
     }
 
+    /// Convert a [`IdentifierName`] into a [`TSModuleDeclarationName::Identifier`]
     #[inline]
     pub fn ts_module_declaration_name_from_identifier_name<T>(
         self,
@@ -7324,6 +11436,11 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclarationName::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSModuleDeclarationName::StringLiteral`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn ts_module_declaration_name_string_literal<A>(
         self,
@@ -7336,6 +11453,7 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclarationName::StringLiteral(self.string_literal(span, value))
     }
 
+    /// Convert a [`StringLiteral`] into a [`TSModuleDeclarationName::StringLiteral`]
     #[inline]
     pub fn ts_module_declaration_name_from_string_literal<T>(
         self,
@@ -7347,6 +11465,16 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclarationName::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSModuleDeclarationBody::TSModuleDeclaration`]
+    ///
+    /// This node contains a [`TSModuleDeclaration`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - body
+    /// - kind: The keyword used to define this module declaration
+    /// - declare
     #[inline]
     pub fn ts_module_declaration_body_module_declaration(
         self,
@@ -7361,6 +11489,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSModuleDeclaration`] into a [`TSModuleDeclarationBody::TSModuleDeclaration`]
     #[inline]
     pub fn ts_module_declaration_body_from_ts_module_declaration<T>(
         self,
@@ -7372,6 +11501,14 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclarationBody::TSModuleDeclaration(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSModuleDeclarationBody::TSModuleBlock`]
+    ///
+    /// This node contains a [`TSModuleBlock`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - directives
+    /// - body
     #[inline]
     pub fn ts_module_declaration_body_module_block(
         self,
@@ -7384,6 +11521,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSModuleBlock`] into a [`TSModuleDeclarationBody::TSModuleBlock`]
     #[inline]
     pub fn ts_module_declaration_body_from_ts_module_block<T>(
         self,
@@ -7395,6 +11533,14 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclarationBody::TSModuleBlock(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSModuleBlock`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_module_block`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - directives
+    /// - body
     #[inline]
     pub fn ts_module_block(
         self,
@@ -7405,6 +11551,14 @@ impl<'a> AstBuilder<'a> {
         TSModuleBlock { span, directives, body }
     }
 
+    /// Builds a [`TSModuleBlock`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_module_block`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - directives
+    /// - body
     #[inline]
     pub fn alloc_ts_module_block(
         self,
@@ -7415,6 +11569,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_module_block(span, directives, body), self.allocator)
     }
 
+    /// Builds a [`TSTypeLiteral`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - members
     #[inline]
     pub fn ts_type_literal(
         self,
@@ -7424,6 +11585,13 @@ impl<'a> AstBuilder<'a> {
         TSTypeLiteral { span, members }
     }
 
+    /// Builds a [`TSTypeLiteral`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_literal`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - members
     #[inline]
     pub fn alloc_ts_type_literal(
         self,
@@ -7433,6 +11601,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_literal(span, members), self.allocator)
     }
 
+    /// Builds a [`TSInferType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_infer_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_parameter
     #[inline]
     pub fn ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSInferType<'a>
     where
@@ -7441,6 +11616,13 @@ impl<'a> AstBuilder<'a> {
         TSInferType { span, type_parameter: type_parameter.into_in(self.allocator) }
     }
 
+    /// Builds a [`TSInferType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_infer_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_parameter
     #[inline]
     pub fn alloc_ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> Box<'a, TSInferType<'a>>
     where
@@ -7449,6 +11631,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_infer_type(span, type_parameter), self.allocator)
     }
 
+    /// Builds a [`TSTypeQuery`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_query`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expr_name
+    /// - type_parameters
     #[inline]
     pub fn ts_type_query<T1>(
         self,
@@ -7462,6 +11652,14 @@ impl<'a> AstBuilder<'a> {
         TSTypeQuery { span, expr_name, type_parameters: type_parameters.into_in(self.allocator) }
     }
 
+    /// Builds a [`TSTypeQuery`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_query`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expr_name
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_type_query<T1>(
         self,
@@ -7475,6 +11673,17 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_query(span, expr_name, type_parameters), self.allocator)
     }
 
+    /// Build a [`TSTypeQueryExprName::TSImportType`]
+    ///
+    /// This node contains a [`TSImportType`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_type_of
+    /// - parameter
+    /// - qualifier
+    /// - attributes
+    /// - type_parameters
     #[inline]
     pub fn ts_type_query_expr_name_import_type<T1>(
         self,
@@ -7498,6 +11707,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`TSImportType`] into a [`TSTypeQueryExprName::TSImportType`]
     #[inline]
     pub fn ts_type_query_expr_name_from_ts_import_type<T>(self, inner: T) -> TSTypeQueryExprName<'a>
     where
@@ -7514,6 +11724,17 @@ impl<'a> AstBuilder<'a> {
         TSTypeQueryExprName::from(inner)
     }
 
+    /// Builds a [`TSImportType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_type_of
+    /// - parameter
+    /// - qualifier
+    /// - attributes
+    /// - type_parameters
     #[inline]
     pub fn ts_import_type<T1>(
         self,
@@ -7537,6 +11758,17 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSImportType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - is_type_of
+    /// - parameter
+    /// - qualifier
+    /// - attributes
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_import_type<T1>(
         self,
@@ -7563,6 +11795,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSImportAttributes`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_attributes`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
     #[inline]
     pub fn ts_import_attributes(
         self,
@@ -7572,6 +11811,13 @@ impl<'a> AstBuilder<'a> {
         TSImportAttributes { span, elements }
     }
 
+    /// Builds a [`TSImportAttributes`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_attributes`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - elements
     #[inline]
     pub fn alloc_ts_import_attributes(
         self,
@@ -7581,6 +11827,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_import_attributes(span, elements), self.allocator)
     }
 
+    /// Builds a [`TSImportAttribute`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - value
     #[inline]
     pub fn ts_import_attribute(
         self,
@@ -7591,6 +11845,14 @@ impl<'a> AstBuilder<'a> {
         TSImportAttribute { span, name, value }
     }
 
+    /// Builds a [`TSImportAttribute`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - value
     #[inline]
     pub fn alloc_ts_import_attribute(
         self,
@@ -7601,6 +11863,11 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_import_attribute(span, name, value), self.allocator)
     }
 
+    /// Build a [`TSImportAttributeName::Identifier`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn ts_import_attribute_name_identifier_name<A>(
         self,
@@ -7613,6 +11880,7 @@ impl<'a> AstBuilder<'a> {
         TSImportAttributeName::Identifier(self.identifier_name(span, name))
     }
 
+    /// Convert a [`IdentifierName`] into a [`TSImportAttributeName::Identifier`]
     #[inline]
     pub fn ts_import_attribute_name_from_identifier_name<T>(
         self,
@@ -7624,6 +11892,11 @@ impl<'a> AstBuilder<'a> {
         TSImportAttributeName::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`TSImportAttributeName::StringLiteral`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn ts_import_attribute_name_string_literal<A>(
         self,
@@ -7636,6 +11909,7 @@ impl<'a> AstBuilder<'a> {
         TSImportAttributeName::StringLiteral(self.string_literal(span, value))
     }
 
+    /// Convert a [`StringLiteral`] into a [`TSImportAttributeName::StringLiteral`]
     #[inline]
     pub fn ts_import_attribute_name_from_string_literal<T>(
         self,
@@ -7647,6 +11921,16 @@ impl<'a> AstBuilder<'a> {
         TSImportAttributeName::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`TSFunctionType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_function_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_function_type<T1, T2, T3>(
         self,
@@ -7670,6 +11954,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSFunctionType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_function_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - this_param
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_function_type<T1, T2, T3>(
         self,
@@ -7690,6 +11984,16 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSConstructorType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_constructor_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - r#abstract
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn ts_constructor_type<T1, T2, T3>(
         self,
@@ -7713,6 +12017,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSConstructorType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_constructor_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - r#abstract
+    /// - params
+    /// - return_type
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_constructor_type<T1, T2, T3>(
         self,
@@ -7733,6 +12047,17 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSMappedType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_mapped_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_parameter
+    /// - name_type
+    /// - type_annotation
+    /// - optional
+    /// - readonly
     #[inline]
     pub fn ts_mapped_type<T1>(
         self,
@@ -7757,6 +12082,17 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSMappedType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_parameter
+    /// - name_type
+    /// - type_annotation
+    /// - optional
+    /// - readonly
     #[inline]
     pub fn alloc_ts_mapped_type<T1>(
         self,
@@ -7783,6 +12119,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`TSTemplateLiteralType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_template_literal_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - types
     #[inline]
     pub fn ts_template_literal_type(
         self,
@@ -7793,6 +12137,14 @@ impl<'a> AstBuilder<'a> {
         TSTemplateLiteralType { span, quasis, types }
     }
 
+    /// Builds a [`TSTemplateLiteralType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_template_literal_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - quasis
+    /// - types
     #[inline]
     pub fn alloc_ts_template_literal_type(
         self,
@@ -7803,6 +12155,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_template_literal_type(span, quasis, types), self.allocator)
     }
 
+    /// Builds a [`TSAsExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_as_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn ts_as_expression(
         self,
@@ -7813,6 +12173,14 @@ impl<'a> AstBuilder<'a> {
         TSAsExpression { span, expression, type_annotation }
     }
 
+    /// Builds a [`TSAsExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_as_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_as_expression(
         self,
@@ -7823,6 +12191,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_as_expression(span, expression, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSSatisfiesExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_satisfies_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn ts_satisfies_expression(
         self,
@@ -7833,6 +12209,14 @@ impl<'a> AstBuilder<'a> {
         TSSatisfiesExpression { span, expression, type_annotation }
     }
 
+    /// Builds a [`TSSatisfiesExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_satisfies_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_satisfies_expression(
         self,
@@ -7843,6 +12227,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_satisfies_expression(span, expression, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSTypeAssertion`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_assertion`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn ts_type_assertion(
         self,
@@ -7853,6 +12245,14 @@ impl<'a> AstBuilder<'a> {
         TSTypeAssertion { span, expression, type_annotation }
     }
 
+    /// Builds a [`TSTypeAssertion`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_assertion`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_annotation
     #[inline]
     pub fn alloc_ts_type_assertion(
         self,
@@ -7863,6 +12263,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_type_assertion(span, expression, type_annotation), self.allocator)
     }
 
+    /// Builds a [`TSImportEqualsDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_equals_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - module_reference
+    /// - import_kind
     #[inline]
     pub fn ts_import_equals_declaration(
         self,
@@ -7874,6 +12283,15 @@ impl<'a> AstBuilder<'a> {
         TSImportEqualsDeclaration { span, id, module_reference, import_kind }
     }
 
+    /// Builds a [`TSImportEqualsDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_equals_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
+    /// - module_reference
+    /// - import_kind
     #[inline]
     pub fn alloc_ts_import_equals_declaration(
         self,
@@ -7888,6 +12306,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`TSModuleReference::ExternalModuleReference`]
+    ///
+    /// This node contains a [`TSExternalModuleReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn ts_module_reference_external_module_reference(
         self,
@@ -7899,6 +12324,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`TSExternalModuleReference`] into a [`TSModuleReference::ExternalModuleReference`]
     #[inline]
     pub fn ts_module_reference_from_ts_external_module_reference<T>(
         self,
@@ -7915,6 +12341,13 @@ impl<'a> AstBuilder<'a> {
         TSModuleReference::from(inner)
     }
 
+    /// Builds a [`TSExternalModuleReference`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_external_module_reference`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn ts_external_module_reference(
         self,
@@ -7924,6 +12357,13 @@ impl<'a> AstBuilder<'a> {
         TSExternalModuleReference { span, expression }
     }
 
+    /// Builds a [`TSExternalModuleReference`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_external_module_reference`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_ts_external_module_reference(
         self,
@@ -7933,6 +12373,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_external_module_reference(span, expression), self.allocator)
     }
 
+    /// Builds a [`TSNonNullExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_non_null_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn ts_non_null_expression(
         self,
@@ -7942,6 +12389,13 @@ impl<'a> AstBuilder<'a> {
         TSNonNullExpression { span, expression }
     }
 
+    /// Builds a [`TSNonNullExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_non_null_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_ts_non_null_expression(
         self,
@@ -7951,16 +12405,37 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_non_null_expression(span, expression), self.allocator)
     }
 
+    /// Builds a [`Decorator`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_decorator`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn decorator(self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
         Decorator { span, expression }
     }
 
+    /// Builds a [`Decorator`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::decorator`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_decorator(self, span: Span, expression: Expression<'a>) -> Box<'a, Decorator<'a>> {
         Box::new_in(self.decorator(span, expression), self.allocator)
     }
 
+    /// Builds a [`TSExportAssignment`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_export_assignment`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn ts_export_assignment(
         self,
@@ -7970,6 +12445,13 @@ impl<'a> AstBuilder<'a> {
         TSExportAssignment { span, expression }
     }
 
+    /// Builds a [`TSExportAssignment`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_export_assignment`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_ts_export_assignment(
         self,
@@ -7979,6 +12461,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_export_assignment(span, expression), self.allocator)
     }
 
+    /// Builds a [`TSNamespaceExportDeclaration`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_namespace_export_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
     #[inline]
     pub fn ts_namespace_export_declaration(
         self,
@@ -7988,6 +12477,13 @@ impl<'a> AstBuilder<'a> {
         TSNamespaceExportDeclaration { span, id }
     }
 
+    /// Builds a [`TSNamespaceExportDeclaration`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_namespace_export_declaration`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - id
     #[inline]
     pub fn alloc_ts_namespace_export_declaration(
         self,
@@ -7997,6 +12493,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_namespace_export_declaration(span, id), self.allocator)
     }
 
+    /// Builds a [`TSInstantiationExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_instantiation_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn ts_instantiation_expression<T1>(
         self,
@@ -8014,6 +12518,14 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`TSInstantiationExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_instantiation_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
+    /// - type_parameters
     #[inline]
     pub fn alloc_ts_instantiation_expression<T1>(
         self,
@@ -8030,6 +12542,14 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`JSDocNullableType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_js_doc_nullable_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
+    /// - postfix: Was `?` after the type annotation?
     #[inline]
     pub fn js_doc_nullable_type(
         self,
@@ -8040,6 +12560,14 @@ impl<'a> AstBuilder<'a> {
         JSDocNullableType { span, type_annotation, postfix }
     }
 
+    /// Builds a [`JSDocNullableType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::js_doc_nullable_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
+    /// - postfix: Was `?` after the type annotation?
     #[inline]
     pub fn alloc_js_doc_nullable_type(
         self,
@@ -8050,6 +12578,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.js_doc_nullable_type(span, type_annotation, postfix), self.allocator)
     }
 
+    /// Builds a [`JSDocNonNullableType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_js_doc_non_nullable_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
+    /// - postfix
     #[inline]
     pub fn js_doc_non_nullable_type(
         self,
@@ -8060,6 +12596,14 @@ impl<'a> AstBuilder<'a> {
         JSDocNonNullableType { span, type_annotation, postfix }
     }
 
+    /// Builds a [`JSDocNonNullableType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::js_doc_non_nullable_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - type_annotation
+    /// - postfix
     #[inline]
     pub fn alloc_js_doc_non_nullable_type(
         self,
@@ -8070,16 +12614,37 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.js_doc_non_nullable_type(span, type_annotation, postfix), self.allocator)
     }
 
+    /// Builds a [`JSDocUnknownType`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_js_doc_unknown_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn js_doc_unknown_type(self, span: Span) -> JSDocUnknownType {
         JSDocUnknownType { span }
     }
 
+    /// Builds a [`JSDocUnknownType`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::js_doc_unknown_type`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_js_doc_unknown_type(self, span: Span) -> Box<'a, JSDocUnknownType> {
         Box::new_in(self.js_doc_unknown_type(span), self.allocator)
     }
 
+    /// Builds a [`JSXElement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_element
+    /// - closing_element
+    /// - children
     #[inline]
     pub fn jsx_element<T1, T2>(
         self,
@@ -8100,6 +12665,15 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`JSXElement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_element
+    /// - closing_element
+    /// - children
     #[inline]
     pub fn alloc_jsx_element<T1, T2>(
         self,
@@ -8118,6 +12692,16 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`JSXOpeningElement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_opening_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - self_closing: Is this tag self-closing?
+    /// - name
+    /// - attributes: List of JSX attributes. In React-like applications, these become props.
+    /// - type_parameters: Type parameters for generic JSX elements.
     #[inline]
     pub fn jsx_opening_element<T1>(
         self,
@@ -8139,6 +12723,16 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
+    /// Builds a [`JSXOpeningElement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_opening_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - self_closing: Is this tag self-closing?
+    /// - name
+    /// - attributes: List of JSX attributes. In React-like applications, these become props.
+    /// - type_parameters: Type parameters for generic JSX elements.
     #[inline]
     pub fn alloc_jsx_opening_element<T1>(
         self,
@@ -8157,6 +12751,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Builds a [`JSXClosingElement`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_closing_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn jsx_closing_element(
         self,
@@ -8166,6 +12767,13 @@ impl<'a> AstBuilder<'a> {
         JSXClosingElement { span, name }
     }
 
+    /// Builds a [`JSXClosingElement`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_closing_element`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn alloc_jsx_closing_element(
         self,
@@ -8175,6 +12783,15 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_closing_element(span, name), self.allocator)
     }
 
+    /// Builds a [`JSXFragment`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_fragment
+    /// - closing_fragment
+    /// - children
     #[inline]
     pub fn jsx_fragment(
         self,
@@ -8186,6 +12803,15 @@ impl<'a> AstBuilder<'a> {
         JSXFragment { span, opening_fragment, closing_fragment, children }
     }
 
+    /// Builds a [`JSXFragment`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_fragment
+    /// - closing_fragment
+    /// - children
     #[inline]
     pub fn alloc_jsx_fragment(
         self,
@@ -8200,6 +12826,13 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`JSXElementName::Identifier`]
+    ///
+    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn jsx_element_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXElementName<'a>
     where
@@ -8208,6 +12841,7 @@ impl<'a> AstBuilder<'a> {
         JSXElementName::Identifier(self.alloc(self.jsx_identifier(span, name)))
     }
 
+    /// Convert a [`JSXIdentifier`] into a [`JSXElementName::Identifier`]
     #[inline]
     pub fn jsx_element_name_from_jsx_identifier<T>(self, inner: T) -> JSXElementName<'a>
     where
@@ -8216,6 +12850,14 @@ impl<'a> AstBuilder<'a> {
         JSXElementName::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXElementName::NamespacedName`]
+    ///
+    /// This node contains a [`JSXNamespacedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - namespace: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// - property: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_element_name_jsx_namespaced_name(
         self,
@@ -8228,6 +12870,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`JSXNamespacedName`] into a [`JSXElementName::NamespacedName`]
     #[inline]
     pub fn jsx_element_name_from_jsx_namespaced_name<T>(self, inner: T) -> JSXElementName<'a>
     where
@@ -8236,6 +12879,14 @@ impl<'a> AstBuilder<'a> {
         JSXElementName::NamespacedName(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXElementName::MemberExpression`]
+    ///
+    /// This node contains a [`JSXMemberExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object: The object being accessed. This is everything before the last `.`.
+    /// - property: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_element_name_jsx_member_expression(
         self,
@@ -8248,6 +12899,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`JSXMemberExpression`] into a [`JSXElementName::MemberExpression`]
     #[inline]
     pub fn jsx_element_name_from_jsx_member_expression<T>(self, inner: T) -> JSXElementName<'a>
     where
@@ -8256,6 +12908,14 @@ impl<'a> AstBuilder<'a> {
         JSXElementName::MemberExpression(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`JSXNamespacedName`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_namespaced_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - namespace: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// - property: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_namespaced_name(
         self,
@@ -8266,6 +12926,14 @@ impl<'a> AstBuilder<'a> {
         JSXNamespacedName { span, namespace, property }
     }
 
+    /// Builds a [`JSXNamespacedName`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_namespaced_name`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - namespace: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// - property: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn alloc_jsx_namespaced_name(
         self,
@@ -8276,6 +12944,14 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_namespaced_name(span, namespace, property), self.allocator)
     }
 
+    /// Builds a [`JSXMemberExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object: The object being accessed. This is everything before the last `.`.
+    /// - property: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_member_expression(
         self,
@@ -8286,6 +12962,14 @@ impl<'a> AstBuilder<'a> {
         JSXMemberExpression { span, object, property }
     }
 
+    /// Builds a [`JSXMemberExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object: The object being accessed. This is everything before the last `.`.
+    /// - property: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn alloc_jsx_member_expression(
         self,
@@ -8296,6 +12980,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_member_expression(span, object, property), self.allocator)
     }
 
+    /// Build a [`JSXMemberExpressionObject::Identifier`]
+    ///
+    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn jsx_member_expression_object_jsx_identifier<A>(
         self,
@@ -8308,6 +12999,7 @@ impl<'a> AstBuilder<'a> {
         JSXMemberExpressionObject::Identifier(self.alloc(self.jsx_identifier(span, name)))
     }
 
+    /// Convert a [`JSXIdentifier`] into a [`JSXMemberExpressionObject::Identifier`]
     #[inline]
     pub fn jsx_member_expression_object_from_jsx_identifier<T>(
         self,
@@ -8319,6 +13011,14 @@ impl<'a> AstBuilder<'a> {
         JSXMemberExpressionObject::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXMemberExpressionObject::MemberExpression`]
+    ///
+    /// This node contains a [`JSXMemberExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - object: The object being accessed. This is everything before the last `.`.
+    /// - property: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_member_expression_object_jsx_member_expression(
         self,
@@ -8331,6 +13031,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`JSXMemberExpression`] into a [`JSXMemberExpressionObject::MemberExpression`]
     #[inline]
     pub fn jsx_member_expression_object_from_jsx_member_expression<T>(
         self,
@@ -8342,6 +13043,13 @@ impl<'a> AstBuilder<'a> {
         JSXMemberExpressionObject::MemberExpression(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`JSXExpressionContainer`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_expression_container`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn jsx_expression_container(
         self,
@@ -8351,6 +13059,13 @@ impl<'a> AstBuilder<'a> {
         JSXExpressionContainer { span, expression }
     }
 
+    /// Builds a [`JSXExpressionContainer`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_expression_container`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_jsx_expression_container(
         self,
@@ -8360,11 +13075,16 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_expression_container(span, expression), self.allocator)
     }
 
+    /// Build a [`JSXExpression::EmptyExpression`]
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn jsx_expression_jsx_empty_expression(self, span: Span) -> JSXExpression<'a> {
         JSXExpression::EmptyExpression(self.jsx_empty_expression(span))
     }
 
+    /// Convert a [`JSXEmptyExpression`] into a [`JSXExpression::EmptyExpression`]
     #[inline]
     pub fn jsx_expression_from_jsx_empty_expression<T>(self, inner: T) -> JSXExpression<'a>
     where
@@ -8378,16 +13098,36 @@ impl<'a> AstBuilder<'a> {
         JSXExpression::from(inner)
     }
 
+    /// Builds a [`JSXEmptyExpression`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_empty_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
         JSXEmptyExpression { span }
     }
 
+    /// Builds a [`JSXEmptyExpression`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_empty_expression`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
     #[inline]
     pub fn alloc_jsx_empty_expression(self, span: Span) -> Box<'a, JSXEmptyExpression> {
         Box::new_in(self.jsx_empty_expression(span), self.allocator)
     }
 
+    /// Build a [`JSXAttributeItem::Attribute`]
+    ///
+    /// This node contains a [`JSXAttribute`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - value
     #[inline]
     pub fn jsx_attribute_item_jsx_attribute(
         self,
@@ -8398,6 +13138,7 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeItem::Attribute(self.alloc(self.jsx_attribute(span, name, value)))
     }
 
+    /// Convert a [`JSXAttribute`] into a [`JSXAttributeItem::Attribute`]
     #[inline]
     pub fn jsx_attribute_item_from_jsx_attribute<T>(self, inner: T) -> JSXAttributeItem<'a>
     where
@@ -8406,6 +13147,13 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeItem::Attribute(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXAttributeItem::SpreadAttribute`]
+    ///
+    /// This node contains a [`JSXSpreadAttribute`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn jsx_attribute_item_jsx_spread_attribute(
         self,
@@ -8415,6 +13163,7 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeItem::SpreadAttribute(self.alloc(self.jsx_spread_attribute(span, argument)))
     }
 
+    /// Convert a [`JSXSpreadAttribute`] into a [`JSXAttributeItem::SpreadAttribute`]
     #[inline]
     pub fn jsx_attribute_item_from_jsx_spread_attribute<T>(self, inner: T) -> JSXAttributeItem<'a>
     where
@@ -8423,6 +13172,14 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeItem::SpreadAttribute(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`JSXAttribute`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - value
     #[inline]
     pub fn jsx_attribute(
         self,
@@ -8433,6 +13190,14 @@ impl<'a> AstBuilder<'a> {
         JSXAttribute { span, name, value }
     }
 
+    /// Builds a [`JSXAttribute`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
+    /// - value
     #[inline]
     pub fn alloc_jsx_attribute(
         self,
@@ -8443,6 +13208,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_attribute(span, name, value), self.allocator)
     }
 
+    /// Builds a [`JSXSpreadAttribute`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn jsx_spread_attribute(
         self,
@@ -8452,6 +13224,13 @@ impl<'a> AstBuilder<'a> {
         JSXSpreadAttribute { span, argument }
     }
 
+    /// Builds a [`JSXSpreadAttribute`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - argument
     #[inline]
     pub fn alloc_jsx_spread_attribute(
         self,
@@ -8461,6 +13240,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_spread_attribute(span, argument), self.allocator)
     }
 
+    /// Build a [`JSXAttributeName::Identifier`]
+    ///
+    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn jsx_attribute_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXAttributeName<'a>
     where
@@ -8469,6 +13255,7 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeName::Identifier(self.alloc(self.jsx_identifier(span, name)))
     }
 
+    /// Convert a [`JSXIdentifier`] into a [`JSXAttributeName::Identifier`]
     #[inline]
     pub fn jsx_attribute_name_from_jsx_identifier<T>(self, inner: T) -> JSXAttributeName<'a>
     where
@@ -8477,6 +13264,14 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeName::Identifier(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXAttributeName::NamespacedName`]
+    ///
+    /// This node contains a [`JSXNamespacedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - namespace: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// - property: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_attribute_name_jsx_namespaced_name(
         self,
@@ -8489,6 +13284,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`JSXNamespacedName`] into a [`JSXAttributeName::NamespacedName`]
     #[inline]
     pub fn jsx_attribute_name_from_jsx_namespaced_name<T>(self, inner: T) -> JSXAttributeName<'a>
     where
@@ -8497,6 +13293,13 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeName::NamespacedName(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXAttributeValue::StringLiteral`]
+    ///
+    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn jsx_attribute_value_string_literal<A>(
         self,
@@ -8509,6 +13312,7 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeValue::StringLiteral(self.alloc(self.string_literal(span, value)))
     }
 
+    /// Convert a [`StringLiteral`] into a [`JSXAttributeValue::StringLiteral`]
     #[inline]
     pub fn jsx_attribute_value_from_string_literal<T>(self, inner: T) -> JSXAttributeValue<'a>
     where
@@ -8517,6 +13321,13 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeValue::StringLiteral(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXAttributeValue::ExpressionContainer`]
+    ///
+    /// This node contains a [`JSXExpressionContainer`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn jsx_attribute_value_jsx_expression_container(
         self,
@@ -8528,6 +13339,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Convert a [`JSXExpressionContainer`] into a [`JSXAttributeValue::ExpressionContainer`]
     #[inline]
     pub fn jsx_attribute_value_from_jsx_expression_container<T>(
         self,
@@ -8539,6 +13351,15 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeValue::ExpressionContainer(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXAttributeValue::Element`]
+    ///
+    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_element
+    /// - closing_element
+    /// - children
     #[inline]
     pub fn jsx_attribute_value_jsx_element<T1, T2>(
         self,
@@ -8559,6 +13380,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSXElement`] into a [`JSXAttributeValue::Element`]
     #[inline]
     pub fn jsx_attribute_value_from_jsx_element<T>(self, inner: T) -> JSXAttributeValue<'a>
     where
@@ -8567,6 +13389,15 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeValue::Element(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXAttributeValue::Fragment`]
+    ///
+    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_fragment
+    /// - closing_fragment
+    /// - children
     #[inline]
     pub fn jsx_attribute_value_jsx_fragment(
         self,
@@ -8583,6 +13414,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSXFragment`] into a [`JSXAttributeValue::Fragment`]
     #[inline]
     pub fn jsx_attribute_value_from_jsx_fragment<T>(self, inner: T) -> JSXAttributeValue<'a>
     where
@@ -8591,6 +13423,13 @@ impl<'a> AstBuilder<'a> {
         JSXAttributeValue::Fragment(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`JSXIdentifier`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn jsx_identifier<A>(self, span: Span, name: A) -> JSXIdentifier<'a>
     where
@@ -8599,6 +13438,13 @@ impl<'a> AstBuilder<'a> {
         JSXIdentifier { span, name: name.into_in(self.allocator) }
     }
 
+    /// Builds a [`JSXIdentifier`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - name
     #[inline]
     pub fn alloc_jsx_identifier<A>(self, span: Span, name: A) -> Box<'a, JSXIdentifier<'a>>
     where
@@ -8607,6 +13453,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_identifier(span, name), self.allocator)
     }
 
+    /// Build a [`JSXChild::Text`]
+    ///
+    /// This node contains a [`JSXText`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn jsx_child_jsx_text<A>(self, span: Span, value: A) -> JSXChild<'a>
     where
@@ -8615,6 +13468,7 @@ impl<'a> AstBuilder<'a> {
         JSXChild::Text(self.alloc(self.jsx_text(span, value)))
     }
 
+    /// Convert a [`JSXText`] into a [`JSXChild::Text`]
     #[inline]
     pub fn jsx_child_from_jsx_text<T>(self, inner: T) -> JSXChild<'a>
     where
@@ -8623,6 +13477,15 @@ impl<'a> AstBuilder<'a> {
         JSXChild::Text(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXChild::Element`]
+    ///
+    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_element
+    /// - closing_element
+    /// - children
     #[inline]
     pub fn jsx_child_jsx_element<T1, T2>(
         self,
@@ -8643,6 +13506,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSXElement`] into a [`JSXChild::Element`]
     #[inline]
     pub fn jsx_child_from_jsx_element<T>(self, inner: T) -> JSXChild<'a>
     where
@@ -8651,6 +13515,15 @@ impl<'a> AstBuilder<'a> {
         JSXChild::Element(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXChild::Fragment`]
+    ///
+    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - opening_fragment
+    /// - closing_fragment
+    /// - children
     #[inline]
     pub fn jsx_child_jsx_fragment(
         self,
@@ -8667,6 +13540,7 @@ impl<'a> AstBuilder<'a> {
         )))
     }
 
+    /// Convert a [`JSXFragment`] into a [`JSXChild::Fragment`]
     #[inline]
     pub fn jsx_child_from_jsx_fragment<T>(self, inner: T) -> JSXChild<'a>
     where
@@ -8675,6 +13549,13 @@ impl<'a> AstBuilder<'a> {
         JSXChild::Fragment(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXChild::ExpressionContainer`]
+    ///
+    /// This node contains a [`JSXExpressionContainer`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn jsx_child_jsx_expression_container(
         self,
@@ -8684,6 +13565,7 @@ impl<'a> AstBuilder<'a> {
         JSXChild::ExpressionContainer(self.alloc(self.jsx_expression_container(span, expression)))
     }
 
+    /// Convert a [`JSXExpressionContainer`] into a [`JSXChild::ExpressionContainer`]
     #[inline]
     pub fn jsx_child_from_jsx_expression_container<T>(self, inner: T) -> JSXChild<'a>
     where
@@ -8692,6 +13574,13 @@ impl<'a> AstBuilder<'a> {
         JSXChild::ExpressionContainer(inner.into_in(self.allocator))
     }
 
+    /// Build a [`JSXChild::Spread`]
+    ///
+    /// This node contains a [`JSXSpreadChild`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn jsx_child_jsx_spread_child(
         self,
@@ -8701,6 +13590,7 @@ impl<'a> AstBuilder<'a> {
         JSXChild::Spread(self.alloc(self.jsx_spread_child(span, expression)))
     }
 
+    /// Convert a [`JSXSpreadChild`] into a [`JSXChild::Spread`]
     #[inline]
     pub fn jsx_child_from_jsx_spread_child<T>(self, inner: T) -> JSXChild<'a>
     where
@@ -8709,11 +13599,25 @@ impl<'a> AstBuilder<'a> {
         JSXChild::Spread(inner.into_in(self.allocator))
     }
 
+    /// Builds a [`JSXSpreadChild`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_child`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
         JSXSpreadChild { span, expression }
     }
 
+    /// Builds a [`JSXSpreadChild`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_child`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - expression
     #[inline]
     pub fn alloc_jsx_spread_child(
         self,
@@ -8723,6 +13627,13 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_spread_child(span, expression), self.allocator)
     }
 
+    /// Builds a [`JSXText`]
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_text`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn jsx_text<A>(self, span: Span, value: A) -> JSXText<'a>
     where
@@ -8731,6 +13642,13 @@ impl<'a> AstBuilder<'a> {
         JSXText { span, value: value.into_in(self.allocator) }
     }
 
+    /// Builds a [`JSXText`] and stores it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_text`] instead.
+    ///
+    /// ## Parameters
+    /// - span: The [`Span`] covering this node
+    /// - value
     #[inline]
     pub fn alloc_jsx_text<A>(self, span: Span, value: A) -> Box<'a, JSXText<'a>>
     where


### PR DESCRIPTION
# What This PR Does

Modifies `ast_codegen` to auto-generate rustdoc comments for generated `AstBuilder` methods. As we add more doc comments to AST node fields, the generated documentation will get better.

![image](https://github.com/user-attachments/assets/d27f0d53-38dd-4ba8-93e0-ffaf5c8e6809)
