### PR TITLE
fix(linter): improve the boundary for eslint/for-direction

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -130,8 +130,7 @@ fn get_assignment_direction(assign: &AssignmentExpression) -> UpdateDirection {
         Expression::NumericLiteral(r) => {
             match r.value {
                 0.0 => return UNKNOWN,
-                _ if r.value.is_sign_positive() => true,
-                _ => false,
+                _ => r.value.is_sign_positive(),
             }
         },
         Expression::UnaryExpression(right) => right.operator != UnaryOperator::UnaryNegation,

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -127,11 +127,9 @@ fn get_assignment_direction(assign: &AssignmentExpression) -> UpdateDirection {
     let operator = &assign.operator;
     let right = &assign.right;
     let positive = match right {
-        Expression::NumericLiteral(r) => {
-            match r.value {
-                0.0 => return UNKNOWN,
-                _ => r.value.is_sign_positive(),
-            }
+        Expression::NumericLiteral(r) => match r.value {
+            0.0 => return UNKNOWN,
+            _ => r.value.is_sign_positive(),
         },
         Expression::UnaryExpression(right) => right.operator != UnaryOperator::UnaryNegation,
         _ => return UNKNOWN,

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -127,7 +127,13 @@ fn get_assignment_direction(assign: &AssignmentExpression) -> UpdateDirection {
     let operator = &assign.operator;
     let right = &assign.right;
     let positive = match right {
-        Expression::NumericLiteral(r) => r.value.is_sign_positive(),
+        Expression::NumericLiteral(r) => {
+            match r.value {
+                0.0 => return UNKNOWN,
+                _ if r.value.is_sign_positive() => true,
+                _ => false,
+            }
+        },
         Expression::UnaryExpression(right) => right.operator != UnaryOperator::UnaryNegation,
         _ => return UNKNOWN,
     };
@@ -175,6 +181,10 @@ fn test() {
         ("for(var i = 10; i >= 0;){}", None),
         ("for(var i = 10; i < 0;){}", None),
         ("for(var i = 10; i <= 0;){}", None),
+        ("for(var i = 0; i < 10; i+=0){}", None),
+        ("for(var i = 0; i < 10; i-=0){}", None),
+        ("for(var i = 10; i > 0; i+=0){}", None),
+        ("for(var i = 10; i > 0; i-=0){}", None),
         ("for(var i = 10; i <= 0; j++){}", None),
         ("for(var i = 10; i <= 0; j--){}", None),
         ("for(var i = 10; i >= 0; j++){}", None),


### PR DESCRIPTION
is_sign_positive() will treat 0.0 as true, which may cause some errors.

https://eslint.org/docs/latest/rules/for-direction#rule-details

demo
[oxc](https://oxc-project.github.io/oxc/playground/?code=3YCAAICfgICAgICAgICzm0omL6Rfsn9X7Kj61BmzN0yVAOAXkgdgAKNr9vvkaX9%2FKzKAgA%3D%3D)
[eslint](https://eslint.org/play/#eyJ0ZXh0IjoiZm9yKGxldCBpID0gMDsgaSA8IDEwOyBpLT0wKXtcbn0iLCJvcHRpb25zIjp7InJ1bGVzIjp7ImZvci1kaXJlY3Rpb24iOlsiZXJyb3IiXX0sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)