### PR TITLE
fix(linter): change typescript-eslint/no-namespace to restriction

### DIFF
--- a/apps/oxlint/fixtures/typescript_eslint/eslintrc.json
+++ b/apps/oxlint/fixtures/typescript_eslint/eslintrc.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "no-loss-of-precision": "off",
-    "@typescript-eslint/no-loss-of-precision": "error"
+    "@typescript-eslint/no-loss-of-precision": "error",
+    "@typescript-eslint/no-namespace": "warn"
   }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
     /// declare namespace foo {}
     /// ```
     NoNamespace,
-    correctness
+    restriction
 );
 
 impl Rule for NoNamespace {


### PR DESCRIPTION
This rule prevents the usage of typescript language features, which is what the `restriction` category is intended to handle.