### PR TITLE
refactor(ast_codegen): flatten code

### DIFF
--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -52,54 +52,51 @@ impl Generator for DeriveCloneIn {
 
 fn derive_enum(def: &EnumDef) -> TokenStream {
     let ty_ident = def.ident();
-    let (alloc, body) = {
-        let mut used_alloc = false;
-        let matches = def
-            .all_variants()
-            .map(|var| {
-                let ident = var.ident();
-                if var.is_unit() {
-                    quote!(Self :: #ident => #ty_ident :: #ident)
-                } else {
-                    used_alloc = true;
-                    quote!(Self :: #ident(it) => #ty_ident :: #ident(it.clone_in(alloc)))
-                }
-            })
-            .collect_vec();
-        let alloc_ident = if used_alloc { format_ident!("alloc") } else { format_ident!("_") };
-        (
-            alloc_ident,
-            quote! {
-                match self {
-                    #(#matches),*
-                }
-            },
-        )
+
+    let mut used_alloc = false;
+    let matches = def
+        .all_variants()
+        .map(|var| {
+            let ident = var.ident();
+            if var.is_unit() {
+                quote!(Self :: #ident => #ty_ident :: #ident)
+            } else {
+                used_alloc = true;
+                quote!(Self :: #ident(it) => #ty_ident :: #ident(it.clone_in(alloc)))
+            }
+        })
+        .collect_vec();
+
+    let alloc_ident = if used_alloc { format_ident!("alloc") } else { format_ident!("_") };
+    let body = quote! {
+        match self {
+            #(#matches),*
+        }
     };
-    impl_clone_in(&ty_ident, def.has_lifetime, &alloc, &body)
+
+    impl_clone_in(&ty_ident, def.has_lifetime, &alloc_ident, &body)
 }
 
 fn derive_struct(def: &StructDef) -> TokenStream {
     let ty_ident = def.ident();
-    let (alloc, body) = {
-        let (alloc_ident, body) = if def.fields.is_empty() {
-            (format_ident!("_"), TokenStream::default())
-        } else {
-            let fields = def.fields.iter().map(|field| {
-                let ident = field.ident();
-                quote!(#ident: self.#ident.clone_in(alloc))
-            });
-            (format_ident!("alloc"), quote!({ #(#fields),* }))
-        };
-        (alloc_ident, quote!( #ty_ident #body ))
+
+    let (alloc_ident, body) = if def.fields.is_empty() {
+        (format_ident!("_"), quote!(#ty_ident))
+    } else {
+        let fields = def.fields.iter().map(|field| {
+            let ident = field.ident();
+            quote!(#ident: self.#ident.clone_in(alloc))
+        });
+        (format_ident!("alloc"), quote!(#ty_ident { #(#fields),* }))
     };
-    impl_clone_in(&ty_ident, def.has_lifetime, &alloc, &body)
+
+    impl_clone_in(&ty_ident, def.has_lifetime, &alloc_ident, &body)
 }
 
 fn impl_clone_in(
     ty_ident: &Ident,
     has_lifetime: bool,
-    alloc: &Ident,
+    alloc_ident: &Ident,
     body: &TokenStream,
 ) -> TokenStream {
     if has_lifetime {
@@ -107,7 +104,7 @@ fn impl_clone_in(
             endl!();
             impl <'old_alloc, 'new_alloc> CloneIn<'new_alloc> for #ty_ident<'old_alloc> {
                 type Cloned = #ty_ident<'new_alloc>;
-                fn clone_in(&self, #alloc: &'new_alloc Allocator) -> Self::Cloned {
+                fn clone_in(&self, #alloc_ident: &'new_alloc Allocator) -> Self::Cloned {
                     #body
                 }
             }
@@ -117,7 +114,7 @@ fn impl_clone_in(
             endl!();
             impl <'alloc> CloneIn<'alloc> for #ty_ident {
                 type Cloned = #ty_ident;
-                fn clone_in(&self, #alloc: &'alloc Allocator) -> Self::Cloned {
+                fn clone_in(&self, #alloc_ident: &'alloc Allocator) -> Self::Cloned {
                     #body
                 }
             }


### PR DESCRIPTION
A bit of code style simplification after #4731. Remove unnecessary nesting and rename some vars for consistency.