### PR TITLE
fix(transformer): strip TS statements from for in/of statement bodies

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -295,6 +295,14 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x0_typescript.transform_for_statement(stmt, ctx);
     }
 
+    fn enter_for_of_statement(&mut self, stmt: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.x0_typescript.transform_for_of_statement(stmt, ctx);
+    }
+
+    fn enter_for_in_statement(&mut self, stmt: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.x0_typescript.transform_for_in_statement(stmt, ctx);
+    }
+
     fn enter_ts_export_assignment(
         &mut self,
         export_assignment: &mut TSExportAssignment<'a>,

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -445,8 +445,35 @@ impl<'a> TypeScriptAnnotations<'a> {
         stmt: &mut ForStatement<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        let scope_id = stmt.scope_id.get().unwrap_or(ctx.current_scope_id());
-        Self::replace_with_empty_block_if_ts(&mut stmt.body, scope_id, ctx);
+        Self::replace_for_statement_body_with_empty_block_if_ts(
+            &mut stmt.body,
+            &stmt.scope_id,
+            ctx,
+        );
+    }
+
+    pub fn transform_for_in_statement(
+        &mut self,
+        stmt: &mut ForInStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        Self::replace_for_statement_body_with_empty_block_if_ts(
+            &mut stmt.body,
+            &stmt.scope_id,
+            ctx,
+        );
+    }
+
+    pub fn transform_for_of_statement(
+        &mut self,
+        stmt: &mut ForOfStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        Self::replace_for_statement_body_with_empty_block_if_ts(
+            &mut stmt.body,
+            &stmt.scope_id,
+            ctx,
+        );
     }
 
     pub fn transform_while_statement(
@@ -463,6 +490,15 @@ impl<'a> TypeScriptAnnotations<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         Self::replace_with_empty_block_if_ts(&mut stmt.body, ctx.current_scope_id(), ctx);
+    }
+
+    fn replace_for_statement_body_with_empty_block_if_ts(
+        body: &mut Statement<'a>,
+        scope_id: &Cell<Option<ScopeId>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let scope_id = scope_id.get().unwrap_or(ctx.current_scope_id());
+        Self::replace_with_empty_block_if_ts(body, scope_id, ctx);
     }
 
     fn replace_with_empty_block_if_ts(

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -195,6 +195,22 @@ impl<'a> TypeScript<'a> {
         self.annotations.transform_for_statement(stmt, ctx);
     }
 
+    pub fn transform_for_in_statement(
+        &mut self,
+        stmt: &mut ForInStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.annotations.transform_for_in_statement(stmt, ctx);
+    }
+
+    pub fn transform_for_of_statement(
+        &mut self,
+        stmt: &mut ForOfStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.annotations.transform_for_of_statement(stmt, ctx);
+    }
+
     pub fn transform_tagged_template_expression(
         &mut self,
         expr: &mut TaggedTemplateExpression<'a>,

--- a/tasks/coverage/transformer_typescript.snap
+++ b/tasks/coverage/transformer_typescript.snap
@@ -2,8 +2,7 @@ commit: d8086f14
 
 transformer_typescript Summary:
 AST Parsed     : 6456/6456 (100.00%)
-Positive Passed: 6452/6456 (99.94%)
+Positive Passed: 6453/6456 (99.95%)
 Mismatch: "compiler/constEnumNamespaceReferenceCausesNoImport2.ts"
-Mismatch: "compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts"
 Mismatch: "conformance/externalModules/typeOnly/exportDeclaration.ts"
 Mismatch: "conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx"


### PR DESCRIPTION
Remove TS statements in body of `for of` and `for in` statements, as well as plain `for`.