### PR TITLE
perf(semantic)!: remove `SymbolTable::spans` field

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -35,13 +35,14 @@ declare_oxc_lint!(
 
 impl Rule for NoClassAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.semantic().symbols();
+        let semantic = &**ctx.semantic();
+        let symbol_table = semantic.symbols();
         if symbol_table.get_flag(symbol_id).is_class() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_class_assign_diagnostic(
                         symbol_table.get_name(symbol_id),
-                        symbol_table.get_span(symbol_id),
+                        semantic.symbol_span(symbol_id),
                         ctx.semantic().reference_span(reference),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -34,13 +34,14 @@ declare_oxc_lint!(
 
 impl Rule for NoConstAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let symbol_table = ctx.semantic().symbols();
+        let semantic = &**ctx.semantic();
+        let symbol_table = semantic.symbols();
         if symbol_table.get_flag(symbol_id).is_const_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_const_assign_diagnostic(
                         symbol_table.get_name(symbol_id),
-                        symbol_table.get_span(symbol_id),
+                        semantic.symbol_span(symbol_id),
                         ctx.semantic().reference_span(reference),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -47,7 +47,7 @@ impl Rule for NoLabelVar {
         if let Some(symbol_id) =
             ctx.scopes().find_binding(node.scope_id(), &labeled_stmt.label.name)
         {
-            let decl_span = ctx.symbols().get_span(symbol_id);
+            let decl_span = ctx.semantic().symbol_span(symbol_id);
             let label_decl = labeled_stmt.span.start;
             ctx.diagnostic(no_label_var_diagnostic(
                 &labeled_stmt.label.name,

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -60,7 +60,7 @@ impl Rule for NoShadowRestrictedNames {
                 }
             }
 
-            let span = ctx.symbols().get_span(symbol_id);
+            let span = ctx.semantic().symbol_span(symbol_id);
             ctx.diagnostic(no_shadow_restricted_names_diagnostic(name, span));
 
             for &span in ctx.symbols().get_redeclarations(symbol_id) {

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -98,8 +98,7 @@ impl Rule for Namespace {
                 return;
             }
 
-            let Some(symbol_id) =
-                ctx.semantic().symbols().get_symbol_id_from_span(entry.local_name.span())
+            let Some(symbol_id) = ctx.semantic().get_symbol_id_from_span(entry.local_name.span())
             else {
                 return;
             };

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -71,7 +71,7 @@ impl Rule for NoNamedAsDefaultMember {
 
             if !remote_module_record_ref.exported_bindings.is_empty() {
                 has_members_map.insert(
-                    ctx.symbols().get_symbol_id_from_span(import_entry.local_name.span()).unwrap(),
+                    ctx.semantic().get_symbol_id_from_span(import_entry.local_name.span()).unwrap(),
                     (remote_module_record_ref, import_entry.module_request.name().clone()),
                 );
             }

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -254,8 +254,7 @@ impl<'a> Binder<'a> for CatchParameter<'a> {
         // unless CatchParameter is CatchParameter : BindingIdentifier
         if let BindingPatternKind::BindingIdentifier(ident) = &self.pattern.kind {
             let includes = SymbolFlags::FunctionScopedVariable | SymbolFlags::CatchVariable;
-            let symbol_id =
-                builder.declare_shadow_symbol(&ident.name, ident.span, current_scope_id, includes);
+            let symbol_id = builder.declare_shadow_symbol(&ident.name, current_scope_id, includes);
             ident.symbol_id.set(Some(symbol_id));
         } else {
             self.pattern.bound_names(&mut |ident| {

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -136,6 +136,10 @@ impl<'a> Semantic<'a> {
         self.nodes.get_node(self.symbols.get_declaration(symbol_id))
     }
 
+    pub fn symbol_span(&self, symbol_id: SymbolId) -> Span {
+        self.symbol_declaration(symbol_id).kind().span()
+    }
+
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
         self.scopes().root_unresolved_references().contains_key(ident.name.as_str())
     }
@@ -152,6 +156,21 @@ impl<'a> Semantic<'a> {
     pub fn reference_span(&self, reference: &Reference) -> Span {
         let node = self.nodes.get_node(reference.node_id());
         node.kind().span()
+    }
+
+    pub fn get_symbol_id_from_span(&self, span: Span) -> Option<SymbolId> {
+        self.symbols.declarations.iter_enumerated().find_map(|(symbol_id, &node_id)| {
+            let inner_span = self.nodes.kind(node_id).span();
+            if inner_span == span {
+                Some(symbol_id)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn get_scope_id_from_span(&self, span: Span) -> Option<ScopeId> {
+        self.get_symbol_id_from_span(span).map(|symbol_id| self.symbols.get_scope_id(symbol_id))
     }
 }
 

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -76,7 +76,6 @@ impl<'a> TypeScriptEnum<'a> {
         let enum_name = decl.id.name.clone();
         let func_scope_id = decl.scope_id.get().unwrap();
         let param_symbol_id = ctx.symbols_mut().create_symbol(
-            decl.id.span,
             enum_name.to_compact_str(),
             SymbolFlags::FunctionScopedVariable,
             func_scope_id,

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
     visit::{walk, Visit},
 };
 use oxc_semantic::{AstNodeId, Reference, ScopeTree, SymbolTable};
-use oxc_span::{Atom, CompactStr, Span, SPAN};
+use oxc_span::{Atom, CompactStr, Span};
 use oxc_syntax::{
     reference::{ReferenceFlag, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -245,8 +245,7 @@ impl TraverseScoping {
         let name = CompactStr::new(&self.find_uid_name(name));
 
         // Add binding to scope
-        let symbol_id =
-            self.symbols.create_symbol(SPAN, name.clone(), flags, scope_id, AstNodeId::DUMMY);
+        let symbol_id = self.symbols.create_symbol(name.clone(), flags, scope_id, AstNodeId::DUMMY);
         self.scopes.add_binding(scope_id, name, symbol_id);
         symbol_id
     }


### PR DESCRIPTION
Remove `spans` field from `SymbolTable`. It's unnecessary because you can get the `Span` from the `AstNodeId`, and these lookups only happen in the linter when generating diagnostics (i.e. cold path).

Lots of tests failing. I believe this isn't due to this PR being incorrect, but that it's surfacing existing bugs where `AstNodeId` for a lot of symbols is set incorrectly.

@DonIsaac Are these the same bugs you've found already? Or new ones?