### PR TITLE
refactor(ast): remove defunct `visit_as` + `visit_args` attrs from `#[ast]` macro

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -25,7 +25,7 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// Does not generate any code.
 /// Only purpose is to allow using `#[scope]`, `#[visit]`, and other attrs in the AST node type defs.
-#[proc_macro_derive(Ast, attributes(span, scope, visit, visit_as, visit_args, serde, tsify))]
+#[proc_macro_derive(Ast, attributes(scope, visit, span, serde, tsify))]
 pub fn ast_derive(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }


### PR DESCRIPTION
#4371 replaced `#[visit_as(...)]` and `#[visit_args(...)]` with `#[visit(as(...))]` and `#[visit(args(...))]`. Remove these defunct helper attributes from the `#[ast]` macro.