### PR TITLE
fix(semantic): params in `export default (function() {})` flagged as `SymbolFlags::Export`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1675,7 +1675,8 @@ impl<'a> SemanticBuilder<'a> {
                         func.id.is_some()
                     }
                     ExportDefaultDeclarationKind::ClassDeclaration(ref class) => class.id.is_some(),
-                    _ => true,
+                    ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => true,
+                    _ => false,
                 } {
                     self.current_symbol_flags |= SymbolFlags::Export;
                 }

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -136,9 +136,30 @@ fn test_export_flag() {
     ",
     );
 
-    tester.has_root_symbol("a").contains_flags(SymbolFlags::Export).test();
-    tester.has_root_symbol("b").contains_flags(SymbolFlags::Export).test();
-    tester.has_root_symbol("c").contains_flags(SymbolFlags::Export).test();
+    tester.has_root_symbol("a").is_exported().test();
+    tester.has_root_symbol("b").is_exported().test();
+    tester.has_root_symbol("c").is_exported().test();
+}
+
+#[test]
+fn test_export_default_flag() {
+    let tester = SemanticTester::ts(
+        "
+        export default function func() {}
+        export default class cls {}
+        export default interface face {}
+
+        export default (function funcExpr() {});
+        export default (function(param) {});
+    ",
+    );
+
+    tester.has_root_symbol("func").is_exported().test();
+    tester.has_root_symbol("cls").is_exported().test();
+    tester.has_root_symbol("face").is_exported().test();
+
+    tester.has_symbol("funcExpr").is_not_exported().test();
+    tester.has_symbol("param").is_not_exported().test();
 }
 
 #[test]


### PR DESCRIPTION
The code changes in `builder.rs` optimize the export flag check in the `SemanticBuilder` implementation. Instead of setting the export flag to `true` for all cases except `ExportDefaultDeclarationKind::ClassDeclaration(ref class)`, the flag is now set to `true` only for `ExportDefaultDeclarationKind::ClassDeclaration` and `false` for all other cases. This change improves the efficiency of the export flag check.
