### PR TITLE
ci: add jest test file to benchmarks

### DIFF
--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -61,7 +61,7 @@ impl TestFiles {
         Self { files: vec![file] }
     }
 
-    fn complicated_urls() -> [&'static str; 5] {
+    fn complicated_urls() -> [&'static str; 6] {
         [
             // TypeScript syntax (2.81MB)
             "https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts",

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -73,6 +73,8 @@ impl TestFiles {
             "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
             // ES5 (3.9M)
             "https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js",
+            // Jest test file from Jest's own repo (8.0K)
+            "https://raw.githubusercontent.com/jestjs/jest/main/e2e/__tests__/coverageReport.test.ts",
         ]
     }
 }


### PR DESCRIPTION
This will help bench Jest linter rules. See conversation in #4787 for details.