### PR TITLE
refactor(traverse)!: replace `find_ancestor` with `ancestors` returning iterator

### DIFF
--- a/crates/oxc_transformer/src/react/jsx_self.rs
+++ b/crates/oxc_transformer/src/react/jsx_self.rs
@@ -54,11 +54,12 @@ impl<'a> ReactJsxSelf<'a> {
     }
 
     fn has_no_super_class(ctx: &TraverseCtx<'a>) -> bool {
-        ctx.find_ancestor(|ancestor| match ancestor {
-            Ancestor::ClassBody(class) => FinderRet::Found(class.super_class().is_none()),
-            _ => FinderRet::Continue,
-        })
-        .unwrap_or(true)
+        for ancestor in ctx.ancestors() {
+            if let Ancestor::ClassBody(class) = ancestor {
+                return class.super_class().is_none();
+            }
+        }
+        true
     }
 
     pub fn can_add_self_attribute(&self, ctx: &TraverseCtx<'a>) -> bool {

--- a/crates/oxc_traverse/src/compile_fail_tests.rs
+++ b/crates/oxc_traverse/src/compile_fail_tests.rs
@@ -79,3 +79,77 @@ impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
 ```
 */
 const CANNOT_HOLD_ONTO_AST_NODE: () = ();
+
+/**
+```compile_fail
+use oxc_ast::ast::IdentifierReference;
+use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
+
+struct Trans<'a, 'b> {
+    ancestor: Option<&'b Ancestor<'a>>,
+}
+
+impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
+    fn enter_identifier_reference(
+        &mut self,
+        _node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.ancestor = ctx.ancestors().next();
+    }
+}
+```
+*/
+const CANNOT_HOLD_ONTO_ANCESTOR_FROM_ANCESTORS_ITERATOR: () = ();
+
+/**
+```compile_fail
+use oxc_ast::ast::IdentifierReference;
+use oxc_traverse::{ancestor::ProgramWithoutDirectives, Ancestor, Traverse, TraverseCtx};
+
+struct Trans<'a, 'b> {
+    program: Option<&'b ProgramWithoutDirectives<'a>>,
+}
+
+impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
+    fn enter_identifier_reference(
+        &mut self,
+        _node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let parent = ctx.ancestors().next().unwrap();
+        if let Ancestor::ProgramDirectives(program) = parent {
+            self.program = Some(program);
+        }
+    }
+}
+```
+*/
+const CANNOT_HOLD_ONTO_ANCESTOR_NODE_FROM_ANCESTORS_ITERATOR: () = ();
+
+/**
+```compile_fail
+use oxc_ast::ast::{IdentifierReference, Statement};
+use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
+
+struct Trans<'a, 'b> {
+    stmt: Option<&'b Statement<'a>>,
+}
+
+impl<'a, 'b> Traverse<'a> for Trans<'a, 'b> {
+    fn enter_identifier_reference(
+        &mut self,
+        _node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let parent = ctx.ancestors().next().unwrap();
+        if let Ancestor::ProgramDirectives(program) = parent {
+            let body = program.body();
+            let stmt = &body[0];
+            self.stmt = Some(stmt);
+        }
+    }
+}
+```
+*/
+const CANNOT_HOLD_ONTO_AST_NODE_FROM_ANCESTORS_ITERATOR: () = ();

--- a/crates/oxc_traverse/src/context/ancestry.rs
+++ b/crates/oxc_traverse/src/context/ancestry.rs
@@ -1,4 +1,3 @@
-use super::FinderRet;
 use crate::ancestor::{Ancestor, AncestorType};
 
 const INITIAL_STACK_CAPACITY: usize = 64; // 64 entries = 1 KiB
@@ -48,49 +47,9 @@ impl<'a> TraverseAncestry<'a> {
         self.stack.get(self.stack.len() - level)
     }
 
-    /// Walk up trail of ancestors to find a node.
-    ///
-    /// `finder` should return:
-    /// * `FinderRet::Found(value)` to stop walking and return `Some(value)`.
-    /// * `FinderRet::Stop` to stop walking and return `None`.
-    /// * `FinderRet::Continue` to continue walking up.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use oxc_ast::ast::ThisExpression;
-    /// use oxc_traverse::{Ancestor, FinderRet, Traverse, TraverseCtx};
-    ///
-    /// struct MyTraverse;
-    /// impl<'a> Traverse<'a> for MyTraverse {
-    ///     fn enter_this_expression(&mut self, this_expr: &mut ThisExpression, ctx: &mut TraverseCtx<'a>) {
-    ///         // Get name of function where `this` is bound.
-    ///         // NB: This example doesn't handle `this` in class fields or static blocks.
-    ///         let fn_id = ctx.ancestry.find_ancestor(|ancestor| {
-    ///             match ancestor {
-    ///                 Ancestor::FunctionBody(func) => FinderRet::Found(func.id()),
-    ///                 Ancestor::FunctionParams(func) => FinderRet::Found(func.id()),
-    ///                 _ => FinderRet::Continue
-    ///             }
-    ///         });
-    ///     }
-    /// }
-    /// ```
-    //
-    // `'c` lifetime on `&'c self` and `&'c Ancestor` passed into the closure
-    // allows an `Ancestor` or AST node to be returned from the closure.
-    pub fn find_ancestor<'c, F, O>(&'c self, finder: F) -> Option<O>
-    where
-        F: Fn(&'c Ancestor<'a>) -> FinderRet<O>,
-    {
-        for ancestor in self.stack.iter().rev() {
-            match finder(ancestor) {
-                FinderRet::Found(res) => return Some(res),
-                FinderRet::Stop => return None,
-                FinderRet::Continue => {}
-            }
-        }
-        None
+    /// Get iterator over ancestors, starting with closest ancestor
+    pub fn ancestors<'b>(&'b self) -> impl Iterator<Item = &'b Ancestor<'a>> {
+        self.stack.iter().rev()
     }
 
     /// Get depth in the AST.


### PR DESCRIPTION
Replace `find_ancestor` with `ancestors` method which returns an iterator. This does the same thing, but is more idiomatic.