### PR TITLE
refactor(ast_codegen): consistent import order

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -3,9 +3,10 @@
 
 use std::mem::{align_of, offset_of, size_of};
 
-use crate::ast::*;
 use oxc_span::*;
 use oxc_syntax::{number::*, operator::*};
+
+use crate::ast::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -1,8 +1,9 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_codegen/src/generators/ast_kind.rs`
 
-use crate::ast::*;
 use oxc_span::{GetSpan, Span};
+
+use crate::ast::*;
 
 #[derive(Debug, Clone, Copy)]
 pub enum AstType {

--- a/tasks/ast_codegen/src/generators/assert_layouts.rs
+++ b/tasks/ast_codegen/src/generators/assert_layouts.rs
@@ -41,11 +41,11 @@ impl Generator for AssertLayouts {
 
                 endl!();
 
-                use crate::ast::*;
                 use oxc_span::*;
                 use oxc_syntax::{number::*, operator::*};
+                endl!();
 
-
+                use crate::ast::*;
                 endl!();
 
                 #[cfg(target_pointer_width = "64")]

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -170,9 +170,10 @@ impl Generator for AstKindGenerator {
             quote! {
                 #header
 
-                use crate::ast::*;
                 use oxc_span::{GetSpan, Span};
+                endl!();
 
+                use crate::ast::*;
                 endl!();
 
                 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Pure refactor. Alter import order in generated code to consistent order - `std`, external crates, `crate`, `super`.