### PR TITLE
chore: remove `.idea` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 target/
 **/*.rs.bk
-.idea
 
 /node_modules/
 /website/node_modules/


### PR DESCRIPTION
`.idea` snuck its way into `.gitignore` in #4484. Remove it again.

See #4355 for reason why it shouldn't be there.