### PR TITLE
refactor(parser): adjust function inlining

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -265,6 +265,7 @@ impl<'a> Lexer<'a> {
 
     /// Peek the next byte, and advance the current position if it matches
     /// the given ASCII char.
+    // `#[inline(always)]` to make sure the `assert!` gets optimized out.
     #[allow(clippy::inline_always)]
     #[inline(always)]
     fn next_ascii_char_eq(&mut self, b: u8) -> bool {

--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -202,8 +202,7 @@ impl<'a> Source<'a> {
     /// # SAFETY
     ///
     /// Caller must ensure that `ascii_byte` is a valid ASCII character.
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
+    #[inline]
     pub(super) unsafe fn advance_if_ascii_eq(&mut self, ascii_byte: u8) -> bool {
         debug_assert!(ascii_byte.is_ascii());
         let matched = self.peek_byte() == Some(ascii_byte);


### PR DESCRIPTION
These 2 `#[inline(always)]` were introduced by accident by me just playing around in #4298. One should be kept, but the other one we should leave to compiler to decide.