### PR TITLE
refactor(sourcemap): remove unnecessary `reserve`s

### DIFF
--- a/crates/oxc_sourcemap/src/concat_sourcemap_builder.rs
+++ b/crates/oxc_sourcemap/src/concat_sourcemap_builder.rs
@@ -55,11 +55,9 @@ impl ConcatSourceMapBuilder {
         }
 
         // Extend `names`.
-        self.names.reserve(sourcemap.names.len());
         self.names.extend(sourcemap.get_names().map(Into::into));
 
         // Extend `tokens`.
-        self.tokens.reserve(sourcemap.tokens.len());
         let tokens = sourcemap.get_tokens().map(|token| {
             Token::new(
                 token.get_dst_line() + line_offset,


### PR DESCRIPTION
`Vec::reserve` before `Vec::extend` is unnecessary where extending from a "trusted" iterator which accurately reports its length. Rust already reserves required space in these cases.