### PR TITLE
fix(syntax): correct `is_reserved_keyword_or_global_object`'s incorrect function calling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 **/*.rs.bk
+.idea
 
 /node_modules/
 /website/node_modules/

--- a/crates/oxc_syntax/src/keyword.rs
+++ b/crates/oxc_syntax/src/keyword.rs
@@ -2,7 +2,7 @@ use phf::{phf_set, Set};
 
 #[inline]
 pub fn is_reserved_keyword_or_global_object(s: &str) -> bool {
-    is_reserved_keyword(s) || is_reserved_keyword(s)
+    is_reserved_keyword(s) || is_global_object(s)
 }
 
 #[inline]


### PR DESCRIPTION
It may be a problem, but doesn't matter previously.

Formerly, the `is_reserved_keyword_or_global_object` is `is_reserved_keyword(s) || is_reserved_keyword(s)`. I think it should be `is_reserved_keyword(s) || is_global_object(s)` according to its name.

Also, the `.idea` may be because I am using RustRover, which may automatically create `.idea` folder. So I ignore it in `.gitignore`.

I think I can contribute to `oxc` more when I am free.