### PR TITLE
feat(ast_codegen, span): process `Span` through ast_codegen

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1140,6 +1140,10 @@ const _: () = {
     assert!(align_of::<UnaryOperator>() == 1usize);
     assert!(size_of::<UpdateOperator>() == 1usize);
     assert!(align_of::<UpdateOperator>() == 1usize);
+    assert!(size_of::<Span>() == 8usize);
+    assert!(align_of::<Span>() == 4usize);
+    assert!(offset_of!(Span, start) == 0usize);
+    assert!(offset_of!(Span, end) == 4usize);
     assert!(size_of::<SourceType>() == 4usize);
     assert!(align_of::<SourceType>() == 1usize);
     assert!(size_of::<Language>() == 1usize);
@@ -2283,6 +2287,10 @@ const _: () = {
     assert!(align_of::<UnaryOperator>() == 1usize);
     assert!(size_of::<UpdateOperator>() == 1usize);
     assert!(align_of::<UpdateOperator>() == 1usize);
+    assert!(size_of::<Span>() == 8usize);
+    assert!(align_of::<Span>() == 4usize);
+    assert!(offset_of!(Span, start) == 0usize);
+    assert!(offset_of!(Span, end) == 4usize);
     assert!(size_of::<SourceType>() == 4usize);
     assert!(align_of::<SourceType>() == 1usize);
     assert!(size_of::<Language>() == 1usize);

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -1,10 +1,6 @@
-// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
-#![allow(non_snake_case)]
-
-mod types;
-
 use std::path::Path;
 
+mod types;
 pub use types::*;
 
 #[derive(Debug)]

--- a/crates/oxc_span/src/source_type/types.rs
+++ b/crates/oxc_span/src/source_type/types.rs
@@ -1,3 +1,6 @@
+// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
+#![allow(non_snake_case)]
+
 use oxc_ast_macros::ast;
 #[cfg(feature = "serialize")]
 use ::{serde::Serialize, tsify::Tsify};

--- a/crates/oxc_span/src/span/mod.rs
+++ b/crates/oxc_span/src/span/mod.rs
@@ -1,47 +1,15 @@
-// Silence erroneous warnings from Rust Analyzer for `#[derive(Tsify)]`
-#![allow(non_snake_case)]
-
 use std::{
     hash::{Hash, Hasher},
     ops::{Index, IndexMut, Range},
 };
 
 use miette::{LabeledSpan, SourceOffset, SourceSpan};
-#[cfg(feature = "serialize")]
-use ::{serde::Serialize, tsify::Tsify};
+
+mod types;
+pub use types::Span;
 
 /// An Empty span useful for creating AST nodes.
 pub const SPAN: Span = Span::new(0, 0);
-
-/// Newtype for working with text ranges
-///
-/// See the [`text-size`](https://docs.rs/text-size) crate for details.
-/// Utility methods can be copied from the `text-size` crate if they are needed.
-/// NOTE: `u32` is sufficient for "all" reasonable programs. Larger than u32 is a 4GB JS file.
-///
-/// ## Hashing
-/// [`Span`]'s implementation of [`Hash`] is a no-op so that AST nodes can be
-/// compared by hash. This makes them unsuitable for use as keys in a hash map.
-///
-/// ```
-/// use std::hash::{Hash, Hasher, DefaultHasher};
-/// use oxc_span::Span;
-///
-/// let mut first = DefaultHasher::new();
-/// let mut second = DefaultHasher::new();
-///
-/// Span::new(0, 5).hash(&mut first);
-/// Span::new(10, 20).hash(&mut second);
-///
-/// assert_eq!(first.finish(), second.finish());
-/// ```
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
-#[non_exhaustive] // disallow struct expression constructor `Span {}`
-pub struct Span {
-    pub start: u32,
-    pub end: u32,
-}
 
 impl Span {
     /// Create a new [`Span`] from a start and end position.

--- a/crates/oxc_span/src/span/types.rs
+++ b/crates/oxc_span/src/span/types.rs
@@ -1,0 +1,38 @@
+// Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
+#![allow(non_snake_case)]
+
+#[cfg(feature = "serialize")]
+use ::{serde::Serialize, tsify::Tsify};
+
+use oxc_ast_macros::ast;
+
+/// Newtype for working with text ranges
+///
+/// See the [`text-size`](https://docs.rs/text-size) crate for details.
+/// Utility methods can be copied from the `text-size` crate if they are needed.
+/// NOTE: `u32` is sufficient for "all" reasonable programs. Larger than u32 is a 4GB JS file.
+///
+/// ## Hashing
+/// [`Span`]'s implementation of [`Hash`] is a no-op so that AST nodes can be
+/// compared by hash. This makes them unsuitable for use as keys in a hash map.
+///
+/// ```
+/// use std::hash::{Hash, Hasher, DefaultHasher};
+/// use oxc_span::Span;
+///
+/// let mut first = DefaultHasher::new();
+/// let mut second = DefaultHasher::new();
+///
+/// Span::new(0, 5).hash(&mut first);
+/// Span::new(10, 20).hash(&mut second);
+///
+/// assert_eq!(first.finish(), second.finish());
+/// ```
+#[ast]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
+#[non_exhaustive] // Disallow struct expression constructor `Span {}`
+pub struct Span {
+    pub start: u32,
+    pub end: u32,
+}

--- a/tasks/ast_codegen/src/main.rs
+++ b/tasks/ast_codegen/src/main.rs
@@ -264,6 +264,7 @@ fn files() -> impl std::iter::Iterator<Item = String> {
         ast("jsx"),
         syntax("number"),
         syntax("operator"),
+        span("span/types"),
         span("source_type/types"),
     ]
     .into_iter()

--- a/tasks/ast_codegen/src/passes/calc_layout.rs
+++ b/tasks/ast_codegen/src/passes/calc_layout.rs
@@ -346,7 +346,6 @@ lazy_static! {
         },
         // well known types
         // TODO: generate const assertions for these in the ast crate
-        Span: { _ => Layout::known(8, 4, 0), },
         Atom: {
             64 => Layout::wide_ptr_64(),
             32 => Layout::wide_ptr_32(),


### PR DESCRIPTION
Add `#[ast]` attr to `Span`.

Due to how AST codegen works, this necessitates putting the type def in a separate file. https://github.com/oxc-project/oxc/pull/4696#issuecomment-2271781995