### PR TITLE
refactor(sourcemap)!: avoid passing `Result`s

### DIFF
--- a/crates/oxc_codegen/examples/sourcemap.rs
+++ b/crates/oxc_codegen/examples/sourcemap.rs
@@ -32,7 +32,7 @@ fn main() -> std::io::Result<()> {
         .build(&ret.program);
 
     if let Some(source_map) = source_map {
-        let result = source_map.to_json_string().unwrap();
+        let result = source_map.to_json_string();
         let hash = BASE64_STANDARD.encode(format!(
             "{}\0{}{}\0{}",
             source_text.len(),

--- a/crates/oxc_sourcemap/src/sourcemap.rs
+++ b/crates/oxc_sourcemap/src/sourcemap.rs
@@ -63,28 +63,19 @@ impl SourceMap {
     }
 
     /// Convert `SourceMap` to vlq sourcemap.
-    /// # Errors
-    ///
-    /// The `serde_json` serialization Error.
     pub fn to_json(&self) -> JSONSourceMap {
         encode(self)
     }
 
     /// Convert `SourceMap` to vlq sourcemap string.
-    /// # Errors
-    ///
-    /// The `serde_json` serialization Error.
-    pub fn to_json_string(&self) -> Result<String> {
+    pub fn to_json_string(&self) -> String {
         encode_to_string(self)
     }
 
     /// Convert `SourceMap` to vlq sourcemap data url.
-    /// # Errors
-    ///
-    /// The `serde_json` serialization Error.
-    pub fn to_data_url(&self) -> Result<String> {
-        let base_64_str = base64_simd::STANDARD.encode_to_string(self.to_json_string()?.as_bytes());
-        Ok(format!("data:application/json;charset=utf-8;base64,{base_64_str}"))
+    pub fn to_data_url(&self) -> String {
+        let base_64_str = base64_simd::STANDARD.encode_to_string(self.to_json_string().as_bytes());
+        format!("data:application/json;charset=utf-8;base64,{base_64_str}")
     }
 
     pub fn get_file(&self) -> Option<&str> {

--- a/crates/oxc_sourcemap/src/sourcemap_builder.rs
+++ b/crates/oxc_sourcemap/src/sourcemap_builder.rs
@@ -101,5 +101,5 @@ fn test_sourcemap_builder() {
     assert_eq!(sm.get_file(), Some("file"));
 
     let expected = r#"{"version":3,"file":"file","names":["x"],"sources":["baz.js"],"sourcesContent":[""],"mappings":""}"#;
-    assert_eq!(expected, sm.to_json_string().unwrap());
+    assert_eq!(expected, sm.to_json_string());
 }

--- a/tasks/benchmark/benches/sourcemap.rs
+++ b/tasks/benchmark/benches/sourcemap.rs
@@ -31,7 +31,7 @@ fn bench_sourcemap(criterion: &mut Criterion) {
                     for i in 0..2 {
                         concat_sourcemap_builder.add_sourcemap(&sourcemap, lines * i);
                     }
-                    concat_sourcemap_builder.into_sourcemap().to_json_string().unwrap();
+                    concat_sourcemap_builder.into_sourcemap().to_json_string();
                 }
             });
         });


### PR DESCRIPTION
Refactor building sourcemap JSON to avoid passing `Result`s. `Serialize::serialize` is infallible here as writing to a `Vec<u8>` is infallible.