### PR TITLE
refactor(ast_codegen): re-order code in `fmt` module

### DIFF
--- a/tasks/ast_codegen/src/fmt.rs
+++ b/tasks/ast_codegen/src/fmt.rs
@@ -9,6 +9,60 @@ static INSERT_MACRO_IDENT: &str = "insert";
 static ENDL_MACRO_IDENT: &str = "endl";
 static WHITE_SPACES: &str = " \t";
 
+/// Pretty print
+pub fn pretty_print(input: &TokenStream) -> String {
+    let result = prettyplease::unparse(&parse_file(input.to_string().as_str()).unwrap());
+    // `insert!` and `endl!` macros are not currently used
+    // let result = ENDL_REGEX.replace_all(&result, EndlReplacer);
+    // let result = INSERT_REGEX.replace_all(&result, InsertReplacer).to_string();
+    let result = COMMENT_REGEX.replace_all(&result, CommentReplacer).to_string();
+    result
+}
+
+/// Run `cargo fmt`
+pub fn cargo_fmt() {
+    Command::new("cargo").arg("fmt").status().unwrap();
+}
+
+/// Replace doc comments which start with `@` with plain comments or line breaks.
+///
+/// Original comment can be either `///@` or `//!@`.
+///
+/// * `///@ foo` becomes `// foo`.
+/// * `//!@ foo` becomes `// foo`.
+/// * `///@@` is removed - i.e. line break.
+/// * `//!@@` is removed - i.e. line break.
+///
+/// `quote!` macro ignores plain comments, but we can use these to generate plain comments
+/// in generated code.
+///
+/// To dynamically generate a comment:
+/// ```
+/// let comment = format!("@ NOTE: {} doesn't exist!", name);
+/// quote!(#[doc = #comment])
+/// // or `quote!(#![doc = #comment])`
+/// ```
+///
+/// `//!@@` can be used to insert a line break in a position where `///@@`
+/// is not valid syntax e.g. before an `#![allow(...)]`.
+struct CommentReplacer;
+
+impl Replacer for CommentReplacer {
+    fn replace_append(&mut self, caps: &Captures, dst: &mut String) {
+        assert_eq!(caps.len(), 2);
+        let body = caps.get(1).unwrap().as_str();
+        if body != "@" {
+            dst.push_str("//");
+            dst.push_str(body);
+        }
+    }
+}
+
+lazy_static! {
+    static ref COMMENT_REGEX: Regex =
+        Regex::new(format!(r"[{WHITE_SPACES}]*//[/!]@(.*)").as_str()).unwrap();
+}
+
 /// Replace `insert!` macro calls with the contents of the `insert!`.
 ///
 /// e.g. `insert!("#![allow(dead_code)]")` is replaced by `#![allow(dead_code)]`.
@@ -65,58 +119,4 @@ impl Replacer for EndlReplacer {
 lazy_static! {
     static ref ENDL_REGEX: Regex =
         Regex::new(format!(r"[{WHITE_SPACES}]*{ENDL_MACRO_IDENT}!\(\);").as_str()).unwrap();
-}
-
-/// Replace doc comments which start with `@` with plain comments or line breaks.
-///
-/// Original comment can be either `///@` or `//!@`.
-///
-/// * `///@ foo` becomes `// foo`.
-/// * `//!@ foo` becomes `// foo`.
-/// * `///@@` is removed - i.e. line break.
-/// * `//!@@` is removed - i.e. line break.
-///
-/// `quote!` macro ignores plain comments, but we can use these to generate plain comments
-/// in generated code.
-///
-/// To dynamically generate a comment:
-/// ```
-/// let comment = format!("@ NOTE: {} doesn't exist!", name);
-/// quote!(#[doc = #comment])
-/// // or `quote!(#![doc = #comment])`
-/// ```
-///
-/// `//!@@` is particularly useful for inserting a line break in a position where `endl!();`
-/// is not valid syntax e.g. before an `#![allow(...)]`.
-struct CommentReplacer;
-
-impl Replacer for CommentReplacer {
-    fn replace_append(&mut self, caps: &Captures, dst: &mut String) {
-        assert_eq!(caps.len(), 2);
-        let body = caps.get(1).unwrap().as_str();
-        if body != "@" {
-            dst.push_str("//");
-            dst.push_str(body);
-        }
-    }
-}
-
-lazy_static! {
-    static ref COMMENT_REGEX: Regex =
-        Regex::new(format!(r"[{WHITE_SPACES}]*//[/!]@(.*)").as_str()).unwrap();
-}
-
-/// Pretty print
-pub fn pprint(input: &TokenStream) -> String {
-    let result = prettyplease::unparse(&parse_file(input.to_string().as_str()).unwrap());
-    // `insert!` and `endl!` macros are not currently used
-    // let result = ENDL_REGEX.replace_all(&result, EndlReplacer);
-    // let result = INSERT_REGEX.replace_all(&result, InsertReplacer).to_string();
-    let result = COMMENT_REGEX.replace_all(&result, CommentReplacer).to_string();
-    result
-}
-
-/// Run `cargo fmt`
-pub fn cargo_fmt() {
-    Command::new("cargo").arg("fmt").status().unwrap();
 }

--- a/tasks/ast_codegen/src/main.rs
+++ b/tasks/ast_codegen/src/main.rs
@@ -15,7 +15,7 @@ mod rust_ast;
 mod schema;
 mod util;
 
-use fmt::{cargo_fmt, pprint};
+use fmt::{cargo_fmt, pretty_print};
 use generators::{
     AssertLayouts, AstBuilderGenerator, AstKindGenerator, DeriveCloneIn, DeriveGetSpan,
     DeriveGetSpanMut, GeneratedDataStream, GeneratedTokenStream, Generator, GeneratorOutput,
@@ -111,7 +111,7 @@ fn write_generated_streams(
         .map(|(path, stream)| {
             let path = path.into_os_string();
             let path = path.to_str().unwrap();
-            let content = pprint(&stream);
+            let content = pretty_print(&stream);
             write_all_to(content.as_bytes(), path)?;
             Ok(path.to_string().replace('\\', "/"))
         })


### PR DESCRIPTION
Pure refactor. Just move code which is most used to top of `fmt` module. And rename `pprint` to `pretty_print` to be a little clearer.