### PR TITLE
refactor(parser): convert lexer byte handler for `|` to a single match

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -495,16 +495,21 @@ ascii_byte_handler!(BEO(lexer) {
 // |
 ascii_byte_handler!(PIP(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_byte_eq(b'|') {
-        if lexer.next_ascii_byte_eq(b'=') {
-            Kind::Pipe2Eq
-        } else {
-            Kind::Pipe2
+
+    match lexer.peek_byte() {
+        Some(b'|') => {
+            lexer.consume_char();
+            if lexer.next_ascii_byte_eq(b'=') {
+                Kind::Pipe2Eq
+            } else {
+                Kind::Pipe2
+            }
         }
-    } else if lexer.next_ascii_byte_eq(b'=') {
-        Kind::PipeEq
-    } else {
-        Kind::Pipe
+        Some(b'=') => {
+            lexer.consume_char();
+            Kind::PipeEq
+        }
+        _ => Kind::Pipe
     }
 });
 


### PR DESCRIPTION
Same as #4573 and #4574. Convert lexer's byte handler for `|` to a single match rather than multiple `next_ascii_byte_eq` calls.