### PR TITLE
ci: run benchmarks on `rust-toolchain.toml` changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,7 @@ on:
       - 'napi/parser/**/*.js'
       - 'napi/parser/**/*.mjs'
       - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - '.github/workflows/benchmark.yml'
       - 'tasks/benchmark/codspeed/*.mjs'
   push:
@@ -32,6 +33,7 @@ on:
       - 'napi/parser/**/*.js'
       - 'napi/parser/**/*.mjs'
       - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - '.github/workflows/benchmark.yml'
       - 'tasks/benchmark/codspeed/*.mjs'
 


### PR DESCRIPTION
Upgrading to Rust 1.80.0 (#4474) regressed some benchmarks (#4478). We didn't notice because benchmarks didn't run on the PR. Make benchmarks run on changes to `rust-toolchain.toml` so we'll be alerted if this happens again on any future updates.