### PR TITLE
refactor(parser): rename function

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -209,8 +209,8 @@ ascii_byte_handler!(LIN(lexer) {
 // !
 ascii_byte_handler!(EXL(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'=') {
-        if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'=') {
+        if lexer.next_ascii_byte_eq(b'=') {
             Kind::Neq2
         } else {
             Kind::Neq
@@ -237,7 +237,7 @@ ascii_byte_handler!(HAS(lexer) {
     lexer.consume_char();
     // HashbangComment ::
     //     `#!` SingleLineCommentChars?
-    if lexer.token.start == 0 && lexer.next_ascii_char_eq(b'!') {
+    if lexer.token.start == 0 && lexer.next_ascii_byte_eq(b'!') {
         lexer.read_hashbang_comment()
     } else {
         lexer.private_identifier()
@@ -252,7 +252,7 @@ ascii_identifier_handler!(IDT(_id_without_first_char) {
 // %
 ascii_byte_handler!(PRC(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'=') {
         Kind::PercentEq
     } else {
         Kind::Percent
@@ -262,13 +262,13 @@ ascii_byte_handler!(PRC(lexer) {
 // &
 ascii_byte_handler!(AMP(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'&') {
-        if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'&') {
+        if lexer.next_ascii_byte_eq(b'=') {
             Kind::Amp2Eq
         } else {
             Kind::Amp2
         }
-    } else if lexer.next_ascii_char_eq(b'=') {
+    } else if lexer.next_ascii_byte_eq(b'=') {
         Kind::AmpEq
     } else {
         Kind::Amp
@@ -290,13 +290,13 @@ ascii_byte_handler!(PNC(lexer) {
 // *
 ascii_byte_handler!(ATR(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'*') {
-        if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'*') {
+        if lexer.next_ascii_byte_eq(b'=') {
             Kind::Star2Eq
         } else {
             Kind::Star2
         }
-    } else if lexer.next_ascii_char_eq(b'=') {
+    } else if lexer.next_ascii_byte_eq(b'=') {
         Kind::StarEq
     } else {
         Kind::Star
@@ -306,9 +306,9 @@ ascii_byte_handler!(ATR(lexer) {
 // +
 ascii_byte_handler!(PLS(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'+') {
+    if lexer.next_ascii_byte_eq(b'+') {
         Kind::Plus2
-    } else if lexer.next_ascii_char_eq(b'=') {
+    } else if lexer.next_ascii_byte_eq(b'=') {
         Kind::PlusEq
     } else {
         Kind::Plus
@@ -347,7 +347,7 @@ ascii_byte_handler!(SLH(lexer) {
         }
         _ => {
             // regex is handled separately, see `next_regex`
-            if lexer.next_ascii_char_eq(b'=') {
+            if lexer.next_ascii_byte_eq(b'=') {
                 Kind::SlashEq
             } else {
                 Kind::Slash
@@ -389,13 +389,13 @@ ascii_byte_handler!(LSS(lexer) {
 // =
 ascii_byte_handler!(EQL(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'=') {
-        if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'=') {
+        if lexer.next_ascii_byte_eq(b'=') {
             Kind::Eq3
         } else {
             Kind::Eq2
         }
-    } else if lexer.next_ascii_char_eq(b'>') {
+    } else if lexer.next_ascii_byte_eq(b'>') {
         Kind::Arrow
     } else {
         Kind::Eq
@@ -474,7 +474,7 @@ ascii_byte_handler!(BTC(lexer) {
 // ^
 ascii_byte_handler!(CRT(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'=') {
         Kind::CaretEq
     } else {
         Kind::Caret
@@ -496,13 +496,13 @@ ascii_byte_handler!(BEO(lexer) {
 // |
 ascii_byte_handler!(PIP(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_char_eq(b'|') {
-        if lexer.next_ascii_char_eq(b'=') {
+    if lexer.next_ascii_byte_eq(b'|') {
+        if lexer.next_ascii_byte_eq(b'=') {
             Kind::Pipe2Eq
         } else {
             Kind::Pipe2
         }
-    } else if lexer.next_ascii_char_eq(b'=') {
+    } else if lexer.next_ascii_byte_eq(b'=') {
         Kind::PipeEq
     } else {
         Kind::Pipe

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -274,7 +274,7 @@ impl<'a> Lexer<'a> {
     // `#[inline(always)]` to make sure the `assert!` gets optimized out.
     #[allow(clippy::inline_always)]
     #[inline(always)]
-    fn next_ascii_char_eq(&mut self, b: u8) -> bool {
+    fn next_ascii_byte_eq(&mut self, b: u8) -> bool {
         // TODO: can be replaced by `std::ascii:Char` once stabilized.
         // https://github.com/rust-lang/rust/issues/110998
         assert!(b.is_ascii());

--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -29,9 +29,9 @@ impl<'a> Lexer<'a> {
 
     pub(super) fn decimal_literal_after_first_digit(&mut self) -> Kind {
         self.read_decimal_digits_after_first_digit();
-        if self.next_ascii_char_eq(b'.') {
+        if self.next_ascii_byte_eq(b'.') {
             return self.decimal_literal_after_decimal_point_after_digits();
-        } else if self.next_ascii_char_eq(b'n') {
+        } else if self.next_ascii_byte_eq(b'n') {
             return self.check_after_numeric_literal(Kind::Decimal);
         }
 
@@ -71,7 +71,7 @@ impl<'a> Lexer<'a> {
                 _ => break,
             }
         }
-        self.next_ascii_char_eq(b'n');
+        self.next_ascii_byte_eq(b'n');
         self.check_after_numeric_literal(kind)
     }
 

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -17,13 +17,13 @@ impl<'a> Lexer<'a> {
 
     /// returns None for `SingleLineHTMLOpenComment` `<!--` in script mode
     pub(super) fn read_left_angle(&mut self) -> Option<Kind> {
-        if self.next_ascii_char_eq(b'<') {
-            if self.next_ascii_char_eq(b'=') {
+        if self.next_ascii_byte_eq(b'<') {
+            if self.next_ascii_byte_eq(b'=') {
                 Some(Kind::ShiftLeftEq)
             } else {
                 Some(Kind::ShiftLeft)
             }
-        } else if self.next_ascii_char_eq(b'=') {
+        } else if self.next_ascii_byte_eq(b'=') {
             Some(Kind::LtEq)
         } else if self.peek_byte() == Some(b'!')
             // SingleLineHTMLOpenComment `<!--` in script mode
@@ -38,17 +38,17 @@ impl<'a> Lexer<'a> {
 
     /// returns None for `SingleLineHTMLCloseComment` `-->` in script mode
     pub(super) fn read_minus(&mut self) -> Option<Kind> {
-        if self.next_ascii_char_eq(b'-') {
+        if self.next_ascii_byte_eq(b'-') {
             // SingleLineHTMLCloseComment `-->` in script mode
             if self.token.is_on_new_line
                 && self.source_type.is_script()
-                && self.next_ascii_char_eq(b'>')
+                && self.next_ascii_byte_eq(b'>')
             {
                 None
             } else {
                 Some(Kind::Minus2)
             }
-        } else if self.next_ascii_char_eq(b'=') {
+        } else if self.next_ascii_byte_eq(b'=') {
             Some(Kind::MinusEq)
         } else {
             Some(Kind::Minus)
@@ -62,19 +62,19 @@ impl<'a> Lexer<'a> {
     }
 
     fn read_right_angle(&mut self) -> Kind {
-        if self.next_ascii_char_eq(b'>') {
-            if self.next_ascii_char_eq(b'>') {
-                if self.next_ascii_char_eq(b'=') {
+        if self.next_ascii_byte_eq(b'>') {
+            if self.next_ascii_byte_eq(b'>') {
+                if self.next_ascii_byte_eq(b'=') {
                     Kind::ShiftRight3Eq
                 } else {
                     Kind::ShiftRight3
                 }
-            } else if self.next_ascii_char_eq(b'=') {
+            } else if self.next_ascii_byte_eq(b'=') {
                 Kind::ShiftRightEq
             } else {
                 Kind::ShiftRight
             }
-        } else if self.next_ascii_char_eq(b'=') {
+        } else if self.next_ascii_byte_eq(b'=') {
             Kind::GtEq
         } else {
             Kind::RAngle

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -141,11 +141,11 @@ impl<'a> Lexer<'a> {
     }
 
     fn unicode_code_point(&mut self) -> Option<SurrogatePair> {
-        if !self.next_ascii_char_eq(b'{') {
+        if !self.next_ascii_byte_eq(b'{') {
             return None;
         }
         let value = self.code_point()?;
-        if !self.next_ascii_char_eq(b'}') {
+        if !self.next_ascii_byte_eq(b'}') {
             return None;
         }
         Some(SurrogatePair::CodePoint(value))
@@ -231,7 +231,7 @@ impl<'a> Lexer<'a> {
                 // <CR> <LF>
                 LF | LS | PS => {}
                 CR => {
-                    self.next_ascii_char_eq(b'\n');
+                    self.next_ascii_byte_eq(b'\n');
                 }
                 // SingleEscapeCharacter :: one of
                 //   ' " \ b f n r t v


### PR DESCRIPTION
Rename `Lexer::next_ascii_char_eq` to `next_ascii_byte_eq`, for consistency with other method names which operate on bytes.