### PR TITLE
feat(semantic): remove `ReferenceFlags::Value` from non-type-only exports that referenced type binding

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -442,6 +442,9 @@ impl<'a> SemanticBuilder<'a> {
                         // If the symbol is a value symbol and reference flag is not type-only, remove the type flag.
                         if symbol_flag.is_value() && !flag.is_type_only() {
                             *self.symbols.references[*id].flag_mut() -= ReferenceFlag::Type;
+                        } else {
+                            // If the symbol is a type symbol and reference flag is not type-only, remove the value flag.
+                            *self.symbols.references[*id].flag_mut() -= ReferenceFlag::Value;
                         }
 
                         // import type { T } from './mod'; type A = typeof T

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Type)",
+            "flag": "ReferenceFlag(Type)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Type)",
+            "flag": "ReferenceFlag(Type)",
             "id": 0,
             "name": "A",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Type)",
+            "flag": "ReferenceFlag(Type)",
             "id": 0,
             "name": "V",
             "node_id": 8


### PR DESCRIPTION
```ts
type T = 0;
export { T }
         ^ ReferenceFlags::Type | ReferenceFlags::Read
```
The export `T` only referenced type binding. We should remove `ReferenceFlags::Read` for it. 