### PR TITLE
fix(transformer/typescript): generated assignment for constructor arguments with access modifiers should be injected to the top of the constructor

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -298,7 +298,8 @@ impl<'a> TypeScriptAnnotations<'a> {
                         )
                     })
                     .statements
-                    .extend(
+                    .splice(
+                        0..0,
                         self.assignments
                             .drain(..)
                             .map(|assignment| assignment.create_this_property_assignment(ctx)),

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/input.ts
@@ -1,7 +1,7 @@
 class Foo {
   boom: number;
   constructor(public foo, private bar, protected zoo, readonly bang, too) {
-
+    console.log(this.foo, this.bar, this.zoo, this.bang);
   }
 }
 class Bar extends Foo {

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/output.js
@@ -5,6 +5,7 @@ class Foo {
     this.bar = bar;
     this.zoo = zoo;
     this.bang = bang;
+    console.log(this.foo, this.bar, this.zoo, this.bang);
   }
 }
 class Bar extends Foo {


### PR DESCRIPTION
fix: #4789
