### PR TITLE
refactor(ast_codegen): remove `Generator::name` and `Pass::name` methods

### DIFF
--- a/tasks/ast_codegen/src/generators/assert_layouts.rs
+++ b/tasks/ast_codegen/src/generators/assert_layouts.rs
@@ -15,10 +15,6 @@ define_generator! {
 }
 
 impl Generator for AssertLayouts {
-    fn name(&self) -> &'static str {
-        stringify!(AssertLayouts)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         let (assertions_64, assertions_32) = ctx
             .schema

--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -25,10 +25,6 @@ define_generator! {
 }
 
 impl Generator for AstBuilderGenerator {
-    fn name(&self) -> &'static str {
-        stringify!(AstBuilderGenerator)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         let fns = ctx
             .schema

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -135,10 +135,6 @@ pub fn process_types(def: &TypeDef, _: &LateCtx) -> Vec<(Ident, Type)> {
 }
 
 impl Generator for AstKindGenerator {
-    fn name(&self) -> &'static str {
-        stringify!(AstKindGenerator)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         let have_kinds: Vec<(Ident, Type)> = ctx
             .schema.definitions

--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -16,10 +16,6 @@ define_generator! {
 }
 
 impl Generator for DeriveCloneIn {
-    fn name(&self) -> &'static str {
-        stringify!(DeriveCloneIn)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         let impls: Vec<TokenStream> = ctx
             .schema

--- a/tasks/ast_codegen/src/generators/derive_get_span.rs
+++ b/tasks/ast_codegen/src/generators/derive_get_span.rs
@@ -16,10 +16,6 @@ define_generator! {
 }
 
 impl Generator for DeriveGetSpan {
-    fn name(&self) -> &'static str {
-        stringify!(DeriveGetSpan)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         let trait_name = format_ident!("GetSpan");
         let method_name = format_ident!("span");
@@ -37,10 +33,6 @@ define_generator! {
 }
 
 impl Generator for DeriveGetSpanMut {
-    fn name(&self) -> &'static str {
-        stringify!(DeriveGetSpanMut)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         let trait_name = format_ident!("GetSpanMut");
         let method_name = format_ident!("span_mut");

--- a/tasks/ast_codegen/src/generators/mod.rs
+++ b/tasks/ast_codegen/src/generators/mod.rs
@@ -50,7 +50,6 @@ macro_rules! generated_header {
 pub(crate) use generated_header;
 
 pub trait Generator {
-    fn name(&self) -> &'static str;
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput;
 }
 
@@ -62,7 +61,7 @@ macro_rules! define_generator {
             type Output = $crate::GeneratorOutput;
 
             fn name(&self) -> &'static str {
-                $crate::Generator::name(self)
+                stringify!($ident)
             }
 
             fn run(&mut self, ctx: &$crate::LateCtx) -> $crate::Result<Self::Output> {

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -26,10 +26,6 @@ define_generator! {
 }
 
 impl Generator for VisitGenerator {
-    fn name(&self) -> &'static str {
-        stringify!(VisitGenerator)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         GeneratorOutput::Stream((
             output(crate::AST_CRATE, "visit.rs"),
@@ -39,10 +35,6 @@ impl Generator for VisitGenerator {
 }
 
 impl Generator for VisitMutGenerator {
-    fn name(&self) -> &'static str {
-        stringify!(VisitMutGenerator)
-    }
-
     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
         GeneratorOutput::Stream((
             output(crate::AST_CRATE, "visit_mut.rs"),

--- a/tasks/ast_codegen/src/passes/calc_layout.rs
+++ b/tasks/ast_codegen/src/passes/calc_layout.rs
@@ -25,10 +25,6 @@ define_pass! {
 }
 
 impl Pass for CalcLayout {
-    fn name(&self) -> &'static str {
-        stringify!(CalcLayout)
-    }
-
     fn each(&mut self, ty: &mut AstType, ctx: &EarlyCtx) -> crate::Result<bool> {
         calc_layout(ty, ctx)
     }

--- a/tasks/ast_codegen/src/passes/linker.rs
+++ b/tasks/ast_codegen/src/passes/linker.rs
@@ -33,10 +33,6 @@ define_pass! {
 }
 
 impl Pass for Linker {
-    fn name(&self) -> &'static str {
-        stringify!(Linker)
-    }
-
     /// # Panics
     /// On invalid inheritance.
     fn each(&mut self, ty: &mut AstType, ctx: &EarlyCtx) -> crate::Result<bool> {

--- a/tasks/ast_codegen/src/passes/mod.rs
+++ b/tasks/ast_codegen/src/passes/mod.rs
@@ -10,8 +10,6 @@ pub use calc_layout::CalcLayout;
 pub use linker::Linker;
 
 pub trait Pass {
-    fn name(&self) -> &'static str;
-
     /// Returns false if can't resolve
     fn once(&mut self, _ctx: &EarlyCtx) -> Result<bool> {
         Ok(true)
@@ -53,7 +51,7 @@ macro_rules! define_pass {
             type Context = $crate::EarlyCtx;
             type Output = ();
             fn name(&self) -> &'static str {
-                $crate::Pass::name(self)
+                stringify!($ident)
             }
 
             fn run(&mut self, ctx: &Self::Context) -> $crate::Result<Self::Output> {


### PR DESCRIPTION
Remove `Generator::name` and `Pass::name` methods. All impls for these methods return a string identical to the struct name, so can set return value of `Runner::name` in `define_generator!` and `define_pass!` macros instead.