### PR TITLE
fix(transformer/typescript): incorrect eliminate exports when the referenced symbol is both value and type

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -87,7 +87,7 @@ impl<'a> TypeScriptAnnotations<'a> {
                                         ident.reference_id.get().is_some_and(|id| {
                                             ctx.symbols().references[id].symbol_id().is_some_and(
                                                 |symbol_id| {
-                                                    ctx.symbols().get_flag(symbol_id).is_type()
+                                                    !ctx.symbols().get_flag(symbol_id).is_value()
                                                 },
                                             )
                                         })

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/input.ts
@@ -9,3 +9,9 @@ namespace Name {
 }
 
 export { Im, Ok, Foo, Bar, Func, Baz, Baq, Name };
+
+type T = number;
+function T(): T {
+  return 123;
+}
+export { T }

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/output.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/output.ts
@@ -6,4 +6,10 @@ let Name;
 (function(_Name) {
 	const Q = _Name.Q = 0;
 })(Name || (Name = {}));
+
 export { Im, Ok, Foo, Bar, Func, Name };
+
+function T() {
+	return 123;
+}
+export { T }


### PR DESCRIPTION
close: #4504
