### PR TITLE
refactor(traverse): simplify `ChildScopeCollector` to use `enter_scope` method

### DIFF
--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -2,10 +2,7 @@ use std::{cell::Cell, str};
 
 use compact_str::{format_compact, CompactString};
 #[allow(clippy::wildcard_imports)]
-use oxc_ast::{
-    ast::*,
-    visit::{walk, Visit},
-};
+use oxc_ast::{ast::*, visit::Visit};
 use oxc_semantic::{AstNodeId, Reference, ScopeTree, SymbolTable};
 use oxc_span::{Atom, CompactStr, Span, SPAN};
 use oxc_syntax::{
@@ -495,83 +492,9 @@ impl ChildScopeCollector {
 }
 
 impl<'a> Visit<'a> for ChildScopeCollector {
-    fn visit_block_statement(&mut self, stmt: &BlockStatement<'a>) {
-        self.scope_ids.push(stmt.scope_id.get().unwrap());
-    }
-
-    fn visit_for_statement(&mut self, stmt: &ForStatement<'a>) {
-        if let Some(scope_id) = stmt.scope_id.get() {
+    fn enter_scope(&mut self, _flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
+        if let Some(scope_id) = scope_id.get() {
             self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_for_statement(self, stmt);
         }
-    }
-
-    fn visit_for_in_statement(&mut self, stmt: &ForInStatement<'a>) {
-        if let Some(scope_id) = stmt.scope_id.get() {
-            self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_for_in_statement(self, stmt);
-        }
-    }
-
-    fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
-        if let Some(scope_id) = stmt.scope_id.get() {
-            self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_for_of_statement(self, stmt);
-        }
-    }
-
-    fn visit_switch_statement(&mut self, stmt: &SwitchStatement<'a>) {
-        self.scope_ids.push(stmt.scope_id.get().unwrap());
-    }
-
-    fn visit_catch_clause(&mut self, clause: &CatchClause<'a>) {
-        self.scope_ids.push(clause.scope_id.get().unwrap());
-    }
-
-    fn visit_finally_clause(&mut self, clause: &BlockStatement<'a>) {
-        self.scope_ids.push(clause.scope_id.get().unwrap());
-    }
-
-    fn visit_function(&mut self, func: &Function<'a>, _flags: ScopeFlags) {
-        self.scope_ids.push(func.scope_id.get().unwrap());
-    }
-
-    fn visit_class(&mut self, class: &Class<'a>) {
-        if let Some(scope_id) = class.scope_id.get() {
-            self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_class(self, class);
-        }
-    }
-
-    fn visit_static_block(&mut self, block: &StaticBlock<'a>) {
-        self.scope_ids.push(block.scope_id.get().unwrap());
-    }
-
-    fn visit_arrow_function_expression(&mut self, expr: &ArrowFunctionExpression<'a>) {
-        self.scope_ids.push(expr.scope_id.get().unwrap());
-    }
-
-    fn visit_ts_enum_declaration(&mut self, decl: &TSEnumDeclaration<'a>) {
-        self.scope_ids.push(decl.scope_id.get().unwrap());
-    }
-
-    fn visit_ts_module_declaration(&mut self, decl: &TSModuleDeclaration<'a>) {
-        self.scope_ids.push(decl.scope_id.get().unwrap());
-    }
-
-    fn visit_ts_interface_declaration(&mut self, it: &TSInterfaceDeclaration<'a>) {
-        self.scope_ids.push(it.scope_id.get().unwrap());
-    }
-
-    fn visit_ts_mapped_type(&mut self, it: &TSMappedType<'a>) {
-        self.scope_ids.push(it.scope_id.get().unwrap());
-    }
-
-    fn visit_ts_conditional_type(&mut self, it: &TSConditionalType<'a>) {
-        self.scope_ids.push(it.scope_id.get().unwrap());
     }
 }


### PR DESCRIPTION
related: https://github.com/oxc-project/oxc/pull/4168