### PR TITLE
refactor(ast_codegen): remove excess space from start of doc comments

### DIFF
--- a/tasks/ast_codegen/src/schema/mod.rs
+++ b/tasks/ast_codegen/src/schema/mod.rs
@@ -274,7 +274,7 @@ fn get_docs(attrs: &[syn::Attribute]) -> Vec<String> {
                     return None;
                 }
                 match &lit.lit {
-                    syn::Lit::Str(lit) => Some(lit.value()),
+                    syn::Lit::Str(lit) => Some(lit.value().trim().to_string()),
                     _ => None,
                 }
             } else {


### PR DESCRIPTION
I noticed that in JSON schema the `docs` property contains e.g. `" The name of the identifier being referenced."` (with an excess space on the start). Trim that off.