### PR TITLE
refactor(ast_codegen): replace `///@@` with `///@@line_break`

### DIFF
--- a/tasks/ast_codegen/src/fmt.rs
+++ b/tasks/ast_codegen/src/fmt.rs
@@ -30,8 +30,8 @@ pub fn cargo_fmt() {
 ///
 /// * `///@ foo` becomes `// foo`.
 /// * `//!@ foo` becomes `// foo`.
-/// * `///@@` is removed - i.e. line break.
-/// * `//!@@` is removed - i.e. line break.
+/// * `///@@line_break` is removed - i.e. line break.
+/// * `//!@@line_break` is removed - i.e. line break.
 ///
 /// `quote!` macro ignores plain comments, but we can use these to generate plain comments
 /// in generated code.
@@ -43,7 +43,7 @@ pub fn cargo_fmt() {
 /// // or `quote!(#![doc = #comment])`
 /// ```
 ///
-/// `//!@@` can be used to insert a line break in a position where `///@@`
+/// `//!@@line_break` can be used to insert a line break in a position where `///@@line_break`
 /// is not valid syntax e.g. before an `#![allow(...)]`.
 struct CommentReplacer;
 
@@ -51,7 +51,7 @@ impl Replacer for CommentReplacer {
     fn replace_append(&mut self, caps: &Captures, dst: &mut String) {
         assert_eq!(caps.len(), 2);
         let body = caps.get(1).unwrap().as_str();
-        if body != "@" {
+        if body != "@line_break" {
             dst.push_str("//");
             dst.push_str(body);
         }

--- a/tasks/ast_codegen/src/generators/assert_layouts.rs
+++ b/tasks/ast_codegen/src/generators/assert_layouts.rs
@@ -36,19 +36,19 @@ impl Generator for AssertLayouts {
 
                 use std::mem::{align_of, offset_of, size_of};
 
-                ///@@
+                ///@@line_break
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
 
-                ///@@
+                ///@@line_break
                 #[cfg(target_pointer_width = "64")]
                 const _: () = { #(#assertions_64)* };
 
-                ///@@
+                ///@@line_break
                 #[cfg(target_pointer_width = "32")]
                 const _: () = { #(#assertions_32)* };
 
-                ///@@
+                ///@@line_break
                 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]
                 const _: () = panic!("Platforms with pointer width other than 64 or 32 bit are not supported");
             },
@@ -81,7 +81,7 @@ fn assert_type(ty: &Type, def: &TypeDef) -> (TokenStream, TokenStream) {
 
 fn assert_size_align(ty: &Type, size: usize, align: usize) -> TokenStream {
     quote! {
-        ///@@
+        ///@@line_break
         assert!(size_of::<#ty>() == #size);
         assert!(align_of::<#ty>() == #align);
     }

--- a/tasks/ast_codegen/src/generators/ast_builder.rs
+++ b/tasks/ast_codegen/src/generators/ast_builder.rs
@@ -47,21 +47,21 @@ impl Generator for AstBuilderGenerator {
                     clippy::fn_params_excessive_bools,
                 )]
 
-                ///@@
+                ///@@line_break
                 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
 
-                ///@@
+                ///@@line_break
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
 
-                ///@@
+                ///@@line_break
                 /// AST builder for creating AST nodes
                 #[derive(Clone, Copy)]
                 pub struct AstBuilder<'a> {
                     pub allocator: &'a Allocator,
                 }
 
-                ///@@
+                ///@@line_break
                 impl<'a> AstBuilder<'a> {
                     #(#fns)*
                 }
@@ -124,7 +124,7 @@ fn generate_enum_inherit_builder_fn(
         enum_builder_name(enum_ident.to_string(), inherit.super_.name().inner_name().to_string());
 
     quote! {
-        ///@@
+        ///@@line_break
         #[inline]
         pub fn #fn_name(self, inner: #super_type) -> #enum_as_type {
             #enum_ident::from(inner)
@@ -180,7 +180,7 @@ fn generate_enum_variant_builder_fn(
     }
 
     quote! {
-        ///@@
+        ///@@line_break
         #docs
         #[inline]
         pub fn #fn_name #generic_params (self, #(#params),*) -> #enum_type #where_clause {
@@ -214,7 +214,7 @@ fn generate_enum_from_variant_builder_fn(
         " Convert {from_article} [`{var_type_name}`] into {to_article} [`{enum_ident}::{var_ident}`]",
     ));
     quote! {
-        ///@@
+        ///@@line_break
         #docs
         #[inline]
         pub fn #fn_name<T>(self, inner: T) -> #enum_type where T: IntoIn<'a, #var_type> {
@@ -289,14 +289,14 @@ fn generate_struct_builder_fn(ty: &StructDef, ctx: &LateCtx) -> TokenStream {
             .with_params(&params);
 
     quote! {
-        ///@@
+        ///@@line_break
         #fn_docs
         #[inline]
         pub fn #fn_name #generic_params (self, #(#params),*) -> #as_type  #where_clause {
             #ident { #(#fields),* }
         }
 
-        ///@@
+        ///@@line_break
         #alloc_docs
         #[inline]
         pub fn #alloc_fn_name #generic_params (self, #(#params),*) -> Box<'a, #as_type> #where_clause {

--- a/tasks/ast_codegen/src/generators/ast_kind.rs
+++ b/tasks/ast_codegen/src/generators/ast_kind.rs
@@ -169,24 +169,24 @@ impl Generator for AstKindGenerator {
 
                 use oxc_span::{GetSpan, Span};
 
-                ///@@
+                ///@@line_break
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
 
-                ///@@
+                ///@@line_break
                 #[derive(Debug, Clone, Copy)]
                 pub enum AstType {
                     #(#types),*,
                 }
 
-                ///@@
+                ///@@line_break
                 /// Untyped AST Node Kind
                 #[derive(Debug, Clone, Copy)]
                 pub enum AstKind<'a> {
                     #(#kinds),*,
                 }
 
-                ///@@
+                ///@@line_break
                 impl<'a> GetSpan for AstKind<'a> {
                     #[allow(clippy::match_same_arms)]
                     fn span(&self) -> Span {

--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -37,11 +37,11 @@ impl Generator for DeriveCloneIn {
 
                 use oxc_allocator::{Allocator, CloneIn};
 
-                ///@@
+                ///@@line_break
                 #[allow(clippy::wildcard_imports)]
                 use crate::ast::*;
 
-                ///@@
+                ///@@line_break
                 #(#impls)*
             },
         ))
@@ -99,7 +99,7 @@ fn impl_clone_in(
 ) -> TokenStream {
     if has_lifetime {
         quote! {
-            ///@@
+            ///@@line_break
             impl <'old_alloc, 'new_alloc> CloneIn<'new_alloc> for #ty_ident<'old_alloc> {
                 type Cloned = #ty_ident<'new_alloc>;
                 fn clone_in(&self, #alloc_ident: &'new_alloc Allocator) -> Self::Cloned {
@@ -109,7 +109,7 @@ fn impl_clone_in(
         }
     } else {
         quote! {
-            ///@@
+            ///@@line_break
             impl <'alloc> CloneIn<'alloc> for #ty_ident {
                 type Cloned = #ty_ident;
                 fn clone_in(&self, #alloc_ident: &'alloc Allocator) -> Self::Cloned {

--- a/tasks/ast_codegen/src/generators/derive_get_span.rs
+++ b/tasks/ast_codegen/src/generators/derive_get_span.rs
@@ -73,14 +73,14 @@ fn derive(
 
         #![allow(clippy::match_same_arms)]
 
-        ///@@
+        ///@@line_break
         use oxc_span::#trait_ident;
 
-        ///@@
+        ///@@line_break
         #[allow(clippy::wildcard_imports)]
         use crate::ast::*;
 
-        ///@@
+        ///@@line_break
         #(#impls)*
     }
 }
@@ -101,7 +101,7 @@ fn derive_enum(
     });
 
     quote! {
-        ///@@
+        ///@@line_break
         impl #generics #trait_name for #target_type {
             fn #method_name(#self_type) -> #result_type {
                 match self {
@@ -132,7 +132,7 @@ fn derive_struct(
     };
 
     quote! {
-        ///@@
+        ///@@line_break
         impl #generics #trait_name for #target_type {
             #[inline]
             fn #method_name(#self_type) -> #result_type {

--- a/tasks/ast_codegen/src/generators/mod.rs
+++ b/tasks/ast_codegen/src/generators/mod.rs
@@ -144,7 +144,7 @@ macro_rules! generated_header {
         quote::quote! {
             //!@ Auto-generated code, DO NOT EDIT DIRECTLY!
             #![doc = #edit_comment]
-            //!@@
+            //!@@line_break
         }
     }};
 }

--- a/tasks/ast_codegen/src/generators/visit.rs
+++ b/tasks/ast_codegen/src/generators/visit.rs
@@ -58,7 +58,7 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
         TokenStream::default()
     } else {
         quote! {
-            ///@@
+            ///@@line_break
             #[inline]
             fn alloc<T>(&self, t: &T) -> &'a T {
                 ///@ SAFETY:
@@ -79,8 +79,8 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
         //! See:
         //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
         //! * [rustc visitor](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/visit.rs)
-        //!@@
 
+        //!@@line_break
         #![allow(
             unused_variables,
             clippy::extra_unused_type_parameters,
@@ -90,22 +90,22 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
             clippy::match_wildcard_for_single_variants
         )]
 
-        ///@@
+        ///@@line_break
         use std::cell::Cell;
 
-        ///@@
+        ///@@line_break
         use oxc_allocator::Vec;
         use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
-        ///@@
+        ///@@line_break
         #[allow(clippy::wildcard_imports)]
         use crate::ast::*;
         use crate::ast_kind::#ast_kind_type;
 
-        ///@@
+        ///@@line_break
         use #walk_mod::*;
 
-        ///@@
+        ///@@line_break
         /// Syntax tree traversal
         pub trait #trait_name <'a>: Sized {
             #[inline]
@@ -113,23 +113,23 @@ fn generate_visit<const MUT: bool>(ctx: &LateCtx) -> TokenStream {
             #[inline]
             fn leave_node(&mut self, kind: #ast_kind_type #ast_kind_life) {}
 
-            ///@@
+            ///@@line_break
             #[inline]
             fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {}
             #[inline]
             fn leave_scope(&mut self) {}
 
-            ///@@
+            ///@@line_break
             #may_alloc
 
             #(#visits)*
         }
 
-        ///@@
+        ///@@line_break
         pub mod #walk_mod {
             use super::*;
 
-            ///@@
+            ///@@line_break
             #(#walks)*
         }
     }
@@ -255,7 +255,7 @@ impl<'a> VisitBuilder<'a> {
         let walk_name = format_ident!("walk_{}", ident_snake);
 
         self.visits.push(quote! {
-            ///@@
+            ///@@line_break
             #[inline]
             fn #visit_name (&mut self, it: #as_param_type #extra_params) {
                 #walk_name(self, it #extra_args);
@@ -310,7 +310,7 @@ impl<'a> VisitBuilder<'a> {
 
         // replace the placeholder walker with the actual one!
         self.walks[this_walker] = quote! {
-            ///@@
+            ///@@line_break
             #may_inline
             pub fn #walk_name <'a, V: #visit_trait<'a>>(visitor: &mut V, it: #as_param_type #extra_params) {
                 #walk_body


### PR DESCRIPTION
Follow-on after #4778. `///@@line_break` is more verbose, but it's clearer what it does.