### PR TITLE
refactor(parser): convert `Lexer::read_left_angle` to a single match

### DIFF
--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -16,22 +16,23 @@ impl<'a> Lexer<'a> {
 
     /// returns None for `SingleLineHTMLOpenComment` `<!--` in script mode
     pub(super) fn read_left_angle(&mut self) -> Option<Kind> {
-        if self.next_ascii_byte_eq(b'<') {
-            if self.next_ascii_byte_eq(b'=') {
-                Some(Kind::ShiftLeftEq)
-            } else {
-                Some(Kind::ShiftLeft)
+        match self.peek_byte() {
+            Some(b'<') => {
+                self.consume_char();
+                if self.next_ascii_byte_eq(b'=') {
+                    Some(Kind::ShiftLeftEq)
+                } else {
+                    Some(Kind::ShiftLeft)
+                }
             }
-        } else if self.next_ascii_byte_eq(b'=') {
-            Some(Kind::LtEq)
-        } else if self.peek_byte() == Some(b'!')
-            // SingleLineHTMLOpenComment `<!--` in script mode
-            && self.source_type.is_script()
-            && self.remaining().starts_with("!--")
-        {
-            None
-        } else {
-            Some(Kind::LAngle)
+            Some(b'=') => {
+                self.consume_char();
+                Some(Kind::LtEq)
+            }
+            Some(b'!') if self.source_type.is_script() && self.remaining().starts_with("!--") => {
+                None
+            }
+            _ => Some(Kind::LAngle),
         }
     }
 


### PR DESCRIPTION
`Lexer::read_left_angle` was a series of disparate `next_ascii_byte_eq` and `peek_byte` calls. Convert it to a single match on `peek_byte`. This I think will remove a couple of bounds checks.