### PR TITLE
refactor(sourcemap): align Base64 chars lookup table to cache line

### DIFF
--- a/crates/oxc_sourcemap/src/encode.rs
+++ b/crates/oxc_sourcemap/src/encode.rs
@@ -168,7 +168,16 @@ fn encode_vlq_diff(out: &mut String, a: u32, b: u32) {
     encode_vlq(out, i64::from(a) - i64::from(b));
 }
 
-const B64_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+// Align chars lookup table on 64 so occupies a single cache line
+#[repr(align(64))]
+struct Aligned64([u8; 64]);
+
+static B64_CHARS: Aligned64 = Aligned64([
+    b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O', b'P',
+    b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z', b'a', b'b', b'c', b'd', b'e', b'f',
+    b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v',
+    b'w', b'x', b'y', b'z', b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'+', b'/',
+]);
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn encode_vlq(out: &mut String, num: i64) {
@@ -180,7 +189,7 @@ fn encode_vlq(out: &mut String, num: i64) {
         if num > 0 {
             digit |= 1 << 5;
         }
-        out.push(B64_CHARS[digit as usize] as char);
+        out.push(B64_CHARS.0[digit as usize] as char);
         if num == 0 {
             break;
         }


### PR DESCRIPTION
Align the Base64 chars lookup table in sourcemap generator so it occupies a single cache line.