### PR TITLE
refactor(ast_codegen): use doc comments instead of `endl!`

### DIFF
--- a/tasks/ast_codegen/src/fmt.rs
+++ b/tasks/ast_codegen/src/fmt.rs
@@ -55,6 +55,7 @@ lazy_static! {
 ///
 /// We use `endl!();` because `quote!` macro ignores whitespace,
 /// so we have to use another means to generate line breaks.
+#[allow(dead_code)] // `endl!` macro is not currently used
 struct EndlReplacer;
 
 impl Replacer for EndlReplacer {
@@ -108,8 +109,8 @@ lazy_static! {
 /// Pretty print
 pub fn pprint(input: &TokenStream) -> String {
     let result = prettyplease::unparse(&parse_file(input.to_string().as_str()).unwrap());
-    let result = ENDL_REGEX.replace_all(&result, EndlReplacer);
-    // `insert!` macro is not currently used
+    // `insert!` and `endl!` macros are not currently used
+    // let result = ENDL_REGEX.replace_all(&result, EndlReplacer);
     // let result = INSERT_REGEX.replace_all(&result, InsertReplacer).to_string();
     let result = COMMENT_REGEX.replace_all(&result, CommentReplacer).to_string();
     result

--- a/tasks/ast_codegen/src/generators/assert_layouts.rs
+++ b/tasks/ast_codegen/src/generators/assert_layouts.rs
@@ -34,20 +34,20 @@ impl Generator for AssertLayouts {
                 #header
 
                 use std::mem::{align_of, offset_of, size_of};
-                endl!();
 
+                ///@@
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
-                endl!();
 
+                ///@@
                 #[cfg(target_pointer_width = "64")]
                 const _: () = { #(#assertions_64)* };
-                endl!();
 
+                ///@@
                 #[cfg(target_pointer_width = "32")]
                 const _: () = { #(#assertions_32)* };
-                endl!();
 
+                ///@@
                 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]
                 const _: () = panic!("Platforms with pointer width other than 64 or 32 bit are not supported");
             },

--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -46,22 +46,22 @@ impl Generator for AstBuilderGenerator {
                     clippy::too_many_arguments,
                     clippy::fn_params_excessive_bools,
                 )]
-                endl!();
 
+                ///@@
                 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-                endl!();
 
+                ///@@
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
-                endl!();
 
+                ///@@
                 /// AST builder for creating AST nodes
                 #[derive(Clone, Copy)]
                 pub struct AstBuilder<'a> {
                     pub allocator: &'a Allocator,
                 }
-                endl!();
 
+                ///@@
                 impl<'a> AstBuilder<'a> {
                     #(#fns)*
                 }
@@ -124,11 +124,11 @@ fn generate_enum_inherit_builder_fn(
         enum_builder_name(enum_ident.to_string(), inherit.super_.name().inner_name().to_string());
 
     quote! {
+        ///@@
         #[inline]
         pub fn #fn_name(self, inner: #super_type) -> #enum_as_type {
             #enum_ident::from(inner)
         }
-        endl!();
     }
 }
 
@@ -180,12 +180,12 @@ fn generate_enum_variant_builder_fn(
     }
 
     quote! {
+        ///@@
         #docs
         #[inline]
         pub fn #fn_name #generic_params (self, #(#params),*) -> #enum_type #where_clause {
             #enum_ident::#var_ident(#inner)
         }
-        endl!();
 
         #from_variant_builder
     }
@@ -214,12 +214,12 @@ fn generate_enum_from_variant_builder_fn(
         " Convert {from_article} [`{var_type_name}`] into {to_article} [`{enum_ident}::{var_ident}`]",
     ));
     quote! {
+        ///@@
         #docs
         #[inline]
         pub fn #fn_name<T>(self, inner: T) -> #enum_type where T: IntoIn<'a, #var_type> {
             #enum_ident::#var_ident(inner.into_in(self.allocator))
         }
-        endl!();
     }
 }
 
@@ -289,19 +289,19 @@ fn generate_struct_builder_fn(ty: &StructDef, ctx: &LateCtx) -> TokenStream {
             .with_params(&params);
 
     quote! {
+        ///@@
         #fn_docs
         #[inline]
         pub fn #fn_name #generic_params (self, #(#params),*) -> #as_type  #where_clause {
             #ident { #(#fields),* }
         }
-        endl!();
 
+        ///@@
         #alloc_docs
         #[inline]
         pub fn #alloc_fn_name #generic_params (self, #(#params),*) -> Box<'a, #as_type> #where_clause {
             Box::new_in(self.#fn_name(#(#args),*), self.allocator)
         }
-        endl!();
     }
 }
 

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -168,25 +168,25 @@ impl Generator for AstKindGenerator {
                 #header
 
                 use oxc_span::{GetSpan, Span};
-                endl!();
 
+                ///@@
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
-                endl!();
 
+                ///@@
                 #[derive(Debug, Clone, Copy)]
                 pub enum AstType {
                     #(#types),*,
                 }
-                endl!();
 
+                ///@@
                 /// Untyped AST Node Kind
                 #[derive(Debug, Clone, Copy)]
                 pub enum AstKind<'a> {
                     #(#kinds),*,
                 }
-                endl!();
 
+                ///@@
                 impl<'a> GetSpan for AstKind<'a> {
                     #[allow(clippy::match_same_arms)]
                     fn span(&self) -> Span {

--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -36,12 +36,12 @@ impl Generator for DeriveCloneIn {
                 #header
 
                 use oxc_allocator::{Allocator, CloneIn};
-                endl!();
 
+                ///@@
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
-                endl!();
 
+                ///@@
                 #(#impls)*
             },
         ))
@@ -99,23 +99,23 @@ fn impl_clone_in(
 ) -> TokenStream {
     if has_lifetime {
         quote! {
+            ///@@
             impl <'old_alloc, 'new_alloc> CloneIn<'new_alloc> for #ty_ident<'old_alloc> {
                 type Cloned = #ty_ident<'new_alloc>;
                 fn clone_in(&self, #alloc_ident: &'new_alloc Allocator) -> Self::Cloned {
                     #body
                 }
             }
-            endl!();
         }
     } else {
         quote! {
+            ///@@
             impl <'alloc> CloneIn<'alloc> for #ty_ident {
                 type Cloned = #ty_ident;
                 fn clone_in(&self, #alloc_ident: &'alloc Allocator) -> Self::Cloned {
                     #body
                 }
             }
-            endl!();
         }
     }
 }

--- a/tasks/ast_codegen/src/generators/derive_get_span.rs
+++ b/tasks/ast_codegen/src/generators/derive_get_span.rs
@@ -72,15 +72,15 @@ fn derive(
         #header
 
         #![allow(clippy::match_same_arms)]
-        endl!();
 
+        ///@@
         use oxc_span::#trait_ident;
-        endl!();
 
+        ///@@
         #[allow(clippy::wildcard_imports)]
         use crate::ast::*;
-        endl!();
 
+        ///@@
         #(#impls)*
     }
 }
@@ -101,6 +101,7 @@ fn derive_enum(
     });
 
     quote! {
+        ///@@
         impl #generics #trait_name for #target_type {
             fn #method_name(#self_type) -> #result_type {
                 match self {
@@ -108,7 +109,6 @@ fn derive_enum(
                 }
             }
         }
-        endl!();
     }
 }
 
@@ -132,12 +132,12 @@ fn derive_struct(
     };
 
     quote! {
+        ///@@
         impl #generics #trait_name for #target_type {
             #[inline]
             fn #method_name(#self_type) -> #result_type {
                 #result_expr
             }
         }
-        endl!();
     }
 }

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -58,6 +58,7 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
         TokenStream::default()
     } else {
         quote! {
+            ///@@
             #[inline]
             fn alloc<T>(&self, t: &T) -> &'a T {
                 ///@ SAFETY:
@@ -67,7 +68,6 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
                     std::mem::transmute(t)
                 }
             }
-            endl!();
         }
     };
 
@@ -89,47 +89,47 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
             clippy::semicolon_if_nothing_returned,
             clippy::match_wildcard_for_single_variants
         )]
-        endl!();
 
+        ///@@
         use std::cell::Cell;
-        endl!();
 
+        ///@@
         use oxc_allocator::Vec;
         use oxc_syntax::scope::{ScopeFlags, ScopeId};
-        endl!();
 
+        ///@@
         #[allow(clippy::wildcard_imports)]
         use crate::ast::*;
         use crate::ast_kind::#ast_kind_type;
-        endl!();
 
+        ///@@
         use #walk_mod::*;
-        endl!();
 
+        ///@@
         /// Syntax tree traversal
         pub trait #trait_name <'a>: Sized {
             #[inline]
             fn enter_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
             #[inline]
             fn leave_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
-            endl!();
 
+            ///@@
             #[inline]
             fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}
             #[inline]
             fn leave_scope(&mut self) {}
-            endl!();
 
+            ///@@
             #may_alloc
 
             #(#visits)*
         }
-        endl!();
 
+        ///@@
         pub mod #walk_mod {
             use super::*;
-            endl!();
 
+            ///@@
             #(#walks)*
         }
     }
@@ -255,11 +255,11 @@ impl<'a> VisitBuilder<'a> {
         let walk_name = format_ident!("walk_{}", ident_snake);
 
         self.visits.push(quote! {
+            ///@@
             #[inline]
             fn #visit_name (&mut self, it: #as_param_type #extra_params) {
                 #walk_name(self, it #extra_args);
             }
-            endl!();
         });
 
         // We push an empty walk first, because we evaluate - and generate - each walk as we go,
@@ -310,11 +310,11 @@ impl<'a> VisitBuilder<'a> {
 
         // replace the placeholder walker with the actual one!
         self.walks[this_walker] = quote! {
+            ///@@
             #may_inline
             pub fn #walk_name <'a, V: #visit_trait<'a>>(visitor: &mut V, it: #as_param_type #extra_params) {
                 #walk_body
             }
-            endl!();
         };
 
         visit_name


### PR DESCRIPTION
Similar to #4777.

Use `///@@` instead of `endl!();` in AST codegen to create line breaks.

NB: `///@@` needs to be before an item, not after it.