### PR TITLE
perf(sourcemap): `ConcatSourceMapBuilder` extend `source_contents` in separate loop

### DIFF
--- a/crates/oxc_sourcemap/src/concat_sourcemap_builder.rs
+++ b/crates/oxc_sourcemap/src/concat_sourcemap_builder.rs
@@ -46,11 +46,12 @@ impl ConcatSourceMapBuilder {
         }
 
         // Extend `sources` and `source_contents`.
-        self.sources.reserve(sourcemap.sources.len());
-        for (index, source) in sourcemap.get_sources().enumerate() {
-            let source_content = sourcemap.get_source_content(index as u32).unwrap_or_default();
-            self.sources.push(source.into());
-            self.source_contents.push(source_content.into());
+        self.sources.extend(sourcemap.get_sources().map(Into::into));
+
+        if let Some(source_contents) = &sourcemap.source_contents {
+            self.source_contents.extend(source_contents.iter().map(AsRef::as_ref).map(Into::into));
+        } else {
+            self.source_contents.extend((0..sourcemap.sources.len()).map(|_| Arc::default()));
         }
 
         // Extend `names`.


### PR DESCRIPTION
Small optimization to source map concatenation. Check if input sourcemap has `source_contents` once, rather than on each turn of the loop.