### PR TITLE
refactor(ast_codegen): remove unnecessary imports from generated files

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -3,9 +3,7 @@
 
 use std::mem::{align_of, offset_of, size_of};
 
-use oxc_span::*;
-use oxc_syntax::{number::*, operator::*};
-
+#[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
 #[cfg(target_pointer_width = "64")]

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8,13 +8,6 @@
 )]
 
 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-use oxc_span::{Atom, SourceType, Span};
-use oxc_syntax::{
-    number::{BigintBase, NumberBase},
-    operator::{
-        AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
-    },
-};
 
 #[allow(clippy::wildcard_imports)]
 use crate::ast::*;

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -3,6 +3,7 @@
 
 use oxc_span::{GetSpan, Span};
 
+#[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3,6 +3,7 @@
 
 use oxc_allocator::{Allocator, CloneIn};
 
+#[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
 impl<'alloc> CloneIn<'alloc> for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -3,8 +3,9 @@
 
 #![allow(clippy::match_same_arms)]
 
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 
+#[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
 impl GetSpan for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -3,8 +3,9 @@
 
 #![allow(clippy::match_same_arms)]
 
-use oxc_span::{GetSpanMut, Span};
+use oxc_span::GetSpanMut;
 
+#[allow(clippy::wildcard_imports)]
 use crate::ast::*;
 
 impl GetSpanMut for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -21,7 +21,9 @@ use std::cell::Cell;
 use oxc_allocator::Vec;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
-use crate::{ast::*, ast_kind::AstKind};
+#[allow(clippy::wildcard_imports)]
+use crate::ast::*;
+use crate::ast_kind::AstKind;
 
 use walk::*;
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -21,7 +21,9 @@ use std::cell::Cell;
 use oxc_allocator::Vec;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
-use crate::{ast::*, ast_kind::AstType};
+#[allow(clippy::wildcard_imports)]
+use crate::ast::*;
+use crate::ast_kind::AstType;
 
 use walk_mut::*;
 

--- a/tasks/ast_codegen/src/generators/assert_layouts.rs
+++ b/tasks/ast_codegen/src/generators/assert_layouts.rs
@@ -36,10 +36,7 @@ impl Generator for AssertLayouts {
                 use std::mem::{align_of, offset_of, size_of};
                 endl!();
 
-                use oxc_span::*;
-                use oxc_syntax::{number::*, operator::*};
-                endl!();
-
+                #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
                 endl!();
 

--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -45,13 +45,6 @@ impl Generator for AstBuilderGenerator {
                 endl!();
 
                 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-                use oxc_span::{Atom, SourceType, Span};
-                use oxc_syntax::{
-                    number::{BigintBase, NumberBase},
-                    operator::{
-                        AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
-                    },
-                };
                 endl!();
 
                 #[allow(clippy::wildcard_imports)]

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -170,6 +170,7 @@ impl Generator for AstKindGenerator {
                 use oxc_span::{GetSpan, Span};
                 endl!();
 
+                #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
                 endl!();
 

--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -38,6 +38,7 @@ impl Generator for DeriveCloneIn {
                 use oxc_allocator::{Allocator, CloneIn};
                 endl!();
 
+                #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
                 endl!();
 

--- a/tasks/ast_codegen/src/generators/derive_get_span.rs
+++ b/tasks/ast_codegen/src/generators/derive_get_span.rs
@@ -74,9 +74,10 @@ fn derive(
         insert!("#![allow(clippy::match_same_arms)]");
         endl!();
 
-        use oxc_span::{#trait_ident, Span};
+        use oxc_span::#trait_ident;
         endl!();
 
+        #[allow(clippy::wildcard_imports)]
         use crate::ast::*;
         endl!();
 

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -104,7 +104,9 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
         use oxc_syntax::scope::{ScopeFlags, ScopeId};
         endl!();
 
-        use crate::{ast::*, ast_kind::#ast_kind_type};
+        #[allow(clippy::wildcard_imports)]
+        use crate::ast::*;
+        use crate::ast_kind::#ast_kind_type;
         endl!();
 
         use #walk_mod::*;


### PR DESCRIPTION
#4773 makes types like `Span` importable from `oxc_ast::ast`, so remove the imports from other crates in generated code.

I'm not sure why clippy's `wildcard_imports` rule was not being triggered for `use crate::ast::*;`, but add `#[allow(clippy::wildcard_imports)]` on these statements just to make sure.