### PR TITLE
refactor(semantic): inline trivial methods

### DIFF
--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -22,6 +22,7 @@ pub struct AstNode<'a> {
 }
 
 impl<'a> AstNode<'a> {
+    #[inline]
     pub(crate) fn new(
         kind: AstKind<'a>,
         scope_id: ScopeId,
@@ -32,26 +33,32 @@ impl<'a> AstNode<'a> {
         Self { id, kind, scope_id, cfg_id, flags }
     }
 
+    #[inline]
     pub fn id(&self) -> AstNodeId {
         self.id
     }
 
+    #[inline]
     pub fn cfg_id(&self) -> BasicBlockId {
         self.cfg_id
     }
 
+    #[inline]
     pub fn kind(&self) -> AstKind<'a> {
         self.kind
     }
 
+    #[inline]
     pub fn scope_id(&self) -> ScopeId {
         self.scope_id
     }
 
+    #[inline]
     pub fn flags(&self) -> NodeFlags {
         self.flags
     }
 
+    #[inline]
     pub fn flags_mut(&mut self) -> &mut NodeFlags {
         &mut self.flags
     }
@@ -73,10 +80,12 @@ impl<'a> AstNodes<'a> {
         self.nodes.iter()
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.nodes.len()
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.nodes.len() == 0
     }
@@ -90,10 +99,12 @@ impl<'a> AstNodes<'a> {
         AstNodeParentIter { curr, nodes: self }
     }
 
+    #[inline]
     pub fn kind(&self, ast_node_id: AstNodeId) -> AstKind<'a> {
         self.nodes[ast_node_id].kind
     }
 
+    #[inline]
     pub fn parent_id(&self, ast_node_id: AstNodeId) -> Option<AstNodeId> {
         self.parent_ids[ast_node_id]
     }
@@ -106,28 +117,33 @@ impl<'a> AstNodes<'a> {
         self.parent_id(ast_node_id).map(|node_id| self.get_node(node_id))
     }
 
+    #[inline]
     pub fn get_node(&self, ast_node_id: AstNodeId) -> &AstNode<'a> {
         &self.nodes[ast_node_id]
     }
 
+    #[inline]
     pub fn get_node_mut(&mut self, ast_node_id: AstNodeId) -> &mut AstNode<'a> {
         &mut self.nodes[ast_node_id]
     }
 
     /// Get the root `AstNodeId`, It is always pointing to a `Program`.
     /// Returns `None` if root node isn't set.
+    #[inline]
     pub fn root(&self) -> Option<AstNodeId> {
         self.root
     }
 
     /// Get the root node as immutable reference, It is always guaranteed to be a `Program`.
     /// Returns `None` if root node isn't set.
+    #[inline]
     pub fn root_node(&self) -> Option<&AstNode<'a>> {
         self.root().map(|id| self.get_node(id))
     }
 
     /// Get the root node as mutable reference, It is always guaranteed to be a `Program`.
     /// Returns `None` if root node isn't set.
+    #[inline]
     pub fn root_node_mut(&mut self) -> Option<&mut AstNode<'a>> {
         self.root().map(|id| self.get_node_mut(id))
     }
@@ -143,6 +159,7 @@ impl<'a> AstNodes<'a> {
 
     /// Create and add an `AstNode` to the `AstNodes` tree and returns its `AstNodeId`.
     /// Node must not be `Program`. Use `add_program_node` instead.
+    #[inline]
     pub fn add_node(
         &mut self,
         kind: AstKind<'a>,

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -21,10 +21,12 @@ pub struct Reference {
 }
 
 impl Reference {
+    #[inline]
     pub fn new(node_id: AstNodeId, flag: ReferenceFlag) -> Self {
         Self { node_id, symbol_id: None, flag }
     }
 
+    #[inline]
     pub fn new_with_symbol_id(
         node_id: AstNodeId,
         symbol_id: SymbolId,
@@ -33,38 +35,46 @@ impl Reference {
         Self { node_id, symbol_id: Some(symbol_id), flag }
     }
 
+    #[inline]
     pub fn node_id(&self) -> AstNodeId {
         self.node_id
     }
 
+    #[inline]
     pub fn symbol_id(&self) -> Option<SymbolId> {
         self.symbol_id
     }
 
+    #[inline]
     pub(crate) fn set_symbol_id(&mut self, symbol_id: SymbolId) {
         self.symbol_id = Some(symbol_id);
     }
 
+    #[inline]
     pub fn flag(&self) -> &ReferenceFlag {
         &self.flag
     }
 
+    #[inline]
     pub fn flag_mut(&mut self) -> &mut ReferenceFlag {
         &mut self.flag
     }
 
     /// Returns `true` if the identifier value was read. This is not mutually
     /// exclusive with [`#is_write`]
+    #[inline]
     pub fn is_read(&self) -> bool {
         self.flag.is_read()
     }
 
     /// Returns `true` if the identifier was written to. This is not mutually
     /// exclusive with [`#is_read`]
+    #[inline]
     pub fn is_write(&self) -> bool {
         self.flag.is_write()
     }
 
+    #[inline]
     pub fn is_type(&self) -> bool {
         self.flag.is_type() || self.flag.is_ts_type_query()
     }

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -34,10 +34,12 @@ pub struct ScopeTree {
 impl ScopeTree {
     const ROOT_SCOPE_ID: ScopeId = ScopeId::new(0);
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.parent_ids.len()
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -69,10 +71,12 @@ impl ScopeTree {
         list.into_iter()
     }
 
+    #[inline]
     pub fn get_child_ids(&self, scope_id: ScopeId) -> Option<&Vec<ScopeId>> {
         self.child_ids.get(scope_id)
     }
 
+    #[inline]
     pub fn get_child_ids_mut(&mut self, scope_id: ScopeId) -> Option<&mut Vec<ScopeId>> {
         self.child_ids.get_mut(scope_id)
     }
@@ -86,10 +90,12 @@ impl ScopeTree {
         Self::ROOT_SCOPE_ID
     }
 
+    #[inline]
     pub fn root_flags(&self) -> ScopeFlags {
         self.flags[self.root_scope_id()]
     }
 
+    #[inline]
     pub fn root_unresolved_references(&self) -> &UnresolvedReferences {
         &self.root_unresolved_references
     }
@@ -100,10 +106,12 @@ impl ScopeTree {
         self.root_unresolved_references.values().map(|v| v.iter().map(|(id, _)| *id))
     }
 
+    #[inline]
     pub fn get_flags(&self, scope_id: ScopeId) -> ScopeFlags {
         self.flags[scope_id]
     }
 
+    #[inline]
     pub fn get_flags_mut(&mut self, scope_id: ScopeId) -> &mut ScopeFlags {
         &mut self.flags[scope_id]
     }
@@ -134,6 +142,7 @@ impl ScopeTree {
         flags
     }
 
+    #[inline]
     pub fn get_parent_id(&self, scope_id: ScopeId) -> Option<ScopeId> {
         self.parent_ids[scope_id]
     }
@@ -146,6 +155,7 @@ impl ScopeTree {
     }
 
     /// Get a variable binding by name that was declared in the top-level scope
+    #[inline]
     pub fn get_root_binding(&self, name: &str) -> Option<SymbolId> {
         self.get_binding(self.root_scope_id(), name)
     }
@@ -175,10 +185,12 @@ impl ScopeTree {
         None
     }
 
+    #[inline]
     pub fn get_bindings(&self, scope_id: ScopeId) -> &Bindings {
         &self.bindings[scope_id]
     }
 
+    #[inline]
     pub fn get_node_id(&self, scope_id: ScopeId) -> AstNodeId {
         self.node_ids[scope_id]
     }
@@ -189,6 +201,7 @@ impl ScopeTree {
         })
     }
 
+    #[inline]
     pub(crate) fn get_bindings_mut(&mut self, scope_id: ScopeId) -> &mut Bindings {
         &mut self.bindings[scope_id]
     }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -48,10 +48,12 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
+    #[inline]
     pub fn len(&self) -> usize {
         self.spans.len()
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -80,22 +82,27 @@ impl SymbolTable {
         })
     }
 
+    #[inline]
     pub fn get_span(&self, symbol_id: SymbolId) -> Span {
         self.spans[symbol_id]
     }
 
+    #[inline]
     pub fn get_name(&self, symbol_id: SymbolId) -> &str {
         &self.names[symbol_id]
     }
 
+    #[inline]
     pub fn set_name(&mut self, symbol_id: SymbolId, name: CompactStr) {
         self.names[symbol_id] = name;
     }
 
+    #[inline]
     pub fn get_flag(&self, symbol_id: SymbolId) -> SymbolFlags {
         self.flags[symbol_id]
     }
 
+    #[inline]
     pub fn get_redeclarations(&self, symbol_id: SymbolId) -> &[Span] {
         if let Some(redeclaration_id) = self.redeclarations[symbol_id] {
             &self.redeclaration_spans[redeclaration_id]
@@ -105,10 +112,12 @@ impl SymbolTable {
         }
     }
 
+    #[inline]
     pub fn union_flag(&mut self, symbol_id: SymbolId, includes: SymbolFlags) {
         self.flags[symbol_id] |= includes;
     }
 
+    #[inline]
     pub fn get_scope_id(&self, symbol_id: SymbolId) -> ScopeId {
         self.scope_ids[symbol_id]
     }
@@ -121,6 +130,7 @@ impl SymbolTable {
         self.get_symbol_id_from_name(name).map(|symbol_id| self.get_scope_id(symbol_id))
     }
 
+    #[inline]
     pub fn get_declaration(&self, symbol_id: SymbolId) -> AstNodeId {
         self.declarations[symbol_id]
     }
@@ -155,22 +165,27 @@ impl SymbolTable {
         self.references.push(reference)
     }
 
+    #[inline]
     pub fn get_reference(&self, reference_id: ReferenceId) -> &Reference {
         &self.references[reference_id]
     }
 
+    #[inline]
     pub fn get_reference_mut(&mut self, reference_id: ReferenceId) -> &mut Reference {
         &mut self.references[reference_id]
     }
 
+    #[inline]
     pub fn has_binding(&self, reference_id: ReferenceId) -> bool {
         self.references[reference_id].symbol_id().is_some()
     }
 
+    #[inline]
     pub fn is_global_reference(&self, reference_id: ReferenceId) -> bool {
         self.references[reference_id].symbol_id().is_none()
     }
 
+    #[inline]
     pub fn get_resolved_reference_ids(&self, symbol_id: SymbolId) -> &Vec<ReferenceId> {
         &self.resolved_references[symbol_id]
     }

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -57,11 +57,13 @@ impl<'a> UnresolvedReferencesStack<'a> {
         assert!(self.current_scope_depth > 0);
     }
 
+    #[inline]
     pub(crate) fn scope_depth(&self) -> usize {
         self.current_scope_depth
     }
 
     /// Get unresolved references hash map for current scope
+    #[inline]
     pub(crate) fn current_mut(&mut self) -> &mut TempUnresolvedReferences<'a> {
         // SAFETY: `stack.len() > current_scope_depth` initially.
         // Thereafter, `stack` never shrinks, only grows.
@@ -72,6 +74,7 @@ impl<'a> UnresolvedReferencesStack<'a> {
     }
 
     /// Get unresolved references hash maps for current scope, and parent scope
+    #[inline]
     pub(crate) fn current_and_parent_mut(
         &mut self,
     ) -> (&mut TempUnresolvedReferences<'a>, &mut TempUnresolvedReferences<'a>) {
@@ -92,6 +95,7 @@ impl<'a> UnresolvedReferencesStack<'a> {
         (current, parent)
     }
 
+    #[inline]
     pub(crate) fn into_root(self) -> TempUnresolvedReferences<'a> {
         // SAFETY: Stack starts with a non-zero size and never shrinks.
         // This assertion removes bounds check in `.next()`.


### PR DESCRIPTION
Add `#[inline]` to trivial methods `ScopeTree` etc. Hopefully compiler is already inlining them all, but just to make sure.