### PR TITLE
fix(tasks/lint_rules): Refactor syncing typescript-eslint and eslint status

### DIFF
--- a/tasks/lint_rules/src/eslint-rules.cjs
+++ b/tasks/lint_rules/src/eslint-rules.cjs
@@ -263,7 +263,3 @@ exports.loadTargetPluginRules = (linter) => {
   loadPluginReactPerfRules(linter);
   loadPluginNextRules(linter);
 };
-
-// some typescript rules are some extension of the basic eslint rules
-// we need them later to map them for both
-exports.pluginTypeScriptRulesNames = Object.keys(pluginTypeScriptAllRules);

--- a/tasks/lint_rules/src/main.cjs
+++ b/tasks/lint_rules/src/main.cjs
@@ -8,7 +8,8 @@ const {
   createRuleEntries,
   updateNotSupportedStatus,
   updateImplementedStatus,
-  syncTypeScriptPluginStatusWithEslintPluginStatus,
+  overrideTypeScriptPluginStatusWithEslintPluginStatus:
+    syncTypeScriptPluginStatusWithEslintPluginStatus,
 } = require("./oxlint-rules.cjs");
 const { renderMarkdown } = require("./markdown-renderer.cjs");
 const { updateGitHubIssue } = require("./result-reporter.cjs");

--- a/tasks/lint_rules/src/main.cjs
+++ b/tasks/lint_rules/src/main.cjs
@@ -8,6 +8,7 @@ const {
   createRuleEntries,
   updateNotSupportedStatus,
   updateImplementedStatus,
+  syncTypeScriptPluginStatusWithEslintPluginStatus,
 } = require("./oxlint-rules.cjs");
 const { renderMarkdown } = require("./markdown-renderer.cjs");
 const { updateGitHubIssue } = require("./result-reporter.cjs");
@@ -59,6 +60,7 @@ Plugins: ${Array.from(ALL_TARGET_PLUGINS.keys()).join(", ")}
   const ruleEntries = createRuleEntries(linter.getRules());
   await updateImplementedStatus(ruleEntries);
   updateNotSupportedStatus(ruleEntries);
+  syncTypeScriptPluginStatusWithEslintPluginStatus(ruleEntries);
 
   //
   // Render list and update if necessary

--- a/tasks/lint_rules/src/markdown-renderer.cjs
+++ b/tasks/lint_rules/src/markdown-renderer.cjs
@@ -9,7 +9,7 @@ const renderIntroduction = ({ npm }) => `
 > This comment is maintained by CI. Do not edit this comment directly.
 > To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules
 
-This is tracking issue for ${npm.map(n => "`" + n + "`").join(", ")}.
+This is tracking issue for ${npm.map((n) => "`" + n + "`").join(", ")}.
 `;
 
 /**

--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -57,7 +57,8 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   "eslint/no-dupe-args", // superseded by strict mode
   "eslint/no-octal", // superseded by strict mode
   "eslint/no-with", // superseded by strict mode
-  "import/no-unresolved" // Will always contain false positives due to module resolution complexity
+  "eslint/no-new-symbol", // Deprecated as of ESLint v9, but for a while disable manually
+  "import/no-unresolved", // Will always contain false positives due to module resolution complexity
 ]);
 
 /**

--- a/tasks/lint_rules/src/oxlint-rules.cjs
+++ b/tasks/lint_rules/src/oxlint-rules.cjs
@@ -113,11 +113,13 @@ exports.updateNotSupportedStatus = (ruleEntries) => {
  *
  * @param {RuleEntries} ruleEntries
  */
-exports.syncTypeScriptPluginStatusWithEslintPluginStatus = (ruleEntries) => {
+exports.overrideTypeScriptPluginStatusWithEslintPluginStatus = (
+  ruleEntries,
+) => {
   for (const [name, rule] of ruleEntries) {
     if (!name.startsWith("typescript/")) continue;
 
-    // I don't know if the same name
+    // This assumes that if the same name found, it implements the same rule.
     const eslintRule = ruleEntries.get(name.replace("typescript/", "eslint/"));
     if (!eslintRule) continue;
 


### PR DESCRIPTION
Closes #4085 

This issue seemed to have been addressed in #3779 , but partially reverted in #3813 ? 🤔 

Since I wasn't aware of these changes, I've just checked the current implementation through the review requests in #4611 and refactored as the original author.