### PR TITLE
fix(semantic): incorrect `scope_id` for catch parameter symbols

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -675,6 +675,9 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if self.scope.get_flags(parent_scope_id).is_catch_clause() {
             let parent_bindings =
                 self.scope.get_bindings_mut(parent_scope_id).drain(..).collect::<Bindings>();
+            parent_bindings.values().for_each(|symbol_id| {
+                self.symbols.set_scope_id(*symbol_id, self.current_scope_id);
+            });
             *self.scope.get_bindings_mut(self.current_scope_id) = parent_bindings;
         }
 

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -118,6 +118,11 @@ impl SymbolTable {
     }
 
     #[inline]
+    pub fn set_scope_id(&mut self, symbol_id: SymbolId, scope_id: ScopeId) {
+        self.scope_ids[symbol_id] = scope_id;
+    }
+
+    #[inline]
     pub fn get_scope_id(&self, symbol_id: SymbolId) -> ScopeId {
         self.scope_ids[symbol_id]
     }

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 434/927
+Passed: 435/927
 
 # All Passed:
 * babel-preset-react
@@ -445,8 +445,7 @@ Passed: 434/927
 * opts/optimizeConstEnums/input.ts
 * opts/rewriteImportExtensions/input.ts
 
-# babel-plugin-transform-typescript (90/151)
-* catch-clause/param-type/input.ts
+# babel-plugin-transform-typescript (91/151)
 * class/accessor-allowDeclareFields-false/input.ts
 * class/accessor-allowDeclareFields-true/input.ts
 * enum/boolean-value/input.ts


### PR DESCRIPTION
When we move all the bindings in the CatchClause scope to its child scope (BlockStatement), we also need to replace the scope_id in the symbol with the scope_id of the new scope.
