### PR TITLE
(poc) perf(linter): shrink size of `LintContext`

### DIFF
--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -15,7 +15,7 @@ pub use fix::{CompositeFix, Fix, FixKind, RuleFix};
 /// [`RuleFixer`]: https://github.com/eslint/eslint/blob/main/lib/linter/rule-fixer.js
 #[derive(Clone, Copy)]
 #[must_use]
-pub struct RuleFixer<'c, 'a: 'c> {
+pub struct RuleFixer<'c, 'l, 'a> {
     /// What kind of fixes will factory methods produce?
     ///
     /// Controlled via `diagnostic_with_fix`, `diagnostic_with_suggestion`, and
@@ -30,16 +30,16 @@ pub struct RuleFixer<'c, 'a: 'c> {
     ///
     /// Defaults to `true`
     auto_message: bool,
-    ctx: &'c LintContext<'a>,
+    ctx: &'c LintContext<'a, 'l>,
 }
 
-impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
+impl<'c, 'a: 'c, 'l: 'c> RuleFixer<'c, 'l, 'a> {
     /// Maximum length code snippets can be inside auto-created messages before
     /// they get truncated. Prevents the terminal from getting flooded when a
     /// replacement covers a large span.
     const MAX_SNIPPET_LEN: usize = 256;
 
-    pub(super) fn new(kind: FixKind, ctx: &'c LintContext<'a>) -> Self {
+    pub(super) fn new(kind: FixKind, ctx: &'c LintContext<'a, 'l>) -> Self {
         Self { kind, auto_message: true, ctx }
     }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -7,7 +7,10 @@ use std::{
 
 use oxc_semantic::SymbolId;
 
-use crate::{context::LintContext, AllowWarnDeny, AstNode, FixKind, RuleEnum};
+use crate::{
+    context::{LintContext, LinterContext},
+    AllowWarnDeny, AstNode, FixKind, RuleEnum,
+};
 
 pub trait Rule: Sized + Default + fmt::Debug {
     /// Initialize from eslint json configuration
@@ -16,10 +19,10 @@ pub trait Rule: Sized + Default + fmt::Debug {
     }
 
     /// Visit each AST Node
-    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
+    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a, '_>) {}
 
     /// Visit each symbol
-    fn run_on_symbol(&self, _symbol_id: SymbolId, _ctx: &LintContext<'_>) {}
+    fn run_on_symbol(&self, _symbol_id: SymbolId, _ctx: &LintContext<'_, '_>) {}
 
     /// Run only once. Useful for inspecting scopes and trivias etc.
     fn run_once(&self, _ctx: &LintContext) {}
@@ -31,7 +34,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
     /// enabled/disabled; this is handled by the [`linter`].
     ///
     /// [`linter`]: crate::Linter
-    fn should_run(&self, _ctx: &LintContext) -> bool {
+    fn should_run(&self, _ctx: &LinterContext) -> bool {
         true
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -72,7 +72,7 @@ impl Rule for ArrayCallbackReturn {
         Self { check_for_each, allow_implicit_return }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let (function_body, always_explicit_return) = match node.kind() {
             // Async, generator, and single expression arrow functions
             // always have explicit return value
@@ -133,7 +133,7 @@ impl Rule for ArrayCallbackReturn {
 /// to the target array methods we're interested in.
 pub fn get_array_method_name<'a>(
     node: &AstNode<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<&'static str> {
     let mut current_node = node;
     while let Some(parent) = ctx.nodes().parent_node(current_node.id()) {

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ConstructorSuper {
-    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {}
+    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a, '_>) {}
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -62,7 +62,7 @@ impl Rule for DefaultCase {
         Self(Box::new(cfg))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::SwitchStatement(switch) = node.kind() {
             let cases = &switch.cases;
             if !cases.is_empty() && !cases.iter().any(|case| case.test.is_none()) {

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for DefaultCaseLast {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::SwitchStatement(switch) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for DefaultParamLast {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::Function(function) => {
                 if !function.is_declaration() && !function.is_expression() {
@@ -50,7 +50,7 @@ impl Rule for DefaultParamLast {
     }
 }
 
-fn check_params<'a>(items: &'a [FormalParameter<'a>], ctx: &LintContext<'a>) {
+fn check_params<'a>(items: &'a [FormalParameter<'a>], ctx: &LintContext<'a, '_>) {
     let mut has_seen_plain_param = false;
     for param in items.iter().rev() {
         if !param.pattern.kind.is_assignment_pattern() {

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -56,7 +56,7 @@ impl Rule for Eqeqeq {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(binary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ForDirection {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ForStatement(for_loop) = node.kind() {
             if let Some(Expression::BinaryExpression(test)) = &for_loop.test {
                 let (counter, counter_position) = match (&test.left, &test.right) {

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GetterReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // https://eslint.org/docs/latest/rules/getter-return#handled_by_typescript
         if ctx.source_type().is_typescript() {
             return;
@@ -119,7 +119,7 @@ impl GetterReturn {
     }
 
     /// Checks whether it is necessary to check the node
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+    fn is_wanted_node(node: &AstNode, ctx: &LintContext) -> bool {
         if let Some(parent) = ctx.nodes().parent_node(node.id()) {
             match parent.kind() {
                 AstKind::MethodDefinition(mdef) => {
@@ -183,7 +183,7 @@ impl GetterReturn {
         false
     }
 
-    fn run_diagnostic<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>, span: Span) {
+    fn run_diagnostic<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>, span: Span) {
         if !Self::is_wanted_node(node, ctx) {
             return;
         }

--- a/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
+++ b/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GuardForIn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ForInStatement(for_in_statement) = node.kind() {
             match &for_in_statement.body {
                 Statement::EmptyStatement(_) | Statement::IfStatement(_) => return,

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -81,7 +81,7 @@ impl Rule for MaxClassesPerFile {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let mut class_count = ctx.semantic().classes().declarations.len();
 
         if self.ignore_expressions {

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -73,7 +73,7 @@ impl Rule for MaxParams {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::Function(function) => {
                 if !function.is_declaration() & !function.is_expression() {

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoArrayConstructor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let (span, callee, arguments, type_parameters, optional) = match node.kind() {
             AstKind::CallExpression(call_expr) => (
                 call_expr.span,

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAsyncPromiseExecutor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -70,7 +70,7 @@ impl Rule for NoBitwise {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::BinaryExpression(bin_expr) => {
                 let op = bin_expr.operator.as_str();

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCaller {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::MemberExpression(MemberExpression::StaticMemberExpression(expr)) =
             node.kind()
         {

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCaseDeclarations {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::SwitchCase(switch_case) = node.kind() {
             let consequent = &switch_case.consequent;
 

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoClassAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flag(symbol_id).is_class() {
             for reference in symbol_table.get_resolved_references(symbol_id) {

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCompareNegZero {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -52,7 +52,7 @@ impl Rule for NoCondAssign {
         Self { config }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::IfStatement(stmt) => self.check_expression(ctx, &stmt.test),
             AstKind::WhileStatement(stmt) => self.check_expression(ctx, &stmt.test),
@@ -89,7 +89,7 @@ impl Rule for NoCondAssign {
 
 impl NoCondAssign {
     #[allow(clippy::cast_possible_truncation)]
-    fn emit_diagnostic(ctx: &LintContext<'_>, expr: &AssignmentExpression<'_>) {
+    fn emit_diagnostic(ctx: &LintContext, expr: &AssignmentExpression<'_>) {
         let mut operator_span = Span::new(expr.left.span().end, expr.right.span().start);
         let start =
             operator_span.source_text(ctx.source_text()).find(expr.operator.as_str()).unwrap_or(0)
@@ -100,7 +100,7 @@ impl NoCondAssign {
         ctx.diagnostic(no_cond_assign_diagnostic(operator_span));
     }
 
-    fn check_expression(&self, ctx: &LintContext<'_>, expr: &Expression<'_>) {
+    fn check_expression(&self, ctx: &LintContext, expr: &Expression<'_>) {
         let mut expr = expr;
         if self.config == NoCondAssignConfig::Always {
             expr = expr.get_inner_expression();

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -67,7 +67,7 @@ impl Rule for NoConsole {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::CallExpression(call_expr) = node.kind() {
             if let Some(mem) = call_expr.callee.as_member_expression() {
                 if let Expression::Identifier(ident) = mem.object() {

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flag(symbol_id).is_const_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -75,7 +75,7 @@ fn constant_both_always_new(span0: Span) -> OxcDiagnostic {
 }
 
 impl Rule for NoConstantBinaryExpression {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::LogicalExpression(expr) => match expr.operator {
                 LogicalOperator::Or | LogicalOperator::And if expr.left.is_constant(true, ctx) => {
@@ -146,7 +146,7 @@ impl NoConstantBinaryExpression {
     fn has_constant_nullishness<'a>(
         expr: &Expression<'a>,
         non_nullish: bool,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) -> bool {
         if non_nullish && (expr.is_null() || expr.evaluate_to_undefined()) {
             return false;
@@ -197,7 +197,7 @@ impl NoConstantBinaryExpression {
         a: &'a Expression<'a>,
         b: &'a Expression<'a>,
         operator: BinaryOperator,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) -> Option<&'a Expression<'a>> {
         match operator {
             BinaryOperator::Equality | BinaryOperator::Inequality => {
@@ -227,7 +227,7 @@ impl NoConstantBinaryExpression {
     /// `https://262.ecma-international.org/5.1/#sec-11.9.3`
     fn has_constant_loose_boolean_comparison<'a>(
         expr: &Expression<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) -> bool {
         match expr {
             Expression::ObjectExpression(_)
@@ -268,7 +268,7 @@ impl NoConstantBinaryExpression {
     /// if it is always the same boolean value.
     fn has_constant_strict_boolean_comparison<'a>(
         expr: &Expression<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) -> bool {
         match expr {
             Expression::ObjectExpression(_)
@@ -329,7 +329,7 @@ impl NoConstantBinaryExpression {
     }
 
     /// Test if an AST node will always result in a newly constructed object
-    fn is_always_new<'a>(expr: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    fn is_always_new<'a>(expr: &Expression<'a>, ctx: &LintContext<'a, '_>) -> bool {
         match expr {
             Expression::ObjectExpression(_)
             | Expression::ArrayExpression(_)

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -48,7 +48,7 @@ impl Rule for NoConstantCondition {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::IfStatement(if_stmt) => {
                 if if_stmt.test.is_constant(true, ctx) {

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstructorReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ReturnStatement(ret) = node.kind() else { return };
         if ret.argument.is_none() {
             return;

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoContinue {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ContinueStatement(continue_statement) = node.kind() {
             ctx.diagnostic(no_continue_diagnostic(Span::new(
                 continue_statement.span.start,

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoControlRegex {
-    fn run<'a>(&self, node: &AstNode<'a>, context: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, context: &LintContext<'a, '_>) {
         if let Some(RegexPatternData { pattern, flags, span }) = regex_pattern(node) {
             let mut violations: Vec<&str> = Vec::new();
 

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDebugger {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::DebuggerStatement(stmt) = node.kind() {
             ctx.diagnostic_with_fix(no_debugger_diagnostic(stmt.span), |fixer| {
                 let Some(parent) = ctx

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDeleteVar {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::UnaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDivRegex {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::RegExpLiteral(lit) = node.kind() {
             if lit.regex.pattern.starts_with('=') {
                 ctx.diagnostic_with_fix(no_div_regex_diagnostic(lit.span), |fixer| {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDupeElseIf {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // if (a) {} else if (a) {}
         //                ^^ get this if statement
         let AstKind::IfStatement(if_stmt) = node.kind() else {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDupeKeys {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ObjectExpression(obj_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::SwitchStatement(ss) = node.kind() {
             let mut map = FxHashMap::default();
             map.reserve(ss.cases.len());

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -45,7 +45,7 @@ impl Rule for NoEmpty {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::BlockStatement(block) if block.body.is_empty() => {
                 if self.allow_empty_catch

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyCharacterClass {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         lazy_static! {
             /*
             * plain-English description of the following regexp:

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyFunction {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::FunctionBody(fb) = node.kind() {
             if fb.is_empty() && !ctx.semantic().trivias().has_comments_between(fb.span) {
                 ctx.diagnostic(no_empty_function_diagnostic(fb.span));

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -75,7 +75,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyPattern {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let (pattern_type, span) = match node.kind() {
             AstKind::ArrayPattern(array) if array.is_empty() => ("array", array.span),
             AstKind::ObjectPattern(object) if object.is_empty() => ("object", object.span),

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyStaticBlock {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::StaticBlock(static_block) = node.kind() {
             if static_block.body.is_empty() {
                 if ctx.semantic().trivias().has_comments_between(static_block.span) {

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEqNull {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::BinaryExpression(binary_expression) = node.kind() {
             let bad_operator = matches!(
                 binary_expression.operator,

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -56,7 +56,7 @@ impl Rule for NoEval {
         Self { allow_indirect }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let kind = node.kind();
 
         if let AstKind::IdentifierReference(ident) = kind {

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flag(symbol_id).is_catch_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -58,7 +58,7 @@ impl Rule for NoExtraBooleanCast {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::CallExpression(expr)
                 if expr.callee.is_specific_id("Boolean")
@@ -183,7 +183,10 @@ fn is_unary_negation(node: &AstNode) -> bool {
     }
 }
 
-fn get_real_parent<'a, 'b>(node: &AstNode, ctx: &'a LintContext<'b>) -> Option<&'a AstNode<'b>> {
+fn get_real_parent<'a, 'b>(
+    node: &AstNode,
+    ctx: &'a LintContext<'b, '_>,
+) -> Option<&'a AstNode<'b>> {
     for (_, parent) in
         ctx.nodes().iter_parents(node.id()).tuple_windows::<(&AstNode<'b>, &AstNode<'b>)>()
     {

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -88,7 +88,7 @@ impl Rule for NoFallthrough {
         Self::new(comment_pattern, allow_empty_case, report_unused_fallthrough_comment)
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::SwitchStatement(switch) = node.kind() else { return };
 
         let cfg = ctx.cfg();

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFuncAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
         let decl = symbol_table.get_declaration(symbol_id);
         if let AstKind::Function(_) = ctx.nodes().kind(decl) {

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -50,7 +50,7 @@ const REFLECT_MUTATION_METHODS: phf::Set<&'static str> =
     phf_set!("defineProperty", "deleteProperty", "set", "setPrototypeOf");
 
 impl Rule for NoImportAssign {
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flag(symbol_id).is_import() {
             let kind = ctx.nodes().kind(symbol_table.get_declaration(symbol_id));
@@ -106,7 +106,7 @@ impl Rule for NoImportAssign {
 /// - `Reflect.deleteProperty`
 /// - `Reflect.set`
 /// - `Reflect.setPrototypeOf`
-fn is_argument_of_well_known_mutation_function(node_id: AstNodeId, ctx: &LintContext<'_>) -> bool {
+fn is_argument_of_well_known_mutation_function(node_id: AstNodeId, ctx: &LintContext) -> bool {
     let current_node = ctx.nodes().get_node(node_id);
     let call_expression_node =
         ctx.nodes().parent_node(node_id).and_then(|node| ctx.nodes().parent_kind(node.id()));

--- a/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inner_declarations.rs
@@ -59,7 +59,7 @@ impl Rule for NoInnerDeclarations {
         Self { config }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let span = match node.kind() {
             AstKind::VariableDeclaration(decl)
                 if decl.kind.is_var() && self.config == NoInnerDeclarationsConfig::Both =>

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIterator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::MemberExpression(member_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLabelVar {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::LabeledStatement(labeled_stmt) = node.kind() else { return };
 
         if let Some(symbol_id) =

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLossOfPrecision {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::NumericLiteral(node) if Self::lose_precision(node) => {
                 ctx.diagnostic(no_loss_of_precision_diagnostic(node.span));

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMultiStr {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::StringLiteral(literal) = node.kind() {
             let source = literal.span.source_text(ctx.source_text());
             // https://github.com/eslint/eslint/blob/9e6d6405c3ee774c2e716a3453ede9696ced1be7/lib/shared/ast-utils.js#L12

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNew {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewNativeNonconstructor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewWrappers {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNonoctalDecimalEscape {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::StringLiteral(literal) = node.kind() {
             check_string(ctx, literal.span.source_text(ctx.source_text()));
         }
@@ -82,7 +82,7 @@ fn quick_test(s: &str) -> bool {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn check_string(ctx: &LintContext<'_>, string: &str) {
+fn check_string(ctx: &LintContext, string: &str) {
     lazy_static! {
         static ref NONOCTAL_REGEX: Regex =
             Regex::new(r"(?:[^\\]|(?P<previousEscape>\\.))*?(?P<decimalEscape>\\[89])").unwrap();

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -78,7 +78,7 @@ fn global_this_member<'a>(expr: &'a MemberExpression<'_>) -> Option<&'a str> {
 fn resolve_global_binding<'a, 'b: 'a>(
     ident: &'a oxc_allocator::Box<'a, IdentifierReference<'a>>,
     scope_id: ScopeId,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<&'a str> {
     if ctx.semantic().is_reference_to_global_variable(ident) {
         Some(ident.name.as_str())
@@ -127,7 +127,7 @@ fn resolve_global_binding<'a, 'b: 'a>(
 }
 
 impl Rule for NoObjCalls {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         #[allow(clippy::needless_return)]
         let (callee, span) = match node.kind() {
             AstKind::NewExpression(expr) => (&expr.callee, expr.span),

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoProto {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::MemberExpression(member_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 const DISALLOWED_PROPS: &[&str; 3] = &["hasOwnProperty", "isPrototypeOf", "propertyIsEnumerable"];
 
 impl Rule for NoPrototypeBuiltins {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoRegexSpaces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::RegExpLiteral(lit) => {
                 if let Some(span) = Self::find_literal_to_report(lit) {

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -79,7 +79,7 @@ impl Rule for NoRestrictedGlobals {
         Self { restricted_globals: Box::new(list) }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::IdentifierReference(ident) = node.kind() {
             let Some(message) = self.restricted_globals.get(ident.name.as_str()) else {
                 return;

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoScriptUrl {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::StringLiteral(literal)
                 if literal.value.to_lowercase().starts_with("javascript:") =>

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -58,7 +58,7 @@ impl Rule for NoSelfAssign {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::AssignmentExpression(assignment) = node.kind() else {
             return;
         };
@@ -79,7 +79,7 @@ impl NoSelfAssign {
         &self,
         left: &'a AssignmentTarget<'a>,
         right: &'a Expression<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         match left {
             match_simple_assignment_target!(AssignmentTarget) => {
@@ -225,7 +225,7 @@ impl NoSelfAssign {
         &self,
         left: &'a AssignmentTargetProperty<'a>,
         right: &'a ObjectPropertyKind<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         match left {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(id1)

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSelfCompare {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(binary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSetterReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ReturnStatement(stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoShadowRestrictedNames {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         ctx.symbols().iter().for_each(|symbol_id| {
             let name = ctx.symbols().get_name(symbol_id);
 

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSparseArrays {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ArrayExpression(array_expr) = node.kind() {
             let violations = array_expr
                 .elements

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTemplateCurlyInString {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::StringLiteral(literal) = node.kind() {
             let text = literal.value.as_str();
             if let Some(start_index) = text.find("${") {

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTernary {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ConditionalExpression(cond_expr) = node.kind() {
             ctx.diagnostic(no_ternary_diagnostic(Span::new(
                 cond_expr.span.start,

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -131,7 +131,7 @@ impl Rule for NoThisBeforeSuper {
 }
 
 impl NoThisBeforeSuper {
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+    fn is_wanted_node(node: &AstNode, ctx: &LintContext) -> bool {
         if let Some(parent) = ctx.nodes().parent_node(node.id()) {
             if let AstKind::MethodDefinition(mdef) = parent.kind() {
                 if matches!(mdef.kind, MethodDefinitionKind::Constructor) {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -73,7 +73,7 @@ impl Rule for NoUndef {
     }
 }
 
-fn has_typeof_operator(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn has_typeof_operator(node: &AstNode<'_>, ctx: &LintContext) -> bool {
     ctx.nodes().parent_node(node.id()).map_or(false, |parent| match parent.kind() {
         AstKind::UnaryExpression(expr) => expr.operator == UnaryOperator::Typeof,
         AstKind::ParenthesizedExpression(_) => has_typeof_operator(parent, ctx),

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -66,7 +66,7 @@ fn diagnostic_undefined_keyword(name: &str, span0: Span, ctx: &LintContext) {
 }
 
 impl Rule for NoUndefined {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::IdentifierReference(ident) => {
                 diagnostic_undefined_keyword(ident.name.as_str(), ident.span, ctx);

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeFinally {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let kind = node.kind();
 
         let sentinel_node_type = match kind {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -52,7 +52,7 @@ impl Rule for NoUnsafeNegation {
         Self { enforce_for_ordering_relations }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };
@@ -74,12 +74,12 @@ impl NoUnsafeNegation {
 
     /// Precondition:
     /// expr.left is `UnaryExpression` whose operator is '!'
-    fn report_with_fix<'a>(expr: &BinaryExpression, ctx: &LintContext<'a>) {
+    fn report_with_fix<'a>(expr: &BinaryExpression, ctx: &LintContext<'a, '_>) {
         use oxc_codegen::{Context, Gen};
         // Diagnostic points at the unexpected negation
         let diagnostic = no_unsafe_negation_diagnostic(expr.operator.as_str(), expr.left.span());
 
-        let fix_producer = |fixer: RuleFixer<'_, 'a>| {
+        let fix_producer = |fixer: RuleFixer<'_, '_, 'a>| {
             // modify `!a instance of B` to `!(a instanceof B)`
             let modified_code = {
                 let mut codegen = fixer.codegen();

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -63,7 +63,7 @@ impl Rule for NoUnsafeOptionalChaining {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::CallExpression(expr) if !expr.optional => {
                 Self::check_unsafe_usage(&expr.callee, ctx);
@@ -135,11 +135,11 @@ enum ErrorType {
 }
 
 impl NoUnsafeOptionalChaining {
-    fn check_unsafe_usage<'a>(expr: &Expression<'a>, ctx: &LintContext<'a>) {
+    fn check_unsafe_usage<'a>(expr: &Expression<'a>, ctx: &LintContext<'a, '_>) {
         Self::check_undefined_short_circuit(expr, ErrorType::Usage, ctx);
     }
 
-    fn check_unsafe_arithmetic<'a>(&self, expr: &Expression<'a>, ctx: &LintContext<'a>) {
+    fn check_unsafe_arithmetic<'a>(&self, expr: &Expression<'a>, ctx: &LintContext<'a, '_>) {
         if self.disallow_arithmetic_operators {
             Self::check_undefined_short_circuit(expr, ErrorType::Arithmetic, ctx);
         }
@@ -148,7 +148,7 @@ impl NoUnsafeOptionalChaining {
     fn check_undefined_short_circuit<'a>(
         expr: &Expression<'a>,
         error_type: ErrorType,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         match expr.get_inner_expression() {
             Expression::LogicalExpression(expr) => match expr.operator {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -15,7 +15,10 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ScopeFlags, SymbolFlags, SymbolId};
 use oxc_span::GetSpan;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+};
 use options::NoUnusedVarsOptions;
 
 use symbol::Symbol;
@@ -152,7 +155,7 @@ impl Rule for NoUnusedVars {
         Self(Box::new(NoUnusedVarsOptions::from(value)))
     }
 
-    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol = Symbol::new(ctx.semantic().as_ref(), symbol_id);
         if Self::should_skip_symbol(&symbol) {
             return;
@@ -161,7 +164,7 @@ impl Rule for NoUnusedVars {
         self.run_on_symbol_internal(&symbol, ctx);
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         // ignore .d.ts and vue files.
         // 1. declarations have side effects (they get merged together)
         // 2. vue scripts declare variables that get used in the template, which
@@ -172,7 +175,7 @@ impl Rule for NoUnusedVars {
 }
 
 impl NoUnusedVars {
-    fn run_on_symbol_internal<'a>(&self, symbol: &Symbol<'_, 'a>, ctx: &LintContext<'a>) {
+    fn run_on_symbol_internal<'a>(&self, symbol: &Symbol<'_, 'a>, ctx: &LintContext<'a, '_>) {
         let is_ignored = self.is_ignored(symbol);
 
         if is_ignored && !self.report_used_ignore_pattern {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessCatch {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TryStatement(try_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessConcat {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(binary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -81,7 +81,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessConstructor {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::MethodDefinition(constructor) = node.kind() else {
             return;
         };
@@ -123,7 +123,7 @@ impl Rule for NoUselessConstructor {
 
 // Check for an empty constructor in a class without a superclass.
 fn lint_empty_constructor<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     constructor: &MethodDefinition<'a>,
     body: &FunctionBody<'a>,
 ) {
@@ -149,7 +149,7 @@ fn lint_empty_constructor<'a>(
 }
 
 fn lint_redundant_super_call<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     constructor: &MethodDefinition<'a>,
     body: &FunctionBody<'a>,
 ) {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessEscape {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::RegExpLiteral(literal)
                 if literal.regex.pattern.len() + literal.regex.flags.iter().count()
@@ -72,7 +72,7 @@ fn is_within_jsx_attribute_item(id: AstNodeId, ctx: &LintContext) -> bool {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn check(ctx: &LintContext<'_>, node_id: AstNodeId, start: u32, offsets: &[usize]) {
+fn check(ctx: &LintContext, node_id: AstNodeId, start: u32, offsets: &[usize]) {
     let source_text = ctx.source_text();
     for offset in offsets {
         let offset = start as usize + offset;

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -80,7 +80,7 @@ impl Rule for NoUselessRename {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::ObjectPattern(object_pattern) => {
                 if self.ignore_destructuring {

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoVar {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::VariableDeclaration(dec) = node.kind() {
             if dec.kind == VariableDeclarationKind::Var {
                 ctx.diagnostic(no_var_diagnostic(Span::new(dec.span.start, dec.span.start + 3)));

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -49,7 +49,7 @@ impl Rule for NoVoid {
         Self { allow_as_statement }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::UnaryExpression(unary_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWith {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::WithStatement(with_statement) = node.kind() {
             ctx.diagnostic(no_with_diagnostic(Span::new(
                 with_statement.span.start,

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferExponentiationOperator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNumericLiterals {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::CallExpression(call_expr) = node.kind() {
             match &call_expr.callee.without_parenthesized() {
                 Expression::Identifier(ident) if ident.name == "parseInt" => {
@@ -111,7 +111,7 @@ fn is_parse_int_call(
     get_symbol_id_of_variable(ident, ctx).is_none()
 }
 
-fn check_arguments<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
+fn check_arguments<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a, '_>) {
     if call_expr.arguments.len() != 2 {
         return;
     }

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -65,7 +65,7 @@ impl Rule for Radix {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::CallExpression(call_expr) = node.kind() {
             match &call_expr.callee.without_parenthesized() {
                 Expression::Identifier(ident) if ident.name == "parseInt" => {

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireAwait {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::FunctionBody(body) = node.kind() {
             if body.is_empty() {
                 return;

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireYield {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::Function(func) = node.kind() {
             if !node.flags().has_yield()
                 && func.generator

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for SymbolDescription {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -78,7 +78,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for UseIsnan {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::BinaryExpression(expr) if expr.operator.is_compare() => {
                 if is_nan_identifier(&expr.left) {
@@ -176,7 +176,7 @@ fn is_target_callee<'a>(callee: &'a Expression<'a>) -> Option<&'static str> {
 fn make_equality_fix<'a>(
     nan_on_left: bool,
     comparison: &BinaryExpression<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> String {
     let non_nan = if nan_on_left {
         comparison.right.span().source_text(ctx.source_text())

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ValidTypeof {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // match on `typeof` unary expression for better performance
         let _unary_expr = match node.kind() {
             AstKind::UnaryExpression(unary_expr)

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Default {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         for import_entry in &module_record.import_entries {
             let ImportImportName::Default(default_span) = import_entry.import_name else {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Export {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         let named_export = &module_record.exported_bindings;
 

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -83,7 +83,7 @@ impl Rule for MaxDependencies {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         let mut module_count = module_record.import_entries.len();
 

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Named {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let semantic = ctx.semantic();
 
         // This rule is disabled in the typescript config.

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -59,7 +59,7 @@ impl Rule for Namespace {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         module_record.import_entries.iter().for_each(|entry| {
             let (source, module) = match &entry.import_name {
@@ -211,7 +211,7 @@ fn check_deep_namespace_for_node(
     source: &str,
     namespaces: &[String],
     module: &Arc<ModuleRecord>,
-    ctx: &LintContext<'_>,
+    ctx: &LintContext,
 ) {
     if let AstKind::MemberExpression(expr) = node.kind() {
         let Some((span, name)) = expr.static_property_info() else {
@@ -255,7 +255,7 @@ fn check_deep_namespace_for_object_pattern(
     source: &str,
     namespaces: &[String],
     module: &Arc<ModuleRecord>,
-    ctx: &LintContext<'_>,
+    ctx: &LintContext,
 ) {
     for property in &pattern.properties {
         let Some(name) = property.key.name() else {
@@ -300,7 +300,7 @@ fn check_binding_exported(
     name: &str,
     get_diagnostic: impl FnOnce() -> OxcDiagnostic,
     module: &ModuleRecord,
-    ctx: &LintContext<'_>,
+    ctx: &LintContext,
 ) {
     if module.exported_bindings.contains_key(name)
         || (name == "default" && module.export_default.is_some())

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-amd.js>
 impl Rule for NoAmd {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // not in top level
         if node.scope_id() != ctx.scopes().root_scope_id() {
             return;

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -96,7 +96,7 @@ impl Rule for NoCycle {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
 
         let needle = &module_record.resolved_absolute_path;

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDefaultExport {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         write_diagnostic_optional(ctx, module_record.export_default);
         module_record.export_default_duplicated.iter().for_each(|it| write_diagnostic(ctx, *it));
@@ -48,10 +48,10 @@ impl Rule for NoDefaultExport {
     }
 }
 
-fn write_diagnostic(ctx: &LintContext<'_>, span: Span) {
+fn write_diagnostic(ctx: &LintContext, span: Span) {
     ctx.diagnostic(no_default_export_diagnostic(span));
 }
-fn write_diagnostic_optional(ctx: &LintContext<'_>, span_option: Option<Span>) {
+fn write_diagnostic_optional(ctx: &LintContext, span_option: Option<Span>) {
     if let Some(span) = span_option {
         write_diagnostic(ctx, span);
     }

--- a/crates/oxc_linter/src/rules/import/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/import/no_deprecated.rs
@@ -2,7 +2,7 @@ use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
 // use oxc_span::{CompactStr, Span};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::{LintContext, LinterContext}, rule::Rule};
 
 // #[derive(Debug, Error, Diagnostic)]
 // #[error("")]
@@ -22,7 +22,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDeprecated {
-    fn run_once(&self, _ctx: &LintContext<'_>) {}
+    fn run_once(&self, _ctx: &LintContext) {}
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -29,7 +29,7 @@ impl Rule for NoDuplicates {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
 
         let groups = module_record

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNamedAsDefault {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         for import_entry in &module_record.import_entries {
             let ImportImportName::Default(import_span) = &import_entry.import_name else {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -45,17 +45,14 @@ declare_oxc_lint!(
     NoNamedAsDefaultMember,
     suspicious
 );
-fn get_symbol_id_from_ident(
-    ctx: &LintContext<'_>,
-    ident: &IdentifierReference,
-) -> Option<SymbolId> {
+fn get_symbol_id_from_ident(ctx: &LintContext, ident: &IdentifierReference) -> Option<SymbolId> {
     let reference_id = ident.reference_id.get().unwrap();
     let reference = &ctx.symbols().references[reference_id];
     reference.symbol_id()
 }
 
 impl Rule for NoNamedAsDefaultMember {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
 
         let mut has_members_map = FxHashMap::default();

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSelfImport {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         let resolved_absolute_path = &module_record.resolved_absolute_path;
         for (request, requested_modules) in &module_record.requested_modules {

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -1,7 +1,7 @@
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::{LintContext, LinterContext}, rule::Rule};
 
 fn no_exports_found(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No exports found")
@@ -41,7 +41,7 @@ impl Rule for NoUnusedModules {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         if self.missing_exports && module_record.local_export_entries.is_empty() {
             ctx.diagnostic(no_exports_found(Span::new(0, 0)));

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWebpackLoaderSyntax {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // not in top level
         if node.scope_id() != ctx.scopes().root_scope_id() {
             return;

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -207,7 +207,7 @@ impl ConsistentTestIt {
         &self,
         describe_nesting_hash: &mut FxHashMap<ScopeId, i32>,
         possible_jest_node: &PossibleJestNode<'a, '_>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -118,7 +118,7 @@ impl Rule for ExpectExpect {
 fn run<'a>(
     rule: &ExpectExpect,
     possible_jest_node: &PossibleJestNode<'a, '_>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
@@ -159,7 +159,7 @@ fn check_arguments<'a>(
     call_expr: &'a CallExpression<'a>,
     assert_function_names: &[String],
     visited: &mut FxHashSet<Span>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> bool {
     for argument in &call_expr.arguments {
         if let Some(expr) = argument.as_expression() {
@@ -175,7 +175,7 @@ fn check_assert_function_used<'a>(
     expr: &'a Expression<'a>,
     assert_function_names: &[String],
     visited: &mut FxHashSet<Span>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> bool {
     // If we have visited this node before and didn't find any assert function, we can return
     // `false` to avoid infinite loop.
@@ -246,7 +246,7 @@ fn check_statements<'a>(
     statements: &'a oxc_allocator::Vec<Statement<'a>>,
     assert_function_names: &[String],
     visited: &mut FxHashSet<Span>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> bool {
     statements.iter().any(|statement| {
         if let Statement::ExpressionStatement(expr_stmt) = statement {

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -90,7 +90,7 @@ impl MaxExpects {
         &self,
         jest_node: &PossibleJestNode<'a, '_>,
         count_map: &mut FxHashMap<usize, usize>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -143,7 +143,7 @@ impl MaxNestedDescribe {
         &self,
         possible_jest_node: &PossibleJestNode<'a, '_>,
         describes_hooks_depth: &mut Vec<ScopeId>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = possible_jest_node.node;
         let scope_id = node.scope_id();

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -65,7 +65,7 @@ impl Rule for NoAliasMethods {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
         if let Some(jest_fn_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx) {

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -77,7 +77,7 @@ impl Rule for NoConditionalExpect {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
         let Some(jest_fn_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)
@@ -100,7 +100,7 @@ fn check_parents<'a>(
     node: &AstNode<'a>,
     visited: &mut FxHashSet<AstNodeId>,
     in_conditional: InConditional,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> InConditional {
     // if the node is already visited, we should return `false` to avoid infinite loop.
     if !visited.insert(node.id()) {

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -146,7 +146,7 @@ fn collect_jest_reference_id(
 }
 
 fn handle_jest_set_time_out<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     reference_id_list: impl Iterator<Item = ReferenceId>,
     jest_reference_id_list: &Vec<(ReferenceId, Span)>,
     seen_jest_set_timeout: &mut bool,
@@ -199,7 +199,7 @@ fn handle_jest_set_time_out<'a>(
 fn is_jest_fn_call<'a>(
     parent_node: &AstNode<'a>,
     id_to_jest_node_map: &HashMap<AstNodeId, &PossibleJestNode<'a, '_>>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> bool {
     let mut id = parent_node.id();
     loop {

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -106,7 +106,7 @@ impl Rule for NoDeprecatedFunctions {
         }))
     }
 
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::MemberExpression(mem_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -97,7 +97,7 @@ impl Rule for NoDisabledTests {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
         if let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) {

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -84,7 +84,7 @@ impl Rule for NoDoneCallback {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
         if let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) {

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -121,7 +121,7 @@ impl NoDuplicateHooks {
         possible_jest_node: &PossibleJestNode<'a, '_>,
         root_node_id: AstNodeId,
         hook_contexts: &mut HashMap<AstNodeId, Vec<HashMap<String, i32>>>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -72,7 +72,7 @@ impl Rule for NoFocusedTests {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return;

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -102,7 +102,7 @@ impl Rule for NoHooks {
 }
 
 impl NoHooks {
-    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -128,7 +128,7 @@ impl Rule for NoIdenticalTitle {
 fn filter_and_process_jest_result<'a>(
     call_expr: &'a CallExpression<'a>,
     possible_jest_node: &PossibleJestNode<'a, '_>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<(Span, &'a str, JestFnKind, AstNodeId)> {
     let result = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx)?;
     let kind = result.kind;

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -62,7 +62,7 @@ impl Rule for NoInterpolationInSnapshots {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return;

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -64,7 +64,7 @@ impl Rule for NoJasmineGlobals {
         }
     }
 
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::AssignmentExpression(assign_expr) = node.kind() {
             diagnostic_assign_expr(assign_expr, ctx);
         } else if let AstKind::CallExpression(call_expr) = node.kind() {

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -174,7 +174,7 @@ impl Rule for NoLargeSnapshots {
 }
 
 impl NoLargeSnapshots {
-    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -96,7 +96,7 @@ impl NoRestrictedJestMethods {
         self.restricted_jest_methods.get(name).cloned()
     }
 
-    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -88,7 +88,7 @@ impl Rule for NoRestrictedMatchers {
         }))
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         for possible_jest_node in &collect_possible_jest_call_node(ctx) {
             self.run(possible_jest_node, ctx);
         }
@@ -96,7 +96,7 @@ impl Rule for NoRestrictedMatchers {
 }
 
 impl NoRestrictedMatchers {
-    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -74,7 +74,7 @@ impl Rule for NoStandaloneExpect {
         Self(Box::new(NoStandaloneExpectConfig { additional_test_block_functions }))
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let possible_jest_nodes = collect_possible_jest_call_node(ctx);
         let id_nodes_mapping = possible_jest_nodes.iter().fold(HashMap::new(), |mut acc, cur| {
             acc.entry(cur.node.id()).or_insert(cur);
@@ -92,7 +92,7 @@ impl NoStandaloneExpect {
         &self,
         possible_jest_node: &PossibleJestNode<'a, '_>,
         id_nodes_mapping: &HashMap<AstNodeId, &PossibleJestNode<'a, '_>>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
@@ -130,7 +130,7 @@ fn is_correct_place_to_call_expect<'a>(
     node: &AstNode<'a>,
     additional_test_block_functions: &[String],
     id_nodes_mapping: &HashMap<AstNodeId, &PossibleJestNode<'a, '_>>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<()> {
     let mut parent = ctx.nodes().parent_node(node.id())?;
 
@@ -198,7 +198,7 @@ fn is_var_declarator_or_test_block<'a>(
     node: &AstNode<'a>,
     additional_test_block_functions: &[String],
     id_nodes_mapping: &HashMap<AstNodeId, &PossibleJestNode<'a, '_>>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> bool {
     match node.kind() {
         AstKind::VariableDeclarator(_) => return true,

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -64,7 +64,7 @@ impl Rule for NoTestPrefixes {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return;

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTestReturnStatement {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 check_call_expression(call_expr, node, ctx);
@@ -59,7 +59,7 @@ impl Rule for NoTestReturnStatement {
 fn check_call_expression<'a>(
     call_expr: &'a CallExpression<'a>,
     node: &AstNode<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     if !is_type_of_jest_fn_call(
         call_expr,
@@ -89,7 +89,10 @@ fn check_call_expression<'a>(
     }
 }
 
-fn check_test_return_statement<'a>(func_body: &OBox<'_, FunctionBody<'a>>, ctx: &LintContext<'a>) {
+fn check_test_return_statement<'a>(
+    func_body: &OBox<'_, FunctionBody<'a>>,
+    ctx: &LintContext<'a, '_>,
+) {
     let Some(return_stmt) =
         func_body.statements.iter().find(|stmt| matches!(stmt, Statement::ReturnStatement(_)))
     else {

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -91,7 +91,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUntypedMockFactory {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         if !ctx.source_type().is_typescript() {
             return;
         }
@@ -103,7 +103,7 @@ impl Rule for NoUntypedMockFactory {
 }
 
 impl NoUntypedMockFactory {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferCalledWith {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         for possible_jest_node in &collect_possible_jest_call_node(ctx) {
             Self::run(possible_jest_node, ctx);
         }
@@ -56,7 +56,7 @@ impl Rule for PreferCalledWith {
 }
 
 impl PreferCalledWith {
-    pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -67,7 +67,7 @@ impl Rule for PreferComparisonMatcher {
 }
 
 impl PreferComparisonMatcher {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -178,7 +178,7 @@ impl PreferComparisonMatcher {
         local_name: &str,
         modifiers: &[&KnownMemberExpressionProperty<'a>],
         prefer_matcher_name: &str,
-        fixer: RuleFixer<'_, 'a>,
+        fixer: RuleFixer<'_, '_, 'a>,
     ) -> String {
         let mut content = fixer.codegen();
         content.print_str(local_name);

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -53,7 +53,7 @@ impl Rule for PreferEqualityMatcher {
 }
 
 impl PreferEqualityMatcher {
-    pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -83,7 +83,7 @@ impl Rule for PreferExpectResolves {
 }
 
 impl PreferExpectResolves {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -112,7 +112,7 @@ impl PreferExpectResolves {
     }
 
     fn fix<'c, 'a: 'c>(
-        fixer: RuleFixer<'c, 'a>,
+        fixer: RuleFixer<'c, '_, 'a>,
         jest_expect_fn_call: &ParsedExpectFnCall<'a>,
         call_expr: &CallExpression<'a>,
         ident_span: Span,

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -164,7 +164,7 @@ impl PreferHooksInOrder {
         previous_hook_index: &mut i32,
         possible_jest_node: &PossibleJestNode<'a, '_>,
         call_expr: &'a CallExpression<'_>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let Some(ParsedJestFnCallNew::GeneralJestFnCall(jest_fn_call)) =
             parse_jest_fn_call(call_expr, possible_jest_node, ctx)

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -155,7 +155,7 @@ impl PreferHooksOnTop {
     fn run<'a>(
         possible_jest_node: &PossibleJestNode<'a, '_>,
         hooks_context: &mut HashMap<ScopeId, bool>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title.rs
@@ -168,7 +168,7 @@ impl Rule for PreferLowercaseTitle {
 }
 
 impl PreferLowercaseTitle {
-    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -230,7 +230,7 @@ impl PreferLowercaseTitle {
         ignores
     }
 
-    fn lint_string<'a>(&self, ctx: &LintContext<'a>, literal: &'a str, span: Span) {
+    fn lint_string<'a>(&self, ctx: &LintContext<'a, '_>, literal: &'a str, span: Span) {
         if literal.is_empty() || self.allowed_prefixes.iter().any(|name| literal.starts_with(name))
         {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferMockPromiseShorthand {
-    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -128,7 +128,7 @@ impl PreferMockPromiseShorthand {
         property_span: Span,
         arg_span: Option<Span>,
         arg_expr: &'a Expression<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let Expression::CallExpression(call_expr) = arg_expr else {
             return;
@@ -163,7 +163,7 @@ impl PreferMockPromiseShorthand {
     }
 
     fn fix<'a>(
-        fixer: RuleFixer<'_, 'a>,
+        fixer: RuleFixer<'_, '_, 'a>,
         prefer_name: &'a str,
         call_expr: &CallExpression<'a>,
     ) -> String {

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferSpyOn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::AssignmentExpression(assign_expr) = node.kind() else {
             return;
         };
@@ -93,7 +93,7 @@ impl PreferSpyOn {
         call_expr: &'a CallExpression<'a>,
         left_assign: &MemberExpression,
         node: &AstNode<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let Some(jest_fn_call) =
             parse_general_jest_fn_call(call_expr, &PossibleJestNode { node, original: None }, ctx)
@@ -136,7 +136,7 @@ impl PreferSpyOn {
         call_expr: &'a CallExpression<'a>,
         left_assign: &MemberExpression,
         has_mock_implementation: bool,
-        fixer: RuleFixer<'_, 'a>,
+        fixer: RuleFixer<'_, '_, 'a>,
     ) -> String {
         let mut formatter = fixer.codegen();
         formatter.print_str("jest.spyOn(");

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -46,7 +46,7 @@ impl Rule for PreferStrictEqual {
 }
 
 impl PreferStrictEqual {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -86,7 +86,7 @@ impl Rule for PreferToBe {
 }
 
 impl PreferToBe {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -61,7 +61,7 @@ impl Rule for PreferToContain {
 }
 
 impl PreferToContain {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -62,7 +62,7 @@ impl Rule for PreferToHaveLength {
 }
 
 impl PreferToHaveLength {
-    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -122,7 +122,7 @@ impl PreferToHaveLength {
         parsed_expect_call: &ParsedExpectFnCall<'a>,
         kind: Option<&str>,
         property_name: Option<&str>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let Some(argument) = expr_call_expr.arguments.first() else {
             return;
@@ -154,7 +154,7 @@ impl PreferToHaveLength {
     }
 
     fn build_code<'a>(
-        fixer: RuleFixer<'_, 'a>,
+        fixer: RuleFixer<'_, '_, 'a>,
         mem_expr: &MemberExpression<'a>,
         kind: Option<&str>,
         property_name: Option<&str>,

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -57,7 +57,7 @@ impl Rule for PreferTodo {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
         let counts = call_expr.arguments.len();
@@ -135,7 +135,7 @@ fn is_empty_function(expr: &CallExpression) -> bool {
     }
 }
 
-fn build_code<'a>(fixer: RuleFixer<'_, 'a>, expr: &CallExpression<'a>) -> RuleFix<'a> {
+fn build_code<'a>(fixer: RuleFixer<'_, '_, 'a>, expr: &CallExpression<'a>) -> RuleFix<'a> {
     let mut formatter = fixer.codegen();
 
     match &expr.callee {

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -161,7 +161,7 @@ impl Rule for RequireHook {
         Self(Box::new(RequireHookConfig { allowed_function_calls }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let kind = node.kind();
 
         if let AstKind::Program(program) = kind {
@@ -199,14 +199,14 @@ impl RequireHook {
         &self,
         node: &AstNode<'a>,
         statements: &'a OxcVec<'a, Statement<'_>>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         for stmt in statements {
             self.check(node, stmt, ctx);
         }
     }
 
-    fn check<'a>(&self, node: &AstNode<'a>, stmt: &'a Statement<'_>, ctx: &LintContext<'a>) {
+    fn check<'a>(&self, node: &AstNode<'a>, stmt: &'a Statement<'_>, ctx: &LintContext<'a, '_>) {
         if let Statement::ExpressionStatement(expr_stmt) = stmt {
             self.check_should_report_in_hook(node, &expr_stmt.expression, ctx);
         } else if let Statement::VariableDeclaration(var_decl) = stmt {
@@ -227,7 +227,7 @@ impl RequireHook {
         &self,
         node: &AstNode<'a>,
         expr: &'a Expression<'a>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         if let Expression::CallExpression(call_expr) = expr {
             let name: String = get_node_name(&call_expr.callee);

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -54,7 +54,7 @@ impl Rule for RequireToThrowMessage {
 }
 
 impl RequireToThrowMessage {
-    pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -134,7 +134,7 @@ impl RequireTopLevelDescribe {
         &self,
         possible_jest_node: &PossibleJestNode<'a, '_>,
         describe_contexts: &mut HashMap<ScopeId, usize>,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         let node = possible_jest_node.node;
         let scopes = ctx.scopes();

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -83,7 +83,7 @@ impl Rule for ValidDescribeCallback {
     }
 }
 
-fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
     let node = possible_jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return;

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -123,7 +123,7 @@ impl Rule for ValidExpect {
 }
 
 impl ValidExpect {
-    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -231,7 +231,7 @@ impl ValidExpect {
 
 fn find_top_most_member_expression<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> Option<&'b MemberExpression<'a>> {
     let mut top_most_member_expression = None;
     let mut node = node;
@@ -257,7 +257,7 @@ fn find_top_most_member_expression<'a, 'b>(
 fn is_acceptable_return_node<'a, 'b>(
     node: &'b AstNode<'a>,
     allow_return: bool,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> bool {
     let mut node = node;
     loop {
@@ -288,7 +288,7 @@ type ParentAndIsFirstItem<'a, 'b> = (&'b AstNode<'a>, bool);
 // and return whether the first item if parent is an array.
 fn get_parent_with_ignore<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> Option<ParentAndIsFirstItem<'a, 'b>> {
     let mut node = node;
     loop {
@@ -321,7 +321,7 @@ fn get_parent_with_ignore<'a, 'b>(
 
 fn find_promise_call_expression_node<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
     default_node: &'b AstNode<'a>,
 ) -> Option<&'b AstNode<'a>> {
     let Some((mut parent, is_first_array_item)) = get_parent_with_ignore(node, ctx) else {
@@ -359,7 +359,7 @@ fn find_promise_call_expression_node<'a, 'b>(
 
 fn get_parent_if_thenable<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> &'b AstNode<'a> {
     let grandparent =
         ctx.nodes().parent_node(node.id()).and_then(|node| ctx.nodes().parent_node(node.id()));

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -112,7 +112,7 @@ impl Rule for ValidTitle {
 }
 
 impl ValidTitle {
-    fn run<'a>(&self, possible_jest_fn_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, possible_jest_fn_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a, '_>) {
         let node = possible_jest_fn_node.node;
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -53,7 +53,10 @@ declare_oxc_lint!(
     correctness
 );
 
-fn is_function_inside_of_class<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_function_inside_of_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a, '_>,
+) -> bool {
     let mut current_node = node;
     while let Some(parent_node) = ctx.nodes().parent_node(current_node.id()) {
         match parent_node.kind() {
@@ -70,7 +73,7 @@ fn is_function_inside_of_class<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintConte
 }
 
 impl Rule for ImplementsOnClasses {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -58,7 +58,7 @@ impl Rule for NoDefaults {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -102,7 +102,7 @@ impl Rule for RequireParam {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => collect_params(&func.params),

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireParamDescription {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => collect_params(&func.params),

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireParamName {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireParamType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
             AstKind::Function(func) if !func.is_typescript_syntax() => collect_params(&func.params),

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireReturnsDescription {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireReturnsType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !is_function_node(node) {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -95,7 +95,7 @@ impl Rule for RequireYields {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let config = &self.0;
 
         // This rule checks generator function should have JSDoc `@yields` tag.

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -167,7 +167,7 @@ impl Rule for AltText {
         Self(Box::new(alt_text))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };
@@ -246,7 +246,7 @@ fn aria_label_has_value<'a>(item: &'a JSXAttributeItem<'a>) -> bool {
     }
 }
 
-fn img_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a>) {
+fn img_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a, '_>) {
     if let Some(alt_prop) = has_jsx_prop_ignore_case(node, "alt") {
         if !is_valid_alt_prop(alt_prop) {
             ctx.diagnostic(missing_alt_value(node.span));
@@ -279,7 +279,7 @@ fn img_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a>) {
 fn object_rule<'a>(
     node: &'a JSXOpeningElement<'a>,
     parent: &'a JSXElement<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     let has_aria_label =
         has_jsx_prop_ignore_case(node, "aria-label").map_or(false, aria_label_has_value);
@@ -296,7 +296,7 @@ fn object_rule<'a>(
     ctx.diagnostic(object(node.span));
 }
 
-fn area_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a>) {
+fn area_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a, '_>) {
     let has_aria_label =
         has_jsx_prop_ignore_case(node, "aria-label").map_or(false, aria_label_has_value);
     let has_aria_labelledby =
@@ -317,7 +317,7 @@ fn area_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a>) {
     );
 }
 
-fn input_type_image_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a>) {
+fn input_type_image_rule<'a>(node: &'a JSXOpeningElement<'a>, ctx: &LintContext<'a, '_>) {
     let has_aria_label =
         has_jsx_prop_ignore_case(node, "aria-label").map_or(false, aria_label_has_value);
     let has_aria_labelledby =

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AnchorHasContent {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             let Some(name) = &get_element_type(ctx, &jsx_el.opening_element) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -124,7 +124,7 @@ impl Rule for AnchorIsValid {
         Self(Box::new(AnchorIsValidConfig { valid_hrefs }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             let JSXElementName::Identifier(ident) = &jsx_el.opening_element.name else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AriaActivedescendantHasTabindex {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AriaProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) = node.kind() {
             let name = get_jsx_attribute_name(&attr.name).to_lowercase();
             if name.starts_with("aria-") && !VALID_ARIA_PROPS.contains(&name) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -116,7 +116,7 @@ impl Rule for AriaRole {
         Self(Box::new(AriaRoleConfig { ignore_non_dom, allowed_invalid_roles }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             if let Option::Some(aria_role) = has_jsx_prop(&jsx_el.opening_element, "role") {
                 let Some(element_type) = get_element_type(ctx, &jsx_el.opening_element) else {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -40,7 +40,7 @@ fn aria_unsupported_elements_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic 
 }
 
 impl Rule for AriaUnsupportedElements {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(el_type) = get_element_type(ctx, jsx_el) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -174,7 +174,7 @@ impl Rule for AutocompleteValid {
         Self(Box::new(AutocompleteValidConfig { input_components }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(name) = &get_element_type(ctx, jsx_el) else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ClickEventsHaveKeyEvents {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -79,7 +79,7 @@ impl Rule for HeadingHasContent {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for HtmlHasLang {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -58,7 +58,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for IframeHasTitle {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -104,7 +104,7 @@ impl Rule for ImgRedundantAlt {
         Self(Box::new(img_redundant_alt))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -58,7 +58,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Lang {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -87,7 +87,7 @@ impl Rule for MediaHasCaption {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -94,7 +94,7 @@ impl Rule for MouseEventsHaveKeyEvents {
         Self(Box::new(config))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAccessKey {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAriaHiddenOnFocusable {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -87,7 +87,7 @@ impl Rule for NoAutofocus {
         no_focus
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXElement(jsx_el) = node.kind() {
             if let Option::Some(autofocus) = has_jsx_prop(&jsx_el.opening_element, "autoFocus") {
                 let Some(element_type) = get_element_type(ctx, &jsx_el.opening_element) else {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDistractingElements {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -51,7 +51,7 @@ static DEFAULT_ROLE_EXCEPTIONS: phf::Map<&'static str, &'static str> = phf_map! 
 };
 
 impl Rule for NoRedundantRoles {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             if let Some(component) = get_element_type(ctx, jsx_el) {
                 if let Some(JSXAttributeItem::Attribute(attr)) =

--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -48,7 +48,7 @@ impl PreferTagOverRole {
         role_prop: &JSXAttributeItem<'a>,
         role_to_tag: &phf::Map<&str, &str>,
         jsx_name: &str,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
     ) {
         if let JSXAttributeItem::Attribute(attr) = role_prop {
             if let Some(JSXAttributeValue::StringLiteral(role_values)) = &attr.value {
@@ -87,7 +87,7 @@ static ROLE_TO_TAG_MAP: Lazy<phf::Map<&'static str, &'static str>> = Lazy::new(|
 });
 
 impl Rule for PreferTagOverRole {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             if let Some(name) = get_element_type(ctx, jsx_el) {
                 if let Some(role_prop) = has_jsx_prop_ignore_case(jsx_el, "role") {

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -48,7 +48,7 @@ static ROLE_TO_REQUIRED_ARIA_PROPS: phf::Map<&'static str, phf::Set<&'static str
 };
 
 impl Rule for RoleHasRequiredAriaProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(role_prop) = has_jsx_prop_ignore_case(jsx_el, "role") else {
                 return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -60,7 +60,7 @@ fn is_implicit_diagnostic(span0: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagn
 }
 
 impl Rule for RoleSupportsAriaProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             if let Some(el_type) = get_element_type(ctx, jsx_el) {
                 let role = has_jsx_prop_ignore_case(jsx_el, "role");

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for Scope {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for TabindexNoPositive {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
         };
@@ -50,7 +50,7 @@ impl Rule for TabindexNoPositive {
     }
 }
 
-fn check_and_diagnose(attr: &JSXAttributeItem, ctx: &LintContext<'_>) {
+fn check_and_diagnose(attr: &JSXAttributeItem, ctx: &LintContext) {
     match attr {
         JSXAttributeItem::Attribute(attr) => attr.value.as_ref().map_or((), |value| {
             if let Ok(parsed_value) = parse_jsx_value(value) {

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GoogleFontDisplay {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for GoogleFontPreconnect {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for InlineScriptId {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ImportDefaultSpecifier(specifier) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NextScriptForGa {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAssignModuleVariable {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::VariableDeclaration(variable_decl) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoBeforeInteractiveScriptOutsideDocument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let Some(file_path) = ctx.file_path().to_str() else {
                 return;

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCssTags {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDocumentImportInPage {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateHead {
-    fn run_on_symbol(&self, symbol_id: oxc_semantic::SymbolId, ctx: &LintContext<'_>) {
+    fn run_on_symbol(&self, symbol_id: oxc_semantic::SymbolId, ctx: &LintContext) {
         let symbols = ctx.symbols();
         let name = symbols.get_name(symbol_id);
         if name != "Head" {

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoHeadElement {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let Some(full_file_path) = ctx.file_path().to_str() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoHeadImportInDocument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImgElement {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoPageCustomFont {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(element) = node.kind() else {
             return;
         };
@@ -76,7 +76,7 @@ impl Rule for NoPageCustomFont {
     }
 }
 
-fn is_inside_export_default(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn is_inside_export_default(node: &AstNode<'_>, ctx: &LintContext) -> bool {
     let mut is_inside_export_default = false;
     for parent_node in ctx.nodes().iter_parents(node.id()) {
         // export default function/class

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoScriptComponentInHead {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoStyledJsxInDocument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -33,7 +33,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSyncScripts {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_element) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTitleInDocumentHead {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import_decl)) =
             node.kind()
         else {

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -46,7 +46,7 @@ const NEXTJS_DATA_FETCHING_FUNCTIONS: phf::Set<&'static str> = phf_set! {
 const THRESHOLD: i32 = 1;
 
 impl Rule for NoTypos {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let Some(path) = ctx.file_path().to_str() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -106,7 +106,7 @@ const NEXT_POLYFILLED_FEATURES: Set<&'static str> = phf_set! {
 };
 
 impl Rule for NoUnwantedPolyfillio {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let tag_name = if let JSXElementName::Identifier(ident) = &jsx_el.name {
                 &ident.name

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ApproxConstant {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NumericLiteral(number_literal) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadArrayMethodOnArguments {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !node.kind().is_specific_id_reference("arguments") {
             return;
         }

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadBitwiseOperator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::BinaryExpression(bin_expr) => {
                 if is_mistype_short_circuit(node) {

--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadCharAtComparison {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadComparisonSequence {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };
@@ -46,7 +46,7 @@ impl Rule for BadComparisonSequence {
 
 fn has_no_bad_comparison_in_parents<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> bool {
     for node_id in ctx.nodes().ancestors(node.id()).skip(1) {
         let kind = ctx.nodes().kind(node_id);

--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadMinMaxFunc {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadObjectLiteralComparison {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(binary_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BadReplaceAllArg {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -79,7 +79,7 @@ impl Rule for BadReplaceAllArg {
 
 fn resolve_flags<'a>(
     expr: &'a Expression<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<(RegExpFlags, Span)> {
     match expr.without_parenthesized() {
         Expression::RegExpLiteral(regexp_literal) => {

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -70,7 +70,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ConstComparisons {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::LogicalExpression(logical_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 
 #[allow(clippy::similar_names)]
 impl Rule for DoubleComparisons {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::LogicalExpression(logical_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ErasingOp {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(binary_expression) = node.kind() else {
             return;
         };
@@ -77,7 +77,7 @@ fn is_number_value(expr: &Expression, value: f64) -> bool {
 fn check_op<'a, 'b>(
     binary_expression: &'b BinaryExpression<'a>,
     op: &'b Expression<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     if is_number_value(op, 0.0) {
         ctx.diagnostic(erasing_op_diagnostic(binary_expression.span));

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for MisrefactoredAssignOp {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::AssignmentExpression(assignment_expr) = node.kind() else {
             return;
         };
@@ -96,7 +96,7 @@ impl Rule for MisrefactoredAssignOp {
 fn assignment_target_eq_expr<'a>(
     assignment_target: &AssignmentTarget<'a>,
     right_expr: &Expression<'_>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> bool {
     if let Some(simple_assignment_target) = assignment_target.as_simple_assignment_target() {
         return match simple_assignment_target {

--- a/crates/oxc_linter/src/rules/oxc/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/oxc/missing_throw.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for MissingThrow {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };
@@ -40,7 +40,7 @@ impl Rule for MissingThrow {
 }
 
 impl MissingThrow {
-    fn has_missing_throw<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    fn has_missing_throw<'a>(node: &AstNode<'a>, ctx: &LintContext<'a, '_>) -> bool {
         let mut node_ancestors = ctx.nodes().ancestors(node.id()).skip(1);
 
         let Some(node_id) = node_ancestors.next() else {

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -87,7 +87,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAccumulatingSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // only check spreads on identifiers
         let AstKind::SpreadElement(spread) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -31,7 +31,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAsyncAwait {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::Function(func_decl) => {
                 if func_decl.r#async {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -59,7 +59,7 @@ impl Rule for NoBarrelFile {
         }
     }
 
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let semantic = ctx.semantic();
         let module_record = semantic.module_record();
 

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstEnum {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::TSEnumDeclaration(enum_decl) = node.kind() {
             if !enum_decl.r#const {
                 return;

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -76,7 +76,7 @@ impl Rule for NoOptionalChaining {
         Self(Box::new(NoOptionalChainingConfig { message: message.to_string() }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ChainExpression(expr) = node.kind() {
             ctx.diagnostic(no_optional_chaining_diagnostic(expr.span, &self.message));
         }

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -79,7 +79,7 @@ impl Rule for NoRestSpreadProperties {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::SpreadElement(spread_element) => {
                 if ctx

--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NumberArgOutOfRange {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -59,7 +59,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for OnlyUsedInRecursion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::Function(function) = node.kind() else {
             return;
         };
@@ -92,7 +92,7 @@ fn is_argument_only_used_in_recursion<'a>(
     function_id: &'a BindingIdentifier,
     arg: &'a BindingIdentifier,
     arg_index: usize,
-    ctx: &'a LintContext<'_>,
+    ctx: &'a LintContext,
 ) -> bool {
     let mut is_used_only_in_recursion = true;
     let mut has_references = false;
@@ -132,7 +132,7 @@ fn is_argument_only_used_in_recursion<'a>(
 
 fn is_function_maybe_reassigned<'a>(
     function_id: &'a BindingIdentifier,
-    ctx: &'a LintContext<'_>,
+    ctx: &'a LintContext,
 ) -> bool {
     let mut is_maybe_reassigned = false;
 

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for UninvokedArrayCallback {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for AvoidNew {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewStatics {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -73,7 +73,7 @@ impl Rule for ParamNames {
         Self(Box::new(cfg))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{get_prop_value, has_jsx_prop_ignore_case, is_create_element_call},
     AstNode,
@@ -65,7 +65,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ButtonHasType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_el) => {
                 let JSXElementName::Identifier(identifier) = &jsx_el.name else {
@@ -147,7 +147,7 @@ impl Rule for ButtonHasType {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for CheckedRequiresOnchangeOrReadonly {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_opening_el) => {
                 let Some(element_type) = get_element_type(ctx, jsx_opening_el) else {

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -12,7 +12,11 @@ use oxc_semantic::AstNodeId;
 use oxc_span::{GetSpan as _, Span};
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn jsx_curly_brace_presence_unnecessary_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Curly braces are unnecessary here.").with_label(span)
@@ -327,7 +331,7 @@ impl Rule for JsxCurlyBracePresence {
             _ => default,
         }
     }
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXElement(el) => {
                 el.opening_element.attributes.iter().for_each(|attr| {
@@ -347,7 +351,7 @@ impl Rule for JsxCurlyBracePresence {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }
@@ -355,7 +359,7 @@ impl Rule for JsxCurlyBracePresence {
 impl JsxCurlyBracePresence {
     fn check_jsx_child<'a>(
         &self,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
         children: &Vec<'a, JSXChild<'a>>,
         node: &AstNode<'a>,
     ) {
@@ -379,7 +383,7 @@ impl JsxCurlyBracePresence {
 
     fn check_jsx_attribute<'a>(
         &self,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
         attr: &JSXAttributeItem<'a>,
         node: &AstNode<'a>,
     ) {
@@ -412,7 +416,7 @@ impl JsxCurlyBracePresence {
 
     fn check_expression_container<'a>(
         &self,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
         container: &JSXExpressionContainer<'a>,
         node: &AstNode<'a>,
         // true for JSX props, false for JSX children
@@ -464,7 +468,7 @@ impl JsxCurlyBracePresence {
 }
 
 fn is_allowed_string_like<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     s: &'a str,
     container: &JSXExpressionContainer<'a>,
     node_id: AstNodeId,
@@ -517,7 +521,7 @@ fn contains_html_entity(s: &str) -> bool {
 }
 
 fn report_unnecessary_curly<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     _container: &JSXExpressionContainer<'a>,
     inner_span: Span,
 ) {
@@ -525,7 +529,7 @@ fn report_unnecessary_curly<'a>(
 }
 
 fn has_adjacent_jsx_expression_containers<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     container: &JSXExpressionContainer<'a>,
     node_id: AstNodeId,
     // element: &JSXElement<'a>,

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -5,7 +5,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn jsx_no_comment_textnodes_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Comments inside children section of tag should be placed inside braces")
@@ -51,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoCommentTextnodes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXText(jsx_text) = node.kind() else {
             return;
         };
@@ -61,7 +65,7 @@ impl Rule for JsxNoCommentTextnodes {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -7,7 +7,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{Atom, Span};
 use rustc_hash::FxHashMap;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn jsx_no_duplicate_props_diagnostic(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No duplicate props allowed. The prop \"{x0}\" is duplicated."))
@@ -44,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoDuplicateProps {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::JSXOpeningElement(jsx_opening_elem) = node.kind() else {
             return;
         };
@@ -70,7 +74,7 @@ impl Rule for JsxNoDuplicateProps {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -11,7 +11,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn target_blank_without_noreferrer(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using target=`_blank` without rel=`noreferrer` (which implies rel=`noopener`) is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
@@ -119,7 +123,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoTargetBlank {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(jsx_ele) = node.kind() {
             if let JSXElementName::Identifier(tag_identifier) = &jsx_ele.name {
                 let tag_name = tag_identifier.name.as_str();
@@ -244,7 +248,7 @@ impl Rule for JsxNoTargetBlank {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn jsx_no_undef_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow undeclared variables in JSX")
@@ -53,7 +57,7 @@ fn get_member_ident<'a>(expr: &'a JSXMemberExpression<'a>) -> &'a JSXIdentifier 
 }
 
 impl Rule for JsxNoUndef {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXOpeningElement(elem) = &node.kind() {
             if let Some(ident) = get_resolvable_ident(&elem.name) {
                 let name = ident.name.as_str();
@@ -73,7 +77,7 @@ impl Rule for JsxNoUndef {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -10,7 +10,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNodeId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn needs_more_children(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span0)
@@ -60,7 +64,7 @@ impl Rule for JsxNoUselessFragment {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
                 if !is_jsx_fragment(&jsx_elem.opening_element) {
@@ -75,7 +79,7 @@ impl Rule for JsxNoUselessFragment {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -6,7 +6,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    utils::is_create_element_call,
+    AstNode,
+};
 
 fn no_children_prop_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid passing children using a prop.")
@@ -55,7 +60,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoChildrenProp {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) => {
                 let JSXAttributeName::Identifier(attr_ident) = &attr.name else {
@@ -86,7 +91,7 @@ impl Rule for NoChildrenProp {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{has_jsx_prop, is_create_element_call},
     AstNode,
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDanger {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
                 if let Some(JSXAttributeItem::Attribute(prop)) =
@@ -75,7 +75,7 @@ impl Rule for NoDanger {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -7,7 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
     AstNode,
@@ -82,7 +82,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDirectMutationState {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::AssignmentExpression(assignment_expr) => {
                 if should_ignore_component(node, ctx) {
@@ -118,7 +118,7 @@ impl Rule for NoDirectMutationState {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }
@@ -171,7 +171,7 @@ fn get_static_member_expression_obj<'a, 'b>(
     }
 }
 
-fn should_ignore_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn should_ignore_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a, '_>) -> bool {
     let mut is_constructor = false;
     let mut is_call_expression = false;
     let mut is_component = false;

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_find_dom_node_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected call to `findDOMNode`.")
@@ -39,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFindDomNode {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -67,7 +71,7 @@ impl Rule for NoFindDomNode {
         ctx.diagnostic(no_find_dom_node_diagnostic(span));
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_is_mounted_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use isMounted")
@@ -42,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIsMounted {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -67,7 +71,7 @@ impl Rule for NoIsMounted {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_render_return_value_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not depend on the return value from ReactDOM.render.")
@@ -35,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoRenderReturnValue {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -79,7 +83,7 @@ impl Rule for NoRenderReturnValue {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{get_parent_es5_component, get_parent_es6_component},
     AstNode,
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSetState {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -72,7 +72,7 @@ impl Rule for NoSetState {
         ctx.diagnostic(no_set_state_diagnostic(call_expr.callee.span()));
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{get_parent_es5_component, get_parent_es6_component},
     AstNode,
@@ -108,7 +108,7 @@ impl Rule for NoStringRefs {
         Self { no_template_literals }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) => {
                 if is_literal_ref_attribute(attr, self.no_template_literals) {
@@ -128,7 +128,7 @@ impl Rule for NoStringRefs {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::{phf_map, Map};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_unescaped_entities_diagnostic(span0: Span, x1: char, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("`{x1}` can be escaped with {x2}")).with_label(span0)
@@ -43,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnescapedEntities {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::JSXText(jsx_text) = node.kind() {
             let source = jsx_text.span.source_text(ctx.source_text());
             for (i, char) in source.char_indices() {
@@ -62,7 +66,7 @@ impl Rule for NoUnescapedEntities {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -13,7 +13,12 @@ use phf::{phf_map, phf_set, Map, Set};
 use regex::Regex;
 use serde::Deserialize;
 
-use crate::{context::LintContext, rule::Rule, utils::get_jsx_attribute_name, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    utils::get_jsx_attribute_name,
+    AstNode,
+};
 
 fn invalid_prop_on_tag(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid property found")
@@ -452,7 +457,7 @@ impl Rule for NoUnknownProperty {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         static HTML_TAG_CONVENTION: Lazy<Regex> = Lazy::new(|| Regex::new("^[a-z][^-]*$").unwrap());
 
         let AstKind::JSXOpeningElement(el) = &node.kind() else {
@@ -530,7 +535,7 @@ impl Rule for NoUnknownProperty {
             });
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -4,7 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
     AstNode,
@@ -57,7 +57,7 @@ impl Rule for PreferEs6Class {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if matches!(self.prefer_es6_class_option, PreferES6ClassOptionType::Always) {
             if is_es5_component(node) {
                 let AstKind::CallExpression(call_expr) = node.kind() else {
@@ -75,7 +75,7 @@ impl Rule for PreferEs6Class {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn react_in_jsx_scope_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'React' must be in scope when using JSX")
@@ -38,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ReactInJsxScope {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let node_span = match node.kind() {
             AstKind::JSXOpeningElement(v) => v.name.span(),
             AstKind::JSXFragment(v) => v.opening_fragment.span,
@@ -55,7 +59,7 @@ impl Rule for ReactInJsxScope {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -8,7 +8,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::LintContext,
+    context::{LintContext, LinterContext},
     rule::Rule,
     utils::{is_es5_component, is_es6_component},
     AstNode,
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireRenderReturn {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if !matches!(node.kind(), AstKind::ArrowFunctionExpression(_) | AstKind::Function(_)) {
             return;
         }
@@ -79,7 +79,7 @@ impl Rule for RequireRenderReturn {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }
@@ -170,7 +170,7 @@ fn is_render_fn(node: &AstNode) -> bool {
     false
 }
 
-fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a, '_>) -> bool {
     let Some(ancestors_0) = ctx.nodes().parent_node(node.id()) else { return false };
     if !matches!(ancestors_0.kind(), AstKind::ObjectExpression(_)) {
         return false;
@@ -186,7 +186,7 @@ fn is_in_es5_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
     is_es5_component(ancestors_2)
 }
 
-fn is_in_es6_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_in_es6_component<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a, '_>) -> bool {
     let Some(parent) = ctx.nodes().parent_node(node.id()) else { return false };
     if !matches!(parent.kind(), AstKind::ClassBody(_)) {
         return false;

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -108,7 +108,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RulesOfHooks {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call) = node.kind() else { return };
 
         if !is_react_hook(&call.callee) {

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -10,7 +10,12 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use phf::phf_set;
 
-use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    utils::is_create_element_call,
+    AstNode,
+};
 
 fn void_dom_elements_no_children_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -60,7 +65,7 @@ pub fn is_void_dom_element(element_name: &str) -> bool {
 }
 
 impl Rule for VoidDomElementsNoChildren {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::JSXElement(jsx_el) => {
                 let jsx_opening_el = &jsx_el.opening_element;
@@ -138,7 +143,7 @@ impl Rule for VoidDomElementsNoChildren {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -9,7 +9,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn adjacent_overload_signatures_diagnostic(
     x0: &str,
@@ -246,7 +250,7 @@ impl GetMethod for Statement<'_> {
     }
 }
 
-fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext<'_>) {
+fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext) {
     let mut last_method: Option<&Method> = None;
     let mut seen_methods: Vec<&Method> = Vec::new();
 
@@ -280,7 +284,7 @@ fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext<'_>) {
 }
 
 impl Rule for AdjacentOverloadSignatures {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::Class(class) => {
                 let members = &class.body.body;
@@ -320,7 +324,7 @@ impl Rule for AdjacentOverloadSignatures {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -7,7 +7,10 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct ArrayType(Box<ArrayTypeConfig>);
@@ -106,7 +109,7 @@ impl Rule for ArrayType {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let default_config = &self.default;
         let readonly_config: &ArrayOption =
             &self.readonly.clone().unwrap_or_else(|| default_config.clone());
@@ -127,7 +130,7 @@ impl Rule for ArrayType {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -4,7 +4,10 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+};
 
 fn comment(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use @ts-{x0} because it alters compilation errors."))
@@ -205,7 +208,7 @@ impl Rule for BanTsComment {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn type_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use {x0:?} as a type. Use \"{x1}\" instead"))
@@ -50,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for BanTypes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::TSTypeReference(typ) => {
                 let name = match &typ.type_name {
@@ -84,7 +88,7 @@ impl Rule for BanTypes {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn consistent_indexed_object_style_diagnostic(a: &str, b: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("A {a} is preferred over an {b}."))
@@ -68,7 +72,7 @@ impl Rule for ConsistentIndexedObjectStyle {
         Self { is_record_mode: config == ConsistentIndexedObjectStyleConfig::Record }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if self.is_record_mode {
             match node.kind() {
                 AstKind::TSInterfaceDeclaration(inf) => {
@@ -245,7 +249,7 @@ impl Rule for ConsistentIndexedObjectStyle {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn consistent_type_definitions_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use an `{x0}` instead of a `{x1}`"))
@@ -63,7 +67,7 @@ impl Rule for ConsistentTypeDefinitions {
         Self { config }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::TSTypeAliasDeclaration(decl) => match &decl.type_annotation {
                 TSType::TSTypeLiteral(_)
@@ -215,7 +219,7 @@ impl Rule for ConsistentTypeDefinitions {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoConfusingNonNullAssertion;
@@ -62,7 +66,7 @@ fn get_depth_ends_in_bang(expr: &Expression<'_>) -> Option<u32> {
 }
 
 impl Rule for NoConfusingNonNullAssertion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::BinaryExpression(binary_expr) => {
                 let Some(bang_depth) = get_depth_ends_in_bang(&binary_expr.left) else {
@@ -93,7 +97,7 @@ impl Rule for NoConfusingNonNullAssertion {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_duplicate_enum_values_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow duplicate enum member values")
@@ -35,7 +39,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicateEnumValues {
     #[allow(clippy::float_cmp)]
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSEnumDeclaration(enum_body) = node.kind() else {
             return;
         };
@@ -65,7 +69,7 @@ impl Rule for NoDuplicateEnumValues {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -34,7 +34,7 @@ fn no_dynamic_delete_diagnostic(span0: Span) -> OxcDiagnostic {
 }
 
 impl Rule for NoDynamicDelete {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::UnaryExpression(expr) = node.kind() else { return };
         if !matches!(expr.operator, UnaryOperator::Delete) {
             return;

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_empty_interface_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span0)
@@ -50,7 +54,7 @@ impl Rule for NoEmptyInterface {
         Self { allow_single_extends }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::TSInterfaceDeclaration(interface) = node.kind() {
             if interface.body.body.is_empty() {
                 match &interface.extends {
@@ -69,7 +73,7 @@ impl Rule for NoEmptyInterface {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_explicit_any_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected any. Specify a different type.")
@@ -86,7 +90,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExplicitAny {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSAnyKeyword(any) = node.kind() else {
             return;
         };
@@ -113,13 +117,13 @@ impl Rule for NoExplicitAny {
         Self { fix_to_unknown, ignore_rest_args }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }
 
 impl NoExplicitAny {
-    fn is_in_rest<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    fn is_in_rest<'a>(node: &AstNode<'a>, ctx: &LintContext<'a, '_>) -> bool {
         debug_assert!(matches!(node.kind(), AstKind::TSAnyKeyword(_)));
         ctx.nodes()
             .iter_parents(node.id())

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_extra_non_null_assertion_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("extra non-null assertion").with_label(span0)
@@ -30,7 +34,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExtraNonNullAssertion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let expr = match node.kind() {
             AstKind::TSNonNullExpression(expr) => {
                 if let Expression::TSNonNullExpression(expr) =
@@ -65,7 +69,7 @@ impl Rule for NoExtraNonNullAssertion {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -100,7 +100,7 @@ impl Rule for NoExtraneousClass {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::Class(class) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -6,7 +6,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    fixer::Fix,
+    rule::Rule,
+    AstNode,
+};
 
 fn no_import_type_side_effects_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("TypeScript will only remove the inline type specifiers which will leave behind a side effect import at runtime.")
@@ -55,7 +60,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportTypeSideEffects {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ImportDeclaration(import_decl) = node.kind() else {
             return;
         };
@@ -110,7 +115,7 @@ impl Rule for NoImportTypeSideEffects {
         );
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMisusedNew {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(interface_decl) => {
                 let decl_name = &interface_decl.id.name;

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_namespace_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("ES2015 module syntax is preferred over namespaces.")
@@ -57,7 +61,7 @@ impl Rule for NoNamespace {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSModuleDeclaration(declaration) = node.kind() else {
             return;
         };
@@ -99,7 +103,7 @@ impl Rule for NoNamespace {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertedNullishCoalescing;
@@ -34,7 +38,7 @@ fn no_non_null_asserted_nullish_coalescing_diagnostic(span0: Span) -> OxcDiagnos
 }
 
 impl Rule for NoNonNullAssertedNullishCoalescing {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::LogicalExpression(expr) = node.kind() else { return };
         let Expression::TSNonNullExpression(ts_non_null_expr) = &expr.left else { return };
         if let Expression::Identifier(ident) = &ts_non_null_expr.expression {
@@ -48,7 +52,7 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
         ctx.diagnostic(no_non_null_asserted_nullish_coalescing_diagnostic(ts_non_null_expr.span));
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_non_null_asserted_optional_chain_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("non-null assertions after an optional chain expression")
@@ -38,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNonNullAssertedOptionalChain {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::TSNonNullExpression(non_null_expr) = node.kind() {
             let chain_span = match non_null_expr.expression.get_inner_expression() {
                 Expression::ChainExpression(chain) => match &chain.expression {
@@ -89,12 +93,12 @@ impl Rule for NoNonNullAssertedOptionalChain {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }
 
-fn is_parent_member_or_call(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+fn is_parent_member_or_call(node: &AstNode<'_>, ctx: &LintContext) -> bool {
     matches!(
         ctx.nodes().parent_kind(node.id()),
         Some(AstKind::MemberExpression(_) | AstKind::CallExpression(_))

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertion;
@@ -32,12 +36,12 @@ fn no_non_null_assertion_diagnostic(span0: Span) -> OxcDiagnostic {
 }
 
 impl Rule for NoNonNullAssertion {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSNonNullExpression(expr) = node.kind() else { return };
         ctx.diagnostic(no_non_null_assertion_diagnostic(expr.span));
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_this_alias_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected aliasing of 'this' to local variable.")
@@ -86,7 +90,7 @@ impl Rule for NoThisAlias {
         }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::VariableDeclarator(decl) => {
                 let Some(init) = &decl.init else { return };
@@ -143,7 +147,7 @@ impl Rule for NoThisAlias {
             _ => {}
         }
     }
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_unnecessary_type_constraint_diagnostic(
     x0: &str,
@@ -48,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnnecessaryTypeConstraint {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::TSTypeParameterDeclaration(decl) = node.kind() {
             for param in &decl.params {
                 if let Some(ty) = &param.constraint {
@@ -68,7 +72,7 @@ impl Rule for NoUnnecessaryTypeConstraint {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_unsafe_declaration_merging_diagnostic(span0: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe declaration merging between classes and interfaces.")
@@ -35,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeDeclarationMerging {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::Class(decl) => {
                 if let Some(ident) = decl.id.as_ref() {
@@ -61,7 +65,7 @@ impl Rule for NoUnsafeDeclarationMerging {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }
@@ -69,14 +73,14 @@ impl Rule for NoUnsafeDeclarationMerging {
 fn check_and_diagnostic(
     ident: &BindingIdentifier,
     scope_ident: &BindingIdentifier,
-    ctx: &LintContext<'_>,
+    ctx: &LintContext,
 ) {
     if scope_ident.name.as_str() == ident.name.as_str() {
         ctx.diagnostic(no_unsafe_declaration_merging_diagnostic(ident.span, scope_ident.span));
     }
 }
 
-fn get_symbol_kind<'a>(symbol_id: SymbolId, ctx: &LintContext<'a>) -> AstKind<'a> {
+fn get_symbol_kind<'a>(symbol_id: SymbolId, ctx: &LintContext<'a, '_>) -> AstKind<'a> {
     return ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id)).kind();
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessEmptyExport {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ExportNamedDeclaration(decl) = node.kind() else { return };
         if decl.declaration.is_some() || !decl.specifiers.is_empty() {
             return;

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -3,7 +3,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{ast_util::is_global_require_call, context::LintContext, rule::Rule, AstNode};
+use crate::{
+    ast_util::is_global_require_call,
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn no_var_requires_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require statement not part of import statement.")
@@ -33,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoVarRequires {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };
@@ -66,7 +71,7 @@ impl Rule for NoVarRequires {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn prefer_as_const_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a `const` assertion instead of a literal type annotation.")
@@ -39,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferAsConst {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_declarator) => {
                 let Some(type_annotation) = &variable_declarator.id.type_annotation else {
@@ -81,7 +85,7 @@ impl Rule for PreferAsConst {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -3,7 +3,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn prefer_enum_initializers_diagnostic(x0: &str, x1: usize, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("The value of the member {x0:?} should be explicitly defined."))
@@ -34,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEnumInitializers {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSEnumDeclaration(decl) = node.kind() else {
             return;
         };
@@ -52,7 +56,7 @@ impl Rule for PreferEnumInitializers {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -111,7 +111,7 @@ impl<'a> ExpressionExt for Expression<'a> {
 }
 
 impl Rule for PreferForOf {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ForStatement(for_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -6,7 +6,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    fixer::Fix,
+    rule::Rule,
+    AstNode,
+};
 
 fn prefer_function_type_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce using function types instead of interfaces with call signatures.")
@@ -101,7 +106,7 @@ fn has_one_super_type(decl: &TSInterfaceDeclaration) -> bool {
     true
 }
 
-fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>) {
+fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext) {
     match member {
         TSSignature::TSCallSignatureDeclaration(decl) => {
             let start = decl.span.start;
@@ -309,7 +314,7 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
 }
 
 impl Rule for PreferFunctionType {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(decl) => {
                 let body: &oxc_allocator::Vec<'_, TSSignature<'_>> = &decl.body.body;
@@ -393,7 +398,7 @@ impl Rule for PreferFunctionType {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -4,7 +4,11 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn prefer_literal_enum_member_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -54,7 +58,7 @@ impl Rule for PreferLiteralEnumMember {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSEnumMember(decl) = node.kind() else {
             return;
         };
@@ -109,7 +113,7 @@ impl Rule for PreferLiteralEnumMember {
         ctx.diagnostic(prefer_literal_enum_member_diagnostic(decl.span));
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -6,7 +6,11 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+    AstNode,
+};
 
 fn prefer_namespace_keyword_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use 'namespace' instead of 'module' to declare custom TypeScript modules.")
@@ -34,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNamespaceKeyword {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::TSModuleDeclaration(module) = node.kind() else { return };
         if module.id.is_string_literal()
             || !matches!(module.id, TSModuleDeclarationName::Identifier(_))
@@ -54,7 +58,7 @@ impl Rule for PreferNamespaceKeyword {
         });
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -3,7 +3,10 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+};
 
 fn prefer_ts_expect_error_diagnostic(span0: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce using `@ts-expect-error` over `@ts-ignore`")
@@ -72,7 +75,7 @@ impl Rule for PreferTsExpectError {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -8,7 +8,10 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    context::{LintContext, LinterContext},
+    rule::Rule,
+};
 
 fn triple_slash_reference_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use a triple slash reference for {x0}, use `import` style instead."))
@@ -163,7 +166,7 @@ impl Rule for TripleSlashReference {
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_typescript()
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -80,7 +80,7 @@ impl Rule for CatchErrorName {
         Self(Box::new(CatchErrorNameConfig { ignore: ignored_names, name: allowed_name }))
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::CatchParameter(catch_param) = node.kind() {
             if let oxc_ast::ast::BindingPatternKind::BindingIdentifier(binding_ident) =
                 &catch_param.pattern.kind

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for EmptyBraceSpaces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::StaticBlock(static_block) => {
                 let start = static_block.span.start;

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ErrorMessage {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let (callee, span, args) = match &node.kind() {
             AstKind::NewExpression(NewExpression {
                 callee: Expression::Identifier(id),

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -120,7 +120,7 @@ fn check_case(value: &str, is_regex: bool) -> Option<String> {
     }
 }
 impl Rule for EscapeCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::StringLiteral(StringLiteral { span, .. }) => {
                 let text = span.source_text(ctx.source_text());

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -104,7 +104,7 @@ fn is_compare_right(expr: &BinaryExpression, op: BinaryOperator, value: f64) -> 
 }
 fn get_length_check_node<'a, 'b>(
     node: &AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
     // (is_zero_length_check, length_check_node)
 ) -> Option<(bool, &'b AstNode<'a>)> {
     let parent = ctx.nodes().parent_node(node.id());
@@ -155,7 +155,7 @@ fn get_length_check_node<'a, 'b>(
 impl ExplicitLengthCheck {
     fn report<'a>(
         &self,
-        ctx: &LintContext<'a>,
+        ctx: &LintContext<'a, '_>,
         node: &AstNode<'a>,
         is_zero_length_check: bool,
         static_member_expr: &StaticMemberExpression,
@@ -230,7 +230,7 @@ impl ExplicitLengthCheck {
     }
 }
 impl Rule for ExplicitLengthCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::MemberExpression(MemberExpression::StaticMemberExpression(
             static_member_expr,
         )) = node.kind()

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -91,7 +91,7 @@ impl Rule for FilenameCase {
         Self::default()
     }
 
-    fn run_once<'a>(&self, ctx: &LintContext<'_>) {
+    fn run_once<'a>(&self, ctx: &LintContext) {
         let Some(filename) = ctx.file_path().file_stem().and_then(|s| s.to_str()) else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NewForBuiltins {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::NewExpression(new_expr) => {
                 let callee = new_expr.callee.without_parenthesized();
@@ -93,7 +93,7 @@ impl Rule for NewForBuiltins {
 
 fn is_expr_global_builtin<'a, 'b>(
     expr: &'b Expression<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> Option<&'b str> {
     match expr {
         Expression::Identifier(ident) => {

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAnonymousDefaultExport {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let problem_node = match node.kind() {
             // ESM: export default
             AstKind::ExportDefaultDeclaration(export_decl) => match &export_decl.declaration {

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoArrayForEach {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -59,7 +59,7 @@ impl Rule for NoArrayReduce {
         Self { allow_simple_operations }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAwaitExpressionMember {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::MemberExpression(member_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAwaitInPromiseMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConsoleSpaces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -123,7 +123,7 @@ fn report_diagnostic<'a>(
     span: Span,
     literal_raw: &'a str,
     is_template_lit: bool,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     let span = if is_template_lit { span } else { Span::new(span.start + 1, span.end - 1) };
 

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDocumentCookie {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::AssignmentExpression(assignment_expr) = node.kind() else {
             return;
         };
@@ -79,7 +79,7 @@ impl Rule for NoDocumentCookie {
 
 fn is_document_cookie_reference<'a, 'b>(
     expr: &'a Expression<'b>,
-    ctx: &'a LintContext<'b>,
+    ctx: &'a LintContext<'b, '_>,
 ) -> bool {
     match expr {
         Expression::Identifier(ident) => {

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -68,7 +68,7 @@ impl Rule for NoEmptyFile {
     }
 }
 
-fn has_triple_slash_directive(ctx: &LintContext<'_>) -> bool {
+fn has_triple_slash_directive(ctx: &LintContext) -> bool {
     for comment in ctx.semantic().trivias().comments() {
         if !comment.kind.is_single_line() {
             continue;

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -64,7 +64,7 @@ fn check_escape(value: &str) -> Option<String> {
 }
 
 impl Rule for NoHexEscape {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::StringLiteral(StringLiteral { span, .. }) => {
                 let text = span.source_text(ctx.source_text());

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -32,7 +32,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoInstanceofArray {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoInvalidRemoveEventListener {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLengthAsSliceEnd {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLonelyIf {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::IfStatement(if_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMagicArrayFlatDepth {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expression) = node.kind() else {
             return;
         };
@@ -88,7 +88,7 @@ impl Rule for NoMagicArrayFlatDepth {
 #[allow(clippy::cast_possible_truncation)]
 fn get_call_expression_parentheses_pos<'a>(
     call_expr: &CallExpression<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<Span> {
     call_expr.callee.get_member_expr().map(|member_expr| {
         let callee_span = member_expr.object().span();

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNegatedCondition {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let stmt_test = match node.kind() {
             AstKind::IfStatement(if_stmt) => {
                 let Some(if_stmt_alternate) = &if_stmt.alternate else {

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNegationInEqualityCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::BinaryExpression(binary_expr) = node.kind() {
             let Expression::UnaryExpression(left_unary_expr) = &binary_expr.left else {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNestedTernary {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ConditionalExpression(cond_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewArray {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNewBuffer {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NewExpression(new_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -172,7 +172,7 @@ impl Rule for NoNull {
         }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NullLiteral(null_literal) = node.kind() else {
             return;
         };
@@ -220,7 +220,7 @@ impl Rule for NoNull {
     }
 }
 
-fn fix_null<'a>(fixer: RuleFixer<'_, 'a>, null: &NullLiteral) -> RuleFix<'a> {
+fn fix_null<'a>(fixer: RuleFixer<'_, '_, 'a>, null: &NullLiteral) -> RuleFix<'a> {
     fixer.replace(null.span, "undefined")
 }
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoObjectAsDefaultParameter {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::AssignmentPattern(assignment_pat) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoProcessExit {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::CallExpression(expr) = node.kind() {
             if is_method_call(expr, Some(&["process"]), Some(&["exit"]), None, None) {
                 if has_hashbang(ctx)

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSinglePromiseInPromiseMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -119,7 +119,7 @@ fn is_promise_method_with_single_argument(call_expr: &CallExpression) -> bool {
     is_method_call(call_expr, Some(&["Promise"]), Some(&["all", "any", "race"]), Some(1), Some(1))
 }
 
-fn is_fixable(call_node_id: AstNodeId, ctx: &LintContext<'_>) -> bool {
+fn is_fixable(call_node_id: AstNodeId, ctx: &LintContext) -> bool {
     for parent in ctx.semantic().nodes().iter_parents(call_node_id).skip(1) {
         match parent.kind() {
             AstKind::CallExpression(_)

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoStaticOnlyClass {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::Class(class) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -58,7 +58,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoThenable {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::ObjectExpression(expr) => {
                 expr.properties.iter().for_each(|prop| {
@@ -220,7 +220,7 @@ fn check_binding_pattern(pat: &BindingPatternKind, ctx: &LintContext) {
     }
 }
 
-fn check_expression(expr: &Expression, ctx: &LintContext<'_>) -> Option<oxc_span::Span> {
+fn check_expression(expr: &Expression, ctx: &LintContext) -> Option<oxc_span::Span> {
     match expr {
         Expression::StringLiteral(lit) => {
             if lit.value == "then" {

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoThisAssignment {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_decl) => {
                 let Some(init) = &variable_decl.init else {

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoTypeofUndefined {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(bin_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnnecessaryAwait {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::AwaitExpression(expr) = node.kind() {
             if !not_promise(&expr.argument) {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -50,7 +50,7 @@ fn is_unreadable_array_destructuring<T, U>(elements: &Vec<Option<T>>, rest: &Opt
 }
 
 impl Rule for NoUnreadableArrayDestructuring {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::ArrayPattern(array_pattern) = node.kind() {
             if is_unreadable_array_destructuring(&array_pattern.elements, &array_pattern.rest) {
                 ctx.diagnostic(no_unreadable_array_destructuring_diagnostic(array_pattern.span));

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnreadableIife {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessFallbackInSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::LogicalExpression(logical_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -149,7 +149,7 @@ fn is_useless_check<'a>(
 }
 
 impl Rule for NoUselessLengthCheck {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::LogicalExpression(log_expr) = node.kind() {
             if ![LogicalOperator::And, LogicalOperator::Or].contains(&log_expr.operator) {
                 return;

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessPromiseResolveReject {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -134,7 +134,7 @@ impl Rule for NoUselessPromiseResolveReject {
 
 fn get_function_like_node<'a, 'b>(
     node: &'a AstNode<'b>,
-    ctx: &'a LintContext<'b>,
+    ctx: &'a LintContext<'b, '_>,
 ) -> Option<(bool, &'a AstNode<'b>, bool)> {
     let mut parent = node;
     let mut is_in_try_statement = false;
@@ -162,7 +162,7 @@ fn get_function_like_node<'a, 'b>(
     }
 }
 
-fn is_promise_callback<'a, 'b>(node: &'a AstNode<'b>, ctx: &'a LintContext<'b>) -> bool {
+fn is_promise_callback<'a, 'b>(node: &'a AstNode<'b>, ctx: &'a LintContext<'b, '_>) -> bool {
     let Some(parent) = outermost_paren_parent(node, ctx) else {
         return false;
     };
@@ -200,7 +200,7 @@ fn is_promise_callback<'a, 'b>(node: &'a AstNode<'b>, ctx: &'a LintContext<'b>) 
     false
 }
 
-fn match_arrow_function_body<'a>(ctx: &LintContext<'a>, parent: &AstNode<'a>) -> bool {
+fn match_arrow_function_body<'a>(ctx: &LintContext<'a, '_>, parent: &AstNode<'a>) -> bool {
     match ctx.nodes().parent_node(parent.id()) {
         Some(arrow_function_body) => match arrow_function_body.kind() {
             AstKind::FunctionBody(_) => match ctx.nodes().parent_node(arrow_function_body.id()) {
@@ -220,8 +220,8 @@ fn generate_fix<'a>(
     is_reject: bool,
     is_yield: bool,
     is_in_try_statement: bool,
-    fixer: RuleFixer<'_, 'a>,
-    ctx: &LintContext<'a>,
+    fixer: RuleFixer<'_, '_, 'a>,
+    ctx: &LintContext<'a, '_>,
     node: &AstNode<'a>,
 ) -> RuleFix<'a> {
     if call_expr.arguments.len() > 1 {
@@ -314,7 +314,7 @@ fn generate_fix<'a>(
 
 fn get_parenthesized_node<'a, 'b>(
     node: &'a AstNode<'b>,
-    ctx: &'a LintContext<'b>,
+    ctx: &'a LintContext<'b, '_>,
 ) -> &'a AstNode<'b> {
     let mut node = node;
     while let Some(parent_node) = ctx.nodes().parent_node(node.id()) {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread.rs
@@ -131,7 +131,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         check_useless_spread_in_list(node, ctx);
 
         if let AstKind::ArrayExpression(array_expr) = node.kind() {
@@ -141,7 +141,7 @@ impl Rule for NoUselessSpread {
     }
 }
 
-fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
+fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
     if !matches!(node.kind(), AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_)) {
         return;
     }
@@ -192,7 +192,7 @@ fn check_useless_spread_in_list<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
 
 /// `...[ ...[] ]`. May contain multiple spread elements.
 fn diagnose_array_in_array_spread<'a>(
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
     diagnostic: OxcDiagnostic,
     outer_array: &AstKind<'a>,
     inner_array: &ArrayExpression<'a>,
@@ -247,7 +247,7 @@ fn diagnose_array_in_array_spread<'a>(
 fn check_useless_iterable_to_array<'a>(
     node: &AstNode<'a>,
     array_expr: &ArrayExpression<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     let Some(parent) = outermost_paren_parent(node, ctx) else {
         return;
@@ -367,7 +367,7 @@ fn check_useless_iterable_to_array<'a>(
     }
 }
 
-fn check_useless_array_clone<'a>(array_expr: &ArrayExpression<'a>, ctx: &LintContext<'a>) {
+fn check_useless_array_clone<'a>(array_expr: &ArrayExpression<'a>, ctx: &LintContext<'a, '_>) {
     if !is_single_array_spread(array_expr) {
         return;
     }
@@ -446,7 +446,7 @@ fn check_useless_array_clone<'a>(array_expr: &ArrayExpression<'a>, ctx: &LintCon
 }
 
 fn fix_replace<'a, T: GetSpan, U: GetSpan>(
-    fixer: RuleFixer<'_, 'a>,
+    fixer: RuleFixer<'_, '_, 'a>,
     target: &T,
     replacement: &U,
 ) -> RuleFix<'a> {
@@ -456,7 +456,7 @@ fn fix_replace<'a, T: GetSpan, U: GetSpan>(
 
 /// Creates a fix that replaces `[...spread]` with `spread`
 fn fix_by_removing_spread<'a, S: GetSpan>(
-    fixer: RuleFixer<'_, 'a>,
+    fixer: RuleFixer<'_, '_, 'a>,
     iterable: &S,
     spread: &SpreadElement<'a>,
 ) -> RuleFix<'a> {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUselessSwitchCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::SwitchStatement(switch_statement) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -125,7 +125,7 @@ fn is_undefined(arg: &Argument) -> bool {
     false
 }
 
-fn is_has_function_return_type(node: &AstNode, ctx: &LintContext<'_>) -> bool {
+fn is_has_function_return_type(node: &AstNode, ctx: &LintContext) -> bool {
     let Some(parent_node) = ctx.nodes().parent_node(node.id()) else {
         return false;
     };
@@ -148,7 +148,7 @@ impl Rule for NoUselessUndefined {
             .unwrap_or(true);
         Self { check_arguments, check_arrow_function_body }
     }
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::IdentifierReference(undefined_literal)
                 if undefined_literal.name == "undefined" =>

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoZeroFractions {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::NumericLiteral(number_literal) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -71,7 +71,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NumberLiteralCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let (raw_literal, raw_span) = match node.kind() {
             AstKind::NumericLiteral(number) => (number.raw, number.span),
             AstKind::BigIntLiteral(number) => {

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -83,7 +83,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NumericSeparatorsStyle {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::NumericLiteral(number) => {
                 if self.only_if_contains_separator && !number.raw.contains('_') {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferAddEventListener {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::AssignmentExpression(assignment_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -61,7 +61,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferArrayFlat {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -74,7 +74,7 @@ impl Rule for PreferArrayFlat {
 }
 
 // `array.flatMap(x => x)`
-fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
+fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a, '_>) {
     if !is_method_call(call_expr, None, Some(&["flatMap"]), Some(1), Some(1)) {
         return;
     }
@@ -104,7 +104,7 @@ fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintConte
 
 // `array.reduce((a, b) => a.concat(b), [])`
 // `array.reduce((a, b) => [...a, ...b], [])`
-fn check_array_reduce_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
+fn check_array_reduce_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a, '_>) {
     if !is_method_call(call_expr, None, Some(&["reduce"]), Some(2), Some(2)) {
         return;
     }
@@ -199,7 +199,7 @@ fn check_array_reduce_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext
 
 // `[].concat(maybeArray)`
 // `[].concat(...array)`
-fn check_array_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
+fn check_array_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a, '_>) {
     if is_method_call(call_expr, None, Some(&["concat"]), Some(1), Some(1)) {
         // `array.concat(maybeArray)`
         if let Expression::ArrayExpression(array_expr) =
@@ -216,7 +216,10 @@ fn check_array_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext
 // - `[].concat.apply([], array)` and `Array.prototype.concat.apply([], array)`
 // - `[].concat.call([], maybeArray)` and `Array.prototype.concat.call([], maybeArray)`
 // - `[].concat.call([], ...array)` and `Array.prototype.concat.call([], ...array)`
-fn check_array_prototype_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
+fn check_array_prototype_concat_case<'a>(
+    call_expr: &CallExpression<'a>,
+    ctx: &LintContext<'a, '_>,
+) {
     let Some(member_expr) = call_expr.callee.get_member_expr() else {
         return;
     };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferArrayFlatMap {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(flat_call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferArraySome {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 if !is_method_call(call_expr, None, Some(&["find", "findLast"]), Some(1), Some(2)) {
@@ -163,7 +163,7 @@ fn is_node_value_not_function(expr: &Expression) -> bool {
 fn is_checking_undefined<'a, 'b>(
     node: &'b AstNode<'a>,
     _call_expr: &'b CallExpression<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> bool {
     let Some(parent) = outermost_paren_parent(node, ctx) else {
         return false;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferBlobReadingMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferCodePoint {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDateNow {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::CallExpression(call_expr) => {
                 // `new Date().{getTime,valueOf}()`

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeAppend {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -56,7 +56,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeDataset {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeRemove {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferDomNodeTextContent {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         if let AstKind::MemberExpression(member_expr) = node.kind() {
             if let Some((span, name)) = member_expr.static_property_info() {
                 if name == "innerText" && !member_expr.is_computed() {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEventTarget {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::IdentifierReference(ident) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferIncludes {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::BinaryExpression(bin_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferLogicalOperatorOverTernary {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ConditionalExpression(conditional_expression) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferMathTrunc {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let operator = match node.kind() {
             AstKind::UnaryExpression(unary_expr) => {
                 if !matches!(unary_expr.operator, UnaryOperator::BitwiseNot) {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -57,7 +57,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferModernDomApis {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferModernMathApis {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // there are two main cases to check:
         // Bin expression:
         //     `Math.log(x) * Math.LOG10E`
@@ -108,7 +108,7 @@ impl Rule for PreferModernMathApis {
     }
 }
 
-fn check_prefer_log<'a>(expr: &BinaryExpression<'a>, ctx: &LintContext<'a>) {
+fn check_prefer_log<'a>(expr: &BinaryExpression<'a>, ctx: &LintContext<'a, '_>) {
     match expr.operator {
         BinaryOperator::Multiplication => {
             check_multiplication(expr.span, &expr.left, &expr.right, ctx);
@@ -172,7 +172,7 @@ fn check_multiplication<'a, 'b>(
     expr_span: Span,
     left: &'b Expression<'a>,
     right: &'b Expression<'a>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) {
     let Expression::CallExpression(call_expr) = left else {
         return;
@@ -231,7 +231,7 @@ fn flat_plus_expression<'a>(expression: &'a Expression<'a>) -> Vec<&'a Expressio
     expressions
 }
 
-fn is_pow_2_expression(expression: &Expression, ctx: &LintContext<'_>) -> bool {
+fn is_pow_2_expression(expression: &Expression, ctx: &LintContext) -> bool {
     if let Expression::BinaryExpression(bin_expr) = expression.without_parenthesized() {
         match bin_expr.operator {
             BinaryOperator::Exponential => {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNativeCoercionFunctions {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::ArrowFunctionExpression(arrow_expr) => {
                 if arrow_expr.r#async || arrow_expr.params.items.len() == 0 {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -35,7 +35,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNodeProtocol {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let string_lit_value_with_span = match node.kind() {
             AstKind::ImportExpression(import) => match import.source {
                 Expression::StringLiteral(ref str_lit) => {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferNumberProperties {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         match node.kind() {
             AstKind::MemberExpression(member_expr) => {
                 let Expression::Identifier(ident_name) = member_expr.object() else {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferOptionalCatchBinding {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CatchParameter(catch_param) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferPrototypeMethods {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferQuerySelector {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -54,7 +54,7 @@ fn is_static_property_name_equal(expr: &MemberExpression, value: &str) -> bool {
 }
 
 impl Rule for PreferReflectApply {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferRegexpTest {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferSetSize {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::MemberExpression(member_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferSpread {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringReplaceAll {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringSlice {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -48,7 +48,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringStartsEndsWith {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };
@@ -93,7 +93,7 @@ impl Rule for PreferStringStartsEndsWith {
 }
 
 fn do_fix<'a>(
-    fixer: RuleFixer<'_, 'a>,
+    fixer: RuleFixer<'_, '_, 'a>,
     err_kind: ErrorKind,
     call_expr: &CallExpression<'a>,
     regex: &RegExpLiteral,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferStringTrimStartEnd {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferTypeError {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::ThrowStatement(throw_stmt) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -44,7 +44,7 @@ fn is_array_prototype_property(member_expr: &MemberExpression, property: &str) -
 }
 
 impl Rule for RequireArrayJoinSeparator {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireNumberToFixedDigitsArgument {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for SwitchCaseBraces {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::SwitchStatement(switch) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for TextEncodingIdentifierCase {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let (s, span) = match node.kind() {
             AstKind::StringLiteral(string_lit) => (&string_lit.value, string_lit.span),
             AstKind::JSXText(jsx_text) => (&jsx_text.value, jsx_text.span),

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for ThrowNewError {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportNodeTest {
-    fn run_once(&self, ctx: &LintContext<'_>) {
+    fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
 
         if let Some(node_test_module) = module_record.requested_modules.get("node:test") {

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -18,7 +18,7 @@ use crate::{
 pub fn parse_jest_fn_call<'a>(
     call_expr: &'a CallExpression<'a>,
     possible_jest_node: &PossibleJestNode<'a, '_>,
-    ctx: &LintContext<'a>,
+    ctx: &LintContext<'a, '_>,
 ) -> Option<ParsedJestFnCall<'a>> {
     let original = possible_jest_node.original;
     let node = possible_jest_node.node;
@@ -116,7 +116,7 @@ pub fn parse_jest_fn_call<'a>(
 }
 
 fn parse_jest_expect_fn_call<'a>(
-    options: ExpectFnCallOptions<'a, '_>,
+    options: ExpectFnCallOptions<'a, '_, '_>,
 ) -> Option<ParsedJestFnCall<'a>> {
     let ExpectFnCallOptions { call_expr, members, name, local, head, node, ctx } = options;
     let (modifiers, matcher, mut expect_error) = match find_modifiers_and_matcher(&members) {
@@ -215,7 +215,7 @@ fn find_modifiers_and_matcher(
     Err(ExpectError::MatcherNotFound)
 }
 
-fn is_top_most_call_expr<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_top_most_call_expr<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a, '_>) -> bool {
     let mut node = node;
 
     loop {
@@ -257,14 +257,14 @@ pub enum ExpectError {
     MatcherNotCalled,
 }
 
-pub struct ExpectFnCallOptions<'a, 'b> {
+pub struct ExpectFnCallOptions<'a, 'b, 'c> {
     pub call_expr: &'a CallExpression<'a>,
     pub members: Vec<KnownMemberExpressionProperty<'a>>,
     pub name: &'a str,
     pub local: &'a str,
     pub head: KnownMemberExpressionProperty<'a>,
     pub node: &'b AstNode<'a>,
-    pub ctx: &'b LintContext<'a>,
+    pub ctx: &'b LintContext<'a, 'c>,
 }
 
 // If find a match in `VALID_JEST_FN_CALL_CHAINS`, return true.

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -27,7 +27,7 @@ use crate::{config::JSDocPluginSettings, context::LintContext, AstNode};
 /// ```
 pub fn get_function_nearest_jsdoc_node<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> Option<&'b AstNode<'a>> {
     let mut current_node = node;
     // Whether the node has attached JSDoc or not is determined by `JSDocBuilder`

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -213,14 +213,14 @@ pub fn is_es6_component(node: &AstNode) -> bool {
 
 pub fn get_parent_es5_component<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> Option<&'b AstNode<'a>> {
     ctx.nodes().ancestors(node.id()).skip(1).find_map(|node_id| {
         is_es5_component(ctx.nodes().get_node(node_id)).then(|| ctx.nodes().get_node(node_id))
     })
 }
 
-pub fn get_parent_es6_component<'a, 'b>(ctx: &'b LintContext<'a>) -> Option<&'b AstNode<'a>> {
+pub fn get_parent_es6_component<'a, 'b>(ctx: &'b LintContext<'a, '_>) -> Option<&'b AstNode<'a>> {
     ctx.semantic().symbols().iter_rev().find_map(|symbol| {
         let flags = ctx.semantic().symbols().get_flag(symbol);
         if flags.contains(SymbolFlags::Class) {

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{rule::Rule, AstNode, LintContext};
+use crate::{context::LinterContext, rule::Rule, AstNode, LintContext};
 use oxc_ast::{
     ast::{
         BindingIdentifier, BindingPattern, BindingPatternKind, Expression, JSXAttributeItem,
@@ -59,7 +59,7 @@ impl<R> Rule for R
 where
     R: ReactPerfRule,
 {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, '_>) {
         // new objects/arrays/etc created at the root scope do not get
         // re-created on each render and thus do not affect performance.
         if node.scope_id() == ctx.scopes().root_scope_id() {
@@ -118,7 +118,7 @@ where
         }
     }
 
-    fn should_run(&self, ctx: &LintContext) -> bool {
+    fn should_run(&self, ctx: &LinterContext) -> bool {
         ctx.source_type().is_jsx()
     }
 }

--- a/crates/oxc_linter/src/utils/tree_shaking.rs
+++ b/crates/oxc_linter/src/utils/tree_shaking.rs
@@ -14,18 +14,18 @@ use crate::LintContext;
 
 mod pure_functions;
 
-pub struct NodeListenerOptions<'a, 'b> {
+pub struct NodeListenerOptions<'a, 'b, 'c> {
     pub checked_mutated_nodes: RefCell<FxHashSet<SymbolId>>,
     pub checked_called_nodes: RefCell<FxHashSet<SymbolId>>,
-    pub ctx: &'b LintContext<'a>,
+    pub ctx: &'b LintContext<'a, 'c>,
     pub has_valid_this: Cell<bool>,
     pub called_with_new: Cell<bool>,
     pub whitelist_modules: Option<&'b Vec<WhitelistModule>>,
     pub whitelist_functions: Option<&'b Vec<String>>,
 }
 
-impl<'a, 'b> NodeListenerOptions<'a, 'b> {
-    pub fn new(ctx: &'b LintContext<'a>) -> Self {
+impl<'a, 'b, 'c> NodeListenerOptions<'a, 'b, 'c> {
+    pub fn new(ctx: &'b LintContext<'a, 'c>) -> Self {
         Self {
             checked_mutated_nodes: RefCell::new(FxHashSet::default()),
             checked_called_nodes: RefCell::new(FxHashSet::default()),
@@ -136,7 +136,7 @@ impl Value {
 
 pub fn get_write_expr<'a, 'b>(
     node_id: AstNodeId,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
 ) -> Option<&'b Expression<'a>> {
     let parent = ctx.nodes().parent_node(node_id)?;
     match parent.kind() {
@@ -262,7 +262,10 @@ pub fn has_comment_about_side_effect_check(span: Span, ctx: &LintContext) -> boo
 /// let d = 1; /* invalid comment for `e` */
 /// let e = 2
 /// ```
-pub fn get_leading_tree_shaking_comment<'a>(span: Span, ctx: &LintContext<'a>) -> Option<&'a str> {
+pub fn get_leading_tree_shaking_comment<'a>(
+    span: Span,
+    ctx: &LintContext<'a, '_>,
+) -> Option<&'a str> {
     let comment = ctx.semantic().trivias().comments_range(..span.start).next_back()?;
 
     let comment_text = comment.span.source_text(ctx.source_text());

--- a/crates/oxc_linter/src/utils/unicorn/boolean.rs
+++ b/crates/oxc_linter/src/utils/unicorn/boolean.rs
@@ -11,7 +11,7 @@ use crate::{ast_util::outermost_paren_parent, LintContext};
 pub fn is_logic_not(node: &AstKind) -> bool {
     matches!(node, AstKind::UnaryExpression(unary_expr) if unary_expr.operator == UnaryOperator::LogicalNot)
 }
-fn is_logic_not_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+fn is_logic_not_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a, '_>) -> bool {
     let Some(parent) = outermost_paren_parent(node, ctx) else {
         return false;
     };
@@ -27,14 +27,17 @@ pub fn is_boolean_call(kind: &AstKind) -> bool {
         }) if ident.name == "Boolean" && arguments.len() == 1
     )
 }
-pub fn is_boolean_call_argument<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+pub fn is_boolean_call_argument<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a, '_>,
+) -> bool {
     let arg_id = ctx.nodes().parent_id(node.id());
     let parent = arg_id.and_then(|id| ctx.nodes().parent_kind(id));
     // println!("{parent:#?}");
     matches!(parent, Some(parent) if is_boolean_call(&parent))
 }
 
-pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {
+pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a, '_>) -> bool {
     let kind = node.kind();
 
     if is_logic_not(&kind)
@@ -76,7 +79,7 @@ pub fn is_boolean_node<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) 
 
 pub fn get_boolean_ancestor<'a, 'b>(
     node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
+    ctx: &'b LintContext<'a, '_>,
     // (node, is_negative)
 ) -> (&'b AstNode<'a>, bool) {
     let mut is_negative = false;

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -53,7 +53,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let expanded = quote! {
         #(pub use self::#use_stmts::#struct_names;)*
 
-        use crate::{context::LintContext, rule::{Rule, RuleCategory, RuleMeta}, AstNode};
+        use crate::{context::{LinterContext, LintContext}, rule::{Rule, RuleCategory, RuleMeta}, AstNode};
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
@@ -101,25 +101,25 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub(super) fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+            pub(super) fn run<'a, 'c>(&self, node: &AstNode<'a>, ctx: &LintContext<'a, 'c>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run(node, ctx)),*
                 }
             }
 
-            pub(super) fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContext<'a>) {
+            pub(super) fn run_on_symbol<'a>(&self, symbol_id: SymbolId, ctx: &LintContext<'a, '_>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run_on_symbol(symbol_id, ctx)),*
                 }
             }
 
-            pub(super) fn run_once<'a>(&self, ctx: &LintContext<'a>) {
+            pub(super) fn run_once<'a>(&self, ctx: &LintContext<'a, '_>) {
                 match self {
                     #(Self::#struct_names(rule) => rule.run_once(ctx)),*
                 }
             }
 
-            pub(super) fn should_run(&self, ctx: &LintContext) -> bool {
+            pub(super) fn should_run(&self, ctx: &LinterContext) -> bool {
                 match self {
                     #(Self::#struct_names(rule) => rule.should_run(ctx)),*
                 }


### PR DESCRIPTION
Moves file-specific context information into a `LinterContext` struct and refactors `LintContext` to store a reference to it. The result is a much smaller `LintContext` struct with many fewer `Rc` clones. Locally I'm seeing a ~12% speedup on linter benchmarks. 