### PR TITLE
fix(ast): remove `#[visit(ignore)]` from `ExportDefaultDeclarationKind`'s `TSInterfaceDeclaration`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2312,7 +2312,6 @@ pub enum ExportDefaultDeclarationKind<'a> {
     FunctionDeclaration(Box<'a, Function<'a>>) = 64,
     ClassDeclaration(Box<'a, Class<'a>>) = 65,
 
-    #[visit(ignore)]
     TSInterfaceDeclaration(Box<'a, TSInterfaceDeclaration<'a>>) = 66,
 
     // `Expression` variants added here by `inherit_variants!` macro

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -4154,10 +4154,12 @@ pub mod walk {
                 visitor.visit_function(it, flags)
             }
             ExportDefaultDeclarationKind::ClassDeclaration(it) => visitor.visit_class(it),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
+                visitor.visit_ts_interface_declaration(it)
+            }
             match_expression!(ExportDefaultDeclarationKind) => {
                 visitor.visit_expression(it.to_expression())
             }
-            _ => {}
         }
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -4396,10 +4396,12 @@ pub mod walk_mut {
                 visitor.visit_function(it, flags)
             }
             ExportDefaultDeclarationKind::ClassDeclaration(it) => visitor.visit_class(it),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
+                visitor.visit_ts_interface_declaration(it)
+            }
             match_expression!(ExportDefaultDeclarationKind) => {
                 visitor.visit_expression(it.to_expression_mut())
             }
-            _ => {}
         }
     }
 

--- a/crates/oxc_linter/src/snapshots/consistent_type_definitions.snap
+++ b/crates/oxc_linter/src/snapshots/consistent_type_definitions.snap
@@ -120,6 +120,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use an `type` instead of a `interface`
 
+  ⚠ typescript-eslint(consistent-type-definitions): Use an `type` instead of a `interface`
+   ╭─[consistent_type_definitions.tsx:2:19]
+ 1 │ 
+ 2 │             export default interface Test {
+   ·                            ─────────
+ 3 │               bar(): string;
+   ╰────
+  help: Use an `type` instead of a `interface`
+
   ⚠ typescript-eslint(consistent-type-definitions): Use an `interface` instead of a `type`
    ╭─[consistent_type_definitions.tsx:2:19]
  1 │ 

--- a/crates/oxc_linter/src/snapshots/prefer_function_type.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_function_type.snap
@@ -16,6 +16,13 @@ source: crates/oxc_linter/src/tester.rs
   help: The function type form `() => string` is generally preferred when possible for being more succinct.
 
   ⚠ typescript-eslint(prefer-function-type): Enforce using function types instead of interfaces with call signatures.
+   ╭─[prefer_function_type.tsx:1:47]
+ 1 │ export default interface Foo { /** comment */ (): string; }
+   ·                                               ───────────
+   ╰────
+  help: The function type form `() => string` is generally preferred when possible for being more succinct.
+
+  ⚠ typescript-eslint(prefer-function-type): Enforce using function types instead of interfaces with call signatures.
    ╭─[prefer_function_type.tsx:4:11]
  3 │           // comment
  4 │           (): string;


### PR DESCRIPTION
I can't find any reason to add `#[visit(ignore)]` there