### PR TITLE
refactor(ast): `oxc_ast` crate re-export AST types from other crates

### DIFF
--- a/crates/oxc_ast/src/ast/mod.rs
+++ b/crates/oxc_ast/src/ast/mod.rs
@@ -183,3 +183,12 @@ mod ts;
 use macros::inherit_variants;
 
 pub use self::{js::*, jsx::*, literal::*, ts::*};
+
+// Re-export AST types from other crates
+pub use oxc_span::{Atom, Language, LanguageVariant, ModuleKind, SourceType, Span};
+pub use oxc_syntax::{
+    number::{BigintBase, NumberBase},
+    operator::{
+        AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
+    },
+};


### PR DESCRIPTION
Some AST types are defined in crates outside `oxc_ast` crate. Re-export these types from `oxc_ast` crate for ease - so you don't need to remember where they're defined to use them.