### PR TITLE
refactor(linter): use Option to reduce nested level in `eslint/getter-return`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -119,72 +119,66 @@ impl GetterReturn {
     }
 
     /// Checks whether it is necessary to check the node
-    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> bool {
-        if let Some(parent) = ctx.nodes().parent_node(node.id()) {
-            match parent.kind() {
-                AstKind::MethodDefinition(mdef) => {
-                    if matches!(mdef.kind, MethodDefinitionKind::Get) {
-                        return true;
-                    }
+    fn is_wanted_node(node: &AstNode, ctx: &LintContext<'_>) -> Option<bool> {
+        let parent = ctx.nodes().parent_node(node.id())?;
+        match parent.kind() {
+            AstKind::MethodDefinition(mdef) => {
+                if matches!(mdef.kind, MethodDefinitionKind::Get) {
+                    return Some(true);
                 }
-                AstKind::ObjectProperty(ObjectProperty { kind, key: prop_key, .. }) => {
-                    if matches!(kind, PropertyKind::Get) {
-                        return true;
-                    }
-                    if prop_key.name().is_some_and(|key| key != "get") {
-                        return false;
-                    }
+            }
+            AstKind::ObjectProperty(ObjectProperty { kind, key: prop_key, .. }) => {
+                if matches!(kind, PropertyKind::Get) {
+                    return Some(true);
+                }
+                if prop_key.name().is_some_and(|key| key != "get") {
+                    return Some(false);
+                }
 
-                    if let Some(parent_2) = ctx.nodes().parent_node(parent.id()) {
-                        if let Some(parent_3) = ctx.nodes().parent_node(parent_2.id()) {
-                            if let Some(parent_4) = ctx.nodes().parent_node(parent_3.id()) {
-                                // handle (X())
-                                match parent_4.kind() {
-                                    AstKind::ParenthesizedExpression(p) => {
-                                        if Self::handle_paren_expr(&p.expression) {
-                                            return true;
-                                        }
-                                    }
-                                    AstKind::CallExpression(ce) => {
-                                        if Self::handle_actual_expression(&ce.callee) {
-                                            return true;
-                                        }
-                                    }
-                                    _ => {}
-                                }
-
-                                if let Some(parent_5) = ctx.nodes().parent_node(parent_4.id()) {
-                                    if let Some(parent_6) = ctx.nodes().parent_node(parent_5.id()) {
-                                        match parent_6.kind() {
-                                            AstKind::ParenthesizedExpression(p) => {
-                                                if Self::handle_paren_expr(&p.expression) {
-                                                    return true;
-                                                }
-                                            }
-                                            AstKind::CallExpression(ce) => {
-                                                if Self::handle_actual_expression(&ce.callee) {
-                                                    return true;
-                                                }
-                                            }
-                                            _ => {
-                                                return false;
-                                            }
-                                        };
-                                    }
-                                }
-                            }
+                let parent_2 = ctx.nodes().parent_node(parent.id())?;
+                let parent_3 = ctx.nodes().parent_node(parent_2.id())?;
+                let parent_4 = ctx.nodes().parent_node(parent_3.id())?;
+                // handle (X())
+                match parent_4.kind() {
+                    AstKind::ParenthesizedExpression(p) => {
+                        if Self::handle_paren_expr(&p.expression) {
+                            return Some(true);
                         }
                     }
+                    AstKind::CallExpression(ce) => {
+                        if Self::handle_actual_expression(&ce.callee) {
+                            return Some(true);
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
+
+                let parent_5 = ctx.nodes().parent_node(parent_4.id())?;
+                let parent_6 = ctx.nodes().parent_node(parent_5.id())?;
+                match parent_6.kind() {
+                    AstKind::ParenthesizedExpression(p) => {
+                        if Self::handle_paren_expr(&p.expression) {
+                            return Some(true);
+                        }
+                    }
+                    AstKind::CallExpression(ce) => {
+                        if Self::handle_actual_expression(&ce.callee) {
+                            return Some(true);
+                        }
+                    }
+                    _ => {
+                        return Some(false);
+                    }
+                };
             }
+            _ => {}
         }
 
-        false
+        Some(false)
     }
 
     fn run_diagnostic<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>, span: Span) {
-        if !Self::is_wanted_node(node, ctx) {
+        if !Self::is_wanted_node(node, ctx).unwrap_or_default() {
             return;
         }
 


### PR DESCRIPTION
1. Simplify `is_wanted_node`