### PR TITLE
refactor(semantic): use `is_empty()` instead of `len() == 0`

### DIFF
--- a/crates/oxc_semantic/src/node.rs
+++ b/crates/oxc_semantic/src/node.rs
@@ -87,7 +87,7 @@ impl<'a> AstNodes<'a> {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.nodes.len() == 0
+        self.nodes.is_empty()
     }
 
     /// Walk up the AST, iterating over each parent node.

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -41,7 +41,7 @@ impl ScopeTree {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.parent_ids.is_empty()
     }
 
     pub fn ancestors(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {


### PR DESCRIPTION
It's preferred to use `is_empty` where possible. `is_empty` is sometimes slightly more optimized than `len() == 0`.