### PR TITLE
chore: make `test-wasm32-unknown-unknown` run unconditionally.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,6 @@ jobs:
 
   test-wasm32-unknown-unknown:
     name: Check wasm32-unknown-unknown
-    if: ${{ github.ref_name == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@v1


### PR DESCRIPTION
It used to be unconditional before #4547, Having it to run on all PRs allows us to run `oxc_ast::generated::assert_layouts` tests on 32-bit platforms.