### PR TITLE
refactor(transformer/typescript): determine whether to remove `ExportSpeicifer` by `ReferenceFlags`

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -85,11 +85,7 @@ impl<'a> TypeScriptAnnotations<'a> {
                                         &specifier.local
                                     {
                                         ident.reference_id.get().is_some_and(|id| {
-                                            ctx.symbols().references[id].symbol_id().is_some_and(
-                                                |symbol_id| {
-                                                    !ctx.symbols().get_flag(symbol_id).is_value()
-                                                },
-                                            )
+                                            ctx.symbols().get_reference(id).is_type()
                                         })
                                     } else {
                                         false


### PR DESCRIPTION
After https://github.com/oxc-project/oxc/pull/4511. We can determine if a binding is a type binding just by the `ReferenceFlags`.

We can make it even better with `ident.reference_flag` once #4512 is sorted out