### PR TITLE
refactor(ast_codegen): reorder imports

### DIFF
--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -8,12 +8,12 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{parse_quote, Ident, Type};
 
-use crate::schema::{
-    EnumDef, FieldDef, GetIdent, InheritDef, StructDef, ToType, TypeDef, TypeName, VariantDef,
-};
 use crate::{
     generators::generated_header,
     output,
+    schema::{
+        EnumDef, FieldDef, GetIdent, InheritDef, StructDef, ToType, TypeDef, TypeName, VariantDef,
+    },
     util::{TypeAnalysis, TypeWrapper},
     Generator, GeneratorOutput, LateCtx,
 };

--- a/tasks/ast_codegen/src/main.rs
+++ b/tasks/ast_codegen/src/main.rs
@@ -1,3 +1,10 @@
+use std::{cell::RefCell, collections::HashMap, io::Read, path::PathBuf, rc::Rc};
+
+use bpaf::{Bpaf, Parser};
+use itertools::Itertools;
+use proc_macro2::TokenStream;
+use syn::parse_file;
+
 mod fmt;
 mod generators;
 mod layout;
@@ -7,19 +14,12 @@ mod rust_ast;
 mod schema;
 mod util;
 
-use std::{cell::RefCell, collections::HashMap, io::Read, path::PathBuf, rc::Rc};
-
-use bpaf::{Bpaf, Parser};
 use fmt::{cargo_fmt, pprint};
-use itertools::Itertools;
-use passes::{CalcLayout, Linker, Pass};
-use proc_macro2::TokenStream;
-use syn::parse_file;
-
 use generators::{
     AssertLayouts, AstBuilderGenerator, AstKindGenerator, Generator, VisitGenerator,
     VisitMutGenerator,
 };
+use passes::{CalcLayout, Linker, Pass};
 use rust_ast::AstRef;
 use schema::{lower_ast_types, Schema, TypeDef};
 use util::{write_all_to, NormalizeError};

--- a/tasks/ast_codegen/src/passes/calc_layout.rs
+++ b/tasks/ast_codegen/src/passes/calc_layout.rs
@@ -1,6 +1,3 @@
-/// We use compiler to infer 64bit type layouts.
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("`oxc_ast_codegen::layout` only supports 64 architectures.");
 use std::collections::HashMap;
 
 use itertools::Itertools;
@@ -16,6 +13,10 @@ use crate::{
 };
 
 use super::{define_pass, Pass};
+
+/// We use compiler to infer 64bit type layouts.
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("`oxc_ast_codegen::calc_layout` only supports 64 architectures.");
 
 type WellKnown = HashMap<&'static str, PlatformLayout>;
 

--- a/tasks/ast_codegen/src/passes/mod.rs
+++ b/tasks/ast_codegen/src/passes/mod.rs
@@ -1,12 +1,11 @@
-mod calc_layout;
-mod linker;
-
 use std::collections::VecDeque;
 
 use itertools::Itertools;
 
 use crate::{rust_ast::AstType, EarlyCtx, Result};
 
+mod calc_layout;
+mod linker;
 pub use calc_layout::CalcLayout;
 pub use linker::Linker;
 

--- a/tasks/ast_codegen/src/schema/defs.rs
+++ b/tasks/ast_codegen/src/schema/defs.rs
@@ -1,11 +1,12 @@
 use serde::Serialize;
 
-use super::{with_either, TypeName};
 use crate::{
     markers::{ScopeAttr, ScopeMarkers, VisitMarkers},
     util::{ToIdent, TypeAnalysis, TypeWrapper},
     TypeId,
 };
+
+use super::{with_either, TypeName};
 
 #[derive(Debug, Serialize)]
 pub enum TypeDef {

--- a/tasks/ast_codegen/src/schema/mod.rs
+++ b/tasks/ast_codegen/src/schema/mod.rs
@@ -1,18 +1,18 @@
+use quote::ToTokens;
+use serde::Serialize;
+
+use crate::{
+    layout::KnownLayout,
+    markers::{get_scope_attr, get_scope_markers, get_visit_markers},
+    rust_ast as rust,
+    util::{unexpanded_macro_err, TypeExt},
+    DefTable, Result,
+};
+
 mod defs;
 mod get_generics;
 mod get_ident;
 mod to_type;
-
-use crate::rust_ast as rust;
-use crate::{
-    layout::KnownLayout,
-    markers::{get_scope_attr, get_scope_markers, get_visit_markers},
-    util::{unexpanded_macro_err, TypeExt},
-    DefTable, Result,
-};
-use quote::ToTokens;
-use serde::Serialize;
-
 pub use defs::*;
 pub use get_generics::GetGenerics;
 pub use get_ident::GetIdent;


### PR DESCRIPTION
Pure refactor. Reorder imports to clarify what's an external crate and what's a local module.