### PR TITLE
perf(parser): speed up lexing non-decimal numbers

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -206,6 +206,7 @@ impl Kind {
         )
     }
 
+    #[inline] // Inline into `read_non_decimal` - see comment there as to why
     pub fn matches_number_byte(self, b: u8) -> bool {
         match self {
             Decimal => b.is_ascii_digit(),

--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -39,6 +39,10 @@ impl<'a> Lexer<'a> {
         self.check_after_numeric_literal(kind)
     }
 
+    // Inline into the 3 calls from `read_zero` so that value of `kind` is known
+    // and `kind.matches_number_byte` can be statically reduced to just the match arm
+    // that applies for this specific kind. `matches_number_byte` is also marked `#[inline]`.
+    #[inline]
     fn read_non_decimal(&mut self, kind: Kind) -> Kind {
         self.consume_char();
 


### PR DESCRIPTION
Inline `Lexer::read_non_decimal` to reduce branching.