### PR TITLE
test(linter): add fixer test for unicorn/no-zero-fractions

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -134,5 +134,35 @@ fn test() {
         r"function foo(){return.0+.1}",
     ];
 
-    Tester::new(NoZeroFractions::NAME, pass, fail).test_and_snapshot();
+    let fix = vec![
+        (r"const foo = 1.0", r"const foo = 1"),
+        (r"const foo = 1.0 + 1", r"const foo = 1 + 1"),
+        (r"foo(1.0 + 1)", r"foo(1 + 1)"),
+        (r"const foo = 1.00", r"const foo = 1"),
+        (r"const foo = 1.00000", r"const foo = 1"),
+        (r"const foo = -1.0", r"const foo = -1"),
+        (r"const foo = 123123123.0", r"const foo = 123123123"),
+        (r"const foo = 123.11100000000", r"const foo = 123.111"),
+        (r"const foo = 1.", r"const foo = 1"),
+        (r"const foo = +1.", r"const foo = +1"),
+        (r"const foo = -1.", r"const foo = -1"),
+        // maybe todo
+        // In the following tests, the comments did not pass the fixer.
+
+        // (r"const foo = 1.e10", r"const foo = 1e10"),
+        // (r"const foo = +1.e-10", r"const foo = +1e-10"),
+        // (r"const foo = -1.e+10", r"const foo = -1e+10"),
+        (r"const foo = (1.).toString()", r"const foo = (1).toString()"),
+        // (r"1.00.toFixed(2)", r"(1).toFixed(2)"),
+        // (r"1.00 .toFixed(2)", r"(1) .toFixed(2)"),
+        (r"(1.00).toFixed(2)", r"(1).toFixed(2)"),
+        // (r"1.00?.toFixed(2)", r"(1)?.toFixed(2)"),
+        (r"a = .0;", r"a = 0;"),
+        // (r"a = .0.toString()", r"a = (0).toString()"),
+        // (r"function foo(){return.0}", r"function foo(){return 0}"),
+        // (r"function foo(){return.0.toString()}", r"function foo(){return (0).toString()}"),
+        // (r"function foo(){return.0+.1}", r"function foo(){return 0+.1}"),
+    ];
+
+    Tester::new(NoZeroFractions::NAME, pass, fail).expect_fix(fix).test_and_snapshot();
 }


### PR DESCRIPTION
Add fixer test.
Some of them have not passed yet, so I have temporarily made comments as todo.