### PR TITLE
feat(span): implement `CloneIn` for the AST-related items.

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -9,7 +9,7 @@ use compact_str::CompactString;
 use serde::{Serialize, Serializer};
 
 use crate::Span;
-use oxc_allocator::{Allocator, FromIn};
+use oxc_allocator::{Allocator, CloneIn, FromIn};
 
 #[cfg(feature = "serialize")]
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
@@ -56,6 +56,14 @@ impl<'a> Atom<'a> {
     #[inline]
     pub fn to_compact_str(&self) -> CompactStr {
         CompactStr::new(self.as_str())
+    }
+}
+
+impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Atom<'old_alloc> {
+    type Cloned = Atom<'new_alloc>;
+
+    fn clone_in(&self, alloc: &'new_alloc Allocator) -> Self::Cloned {
+        Atom::from_in(self.as_str(), alloc)
     }
 }
 

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 mod types;
+use oxc_allocator::{Allocator, CloneIn};
 pub use types::*;
 
 #[derive(Debug)]
@@ -14,6 +15,14 @@ impl Default for SourceType {
             variant: LanguageVariant::Standard,
             always_strict: false,
         }
+    }
+}
+
+impl<'a> CloneIn<'a> for SourceType {
+    type Cloned = Self;
+    #[inline]
+    fn clone_in(&self, _: &'a Allocator) -> Self {
+        *self
     }
 }
 

--- a/crates/oxc_span/src/span/mod.rs
+++ b/crates/oxc_span/src/span/mod.rs
@@ -6,6 +6,7 @@ use std::{
 use miette::{LabeledSpan, SourceOffset, SourceSpan};
 
 mod types;
+use oxc_allocator::{Allocator, CloneIn};
 pub use types::Span;
 
 /// An Empty span useful for creating AST nodes.
@@ -335,6 +336,14 @@ impl GetSpanMut for Span {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
         self
+    }
+}
+
+impl<'a> CloneIn<'a> for Span {
+    type Cloned = Self;
+    #[inline]
+    fn clone_in(&self, _: &'a Allocator) -> Self {
+        *self
     }
 }
 


### PR DESCRIPTION
Follow-on after #4276, related to #4284.