### PR TITLE
refactor(ast_codegen): move formatting regex definitions

### DIFF
--- a/tasks/ast_codegen/src/fmt.rs
+++ b/tasks/ast_codegen/src/fmt.rs
@@ -7,8 +7,14 @@ use syn::parse_file;
 
 static INSERT_MACRO_IDENT: &str = "insert";
 static ENDL_MACRO_IDENT: &str = "endl";
-static WHITE_SPACES: &str = "   ";
+static WHITE_SPACES: &str = " \t";
 
+/// Replace `insert!` macro calls with the contents of the `insert!`.
+///
+/// e.g. `insert!("#![allow(dead_code)]")` is replaced by `#![allow(dead_code)]`.
+///
+/// We use this when inserting outer attributes (`#![allow(unused)]`) or plain comments (`//` not `///`).
+/// `quote!` macro ignores plain comments, so it's not possible to produce them otherwise.
 struct InsertReplacer;
 
 impl Replacer for InsertReplacer {
@@ -21,36 +27,53 @@ impl Replacer for InsertReplacer {
     }
 }
 
+lazy_static! {
+    static ref INSERT_REGEX: Regex = Regex::new(
+        format!(
+            r#"(?m)^[{WHITE_SPACES}]*{INSERT_MACRO_IDENT}!\([\n\s\S]*?\"([\n\s\S]*?)\"[\n\s\S]*?\);$"#
+        )
+        .as_str()
+    )
+    .unwrap();
+}
+
+/// Remove `endl!();`, so it produces a line break.
+///
+/// e.g.:
+/// ```
+/// use oxc_allocator::Allocator;
+/// endl!();
+/// use oxc_ast::*;
+/// ```
+/// becomes:
+/// ```
+/// use oxc_allocator::Allocator;
+///
+/// use oxc_ast::*;
+/// ```
+///
+/// We use `endl!();` because `quote!` macro ignores whitespace,
+/// so we have to use another means to generate line breaks.
 struct EndlReplacer;
 
 impl Replacer for EndlReplacer {
     fn replace_append(&mut self, _: &Captures, _: &mut String) {}
 }
 
-/// Pretty Print
+lazy_static! {
+    static ref ENDL_REGEX: Regex =
+        Regex::new(format!(r"[{WHITE_SPACES}]*{ENDL_MACRO_IDENT}!\(\);").as_str()).unwrap();
+}
+
+/// Pretty print
 pub fn pprint(input: &TokenStream) -> String {
-    lazy_static! {
-        static ref INSERT_REGEX: Regex = Regex::new(
-            format!(
-                r#"(?m)^[{WHITE_SPACES}]*{INSERT_MACRO_IDENT}!\([\n\s\S]*?\"([\n\s\S]*?)\"[\n\s\S]*?\);$"#
-            )
-            .as_str()
-        )
-        .unwrap();
-    };
-
-    lazy_static! {
-        static ref ENDL_REGEX: Regex =
-            Regex::new(format!(r"[{WHITE_SPACES}]*{ENDL_MACRO_IDENT}!\(\);").as_str()).unwrap();
-    };
-
     let result = prettyplease::unparse(&parse_file(input.to_string().as_str()).unwrap());
     let result = ENDL_REGEX.replace_all(&result, EndlReplacer);
     let result = INSERT_REGEX.replace_all(&result, InsertReplacer).to_string();
     result
 }
 
-/// Runs cargo fmt.
+/// Run `cargo fmt`
 pub fn cargo_fmt() {
     Command::new("cargo").arg("fmt").status().unwrap();
 }


### PR DESCRIPTION
Pure refactor. Move the regex definitions used in formatting to next to the `Replacer`s for those regexes.