### PR TITLE
refactor(parser): rename function

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -206,7 +206,7 @@ impl Kind {
         )
     }
 
-    pub fn matches_number_char(self, b: u8) -> bool {
+    pub fn matches_number_byte(self, b: u8) -> bool {
         match self {
             Decimal => b.is_ascii_digit(),
             Binary => matches!(b, b'0'..=b'1'),

--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -42,7 +42,7 @@ impl<'a> Lexer<'a> {
     fn read_non_decimal(&mut self, kind: Kind) -> Kind {
         self.consume_char();
 
-        if self.peek_byte().is_some_and(|b| kind.matches_number_char(b)) {
+        if self.peek_byte().is_some_and(|b| kind.matches_number_byte(b)) {
             self.consume_char();
         } else {
             self.unexpected_err();
@@ -58,14 +58,14 @@ impl<'a> Lexer<'a> {
                     // call here instead of after we ensure the next character
                     // is a number character
                     self.token.set_has_separator();
-                    if self.peek_byte().is_some_and(|b| kind.matches_number_char(b)) {
+                    if self.peek_byte().is_some_and(|b| kind.matches_number_byte(b)) {
                         self.consume_char();
                     } else {
                         self.unexpected_err();
                         return Kind::Undetermined;
                     }
                 }
-                b if kind.matches_number_char(b) => {
+                b if kind.matches_number_byte(b) => {
                     self.consume_char();
                 }
                 _ => break,


### PR DESCRIPTION
Rename `matches_number_char` function to `matches_number_byte` as it takes a `u8` byte, not a `char`.