### PR TITLE
refactor(ast_codegen): consistent `endl!` position

### DIFF
--- a/tasks/ast_codegen/src/generators/assert_layouts.rs
+++ b/tasks/ast_codegen/src/generators/assert_layouts.rs
@@ -38,7 +38,6 @@ impl Generator for AssertLayouts {
                 #header
 
                 use std::mem::{align_of, offset_of, size_of};
-
                 endl!();
 
                 use oxc_span::*;

--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -44,6 +44,7 @@ impl Generator for AstBuilderGenerator {
             output(crate::AST_CRATE, "ast_builder.rs"),
             quote! {
                 #header
+
                 insert!("#![allow(clippy::default_trait_access, clippy::too_many_arguments, clippy::fn_params_excessive_bools)]");
                 endl!();
 
@@ -55,12 +56,10 @@ impl Generator for AstBuilderGenerator {
                         AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
                     },
                 };
-
                 endl!();
 
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
-
                 endl!();
 
                 /// AST builder for creating AST nodes
@@ -68,7 +67,6 @@ impl Generator for AstBuilderGenerator {
                 pub struct AstBuilder<'a> {
                     pub allocator: &'a Allocator,
                 }
-
                 endl!();
 
                 impl<'a> AstBuilder<'a> {
@@ -133,11 +131,11 @@ fn generate_enum_inherit_builder_fn(
         enum_builder_name(enum_ident.to_string(), inherit.super_.name().inner_name().to_string());
 
     quote! {
-        endl!();
         #[inline]
         pub fn #fn_name(self, inner: #super_type) -> #enum_as_type {
             #enum_ident::from(inner)
         }
+        endl!();
     }
 }
 
@@ -189,12 +187,12 @@ fn generate_enum_variant_builder_fn(
     }
 
     quote! {
-        endl!();
         #docs
         #[inline]
         pub fn #fn_name #generic_params (self, #(#params),*) -> #enum_type #where_clause {
             #enum_ident::#var_ident(#inner)
         }
+        endl!();
 
         #from_variant_builder
     }
@@ -223,12 +221,12 @@ fn generate_enum_from_variant_builder_fn(
         " Convert {from_article} [`{var_type_name}`] into {to_article} [`{enum_ident}::{var_ident}`]",
     ));
     quote! {
-        endl!();
         #docs
         #[inline]
         pub fn #fn_name<T>(self, inner: T) -> #enum_type where T: IntoIn<'a, #var_type> {
             #enum_ident::#var_ident(inner.into_in(self.allocator))
         }
+        endl!();
     }
 }
 
@@ -298,13 +296,11 @@ fn generate_struct_builder_fn(ty: &StructDef, ctx: &LateCtx) -> TokenStream {
             .with_params(&params);
 
     quote! {
-        endl!();
         #fn_docs
         #[inline]
         pub fn #fn_name #generic_params (self, #(#params),*) -> #as_type  #where_clause {
             #ident { #(#fields),* }
         }
-
         endl!();
 
         #alloc_docs
@@ -312,6 +308,7 @@ fn generate_struct_builder_fn(ty: &StructDef, ctx: &LateCtx) -> TokenStream {
         pub fn #alloc_fn_name #generic_params (self, #(#params),*) -> Box<'a, #as_type> #where_clause {
             Box::new_in(self.#fn_name(#(#args),*), self.allocator)
         }
+        endl!();
     }
 }
 

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -180,7 +180,6 @@ impl Generator for AstKindGenerator {
                 pub enum AstType {
                     #(#types),*,
                 }
-
                 endl!();
 
                 /// Untyped AST Node Kind
@@ -188,7 +187,6 @@ impl Generator for AstKindGenerator {
                 pub enum AstKind<'a> {
                     #(#kinds),*,
                 }
-
                 endl!();
 
                 impl<'a> GetSpan for AstKind<'a> {

--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -41,6 +41,7 @@ impl Generator for DeriveCloneIn {
 
                 use oxc_allocator::{Allocator, CloneIn};
                 endl!();
+
                 use crate::ast::*;
                 endl!();
 
@@ -101,23 +102,23 @@ fn impl_clone_in(
 ) -> TokenStream {
     if has_lifetime {
         quote! {
-            endl!();
             impl <'old_alloc, 'new_alloc> CloneIn<'new_alloc> for #ty_ident<'old_alloc> {
                 type Cloned = #ty_ident<'new_alloc>;
                 fn clone_in(&self, #alloc_ident: &'new_alloc Allocator) -> Self::Cloned {
                     #body
                 }
             }
+            endl!();
         }
     } else {
         quote! {
-            endl!();
             impl <'alloc> CloneIn<'alloc> for #ty_ident {
                 type Cloned = #ty_ident;
                 fn clone_in(&self, #alloc_ident: &'alloc Allocator) -> Self::Cloned {
                     #body
                 }
             }
+            endl!();
         }
     }
 }

--- a/tasks/ast_codegen/src/generators/derive_get_span.rs
+++ b/tasks/ast_codegen/src/generators/derive_get_span.rs
@@ -78,11 +78,13 @@ fn derive(
 
     quote! {
         #header
+
         insert!("#![allow(clippy::match_same_arms)]");
         endl!();
 
         use oxc_span::{#trait_name, Span};
         endl!();
+
         use crate::ast::*;
         endl!();
 

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -93,31 +93,28 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
                     std::mem::transmute(t)
                 }
             }
+            endl!();
         }
     };
 
     quote! {
         #header
+
         #file_docs
         #clippy_attr
-
         endl!();
 
         use std::cell::Cell;
-
         endl!();
 
         use oxc_allocator::Vec;
         use oxc_syntax::scope::{ScopeFlags, ScopeId};
-
         endl!();
 
         use crate::{ast::*, ast_kind::#ast_kind_type};
-
         endl!();
 
         use #walk_mod::*;
-
         endl!();
 
         /// Syntax tree traversal
@@ -126,28 +123,25 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
             fn enter_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
             #[inline]
             fn leave_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
-
             endl!();
 
             #[inline]
             fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}
             #[inline]
             fn leave_scope(&mut self) {}
-
             endl!();
 
             #may_alloc
 
             #(#visits)*
         }
-
         endl!();
 
         pub mod #walk_mod {
             use super::*;
+            endl!();
 
             #(#walks)*
-
         }
     }
 }
@@ -273,11 +267,11 @@ impl<'a> VisitBuilder<'a> {
         let walk_name = format_ident!("walk_{}", ident_snake);
 
         self.visits.push(quote! {
-            endl!();
             #[inline]
             fn #visit_name (&mut self, it: #as_param_type #extra_params) {
                 #walk_name(self, it #extra_args);
             }
+            endl!();
         });
 
         // We push an empty walk first, because we evaluate - and generate - each walk as we go,
@@ -328,11 +322,11 @@ impl<'a> VisitBuilder<'a> {
 
         // replace the placeholder walker with the actual one!
         self.walks[this_walker] = quote! {
-            endl!();
             #may_inline
             pub fn #walk_name <'a, V: #visit_trait<'a>>(visitor: &mut V, it: #as_param_type #extra_params) {
                 #walk_body
             }
+            endl!();
         };
 
         visit_name


### PR DESCRIPTION
Pure refactor (style nit). Place `endl!()` macro calls in consistent position throughout codegen.