### PR TITLE
refactor(span): reduce #[cfg_attr] boilerplate in type defs

### DIFF
--- a/crates/oxc_span/src/source_type/types.rs
+++ b/crates/oxc_span/src/source_type/types.rs
@@ -6,7 +6,7 @@ use ::{serde::Serialize, tsify::Tsify};
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
-#[cfg_attr(feature = "serialize", serde(rename_all = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub struct SourceType {
     /// JavaScript or TypeScript, default JavaScript
     pub(super) language: Language,
@@ -26,11 +26,11 @@ pub struct SourceType {
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
-#[cfg_attr(feature = "serialize", serde(rename_all = "lowercase"))]
+#[serde(rename_all = "lowercase")]
 pub enum Language {
     JavaScript = 0,
     TypeScript = 1,
-    #[cfg_attr(feature = "serialize", serde(rename = "typescriptDefinition"))]
+    #[serde(rename = "typescriptDefinition")]
     TypeScriptDefinition = 2,
 }
 
@@ -38,7 +38,7 @@ pub enum Language {
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
-#[cfg_attr(feature = "serialize", serde(rename_all = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub enum ModuleKind {
     Script = 0,
     Module = 1,
@@ -48,7 +48,7 @@ pub enum ModuleKind {
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
-#[cfg_attr(feature = "serialize", serde(rename_all = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub enum LanguageVariant {
     Standard = 0,
     Jsx = 1,

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -8,9 +8,7 @@ use std::{
 
 use miette::{LabeledSpan, SourceOffset, SourceSpan};
 #[cfg(feature = "serialize")]
-use serde::Serialize;
-#[cfg(feature = "serialize")]
-use tsify::Tsify;
+use ::{serde::Serialize, tsify::Tsify};
 
 /// An Empty span useful for creating AST nodes.
 pub const SPAN: Span = Span::new(0, 0);


### PR DESCRIPTION
Similar to #4375 and #4698. #4696 added `#[ast]` attribute to types in `oxc_span`, so these types can use `#[serde]` attrs without the `#[cfg_attr(feature = "serialize", ...)]` guard.