### PR TITLE
fix(linter): fix `oxlint` allocator cfg

### DIFF
--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -24,7 +24,7 @@ path    = "src/main.rs"
 test    = false
 doctest = false
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(all(not(target_env = "msvc"), not(target_os = "windows")))'.dependencies]
 jemallocator = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -1,12 +1,9 @@
-#![cfg(not(miri))] // Miri does not support custom allocators
-
-#[cfg(feature = "allocator")]
-#[cfg(not(target_env = "msvc"))]
+// NB: Miri does not support custom allocators
+#[cfg(all(feature = "allocator", not(miri), not(target_env = "msvc"), not(target_os = "windows")))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[cfg(feature = "allocator")]
-#[cfg(target_os = "windows")]
+#[cfg(all(feature = "allocator", not(miri), target_os = "windows"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
Fix 2 mistakes in the `#[cfg]` for custom allocators in `oxlint` CLI.

1. `#![cfg(not(miri))]` at top of file was disabling the entire module if running miri, rather than just disabling custom allocator.
2. If both `target_os = "windows"` and `not(target_env = "msvc")`, it would try to register both mimalloc and jemalloc as global allocator.

I am actually not sure if it's possible to compile for Windows without using MSVC, but it seems like a good idea not to assume.