### PR TITLE
feat(sourcemap): add `ConcatSourceMapBuilder::from_sourcemaps`

### DIFF
--- a/tasks/benchmark/benches/sourcemap.rs
+++ b/tasks/benchmark/benches/sourcemap.rs
@@ -27,10 +27,10 @@ fn bench_sourcemap(criterion: &mut Criterion) {
                     .enable_source_map(file.file_name.as_str(), source_text)
                     .build(&ret.program);
                 if let Some(sourcemap) = source_map {
-                    let mut concat_sourcemap_builder = ConcatSourceMapBuilder::default();
-                    for i in 0..2 {
-                        concat_sourcemap_builder.add_sourcemap(&sourcemap, lines * i);
-                    }
+                    let concat_sourcemap_builder = ConcatSourceMapBuilder::from_sourcemaps(&[
+                        (&sourcemap, 0),
+                        (&sourcemap, lines),
+                    ]);
                     concat_sourcemap_builder.into_sourcemap().to_json_string();
                 }
             });


### PR DESCRIPTION
Introduce new method `ConcatSourceMapBuilder::from_sourcemaps`.

Where all the sourcemaps being concatenated exist at time that you create `ConcatSourceMapBuilder`, it's faster to use `from_sourcemaps`, because it pre-allocates enough space for the data it will hold and so avoids memory copying.

Before:

```rs
let mut builder = ConcatSourceMapBuilder::default();
builder.add_sourcemap(&sourcemap1, 0);
builder.add_sourcemap(&sourcemap2, 100);
builder.add_sourcemap(&sourcemap3, 100);
let combined = builder.into_sourcemap();
```

After:

```rs
let builder = ConcatSourceMapBuilder::from_sourcemaps(&[
    (&sourcemap1, 0),
    (&sourcemap2, 100),
    (&sourcemap3, 200),
]);
let combined = builder.into_sourcemap();
```