### PR TITLE
build(deps): compile insta in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,10 @@ debug = false
 # Compile macros with some optimizations to make consuming crates build faster
 oxc_macros.opt-level     = 1
 oxc_ast_macros.opt-level = 1
+# Compile insta and its dependencies in release mode for faster snapshot tests
+# See: https://insta.rs/docs/quickstart/#optional-faster-runs
+insta.opt-level          = 3
+similar.opt-level        = 3
 
 [profile.release.package.oxc_wasm]
 opt-level = 'z'


### PR DESCRIPTION
Compile insta and its diffing library in release mode. After the initial build, I'm seeing ~1s shaved off `cargo test` locally.