### PR TITLE
perf(linter): `no_shadow_restricted_names` only look up name in hashmap once

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -36,17 +36,14 @@ declare_oxc_lint!(
     correctness
 );
 
-#[inline]
-fn check_and_diagnostic(s: &str, span: Span, ctx: &LintContext) {
-    if PRE_DEFINE_VAR.contains_key(s) {
-        ctx.diagnostic(no_shadow_restricted_names_diagnostic(s, span));
-    }
-}
-
 impl Rule for NoShadowRestrictedNames {
     fn run_once(&self, ctx: &LintContext<'_>) {
         ctx.symbols().iter().for_each(|symbol_id| {
             let name = ctx.symbols().get_name(symbol_id);
+
+            if !PRE_DEFINE_VAR.contains_key(name) {
+                return;
+            }
 
             if name == "undefined" {
                 // Allow to declare `undefined` variable but not allow to assign value to it.
@@ -63,9 +60,11 @@ impl Rule for NoShadowRestrictedNames {
                 }
             }
 
-            check_and_diagnostic(name, ctx.symbols().get_span(symbol_id), ctx);
-            for span in ctx.symbols().get_redeclarations(symbol_id) {
-                check_and_diagnostic(name, *span, ctx);
+            let span = ctx.symbols().get_span(symbol_id);
+            ctx.diagnostic(no_shadow_restricted_names_diagnostic(name, span));
+
+            for &span in ctx.symbols().get_redeclarations(symbol_id) {
+                ctx.diagnostic(no_shadow_restricted_names_diagnostic(name, span));
             }
         });
     }


### PR DESCRIPTION
`eslint(no_shadow_restricted_names)` lint rule emits a diagnostic for every declaration of a symbol with a restricted name.

Currently for a var which has redeclarations, the var name is looked up in hash map of restricted names repeatedly for each redeclaration. This PR changes that to only do a single hashmap lookup.

Also, do the hashmap lookup first, as the vast majority of symbols will not be restricted names, so function can exit ASAP in that common case without also doing string comparison to `undefined`.