### PR TITLE
fix(linter/eslint): drop quotes around max-params lint warning

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn max_params_diagnostic(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x0:?}"))
+    OxcDiagnostic::warn(x0.to_string())
         .with_help(
             "This rule enforces a maximum number of parameters allowed in function definitions.",
         )

--- a/crates/oxc_linter/src/snapshots/max_params.snap
+++ b/crates/oxc_linter/src/snapshots/max_params.snap
@@ -1,70 +1,70 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (3). Maximum allowed is 2."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (3). Maximum allowed is 2.
    ╭─[max_params.tsx:1:14]
  1 │ function test(a, b, c) {}
    ·              ─────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (4). Maximum allowed is 3."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (4). Maximum allowed is 3.
    ╭─[max_params.tsx:1:14]
  1 │ function test(a, b, c, d) {}
    ·              ────────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function has too many parameters (4). Maximum allowed is 3."
+  ⚠ eslint(max-params): Function has too many parameters (4). Maximum allowed is 3.
    ╭─[max_params.tsx:1:20]
  1 │ var test = function(a, b, c, d) {};
    ·                    ────────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Arrow function has too many parameters (4). Maximum allowed is 3."
+  ⚠ eslint(max-params): Arrow function has too many parameters (4). Maximum allowed is 3.
    ╭─[max_params.tsx:1:12]
  1 │ var test = (a, b, c, d) => {};
    ·            ────────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function has too many parameters (4). Maximum allowed is 3."
+  ⚠ eslint(max-params): Function has too many parameters (4). Maximum allowed is 3.
    ╭─[max_params.tsx:1:10]
  1 │ (function(a, b, c, d) {});
    ·          ────────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (3). Maximum allowed is 1."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (3). Maximum allowed is 1.
    ╭─[max_params.tsx:1:25]
  1 │ var test = function test(a, b, c) {};
    ·                         ─────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (3). Maximum allowed is 2."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (3). Maximum allowed is 2.
    ╭─[max_params.tsx:1:14]
  1 │ function test(a, b, c) {}
    ·              ─────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (4). Maximum allowed is 3."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (4). Maximum allowed is 3.
    ╭─[max_params.tsx:1:14]
  1 │ function test(a, b, c, d) {}
    ·              ────────────
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (1). Maximum allowed is 0."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (1). Maximum allowed is 0.
    ╭─[max_params.tsx:1:14]
  1 │ function test(a) {}
    ·              ───
    ╰────
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
-  ⚠ eslint(max-params): "Function 'test' has too many parameters (3). Maximum allowed is 2."
+  ⚠ eslint(max-params): Function 'test' has too many parameters (3). Maximum allowed is 2.
    ╭─[max_params.tsx:1:14]
  1 │ function test(a, b, c) {
    ·              ─────────


### PR DESCRIPTION
This was introduced by the diagnostic codes in lint rules 7a75e0f8a7.

---

Checked the rest of the codebase and haven't found other issues.