### PR TITLE
refactor(ast): put `assert_layouts.rs` behind `debug_assertions`

### DIFF
--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -37,7 +37,7 @@ pub mod syntax_directed_operations;
 mod trivia;
 
 mod generated {
-    #[cfg(test)]
+    #[cfg(debug_assertions)]
     pub mod assert_layouts;
     pub mod ast_builder;
     pub mod ast_kind;


### PR DESCRIPTION
#4615 was showing as green on all checks, but failed CI on main once merged because of errors in "Test wasm32-wasip1-threads" job, which only runs on main. This change will make sure any such problem gets caught at the PR stage in future.