### PR TITLE
fix(linter): change no-unused-vars to nursery

### DIFF
--- a/apps/oxlint/src/lint/mod.rs
+++ b/apps/oxlint/src/lint/mod.rs
@@ -427,7 +427,7 @@ mod test {
         ];
         let result = test(args);
         assert_eq!(result.number_of_files, 1);
-        assert_eq!(result.number_of_warnings, 3);
+        assert_eq!(result.number_of_warnings, 2);
         assert_eq!(result.number_of_errors, 0);
     }
 
@@ -441,7 +441,7 @@ mod test {
         ];
         let result = test(args);
         assert_eq!(result.number_of_files, 1);
-        assert_eq!(result.number_of_warnings, 2);
+        assert_eq!(result.number_of_warnings, 1);
         assert_eq!(result.number_of_errors, 0);
     }
 
@@ -477,7 +477,7 @@ mod test {
         let args = &["fixtures/svelte/debugger.svelte"];
         let result = test(args);
         assert_eq!(result.number_of_files, 1);
-        assert_eq!(result.number_of_warnings, 2);
+        assert_eq!(result.number_of_warnings, 1);
         assert_eq!(result.number_of_errors, 0);
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -136,7 +136,7 @@ declare_oxc_lint!(
     /// var global_var = 42;
     /// ```
     NoUnusedVars,
-    correctness
+    nursery
 );
 
 impl Deref for NoUnusedVars {


### PR DESCRIPTION
Also sets `^_` as the default `varsIgnorePattern` unless a configuration object is provided.