### PR TITLE
refactor(parser): shorten lexer code

### DIFF
--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -270,7 +270,7 @@ impl<'a> Lexer<'a> {
     /// Handle private identifier whose first byte is not an ASCII identifier start byte.
     #[cold]
     fn private_identifier_not_ascii_id(&mut self) -> Kind {
-        let b = self.source.peek_byte().unwrap();
+        let b = self.peek_byte().unwrap();
         if !b.is_ascii() {
             let c = self.peek_char().unwrap();
             if is_identifier_start_unicode(c) {

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -99,7 +99,7 @@ impl<'a> Lexer<'a> {
     ///   `JSXIdentifier` `IdentifierPart`
     ///   `JSXIdentifier` [no `WhiteSpace` or Comment here] -
     pub(crate) fn continue_lex_jsx_identifier(&mut self) -> Option<Token> {
-        if self.source.peek_byte() != Some(b'-') {
+        if self.peek_byte() != Some(b'-') {
             return None;
         }
         self.consume_char();

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -309,7 +309,7 @@ impl<'a> Lexer<'a> {
             let offset = self.offset();
             self.token.start = offset;
 
-            let Some(byte) = self.source.peek_byte() else {
+            let Some(byte) = self.peek_byte() else {
                 return Kind::Eof;
             };
 

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -100,7 +100,7 @@ macro_rules! handle_string_literal_escape {
 
             // Consume bytes until reach end of string, line break, or another escape
             let chunk_start = $lexer.source.position();
-            while let Some(b) = $lexer.source.peek_byte() {
+            while let Some(b) = $lexer.peek_byte() {
                 match b {
                     b if !$table.matches(b) => {
                         // SAFETY: A byte is available, as we just peeked it.


### PR DESCRIPTION
Use `lexer.peek_byte()` instead of `lexer.source.peek_byte()`.