### PR TITLE
ci: use deterministic allocator for benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,8 @@ dependencies = [
  "oxc_transformer",
  "serde",
  "serde_json",
+ "spin",
+ "talc",
 ]
 
 [[package]]
@@ -2535,6 +2537,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2572,6 +2577,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "talc"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04be12ec299aadd63a0bf781d893e4b6139d33cdca6dcd6f6be31f849cedcac8"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,8 +171,10 @@ serde               = "1.0.203"
 serde_json          = "1.0.117"
 serde-wasm-bindgen  = "0.6.5"
 similar             = "2.5.0"
+spin                = "0.9.8"
 static_assertions   = "1.1.0"
 syn                 = { version = "2.0.58", default-features = false }
+talc                = { version = "4.4.1", default-features = false, features = ["lock_api"] }
 tempfile            = "3.10.1"
 textwrap            = "0.16.1"
 tokio               = "1.38.0"

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -82,6 +82,8 @@ oxc_sourcemap             = { workspace = true, features = ["concurrent"], optio
 oxc_isolated_declarations = { workspace = true, optional = true }
 
 criterion2 = { workspace = true }
+spin       = { workspace = true }
+talc       = { workspace = true }
 
 # Only for NAPI benchmark
 serde      = { workspace = true, optional = true }

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -22,7 +22,8 @@ const ARENA_SIZE: usize = 0x4000_0000;
 #[repr(align(64))]
 struct AlignedBytes([u8; ARENA_SIZE]);
 
-static mut ARENA: AlignedBytes = AlignedBytes([0; ARENA_SIZE]);
+// Initialize with 1s to ensure memory pages are allocated and filled for whole arena
+static mut ARENA: AlignedBytes = AlignedBytes([1; ARENA_SIZE]);
 
 #[global_allocator]
 static GLOBAL: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new({

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -22,8 +22,7 @@ const ARENA_SIZE: usize = 0x4000_0000;
 #[repr(align(64))]
 struct AlignedBytes([u8; ARENA_SIZE]);
 
-// Initialize with 1s to ensure memory pages are allocated and filled for whole arena
-static mut ARENA: AlignedBytes = AlignedBytes([1; ARENA_SIZE]);
+static mut ARENA: AlignedBytes = AlignedBytes([0; ARENA_SIZE]);
 
 #[global_allocator]
 static GLOBAL: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new({

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -19,11 +19,14 @@ use talc::{ClaimOnOom, Span, Talc, Talck};
 /// 1 GiB memory limit
 const ARENA_SIZE: usize = 0x4000_0000;
 
-static mut ARENA: [u8; ARENA_SIZE] = [0; ARENA_SIZE];
+#[repr(align(64))]
+struct AlignedBytes([u8; ARENA_SIZE]);
+
+static mut ARENA: AlignedBytes = AlignedBytes([0; ARENA_SIZE]);
 
 #[global_allocator]
 static GLOBAL: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new({
     // SAFETY: Copied from `talc`'s docs https://github.com/SFBdragon/talc#setup
-    unsafe { ClaimOnOom::new(Span::from_const_array(core::ptr::addr_of!(ARENA))) }
+    unsafe { ClaimOnOom::new(Span::from_const_array(core::ptr::addr_of!(ARENA.0))) }
 })
 .lock();

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -17,14 +17,13 @@ use talc::{ClaimOnOom, Span, Talc, Talck};
 // exhibits the property of determinism that we require. There are probably other viable options.
 
 /// 1 GiB memory limit
-const ARENA_SIZE: usize = 0x40000000;
+const ARENA_SIZE: usize = 0x4000_0000;
 
 static mut ARENA: [u8; ARENA_SIZE] = [0; ARENA_SIZE];
 
 #[global_allocator]
-static GLOBAL: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new(unsafe {
-    // if we're in a hosted environment, the Rust runtime may allocate before
-    // main() is called, so we need to initialize the arena automatically
-    ClaimOnOom::new(Span::from_const_array(core::ptr::addr_of!(ARENA)))
+static GLOBAL: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new({
+    // SAFETY: Copied from `talc`'s docs https://github.com/SFBdragon/talc#setup
+    unsafe { ClaimOnOom::new(Span::from_const_array(core::ptr::addr_of!(ARENA))) }
 })
 .lock();

--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -19,7 +19,8 @@ use talc::{ClaimOnOom, Span, Talc, Talck};
 /// 1 GiB memory limit
 const ARENA_SIZE: usize = 0x4000_0000;
 
-#[repr(align(64))]
+// `align(64)` to specify alignment, `C` to ensure array itself is aligned (no padding before)
+#[repr(C, align(64))]
 struct AlignedBytes([u8; ARENA_SIZE]);
 
 static mut ARENA: AlignedBytes = AlignedBytes([0; ARENA_SIZE]);


### PR DESCRIPTION
An attempt to reduce variance in benchmarks. Just testing at this stage.