### PR TITLE
refactor(parser): fetch 2 bytes in `?` byte handler

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -269,12 +269,6 @@ impl<'a> Lexer<'a> {
         self.source.peek_char()
     }
 
-    /// Peek the next next char without advancing the position
-    #[inline]
-    fn peek_char2(&self) -> Option<char> {
-        self.source.peek_char2()
-    }
-
     /// Peek the next byte, and advance the current position if it matches
     /// the given ASCII char.
     // `#[inline(always)]` to make sure the `assert!` gets optimized out.

--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -470,23 +470,6 @@ impl<'a> Source<'a> {
         Some(c)
     }
 
-    /// Peek next next char of source, without consuming it.
-    #[inline]
-    pub(super) fn peek_char2(&self) -> Option<char> {
-        // Handle EOF
-        if self.is_eof() {
-            return None;
-        }
-
-        // Check invariant that `ptr` is on a UTF-8 character boundary.
-        debug_assert!(!is_utf8_cont_byte(self.peek_byte().unwrap()));
-
-        let mut chars = self.remaining().chars();
-        // SAFETY: We already checked not at EOF, so `chars.next()` must return `Some(_)`
-        unsafe { chars.next().unwrap_unchecked() };
-        chars.next()
-    }
-
     /// Peek next byte of source without consuming it.
     #[inline]
     pub(super) fn peek_byte(&self) -> Option<u8> {


### PR DESCRIPTION
Lexer's `?` byte handler needs to fetch next 2 bytes, so do that in one shot, rather than bounds-checking twice.