### PR TITLE
fix(ast, ast_codegen): use `generate_derive` instead of visitable for generating span derives.

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -426,7 +426,7 @@ pub enum PropertyKey<'a> {
 /// Represents the kind of property in an object literal or class.
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum PropertyKind {
@@ -487,7 +487,7 @@ pub struct TemplateElement<'a> {
 /// See [template-strings-cooked-vs-raw](https://exploringjs.com/js/book/ch_template-literals.html#template-strings-cooked-vs-raw)
 #[ast]
 #[derive(Debug, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub struct TemplateElementValue<'a> {
     /// A raw interpretation where backslashes do not have special meaning.
@@ -1241,7 +1241,7 @@ pub struct VariableDeclaration<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum VariableDeclarationKind {
@@ -1730,7 +1730,7 @@ pub struct Function<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum FunctionType {
     FunctionDeclaration = 0,
@@ -1774,7 +1774,7 @@ pub struct FormalParameter<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum FormalParameterKind {
     /// <https://tc39.es/ecma262/#prod-FormalParameters>
@@ -1912,7 +1912,7 @@ pub struct Class<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum ClassType {
     /// Class declaration statement
@@ -2012,7 +2012,7 @@ pub struct MethodDefinition<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum MethodDefinitionType {
     MethodDefinition = 0,
@@ -2103,7 +2103,7 @@ pub struct PropertyDefinition<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum PropertyDefinitionType {
     PropertyDefinition = 0,
@@ -2112,7 +2112,7 @@ pub enum PropertyDefinitionType {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum MethodDefinitionKind {
@@ -2228,7 +2228,7 @@ pub use match_module_declaration;
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum AccessorPropertyType {
     AccessorProperty = 0,

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -103,7 +103,7 @@ pub struct RegExpLiteral<'a> {
 /// <https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-regular-expression-objects>
 #[ast]
 #[derive(Debug, Clone, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub struct RegExp<'a> {
     /// The regex pattern between the slashes
@@ -114,7 +114,7 @@ pub struct RegExp<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub struct EmptyObject;
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -383,7 +383,7 @@ pub struct TSTypeOperator<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum TSTypeOperatorOperator {
@@ -762,7 +762,7 @@ pub struct TSTypeAliasDeclaration<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum TSAccessibility {
@@ -884,7 +884,7 @@ pub struct TSCallSignatureDeclaration<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum TSMethodSignatureKind {
@@ -1006,7 +1006,7 @@ pub struct TSModuleDeclaration<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum TSModuleDeclarationKind {
@@ -1203,7 +1203,7 @@ pub struct TSMappedType<'a> {
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum TSMappedTypeModifierOperator {
@@ -1394,7 +1394,7 @@ pub struct TSInstantiationExpression<'a> {
 /// See [TypeScript - Type-Only Imports and Exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ImportOrExportKind {

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -2022,6 +2022,20 @@ impl<'a> GetSpan for JSXFragment<'a> {
     }
 }
 
+impl GetSpan for JSXOpeningFragment {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXClosingFragment {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 impl<'a> GetSpan for JSXElementName<'a> {
     fn span(&self) -> Span {
         match self {

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -2022,6 +2022,20 @@ impl<'a> GetSpanMut for JSXFragment<'a> {
     }
 }
 
+impl GetSpanMut for JSXOpeningFragment {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXClosingFragment {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl<'a> GetSpanMut for JSXElementName<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {

--- a/tasks/ast_codegen/src/generators/derive_get_span.rs
+++ b/tasks/ast_codegen/src/generators/derive_get_span.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::Ident;
 
 use crate::{
@@ -18,12 +18,10 @@ define_generator! {
 
 impl Generator for DeriveGetSpan {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        let trait_name = format_ident!("GetSpan");
-        let method_name = format_ident!("span");
         let self_type = quote!(&self);
         let result_type = quote!(Span);
         let result_expr = quote!(self.span);
-        let out = derive(&trait_name, &method_name, &self_type, &result_type, &result_expr, ctx);
+        let out = derive("GetSpan", "span", &self_type, &result_type, &result_expr, ctx);
 
         GeneratorOutput::Stream((output(crate::AST_CRATE, "derive_get_span.rs"), out))
     }
@@ -35,33 +33,35 @@ define_generator! {
 
 impl Generator for DeriveGetSpanMut {
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
-        let trait_name = format_ident!("GetSpanMut");
-        let method_name = format_ident!("span_mut");
         let self_type = quote!(&mut self);
         let result_type = quote!(&mut Span);
         let result_expr = quote!(&mut self.span);
-        let out = derive(&trait_name, &method_name, &self_type, &result_type, &result_expr, ctx);
+        let out = derive("GetSpanMut", "span_mut", &self_type, &result_type, &result_expr, ctx);
 
         GeneratorOutput::Stream((output(crate::AST_CRATE, "derive_get_span_mut.rs"), out))
     }
 }
 
 fn derive(
-    trait_name: &Ident,
-    method_name: &Ident,
+    trait_name: &str,
+    method_name: &str,
     self_type: &TokenStream,
     result_type: &TokenStream,
     result_expr: &TokenStream,
     ctx: &LateCtx,
 ) -> TokenStream {
+    let trait_ident = trait_name.to_ident();
+    let method_ident = method_name.to_ident();
     let impls: Vec<TokenStream> = ctx
         .schema()
         .into_iter()
-        .filter(|def| def.visitable())
+        .filter(|def| def.generates_derive(trait_name))
         .map(|def| match &def {
-            TypeDef::Enum(def) => derive_enum(def, trait_name, method_name, self_type, result_type),
+            TypeDef::Enum(def) => {
+                derive_enum(def, &trait_ident, &method_ident, self_type, result_type)
+            }
             TypeDef::Struct(def) => {
-                derive_struct(def, trait_name, method_name, self_type, result_type, result_expr)
+                derive_struct(def, &trait_ident, &method_ident, self_type, result_type, result_expr)
             }
         })
         .collect();
@@ -74,7 +74,7 @@ fn derive(
         insert!("#![allow(clippy::match_same_arms)]");
         endl!();
 
-        use oxc_span::{#trait_name, Span};
+        use oxc_span::{#trait_ident, Span};
         endl!();
 
         use crate::ast::*;


### PR DESCRIPTION
follow-up to #4735
I was accidentally using the old code to filter the viable target types to derive. It means before this PR we were still using the `#[ast(visit)]` for this purpose.