### PR TITLE
feat(ast): improve `AstKind::debug_name`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -293,6 +293,13 @@ impl<'a> IdentifierName<'a> {
     }
 }
 
+impl<'a> fmt::Display for IdentifierName<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.name.fmt(f)
+    }
+}
+
 impl<'a> Hash for IdentifierReference<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);
@@ -319,6 +326,12 @@ impl<'a> IdentifierReference<'a> {
     }
 }
 
+impl<'a> fmt::Display for IdentifierReference<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
+    }
+}
+
 impl<'a> Hash for BindingIdentifier<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);
@@ -328,6 +341,13 @@ impl<'a> Hash for BindingIdentifier<'a> {
 impl<'a> BindingIdentifier<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
         Self { span, name, symbol_id: Cell::default() }
+    }
+}
+
+impl<'a> fmt::Display for BindingIdentifier<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
     }
 }
 

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -2,11 +2,24 @@
 
 use crate::ast::*;
 use oxc_span::{Atom, Span};
+use std::fmt;
 
 // 1.2 JSX Elements
 
-impl<'a> std::fmt::Display for JSXNamespacedName<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a> JSXIdentifier<'a> {
+    pub fn new(span: Span, name: Atom<'a>) -> Self {
+        Self { span, name }
+    }
+}
+impl<'a> fmt::Display for JSXIdentifier<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for JSXNamespacedName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.namespace.name, self.property.name)
     }
 }
@@ -41,6 +54,31 @@ impl<'a> JSXMemberExpression<'a> {
     }
 }
 
+impl<'a> fmt::Display for JSXMemberExpression<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.object, self.property)
+    }
+}
+
+impl<'a> fmt::Display for JSXMemberExpressionObject<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Identifier(id) => id.fmt(f),
+            Self::MemberExpression(expr) => expr.fmt(f),
+        }
+    }
+}
+
+impl<'a> fmt::Display for JSXElementName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Identifier(ident) => ident.fmt(f),
+            Self::NamespacedName(namespaced) => namespaced.fmt(f),
+            Self::MemberExpression(member_expr) => member_expr.fmt(f),
+        }
+    }
+}
+
 impl<'a> JSXExpression<'a> {
     /// Determines whether the given expr is a `undefined` literal
     pub fn is_undefined(&self) -> bool {
@@ -55,11 +93,5 @@ impl<'a> JSXAttribute<'a> {
 
     pub fn is_key(&self) -> bool {
         self.is_identifier("key")
-    }
-}
-
-impl<'a> JSXIdentifier<'a> {
-    pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name }
     }
 }

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -3,7 +3,7 @@
 //! [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/ast-spec)
 //! [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
 
-use std::{cell::Cell, hash::Hash};
+use std::{cell::Cell, fmt, hash::Hash};
 
 use oxc_allocator::Vec;
 use oxc_span::{Atom, Span};
@@ -100,6 +100,21 @@ impl<'a> TSTypeName<'a> {
     }
 }
 
+impl<'a> fmt::Display for TSTypeName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TSTypeName::IdentifierReference(ident) => ident.fmt(f),
+            TSTypeName::QualifiedName(qualified) => qualified.fmt(f),
+        }
+    }
+}
+
+impl<'a> fmt::Display for TSQualifiedName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.left, self.right)
+    }
+}
+
 impl<'a> TSType<'a> {
     /// Remove nested parentheses from this type.
     pub fn without_parenthesized(&self) -> &Self {
@@ -150,6 +165,15 @@ impl<'a> TSModuleDeclarationName<'a> {
         match self {
             Self::Identifier(ident) => ident.name.clone(),
             Self::StringLiteral(lit) => lit.value.clone(),
+        }
+    }
+}
+
+impl<'a> fmt::Display for TSModuleDeclarationName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Identifier(id) => id.fmt(f),
+            Self::StringLiteral(lit) => lit.fmt(f),
         }
     }
 }

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -178,6 +178,18 @@ impl<'a> AstKind<'a> {
     /// Note that this method does not exist in release builds. Do not include
     /// usage of this method within your code.
     pub fn debug_name(&self) -> std::borrow::Cow<str> {
+        use std::borrow::Cow;
+
+        const COMPUTED: Cow<'static, str> = Cow::Borrowed("<computed>");
+        const UNKNOWN: Cow<'static, str> = Cow::Borrowed("<unknown>");
+        const ANONYMOUS: Cow<'static, str> = Cow::Borrowed("<anonymous>");
+        const DESTRUCTURE: Cow<'static, str> = Cow::Borrowed("<destructure>");
+
+        #[inline]
+        fn or_anonymous<'a>(id: Option<&BindingIdentifier<'a>>) -> Cow<'a, str> {
+            id.map_or_else(|| ANONYMOUS.as_ref(), |id| id.name.as_str()).into()
+        }
+
         match self {
             Self::Program(_) => "Program".into(),
             Self::Directive(d) => d.directive.as_ref().into(),
@@ -195,7 +207,7 @@ impl<'a> AstKind<'a> {
             Self::ForStatement(_) => "ForStatement".into(),
             Self::ForStatementInit(_) => "ForStatementInit".into(),
             Self::IfStatement(_) => "IfStatement".into(),
-            Self::LabeledStatement(_) => "LabeledStatement".into(),
+            Self::LabeledStatement(l) => format!("LabeledStatement({})", l.label.name).into(),
             Self::ReturnStatement(_) => "ReturnStatement".into(),
             Self::SwitchStatement(_) => "SwitchStatement".into(),
             Self::ThrowStatement(_) => "ThrowStatement".into(),
@@ -208,7 +220,11 @@ impl<'a> AstKind<'a> {
             Self::FinallyClause(_) => "FinallyClause".into(),
 
             Self::VariableDeclaration(_) => "VariableDeclaration".into(),
-            Self::VariableDeclarator(_) => "VariableDeclarator".into(),
+            Self::VariableDeclarator(v) => format!(
+                "VariableDeclarator({})",
+                v.id.get_identifier().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
+            )
+            .into(),
 
             Self::UsingDeclaration(_) => "UsingDeclaration".into(),
 
@@ -237,13 +253,26 @@ impl<'a> AstKind<'a> {
             Self::ArrowFunctionExpression(_) => "ArrowFunctionExpression".into(),
             Self::AssignmentExpression(_) => "AssignmentExpression".into(),
             Self::AwaitExpression(_) => "AwaitExpression".into(),
-            Self::BinaryExpression(b) => format!("BinaryExpression{}", b.operator.as_str()).into(),
-            Self::CallExpression(_) => "CallExpression".into(),
+            Self::BinaryExpression(b) => {
+                format!("BinaryExpression({})", b.operator.as_str()).into()
+            }
+            Self::CallExpression(c) => {
+                format!("CallExpression({})", c.callee_name().unwrap_or(&COMPUTED)).into()
+            }
             Self::ChainExpression(_) => "ChainExpression".into(),
             Self::ConditionalExpression(_) => "ConditionalExpression".into(),
             Self::LogicalExpression(_) => "LogicalExpression".into(),
             Self::MemberExpression(_) => "MemberExpression".into(),
-            Self::NewExpression(_) => "NewExpression".into(),
+            Self::NewExpression(n) => {
+                let callee = match &n.callee {
+                    Expression::Identifier(id) => Some(id.name.as_str()),
+                    match_member_expression!(Expression) => {
+                        n.callee.to_member_expression().static_property_name()
+                    }
+                    _ => None,
+                };
+                format!("NewExpression({})", callee.unwrap_or(&COMPUTED)).into()
+            }
             Self::ObjectExpression(_) => "ObjectExpression".into(),
             Self::ParenthesizedExpression(_) => "ParenthesizedExpression".into(),
             Self::SequenceExpression(_) => "SequenceExpression".into(),
@@ -255,12 +284,16 @@ impl<'a> AstKind<'a> {
             Self::ImportExpression(_) => "ImportExpression".into(),
             Self::PrivateInExpression(_) => "PrivateInExpression".into(),
 
-            Self::ObjectProperty(_) => "ObjectProperty".into(),
-            Self::PropertyKey(_) => "PropertyKey".into(),
+            Self::ObjectProperty(p) => {
+                format!("ObjectProperty({})", p.key.name().unwrap_or(COMPUTED)).into()
+            }
+            Self::PropertyKey(p) => format!("PropertyKey({})", p.name().unwrap_or(COMPUTED)).into(),
             Self::Argument(_) => "Argument".into(),
             Self::ArrayExpressionElement(_) => "ArrayExpressionElement".into(),
             Self::AssignmentTarget(_) => "AssignmentTarget".into(),
-            Self::SimpleAssignmentTarget(_) => "SimpleAssignmentTarget".into(),
+            Self::SimpleAssignmentTarget(a) => {
+                format!("SimpleAssignmentTarget({})", a.get_identifier().unwrap_or(&UNKNOWN)).into()
+            }
             Self::AssignmentTargetPattern(_) => "AssignmentTargetPattern".into(),
             Self::ArrayAssignmentTarget(_) => "ArrayAssignmentTarget".into(),
             Self::ObjectAssignmentTarget(_) => "ObjectAssignmentTarget".into(),
@@ -270,21 +303,17 @@ impl<'a> AstKind<'a> {
             Self::ExpressionArrayElement(_) => "ExpressionArrayElement".into(),
             Self::BindingRestElement(_) => "BindingRestElement".into(),
 
-            Self::Function(x) => format!(
-                "Function({})",
-                x.id.as_ref().map_or_else(|| "<anonymous>", |id| id.name.as_str())
-            )
-            .into(),
+            Self::Function(x) => format!("Function({})", or_anonymous(x.id.as_ref())).into(),
             Self::FunctionBody(_) => "FunctionBody".into(),
             Self::FormalParameters(_) => "FormalParameters".into(),
-            Self::FormalParameter(_) => "FormalParameter".into(),
-            Self::CatchParameter(_) => "CatchParameter".into(),
-
-            Self::Class(c) => format!(
-                "Class({})",
-                c.id.as_ref().map_or_else(|| "<anonymous>", |id| id.name.as_str())
+            Self::FormalParameter(p) => format!(
+                "FormalParameter({})",
+                p.pattern.get_identifier().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
             )
             .into(),
+            Self::CatchParameter(_) => "CatchParameter".into(),
+
+            Self::Class(c) => format!("Class({})", or_anonymous(c.id.as_ref())).into(),
             Self::TSClassImplements(_) => "TSClassImplements".into(),
             Self::ClassBody(_) => "ClassBody".into(),
             Self::ClassHeritage(_) => "ClassHeritage".into(),
@@ -300,8 +329,8 @@ impl<'a> AstKind<'a> {
 
             Self::ModuleDeclaration(_) => "ModuleDeclaration".into(),
             Self::ImportDeclaration(_) => "ImportDeclaration".into(),
-            Self::ImportSpecifier(_) => "ImportSpecifier".into(),
-            Self::ExportSpecifier(_) => "ExportSpecifier".into(),
+            Self::ImportSpecifier(i) => format!("ImportSpecifier({})", i.local.name).into(),
+            Self::ExportSpecifier(e) => format!("ExportSpecifier({})", e.local.name()).into(),
             Self::ImportDefaultSpecifier(_) => "ImportDefaultSpecifier".into(),
             Self::ImportNamespaceSpecifier(_) => "ImportNamespaceSpecifier".into(),
             Self::ExportDefaultDeclaration(_) => "ExportDefaultDeclaration".into(),
@@ -309,14 +338,14 @@ impl<'a> AstKind<'a> {
             Self::ExportAllDeclaration(_) => "ExportAllDeclaration".into(),
             Self::JSXOpeningElement(_) => "JSXOpeningElement".into(),
             Self::JSXClosingElement(_) => "JSXClosingElement".into(),
-            Self::JSXElementName(_) => "JSXElementName".into(),
+            Self::JSXElementName(n) => format!("JSXElementName({n})").into(),
             Self::JSXElement(_) => "JSXElement".into(),
             Self::JSXFragment(_) => "JSXFragment".into(),
             Self::JSXAttributeItem(_) => "JSXAttributeItem".into(),
             Self::JSXSpreadAttribute(_) => "JSXSpreadAttribute".into(),
             Self::JSXText(_) => "JSXText".into(),
             Self::JSXExpressionContainer(_) => "JSXExpressionContainer".into(),
-            Self::JSXIdentifier(_) => "JSXIdentifier".into(),
+            Self::JSXIdentifier(id) => format!("JSXIdentifier({id})").into(),
             Self::JSXMemberExpression(_) => "JSXMemberExpression".into(),
             Self::JSXMemberExpressionObject(_) => "JSXMemberExpressionObject".into(),
             Self::JSXNamespacedName(_) => "JSXNamespacedName".into(),
@@ -329,7 +358,7 @@ impl<'a> AstKind<'a> {
             Self::TSMethodSignature(_) => "TSMethodSignature".into(),
             Self::TSNullKeyword(_) => "TSNullKeyword".into(),
             Self::TSTypeLiteral(_) => "TSTypeLiteral".into(),
-            Self::TSTypeReference(_) => "TSTypeReference".into(),
+            Self::TSTypeReference(t) => format!("TSTypeReference({})", t.type_name).into(),
             Self::TSUnionType(_) => "TSUnionType".into(),
             Self::TSParenthesizedType(_) => "TSParenthesizedType".into(),
             Self::TSVoidKeyword(_) => "TSVoidKeyword".into(),
@@ -359,18 +388,18 @@ impl<'a> AstKind<'a> {
             Self::TSEnumMember(_) => "TSEnumMember".into(),
 
             Self::TSImportEqualsDeclaration(_) => "TSImportEqualsDeclaration".into(),
-            Self::TSTypeName(_) => "TSTypeName".into(),
+            Self::TSTypeName(n) => format!("TSTypeName({n})").into(),
             Self::TSExternalModuleReference(_) => "TSExternalModuleReference".into(),
-            Self::TSQualifiedName(_) => "TSQualifiedName".into(),
+            Self::TSQualifiedName(n) => format!("TSQualifiedName({n})").into(),
             Self::TSInterfaceDeclaration(_) => "TSInterfaceDeclaration".into(),
             Self::TSInterfaceHeritage(_) => "TSInterfaceHeritage".into(),
-            Self::TSModuleDeclaration(_) => "TSModuleDeclaration".into(),
+            Self::TSModuleDeclaration(m) => format!("TSModuleDeclaration({})", m.id).into(),
             Self::TSTypeAliasDeclaration(_) => "TSTypeAliasDeclaration".into(),
             Self::TSTypeAnnotation(_) => "TSTypeAnnotation".into(),
             Self::TSTypeQuery(_) => "TSTypeQuery".into(),
             Self::TSTypeAssertion(_) => "TSTypeAssertion".into(),
             Self::TSThisParameter(_) => "TSThisParameter".into(),
-            Self::TSTypeParameter(_) => "TSTypeParameter".into(),
+            Self::TSTypeParameter(t) => format!("TSTypeParameter({})", t.name).into(),
             Self::TSTypeParameterDeclaration(_) => "TSTypeParameterDeclaration".into(),
             Self::TSTypeParameterInstantiation(_) => "TSTypeParameterInstantiation".into(),
             Self::TSImportType(_) => "TSImportType".into(),

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 0,
             "name": "i",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(i)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "j",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(j)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "T",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(T)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
                 "flag": "SymbolFlags(BlockScopedVariable)",
                 "id": 1,
                 "name": "a",
-                "node": "VariableDeclarator",
+                "node": "VariableDeclarator(a)",
                 "references": []
               }
             ]
@@ -58,14 +58,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "dontReference2",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(dontReference2)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.snap
@@ -17,14 +17,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(b)",
                 "references": []
               }
             ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer1",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer1)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "outer2",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer2)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(A)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(A)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(A)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "printName",
-                "node": "FormalParameter",
+                "node": "FormalParameter(printName)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Read)",
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "printerName",
-                "node": "FormalParameter",
+                "node": "FormalParameter(printerName)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Read)",
@@ -37,35 +37,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "c",
-                "node": "FormalParameter",
+                "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "d",
-                "node": "FormalParameter",
+                "node": "FormalParameter(d)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "e",
-                "node": "FormalParameter",
+                "node": "FormalParameter(e)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "f",
-                "node": "FormalParameter",
+                "node": "FormalParameter(f)",
                 "references": []
               }
             ]
@@ -92,14 +92,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 7,
         "name": "unresolved1",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved1)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 8,
         "name": "unresolved2",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved2)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Read)",
@@ -44,35 +44,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(b)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "c",
-                "node": "FormalParameter",
+                "node": "FormalParameter(c)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "d",
-                "node": "FormalParameter",
+                "node": "FormalParameter(d)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 7,
                 "name": "e",
-                "node": "FormalParameter",
+                "node": "FormalParameter(e)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 8,
                 "name": "f",
-                "node": "FormalParameter",
+                "node": "FormalParameter(f)",
                 "references": []
               }
             ]
@@ -92,7 +92,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -127,7 +127,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "v",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(v)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer1",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer1)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "outer2",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer2)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -57,7 +57,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "A",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(A)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "B",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(B)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Read)",
@@ -37,35 +37,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "c",
-                "node": "FormalParameter",
+                "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "d",
-                "node": "FormalParameter",
+                "node": "FormalParameter(d)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "e",
-                "node": "FormalParameter",
+                "node": "FormalParameter(e)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "f",
-                "node": "FormalParameter",
+                "node": "FormalParameter(f)",
                 "references": []
               }
             ]
@@ -85,21 +85,21 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "A",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(A)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 7,
         "name": "unresolved1",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved1)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 8,
         "name": "unresolved2",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved2)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "A",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(A)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Read)",
@@ -44,35 +44,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(b)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "c",
-                "node": "FormalParameter",
+                "node": "FormalParameter(c)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "d",
-                "node": "FormalParameter",
+                "node": "FormalParameter(d)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 7,
                 "name": "e",
-                "node": "FormalParameter",
+                "node": "FormalParameter(e)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 8,
                 "name": "f",
-                "node": "FormalParameter",
+                "node": "FormalParameter(f)",
                 "references": []
               }
             ]
@@ -92,7 +92,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -120,14 +120,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "A",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(A)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.snap
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "Foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(Foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -35,14 +35,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "A",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(A)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "A",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(A)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "value",
-                "node": "FormalParameter",
+                "node": "FormalParameter(value)",
                 "references": []
               }
             ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
@@ -24,14 +24,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(b)",
                 "references": []
               }
             ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
@@ -24,28 +24,28 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "a",
-                "node": "FormalParameter",
+                "node": "FormalParameter(a)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "b",
-                "node": "FormalParameter",
+                "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "c",
-                "node": "FormalParameter",
+                "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "d",
-                "node": "FormalParameter",
+                "node": "FormalParameter(d)",
                 "references": []
               }
             ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
                 "flag": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "baz",
-                "node": "FormalParameter",
+                "node": "FormalParameter(baz)",
                 "references": []
               }
             ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "obj",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(obj)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "b",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(b)",
         "references": [
           {
             "flag": "ReferenceFlag(Write)",
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 2,
         "name": "c",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(c)",
         "references": [
           {
             "flag": "ReferenceFlag(Write)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.snap
@@ -13,49 +13,49 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "b",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "c",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "d",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 4,
         "name": "e",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 5,
         "name": "f",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 6,
         "name": "rest",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "obj",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(obj)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.snap
@@ -13,49 +13,49 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "shorthand",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "value",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "world",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 4,
         "name": "b",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 5,
         "name": "c",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 6,
         "name": "d",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(T)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(T)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.t
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.t
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.t
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "v",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(v)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inl
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
         "id": 0,
         "name": "T",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(T)",
         "references": [
           {
             "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(T)",
         "references": [
           {
             "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(a)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
@@ -23,14 +23,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(a)",
             "references": []
           }
         ]
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -58,7 +58,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
@@ -23,7 +23,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -37,7 +37,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -51,7 +51,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -43,14 +43,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "parentScoped",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 0,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -35,42 +35,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "c",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "d",
-            "node": "FormalParameter",
+            "node": "FormalParameter(d)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "e",
-            "node": "FormalParameter",
+            "node": "FormalParameter(e)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 6,
             "name": "f",
-            "node": "FormalParameter",
+            "node": "FormalParameter(f)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 7,
             "name": "g",
-            "node": "FormalParameter",
+            "node": "FormalParameter(g)",
             "references": []
           }
         ]
@@ -84,7 +84,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -98,7 +98,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 8,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "i",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(i)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "j",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(j)",
             "references": []
           }
         ]
@@ -43,14 +43,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "arrow",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(arrow)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 2,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       },
       {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -57,7 +57,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(a)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
@@ -23,14 +23,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(a)",
             "references": []
           }
         ]
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
@@ -23,7 +23,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -37,7 +37,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": []
       },
       {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "parentScoped",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
             "id": 1,
             "name": "Foo",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(Foo)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(usage)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 0,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -37,7 +37,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -51,7 +51,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -35,42 +35,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "c",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "d",
-            "node": "FormalParameter",
+            "node": "FormalParameter(d)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 6,
             "name": "e",
-            "node": "FormalParameter",
+            "node": "FormalParameter(e)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 7,
             "name": "f",
-            "node": "FormalParameter",
+            "node": "FormalParameter(f)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 8,
             "name": "g",
-            "node": "FormalParameter",
+            "node": "FormalParameter(g)",
             "references": []
           }
         ]
@@ -84,7 +84,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -105,7 +105,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "i",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(i)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "j",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(j)",
             "references": []
           }
         ]
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 2,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(a)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
@@ -23,14 +23,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(a)",
             "references": []
           }
         ]
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -58,7 +58,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
@@ -23,7 +23,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -37,7 +37,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -51,7 +51,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -43,14 +43,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.snap
@@ -15,14 +15,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(b)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "parentScoped",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -35,42 +35,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "b",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "c",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "d",
-            "node": "FormalParameter",
+            "node": "FormalParameter(d)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 6,
             "name": "e",
-            "node": "FormalParameter",
+            "node": "FormalParameter(e)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 7,
             "name": "f",
-            "node": "FormalParameter",
+            "node": "FormalParameter(f)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 8,
             "name": "g",
-            "node": "FormalParameter",
+            "node": "FormalParameter(g)",
             "references": []
           }
         ]
@@ -84,7 +84,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(outer)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -98,14 +98,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "i",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(i)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "j",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(j)",
             "references": []
           }
         ]
@@ -43,14 +43,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(BlockScopedVariable)",
             "id": 2,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           }
         ]
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       },
       {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -57,7 +57,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "top",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(top)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "top",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(top)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "flag": "SymbolFlags(FunctionScopedVariable)",
         "id": 0,
         "name": "top",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(top)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "top",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(top)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "top",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(top)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "flag": "SymbolFlags(FunctionScopedVariable)",
         "id": 0,
         "name": "top",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(top)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implic
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-al
         "flag": "SymbolFlags(Import)",
         "id": 0,
         "name": "t",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(t)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
         "flag": "SymbolFlags(Import)",
         "id": 0,
         "name": "v",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(v)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "flag": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "foo",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Type | TSTypeQuery)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "flag": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "T",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(T)",
         "references": [
           {
             "flag": "ReferenceFlag(Type)",
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "flag": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "foo",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Type | TSTypeQuery)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "flag": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "T",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(T)",
         "references": [
           {
             "flag": "ReferenceFlag(Type)",
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -37,7 +37,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flag": "SymbolFlags(TypeParameter)",
             "id": 3,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "value",
-            "node": "FormalParameter",
+            "node": "FormalParameter(value)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -51,7 +51,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "flag": "SymbolFlags(TypeParameter)",
             "id": 4,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -99,7 +99,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 5,
         "name": "makeStringBox",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(makeStringBox)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-s
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "attr",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(attr)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.ts
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "child",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(child)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "X",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(X)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "Foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(Foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "Foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(Foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
         "flag": "SymbolFlags(Import)",
         "id": 1,
         "name": "Fragment",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(Fragment)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
         "flag": "SymbolFlags(Import)",
         "id": 1,
         "name": "Fragment",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(Fragment)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.snap
@@ -20,14 +20,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
         "flag": "SymbolFlags(Import)",
         "id": 1,
         "name": "h",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(h)",
         "references": []
       },
       {
         "flag": "SymbolFlags(Import)",
         "id": 2,
         "name": "Fragment",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(Fragment)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
         "flag": "SymbolFlags(Import)",
         "id": 1,
         "name": "h",
-        "node": "ImportSpecifier",
+        "node": "ImportSpecifier(h)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-ch
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "child",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(child)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "props",
-            "node": "FormalParameter",
+            "node": "FormalParameter(props)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -50,14 +50,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "y",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(y)",
         "references": []
       },
       {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.tsx
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "Foo",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(Foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxide
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "React",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(React)",
         "references": []
       },
       {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expressi
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "a",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(a)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "T",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(T)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.snap
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.t
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -16,13 +16,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 2,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(usage)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -16,13 +16,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 2,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -50,7 +50,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(usage)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
@@ -9,7 +9,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": []
       }
     ],
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | NameSpaceModule)",
         "id": 0,
         "name": "Foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "usage",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(usage)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -9,13 +9,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
         "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.snap
@@ -9,7 +9,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/globa
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(global)",
         "symbols": []
       }
     ],
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/globa
         "flag": "SymbolFlags(NameSpaceModule | Ambient)",
         "id": 0,
         "name": "global",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(global)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.snap
@@ -9,13 +9,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/impor
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(Import)",
             "id": 1,
             "name": "bar",
-            "node": "ImportSpecifier",
+            "node": "ImportSpecifier(bar)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/impor
         "flag": "SymbolFlags(NameSpaceModule | Ambient)",
         "id": 0,
         "name": "foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(foo)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -9,13 +9,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "Foo",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(Foo)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(usage)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -9,13 +9,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",
@@ -49,7 +49,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
@@ -9,13 +9,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
             "id": 1,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -29,14 +29,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope
         "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "references": []
       },
       {
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(unresolved)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -9,13 +9,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
         "children": [],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
             "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
-            "node": "VariableDeclarator",
+            "node": "VariableDeclarator(x)",
             "references": []
           }
         ]
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
         "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(<destructure>)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
-            "node": "FormalParameter",
+            "node": "FormalParameter(a)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(<destructure>)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "flag": "SymbolFlags(FunctionScopedVariable)",
         "id": 1,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | Write)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | Write)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
@@ -13,7 +13,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "flag": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | Write)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "flag": "SymbolFlags(TypeParameter)",
                     "id": 3,
                     "name": "U",
-                    "node": "TSTypeParameter",
+                    "node": "TSTypeParameter(U)",
                     "references": [
                       {
                         "flag": "ReferenceFlag(Type)",
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "U",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(U)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",
@@ -61,7 +61,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "V",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(V)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 1,
                 "name": "U",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(U)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "I",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(I)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "I",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(I)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -17,7 +17,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "I",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(I)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
         "id": 0,
         "name": "dual",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(dual)",
         "references": [
           {
             "flag": "ReferenceFlag(Type)",
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "reference2",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(reference2)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -21,7 +21,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "arg",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(arg)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | TSTypeQuery)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(A)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(A)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(A)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "k",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(k)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | TSTypeQuery)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 3,
                 "name": "Id",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(Id)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ],
         "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 2,
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Member)",
         "symbols": [
           {
             "flag": "SymbolFlags(Export | TypeAlias)",
@@ -58,7 +58,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(NameSpaceModule)",
         "id": 1,
         "name": "Member",
-        "node": "TSModuleDeclaration",
+        "node": "TSModuleDeclaration(Member)",
         "references": []
       },
       {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "value",
-            "node": "FormalParameter",
+            "node": "FormalParameter(value)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "k",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(k)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "k",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(k)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "U",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(U)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flag": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "U",
-                "node": "TSTypeParameter",
+                "node": "TSTypeParameter(U)",
                 "references": [
                   {
                     "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           }
         ]
@@ -30,7 +30,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 3,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
@@ -22,14 +22,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           },
           {
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "arg",
-            "node": "FormalParameter",
+            "node": "FormalParameter(arg)",
             "references": []
           }
         ]
@@ -71,7 +71,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 4,
         "name": "StyledPayment",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(StyledPayment)",
         "references": []
       }
     ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(U)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": []
           }
         ]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | TSTypeQuery)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -15,7 +15,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",
@@ -29,7 +29,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "y",
-            "node": "FormalParameter",
+            "node": "FormalParameter(y)",
             "references": [
               {
                 "flag": "ReferenceFlag(Read)",
@@ -51,7 +51,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flag": "SymbolFlags(TypeParameter)",
             "id": 4,
             "name": "T",
-            "node": "TSTypeParameter",
+            "node": "TSTypeParameter(T)",
             "references": [
               {
                 "flag": "ReferenceFlag(Type)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
-        "node": "VariableDeclarator",
+        "node": "VariableDeclarator(x)",
         "references": [
           {
             "flag": "ReferenceFlag(Read | TSTypeQuery)",

--- a/crates/oxc_semantic/tests/integration/snapshots/break_from_a_label_in_global_scope.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/break_from_a_label_in_global_scope.snap
@@ -22,7 +22,7 @@ bb3: {
 
 digraph {
     0 [ label = "" ]
-    1 [ label = "LabeledStatement\nbreak <A>" ]
+    1 [ label = "LabeledStatement(A)\nbreak <A>" ]
     2 [ label = "unreachable" ]
     3 [ label = "" ]
     1 -> 0 [ label = "Error(Implicit)" ]

--- a/crates/oxc_semantic/tests/integration/snapshots/cond_expr_in_arrow_fn.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/cond_expr_in_arrow_fn.snap
@@ -40,7 +40,7 @@ digraph {
     1 [ label = "VariableDeclaration" ]
     2 [ label = "" ]
     3 [ label = "ExpressionStatement" ]
-    4 [ label = "Condition(CallExpression)" ]
+    4 [ label = "Condition(CallExpression(a))" ]
     5 [ label = "" ]
     6 [ label = "" ]
     7 [ label = "" ]

--- a/crates/oxc_semantic/tests/integration/snapshots/conditional_expression.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/conditional_expression.snap
@@ -30,7 +30,7 @@ bb5: {
 digraph {
     0 [ label = "" ]
     1 [ label = "VariableDeclaration" ]
-    2 [ label = "Condition(CallExpression)" ]
+    2 [ label = "Condition(CallExpression(a))" ]
     3 [ label = "" ]
     4 [ label = "" ]
     5 [ label = "VariableDeclaration" ]

--- a/crates/oxc_semantic/tests/integration/snapshots/labeled_block_break.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/labeled_block_break.snap
@@ -56,7 +56,7 @@ digraph {
     1 [ label = "TryStatement" ]
     2 [ label = "" ]
     3 [ label = "BlockStatement" ]
-    4 [ label = "BlockStatement\nLabeledStatement\nBlockStatement\nIfStatement" ]
+    4 [ label = "BlockStatement\nLabeledStatement(LABEL)\nBlockStatement\nIfStatement" ]
     5 [ label = "Condition(IdentifierReference(condition))" ]
     6 [ label = "BlockStatement\nbreak <LABEL>" ]
     7 [ label = "unreachable" ]

--- a/crates/oxc_semantic/tests/integration/snapshots/labelled_try_break.snap
+++ b/crates/oxc_semantic/tests/integration/snapshots/labelled_try_break.snap
@@ -61,7 +61,7 @@ digraph {
     0 [ label = "" ]
     1 [ label = "VariableDeclaration" ]
     2 [ label = "" ]
-    3 [ label = "LabeledStatement\nTryStatement" ]
+    3 [ label = "LabeledStatement(label)\nTryStatement" ]
     4 [ label = "" ]
     5 [ label = "BlockStatement\nreturn <value>" ]
     6 [ label = "unreachable" ]


### PR DESCRIPTION
> Part of #4445

Improve `debug_name` to show identifier names for more AST kinds.