### PR TITLE
chore(module_lexer): Fix invalid regex in test

### DIFF
--- a/crates/oxc_module_lexer/tests/esm.rs
+++ b/crates/oxc_module_lexer/tests/esm.rs
@@ -785,7 +785,7 @@ fn bracket_matching() {
 #[test]
 fn division_regex_ambiguity() {
     let source = r"
-      /as)df/; x();
+      /asdf/; x();
       a / 2; '  /  '
       while (true)
         /test'/


### PR DESCRIPTION
To make the #4242 tests pass.

(My `RegExp` parser tells me `/as)df/` is invalid syntax. 😂)