### PR TITLE
feat(linter): add auto-fix metadata to RuleMeta

### DIFF
--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -12,7 +12,7 @@ bitflags! {
     ///
     /// [`FixKind`] is designed to be interopable with [`bool`]. `true` turns
     /// into [`FixKind::Fix`] (applies only safe fixes) and `false` turns into
-    /// `FixKind::None` (do not apply any fixes or suggestions).
+    /// [`FixKind::None`] (do not apply any fixes or suggestions).
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct FixKind: u8 {
         /// An automatic code fix. Most of these are applied with `--fix`

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -9,6 +9,8 @@ use syn::{
 pub struct LintRuleMeta {
     name: Ident,
     category: Ident,
+    /// Describes what auto-fixing capabilities the rule has
+    fix: Option<Ident>,
     documentation: String,
     pub used_in_test: bool,
 }
@@ -32,10 +34,20 @@ impl Parse for LintRuleMeta {
         input.parse::<Token!(,)>()?;
         let category = input.parse()?;
 
+        // Parse FixMeta if it's specified. It will otherwise be excluded from
+        // the RuleMeta impl, falling back on default set by RuleMeta itself.
+        // Do not provide a default value here so that it can be set there instead.
+        let fix: Option<Ident> = if input.peek(Token!(,)) {
+            input.parse::<Token!(,)>()?;
+            input.parse()?
+        } else {
+            None
+        };
+
         // Ignore the rest
         input.parse::<proc_macro2::TokenStream>()?;
 
-        Ok(Self { name: struct_name, category, documentation, used_in_test: false })
+        Ok(Self { name: struct_name, category, fix, documentation, used_in_test: false })
     }
 }
 
@@ -44,7 +56,7 @@ fn rule_name_converter() -> Converter {
 }
 
 pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
-    let LintRuleMeta { name, category, documentation, used_in_test } = metadata;
+    let LintRuleMeta { name, category, fix, documentation, used_in_test } = metadata;
 
     let canonical_name = rule_name_converter().convert(name.to_string());
     let category = match category.to_string().as_str() {
@@ -57,11 +69,17 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
         "nursery" => quote! { RuleCategory::Nursery },
         _ => panic!("invalid rule category"),
     };
+    let fix = fix.as_ref().map(Ident::to_string).map(|fix| {
+        let fix = parse_fix(&fix);
+        quote! {
+            const FIX: RuleFixMeta = #fix;
+        }
+    });
 
     let import_statement = if used_in_test {
         None
     } else {
-        Some(quote! { use crate::rule::{RuleCategory, RuleMeta}; })
+        Some(quote! { use crate::rule::{RuleCategory, RuleMeta, RuleFixMeta}; })
     };
 
     let output = quote! {
@@ -71,6 +89,8 @@ pub fn declare_oxc_lint(metadata: LintRuleMeta) -> TokenStream {
             const NAME: &'static str = #canonical_name;
 
             const CATEGORY: RuleCategory = #category;
+
+            #fix
 
             fn documentation() -> Option<&'static str> {
                 Some(#documentation)
@@ -96,4 +116,20 @@ fn parse_attr<'a, const LEN: usize>(
         }
     }
     None
+}
+
+fn parse_fix(s: &str) -> proc_macro2::TokenStream {
+    match s {
+        "none" => quote! { RuleFixMeta::None },
+        "pending" => quote! { RuleFixMeta::FixPending },
+        "fix" => quote! { RuleFixMeta::Fixable(FixKind::Fix) },
+        "fix-dangerous" => quote! { RuleFixMeta::Fixable(FixKind::Fix.union(FixKind::Dangerous)) },
+        "suggestion" => quote! { RuleFixMeta::Fixable(FixKind::Suggestion) },
+        "suggestion-dangerous" => quote! { RuleFixMeta::Fixable(FixKind::Suggestion.union(FixKind::Dangerous)) },
+        "None" => panic!("Invalid fix kind. Did you mean 'none'?"),
+        "Pending" => panic!("Invalid fix kind. Did you mean 'pending'?"),
+        "Fix" => panic!("Invalid fix kind. Did you mean 'fix'?"),
+        "Suggestion" => panic!("Invalid fix kind. Did you mean 'suggestion'?"),
+        invalid => panic!("invalid fix kind: {invalid}. Valid kinds are none, pending, fix, fix-dangerous, suggestion, and suggestion-dangerous"),
+    }
 }


### PR DESCRIPTION
Add a `FIX` constant to `RuleMeta` that describes what kinds of auto fixes a
rule can perform (if any). This PR also updates `declare_oxc_lint` to accept a
fix capabilities field. Follow-up PRs in this stack will update existing rules
and update other parts of the codebase to use this new field.

The end goal of this stack is to
1. automate creation of #4179 in a similar way we auto-update rule progress,
2. use it in rule documentation pages when we eventually add lint rules to the website