### PR TITLE
feat(ast): `GetSpanMut` trait

### DIFF
--- a/crates/oxc_ast/src/generated/span.rs
+++ b/crates/oxc_ast/src/generated/span.rs
@@ -4,12 +4,19 @@
 #![allow(clippy::match_same_arms)]
 
 use crate::ast::*;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, GetSpanMut, Span};
 
 impl GetSpan for BooleanLiteral {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for BooleanLiteral {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -20,10 +27,24 @@ impl GetSpan for NullLiteral {
     }
 }
 
+impl GetSpanMut for NullLiteral {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for NumericLiteral<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for NumericLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -34,10 +55,24 @@ impl<'a> GetSpan for BigIntLiteral<'a> {
     }
 }
 
+impl<'a> GetSpanMut for BigIntLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for RegExpLiteral<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for RegExpLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -48,10 +83,24 @@ impl<'a> GetSpan for StringLiteral<'a> {
     }
 }
 
+impl<'a> GetSpanMut for StringLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for Program<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for Program<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -104,10 +153,66 @@ impl<'a> GetSpan for Expression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Expression<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for IdentifierName<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for IdentifierName<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -118,10 +223,24 @@ impl<'a> GetSpan for IdentifierReference<'a> {
     }
 }
 
+impl<'a> GetSpanMut for IdentifierReference<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BindingIdentifier<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for BindingIdentifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -132,6 +251,13 @@ impl<'a> GetSpan for LabelIdentifier<'a> {
     }
 }
 
+impl<'a> GetSpanMut for LabelIdentifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for ThisExpression {
     #[inline]
     fn span(&self) -> Span {
@@ -139,10 +265,24 @@ impl GetSpan for ThisExpression {
     }
 }
 
+impl GetSpanMut for ThisExpression {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ArrayExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ArrayExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -197,6 +337,57 @@ impl<'a> GetSpan for ArrayExpressionElement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ArrayExpressionElement<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::SpreadElement(it) => it.span_mut(),
+            Self::Elision(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl GetSpan for Elision {
     #[inline]
     fn span(&self) -> Span {
@@ -204,10 +395,24 @@ impl GetSpan for Elision {
     }
 }
 
+impl GetSpanMut for Elision {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ObjectExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ObjectExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -220,10 +425,26 @@ impl<'a> GetSpan for ObjectPropertyKind<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ObjectPropertyKind<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::ObjectProperty(it) => it.span_mut(),
+            Self::SpreadProperty(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ObjectProperty<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ObjectProperty<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -278,10 +499,68 @@ impl<'a> GetSpan for PropertyKey<'a> {
     }
 }
 
+impl<'a> GetSpanMut for PropertyKey<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::StaticIdentifier(it) => it.span_mut(),
+            Self::PrivateIdentifier(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TemplateLiteral<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TemplateLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -292,10 +571,24 @@ impl<'a> GetSpan for TaggedTemplateExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TaggedTemplateExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TemplateElement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TemplateElement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -309,10 +602,27 @@ impl<'a> GetSpan for MemberExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for MemberExpression<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ComputedMemberExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ComputedMemberExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -323,10 +633,24 @@ impl<'a> GetSpan for StaticMemberExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for StaticMemberExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for PrivateFieldExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for PrivateFieldExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -337,10 +661,24 @@ impl<'a> GetSpan for CallExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for CallExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for NewExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for NewExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -351,10 +689,24 @@ impl<'a> GetSpan for MetaProperty<'a> {
     }
 }
 
+impl<'a> GetSpanMut for MetaProperty<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for SpreadElement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for SpreadElement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -408,10 +760,67 @@ impl<'a> GetSpan for Argument<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Argument<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::SpreadElement(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for UpdateExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for UpdateExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -422,10 +831,24 @@ impl<'a> GetSpan for UnaryExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for UnaryExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BinaryExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for BinaryExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -436,10 +859,24 @@ impl<'a> GetSpan for PrivateInExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for PrivateInExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for LogicalExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for LogicalExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -450,10 +887,24 @@ impl<'a> GetSpan for ConditionalExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ConditionalExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for AssignmentExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for AssignmentExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -475,6 +926,24 @@ impl<'a> GetSpan for AssignmentTarget<'a> {
     }
 }
 
+impl<'a> GetSpanMut for AssignmentTarget<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for SimpleAssignmentTarget<'a> {
     fn span(&self) -> Span {
         match self {
@@ -491,11 +960,36 @@ impl<'a> GetSpan for SimpleAssignmentTarget<'a> {
     }
 }
 
+impl<'a> GetSpanMut for SimpleAssignmentTarget<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for AssignmentTargetPattern<'a> {
     fn span(&self) -> Span {
         match self {
             Self::ArrayAssignmentTarget(it) => it.span(),
             Self::ObjectAssignmentTarget(it) => it.span(),
+        }
+    }
+}
+
+impl<'a> GetSpanMut for AssignmentTargetPattern<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
         }
     }
 }
@@ -507,6 +1001,13 @@ impl<'a> GetSpan for ArrayAssignmentTarget<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ArrayAssignmentTarget<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ObjectAssignmentTarget<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -514,10 +1015,24 @@ impl<'a> GetSpan for ObjectAssignmentTarget<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ObjectAssignmentTarget<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for AssignmentTargetRest<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for AssignmentTargetRest<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -540,10 +1055,36 @@ impl<'a> GetSpan for AssignmentTargetMaybeDefault<'a> {
     }
 }
 
+impl<'a> GetSpanMut for AssignmentTargetMaybeDefault<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::AssignmentTargetWithDefault(it) => it.span_mut(),
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for AssignmentTargetWithDefault<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for AssignmentTargetWithDefault<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -556,10 +1097,26 @@ impl<'a> GetSpan for AssignmentTargetProperty<'a> {
     }
 }
 
+impl<'a> GetSpanMut for AssignmentTargetProperty<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::AssignmentTargetPropertyIdentifier(it) => it.span_mut(),
+            Self::AssignmentTargetPropertyProperty(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for AssignmentTargetPropertyIdentifier<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for AssignmentTargetPropertyIdentifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -570,10 +1127,24 @@ impl<'a> GetSpan for AssignmentTargetPropertyProperty<'a> {
     }
 }
 
+impl<'a> GetSpanMut for AssignmentTargetPropertyProperty<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for SequenceExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for SequenceExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -584,6 +1155,13 @@ impl GetSpan for Super {
     }
 }
 
+impl GetSpanMut for Super {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for AwaitExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -591,10 +1169,24 @@ impl<'a> GetSpan for AwaitExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for AwaitExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ChainExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ChainExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -609,10 +1201,28 @@ impl<'a> GetSpan for ChainElement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ChainElement<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ParenthesizedExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ParenthesizedExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -656,10 +1266,57 @@ impl<'a> GetSpan for Statement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Statement<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::BlockStatement(it) => it.span_mut(),
+            Self::BreakStatement(it) => it.span_mut(),
+            Self::ContinueStatement(it) => it.span_mut(),
+            Self::DebuggerStatement(it) => it.span_mut(),
+            Self::DoWhileStatement(it) => it.span_mut(),
+            Self::EmptyStatement(it) => it.span_mut(),
+            Self::ExpressionStatement(it) => it.span_mut(),
+            Self::ForInStatement(it) => it.span_mut(),
+            Self::ForOfStatement(it) => it.span_mut(),
+            Self::ForStatement(it) => it.span_mut(),
+            Self::IfStatement(it) => it.span_mut(),
+            Self::LabeledStatement(it) => it.span_mut(),
+            Self::ReturnStatement(it) => it.span_mut(),
+            Self::SwitchStatement(it) => it.span_mut(),
+            Self::ThrowStatement(it) => it.span_mut(),
+            Self::TryStatement(it) => it.span_mut(),
+            Self::WhileStatement(it) => it.span_mut(),
+            Self::WithStatement(it) => it.span_mut(),
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::FunctionDeclaration(it) => it.span_mut(),
+            Self::ClassDeclaration(it) => it.span_mut(),
+            Self::UsingDeclaration(it) => it.span_mut(),
+            Self::TSTypeAliasDeclaration(it) => it.span_mut(),
+            Self::TSInterfaceDeclaration(it) => it.span_mut(),
+            Self::TSEnumDeclaration(it) => it.span_mut(),
+            Self::TSModuleDeclaration(it) => it.span_mut(),
+            Self::TSImportEqualsDeclaration(it) => it.span_mut(),
+            Self::ImportDeclaration(it) => it.span_mut(),
+            Self::ExportAllDeclaration(it) => it.span_mut(),
+            Self::ExportDefaultDeclaration(it) => it.span_mut(),
+            Self::ExportNamedDeclaration(it) => it.span_mut(),
+            Self::TSExportAssignment(it) => it.span_mut(),
+            Self::TSNamespaceExportDeclaration(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for Directive<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for Directive<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -670,10 +1327,24 @@ impl<'a> GetSpan for Hashbang<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Hashbang<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BlockStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for BlockStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -693,10 +1364,33 @@ impl<'a> GetSpan for Declaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Declaration<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::FunctionDeclaration(it) => it.span_mut(),
+            Self::ClassDeclaration(it) => it.span_mut(),
+            Self::UsingDeclaration(it) => it.span_mut(),
+            Self::TSTypeAliasDeclaration(it) => it.span_mut(),
+            Self::TSInterfaceDeclaration(it) => it.span_mut(),
+            Self::TSEnumDeclaration(it) => it.span_mut(),
+            Self::TSModuleDeclaration(it) => it.span_mut(),
+            Self::TSImportEqualsDeclaration(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for VariableDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for VariableDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -707,10 +1401,24 @@ impl<'a> GetSpan for VariableDeclarator<'a> {
     }
 }
 
+impl<'a> GetSpanMut for VariableDeclarator<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for UsingDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for UsingDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -721,10 +1429,24 @@ impl GetSpan for EmptyStatement {
     }
 }
 
+impl GetSpanMut for EmptyStatement {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ExpressionStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ExpressionStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -735,10 +1457,24 @@ impl<'a> GetSpan for IfStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for IfStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for DoWhileStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for DoWhileStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -749,10 +1485,24 @@ impl<'a> GetSpan for WhileStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for WhileStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ForStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ForStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -807,10 +1557,68 @@ impl<'a> GetSpan for ForStatementInit<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ForStatementInit<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::UsingDeclaration(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ForInStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ForInStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -834,10 +1642,37 @@ impl<'a> GetSpan for ForStatementLeft<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ForStatementLeft<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::UsingDeclaration(it) => it.span_mut(),
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ForOfStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ForOfStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -848,10 +1683,24 @@ impl<'a> GetSpan for ContinueStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ContinueStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BreakStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for BreakStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -862,10 +1711,24 @@ impl<'a> GetSpan for ReturnStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ReturnStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for WithStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for WithStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -876,10 +1739,24 @@ impl<'a> GetSpan for SwitchStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for SwitchStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for SwitchCase<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for SwitchCase<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -890,10 +1767,24 @@ impl<'a> GetSpan for LabeledStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for LabeledStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ThrowStatement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ThrowStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -904,10 +1795,24 @@ impl<'a> GetSpan for TryStatement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TryStatement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for CatchClause<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for CatchClause<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -918,6 +1823,13 @@ impl<'a> GetSpan for CatchParameter<'a> {
     }
 }
 
+impl<'a> GetSpanMut for CatchParameter<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for DebuggerStatement {
     #[inline]
     fn span(&self) -> Span {
@@ -925,10 +1837,24 @@ impl GetSpan for DebuggerStatement {
     }
 }
 
+impl GetSpanMut for DebuggerStatement {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BindingPattern<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.kind.span()
+    }
+}
+
+impl<'a> GetSpanMut for BindingPattern<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        self.kind.span_mut()
     }
 }
 
@@ -943,10 +1869,28 @@ impl<'a> GetSpan for BindingPatternKind<'a> {
     }
 }
 
+impl<'a> GetSpanMut for BindingPatternKind<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::BindingIdentifier(it) => it.span_mut(),
+            Self::ObjectPattern(it) => it.span_mut(),
+            Self::ArrayPattern(it) => it.span_mut(),
+            Self::AssignmentPattern(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for AssignmentPattern<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for AssignmentPattern<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -957,10 +1901,24 @@ impl<'a> GetSpan for ObjectPattern<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ObjectPattern<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BindingProperty<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for BindingProperty<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -971,10 +1929,24 @@ impl<'a> GetSpan for ArrayPattern<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ArrayPattern<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for BindingRestElement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for BindingRestElement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -985,10 +1957,24 @@ impl<'a> GetSpan for Function<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Function<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for FormalParameters<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for FormalParameters<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -999,10 +1985,24 @@ impl<'a> GetSpan for FormalParameter<'a> {
     }
 }
 
+impl<'a> GetSpanMut for FormalParameter<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for FunctionBody<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for FunctionBody<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1013,10 +2013,24 @@ impl<'a> GetSpan for ArrowFunctionExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ArrowFunctionExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for YieldExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for YieldExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1027,10 +2041,24 @@ impl<'a> GetSpan for Class<'a> {
     }
 }
 
+impl<'a> GetSpanMut for Class<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ClassBody<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ClassBody<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1046,10 +2074,29 @@ impl<'a> GetSpan for ClassElement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ClassElement<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::StaticBlock(it) => it.span_mut(),
+            Self::MethodDefinition(it) => it.span_mut(),
+            Self::PropertyDefinition(it) => it.span_mut(),
+            Self::AccessorProperty(it) => it.span_mut(),
+            Self::TSIndexSignature(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for MethodDefinition<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for MethodDefinition<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1060,6 +2107,13 @@ impl<'a> GetSpan for PropertyDefinition<'a> {
     }
 }
 
+impl<'a> GetSpanMut for PropertyDefinition<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for PrivateIdentifier<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -1067,10 +2121,24 @@ impl<'a> GetSpan for PrivateIdentifier<'a> {
     }
 }
 
+impl<'a> GetSpanMut for PrivateIdentifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for StaticBlock<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for StaticBlock<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1087,10 +2155,30 @@ impl<'a> GetSpan for ModuleDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ModuleDeclaration<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::ImportDeclaration(it) => it.span_mut(),
+            Self::ExportAllDeclaration(it) => it.span_mut(),
+            Self::ExportDefaultDeclaration(it) => it.span_mut(),
+            Self::ExportNamedDeclaration(it) => it.span_mut(),
+            Self::TSExportAssignment(it) => it.span_mut(),
+            Self::TSNamespaceExportDeclaration(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for AccessorProperty<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for AccessorProperty<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1101,10 +2189,24 @@ impl<'a> GetSpan for ImportExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ImportExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ImportDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ImportDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1118,10 +2220,27 @@ impl<'a> GetSpan for ImportDeclarationSpecifier<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ImportDeclarationSpecifier<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::ImportSpecifier(it) => it.span_mut(),
+            Self::ImportDefaultSpecifier(it) => it.span_mut(),
+            Self::ImportNamespaceSpecifier(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ImportSpecifier<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ImportSpecifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1132,10 +2251,24 @@ impl<'a> GetSpan for ImportDefaultSpecifier<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ImportDefaultSpecifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ImportNamespaceSpecifier<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ImportNamespaceSpecifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1146,10 +2279,24 @@ impl<'a> GetSpan for WithClause<'a> {
     }
 }
 
+impl<'a> GetSpanMut for WithClause<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ImportAttribute<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ImportAttribute<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1162,10 +2309,26 @@ impl<'a> GetSpan for ImportAttributeKey<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ImportAttributeKey<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ExportNamedDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ExportNamedDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1176,6 +2339,13 @@ impl<'a> GetSpan for ExportDefaultDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ExportDefaultDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ExportAllDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -1183,10 +2353,24 @@ impl<'a> GetSpan for ExportAllDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ExportAllDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for ExportSpecifier<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for ExportSpecifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1242,12 +2426,74 @@ impl<'a> GetSpan for ExportDefaultDeclarationKind<'a> {
     }
 }
 
+impl<'a> GetSpanMut for ExportDefaultDeclarationKind<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::FunctionDeclaration(it) => it.span_mut(),
+            Self::ClassDeclaration(it) => it.span_mut(),
+            Self::TSInterfaceDeclaration(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for ModuleExportName<'a> {
     fn span(&self) -> Span {
         match self {
             Self::IdentifierName(it) => it.span(),
             Self::IdentifierReference(it) => it.span(),
             Self::StringLiteral(it) => it.span(),
+        }
+    }
+}
+
+impl<'a> GetSpanMut for ModuleExportName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::IdentifierName(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
         }
     }
 }
@@ -1259,6 +2505,13 @@ impl<'a> GetSpan for TSThisParameter<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSThisParameter<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSEnumDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -1266,10 +2519,24 @@ impl<'a> GetSpan for TSEnumDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSEnumDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSEnumMember<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSEnumMember<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1326,6 +2593,59 @@ impl<'a> GetSpan for TSEnumMemberName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSEnumMemberName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::StaticIdentifier(it) => it.span_mut(),
+            Self::StaticStringLiteral(it) => it.span_mut(),
+            Self::StaticTemplateLiteral(it) => it.span_mut(),
+            Self::StaticNumericLiteral(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSTypeAnnotation<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -1333,10 +2653,24 @@ impl<'a> GetSpan for TSTypeAnnotation<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeAnnotation<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSLiteralType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSLiteralType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1351,6 +2685,21 @@ impl<'a> GetSpan for TSLiteral<'a> {
             Self::StringLiteral(it) => it.span(),
             Self::TemplateLiteral(it) => it.span(),
             Self::UnaryExpression(it) => it.span(),
+        }
+    }
+}
+
+impl<'a> GetSpanMut for TSLiteral<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
         }
     }
 }
@@ -1400,10 +2749,62 @@ impl<'a> GetSpan for TSType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSType<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::TSAnyKeyword(it) => it.span_mut(),
+            Self::TSBigIntKeyword(it) => it.span_mut(),
+            Self::TSBooleanKeyword(it) => it.span_mut(),
+            Self::TSIntrinsicKeyword(it) => it.span_mut(),
+            Self::TSNeverKeyword(it) => it.span_mut(),
+            Self::TSNullKeyword(it) => it.span_mut(),
+            Self::TSNumberKeyword(it) => it.span_mut(),
+            Self::TSObjectKeyword(it) => it.span_mut(),
+            Self::TSStringKeyword(it) => it.span_mut(),
+            Self::TSSymbolKeyword(it) => it.span_mut(),
+            Self::TSUndefinedKeyword(it) => it.span_mut(),
+            Self::TSUnknownKeyword(it) => it.span_mut(),
+            Self::TSVoidKeyword(it) => it.span_mut(),
+            Self::TSArrayType(it) => it.span_mut(),
+            Self::TSConditionalType(it) => it.span_mut(),
+            Self::TSConstructorType(it) => it.span_mut(),
+            Self::TSFunctionType(it) => it.span_mut(),
+            Self::TSImportType(it) => it.span_mut(),
+            Self::TSIndexedAccessType(it) => it.span_mut(),
+            Self::TSInferType(it) => it.span_mut(),
+            Self::TSIntersectionType(it) => it.span_mut(),
+            Self::TSLiteralType(it) => it.span_mut(),
+            Self::TSMappedType(it) => it.span_mut(),
+            Self::TSNamedTupleMember(it) => it.span_mut(),
+            Self::TSQualifiedName(it) => it.span_mut(),
+            Self::TSTemplateLiteralType(it) => it.span_mut(),
+            Self::TSThisType(it) => it.span_mut(),
+            Self::TSTupleType(it) => it.span_mut(),
+            Self::TSTypeLiteral(it) => it.span_mut(),
+            Self::TSTypeOperatorType(it) => it.span_mut(),
+            Self::TSTypePredicate(it) => it.span_mut(),
+            Self::TSTypeQuery(it) => it.span_mut(),
+            Self::TSTypeReference(it) => it.span_mut(),
+            Self::TSUnionType(it) => it.span_mut(),
+            Self::TSParenthesizedType(it) => it.span_mut(),
+            Self::JSDocNullableType(it) => it.span_mut(),
+            Self::JSDocNonNullableType(it) => it.span_mut(),
+            Self::JSDocUnknownType(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSConditionalType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSConditionalType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1414,10 +2815,24 @@ impl<'a> GetSpan for TSUnionType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSUnionType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSIntersectionType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSIntersectionType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1428,10 +2843,24 @@ impl<'a> GetSpan for TSParenthesizedType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSParenthesizedType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypeOperator<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSTypeOperator<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1442,10 +2871,24 @@ impl<'a> GetSpan for TSArrayType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSArrayType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSIndexedAccessType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSIndexedAccessType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1456,10 +2899,24 @@ impl<'a> GetSpan for TSTupleType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTupleType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSNamedTupleMember<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSNamedTupleMember<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1470,10 +2927,24 @@ impl<'a> GetSpan for TSOptionalType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSOptionalType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSRestType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSRestType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1524,10 +2995,64 @@ impl<'a> GetSpan for TSTupleElement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTupleElement<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::TSOptionalType(it) => it.span_mut(),
+            Self::TSRestType(it) => it.span_mut(),
+            Self::TSAnyKeyword(it) => it.span_mut(),
+            Self::TSBigIntKeyword(it) => it.span_mut(),
+            Self::TSBooleanKeyword(it) => it.span_mut(),
+            Self::TSIntrinsicKeyword(it) => it.span_mut(),
+            Self::TSNeverKeyword(it) => it.span_mut(),
+            Self::TSNullKeyword(it) => it.span_mut(),
+            Self::TSNumberKeyword(it) => it.span_mut(),
+            Self::TSObjectKeyword(it) => it.span_mut(),
+            Self::TSStringKeyword(it) => it.span_mut(),
+            Self::TSSymbolKeyword(it) => it.span_mut(),
+            Self::TSUndefinedKeyword(it) => it.span_mut(),
+            Self::TSUnknownKeyword(it) => it.span_mut(),
+            Self::TSVoidKeyword(it) => it.span_mut(),
+            Self::TSArrayType(it) => it.span_mut(),
+            Self::TSConditionalType(it) => it.span_mut(),
+            Self::TSConstructorType(it) => it.span_mut(),
+            Self::TSFunctionType(it) => it.span_mut(),
+            Self::TSImportType(it) => it.span_mut(),
+            Self::TSIndexedAccessType(it) => it.span_mut(),
+            Self::TSInferType(it) => it.span_mut(),
+            Self::TSIntersectionType(it) => it.span_mut(),
+            Self::TSLiteralType(it) => it.span_mut(),
+            Self::TSMappedType(it) => it.span_mut(),
+            Self::TSNamedTupleMember(it) => it.span_mut(),
+            Self::TSQualifiedName(it) => it.span_mut(),
+            Self::TSTemplateLiteralType(it) => it.span_mut(),
+            Self::TSThisType(it) => it.span_mut(),
+            Self::TSTupleType(it) => it.span_mut(),
+            Self::TSTypeLiteral(it) => it.span_mut(),
+            Self::TSTypeOperatorType(it) => it.span_mut(),
+            Self::TSTypePredicate(it) => it.span_mut(),
+            Self::TSTypeQuery(it) => it.span_mut(),
+            Self::TSTypeReference(it) => it.span_mut(),
+            Self::TSUnionType(it) => it.span_mut(),
+            Self::TSParenthesizedType(it) => it.span_mut(),
+            Self::JSDocNullableType(it) => it.span_mut(),
+            Self::JSDocNonNullableType(it) => it.span_mut(),
+            Self::JSDocUnknownType(it) => it.span_mut(),
+        }
+    }
+}
+
 impl GetSpan for TSAnyKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSAnyKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1538,10 +3063,24 @@ impl GetSpan for TSStringKeyword {
     }
 }
 
+impl GetSpanMut for TSStringKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for TSBooleanKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSBooleanKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1552,10 +3091,24 @@ impl GetSpan for TSNumberKeyword {
     }
 }
 
+impl GetSpanMut for TSNumberKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for TSNeverKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSNeverKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1566,10 +3119,24 @@ impl GetSpan for TSIntrinsicKeyword {
     }
 }
 
+impl GetSpanMut for TSIntrinsicKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for TSUnknownKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSUnknownKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1580,10 +3147,24 @@ impl GetSpan for TSNullKeyword {
     }
 }
 
+impl GetSpanMut for TSNullKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for TSUndefinedKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSUndefinedKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1594,10 +3175,24 @@ impl GetSpan for TSVoidKeyword {
     }
 }
 
+impl GetSpanMut for TSVoidKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for TSSymbolKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSSymbolKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1608,10 +3203,24 @@ impl GetSpan for TSThisType {
     }
 }
 
+impl GetSpanMut for TSThisType {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for TSObjectKeyword {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for TSObjectKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1622,10 +3231,24 @@ impl GetSpan for TSBigIntKeyword {
     }
 }
 
+impl GetSpanMut for TSBigIntKeyword {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypeReference<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSTypeReference<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1638,10 +3261,26 @@ impl<'a> GetSpan for TSTypeName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::QualifiedName(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSQualifiedName<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSQualifiedName<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1652,10 +3291,24 @@ impl<'a> GetSpan for TSTypeParameterInstantiation<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeParameterInstantiation<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypeParameter<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSTypeParameter<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1666,10 +3319,24 @@ impl<'a> GetSpan for TSTypeParameterDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeParameterDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypeAliasDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSTypeAliasDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1680,10 +3347,24 @@ impl<'a> GetSpan for TSClassImplements<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSClassImplements<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSInterfaceDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSInterfaceDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1694,10 +3375,24 @@ impl<'a> GetSpan for TSInterfaceBody<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSInterfaceBody<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSPropertySignature<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSPropertySignature<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1713,10 +3408,29 @@ impl<'a> GetSpan for TSSignature<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSSignature<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::TSIndexSignature(it) => it.span_mut(),
+            Self::TSPropertySignature(it) => it.span_mut(),
+            Self::TSCallSignatureDeclaration(it) => it.span_mut(),
+            Self::TSConstructSignatureDeclaration(it) => it.span_mut(),
+            Self::TSMethodSignature(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSIndexSignature<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSIndexSignature<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1727,10 +3441,24 @@ impl<'a> GetSpan for TSCallSignatureDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSCallSignatureDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSMethodSignature<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSMethodSignature<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1741,10 +3469,24 @@ impl<'a> GetSpan for TSConstructSignatureDeclaration<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSConstructSignatureDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSIndexSignatureName<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSIndexSignatureName<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1755,10 +3497,24 @@ impl<'a> GetSpan for TSInterfaceHeritage<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSInterfaceHeritage<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypePredicate<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSTypePredicate<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1771,10 +3527,26 @@ impl<'a> GetSpan for TSTypePredicateName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypePredicateName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::This(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSModuleDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSModuleDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1783,6 +3555,15 @@ impl<'a> GetSpan for TSModuleDeclarationName<'a> {
         match self {
             Self::Identifier(it) => it.span(),
             Self::StringLiteral(it) => it.span(),
+        }
+    }
+}
+
+impl<'a> GetSpanMut for TSModuleDeclarationName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
         }
     }
 }
@@ -1796,10 +3577,26 @@ impl<'a> GetSpan for TSModuleDeclarationBody<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSModuleDeclarationBody<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::TSModuleDeclaration(it) => it.span_mut(),
+            Self::TSModuleBlock(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSModuleBlock<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSModuleBlock<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1810,6 +3607,13 @@ impl<'a> GetSpan for TSTypeLiteral<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeLiteral<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSInferType<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -1817,10 +3621,24 @@ impl<'a> GetSpan for TSInferType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSInferType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypeQuery<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSTypeQuery<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1834,10 +3652,27 @@ impl<'a> GetSpan for TSTypeQueryExprName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeQueryExprName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::TSImportType(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::QualifiedName(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSImportType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSImportType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1848,10 +3683,24 @@ impl<'a> GetSpan for TSImportAttributes<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSImportAttributes<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSImportAttribute<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSImportAttribute<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1864,10 +3713,26 @@ impl<'a> GetSpan for TSImportAttributeName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSImportAttributeName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSFunctionType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSFunctionType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1878,10 +3743,24 @@ impl<'a> GetSpan for TSConstructorType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSConstructorType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSMappedType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSMappedType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1892,10 +3771,24 @@ impl<'a> GetSpan for TSTemplateLiteralType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTemplateLiteralType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSAsExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSAsExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1906,6 +3799,13 @@ impl<'a> GetSpan for TSSatisfiesExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSSatisfiesExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSTypeAssertion<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -1913,10 +3813,24 @@ impl<'a> GetSpan for TSTypeAssertion<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSTypeAssertion<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSImportEqualsDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSImportEqualsDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1930,10 +3844,27 @@ impl<'a> GetSpan for TSModuleReference<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSModuleReference<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::ExternalModuleReference(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::QualifiedName(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for TSExternalModuleReference<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSExternalModuleReference<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1944,10 +3875,24 @@ impl<'a> GetSpan for TSNonNullExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSNonNullExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for Decorator<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for Decorator<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1958,10 +3903,24 @@ impl<'a> GetSpan for TSExportAssignment<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSExportAssignment<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for TSNamespaceExportDeclaration<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for TSNamespaceExportDeclaration<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1972,10 +3931,24 @@ impl<'a> GetSpan for TSInstantiationExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for TSInstantiationExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for JSDocNullableType<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSDocNullableType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -1986,10 +3959,24 @@ impl<'a> GetSpan for JSDocNonNullableType<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSDocNonNullableType<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpan for JSDocUnknownType {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for JSDocUnknownType {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2000,10 +3987,24 @@ impl<'a> GetSpan for JSXElement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXElement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for JSXOpeningElement<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXOpeningElement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2014,10 +4015,24 @@ impl<'a> GetSpan for JSXClosingElement<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXClosingElement<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for JSXFragment<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXFragment<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2031,6 +4046,16 @@ impl<'a> GetSpan for JSXElementName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXElementName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::NamespacedName(it) => it.span_mut(),
+            Self::MemberExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for JSXNamespacedName<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -2038,10 +4063,24 @@ impl<'a> GetSpan for JSXNamespacedName<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXNamespacedName<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for JSXMemberExpression<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXMemberExpression<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2054,10 +4093,26 @@ impl<'a> GetSpan for JSXMemberExpressionObject<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXMemberExpressionObject<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::MemberExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for JSXExpressionContainer<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXExpressionContainer<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2111,10 +4166,67 @@ impl<'a> GetSpan for JSXExpression<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXExpression<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::EmptyExpression(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+        }
+    }
+}
+
 impl GetSpan for JSXEmptyExpression {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl GetSpanMut for JSXEmptyExpression {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2127,10 +4239,26 @@ impl<'a> GetSpan for JSXAttributeItem<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXAttributeItem<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Attribute(it) => it.span_mut(),
+            Self::SpreadAttribute(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for JSXAttribute<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXAttribute<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2141,11 +4269,27 @@ impl<'a> GetSpan for JSXSpreadAttribute<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXSpreadAttribute<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for JSXAttributeName<'a> {
     fn span(&self) -> Span {
         match self {
             Self::Identifier(it) => it.span(),
             Self::NamespacedName(it) => it.span(),
+        }
+    }
+}
+
+impl<'a> GetSpanMut for JSXAttributeName<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => it.span_mut(),
+            Self::NamespacedName(it) => it.span_mut(),
         }
     }
 }
@@ -2161,10 +4305,28 @@ impl<'a> GetSpan for JSXAttributeValue<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXAttributeValue<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::ExpressionContainer(it) => it.span_mut(),
+            Self::Element(it) => it.span_mut(),
+            Self::Fragment(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for JSXIdentifier<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXIdentifier<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }
 
@@ -2180,6 +4342,18 @@ impl<'a> GetSpan for JSXChild<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXChild<'a> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Text(it) => it.span_mut(),
+            Self::Element(it) => it.span_mut(),
+            Self::Fragment(it) => it.span_mut(),
+            Self::ExpressionContainer(it) => it.span_mut(),
+            Self::Spread(it) => it.span_mut(),
+        }
+    }
+}
+
 impl<'a> GetSpan for JSXSpreadChild<'a> {
     #[inline]
     fn span(&self) -> Span {
@@ -2187,9 +4361,23 @@ impl<'a> GetSpan for JSXSpreadChild<'a> {
     }
 }
 
+impl<'a> GetSpanMut for JSXSpreadChild<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpan for JSXText<'a> {
     #[inline]
     fn span(&self) -> Span {
         self.span
+    }
+}
+
+impl<'a> GetSpanMut for JSXText<'a> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
     }
 }

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -9,5 +9,5 @@ mod span;
 pub use crate::{
     atom::{Atom, CompactStr, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN},
     source_type::{Language, LanguageVariant, ModuleKind, SourceType, VALID_EXTENSIONS},
-    span::{GetSpan, Span, SPAN},
+    span::{GetSpan, GetSpanMut, Span, SPAN},
 };

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -352,9 +352,23 @@ impl From<Span> for LabeledSpan {
 pub trait GetSpan {
     fn span(&self) -> Span;
 }
+
+/// Get mutable ref to span for an AST node
+pub trait GetSpanMut {
+    fn span_mut(&mut self) -> &mut Span;
+}
+
 impl GetSpan for Span {
+    #[inline]
     fn span(&self) -> Span {
         *self
+    }
+}
+
+impl GetSpanMut for Span {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        self
     }
 }
 


### PR DESCRIPTION
Closes #4606.

Introduce `GetSpanMut` trait and implement it on all AST node types.

This has to be a separate trait, rather than adding `span_mut` method to `GetSpan` because `AstKind` implements `GetSpan`, and it only has an immutable `&` ref to AST node it contains.