### PR TITLE
feat(rulegen): improve examples in documentation

### DIFF
--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -19,8 +19,16 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     ///
-    /// ### Example
-    /// ```javascript
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```{{language}}
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```{{language}}
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
     /// ```
     {{pascal_rule_name}},
     nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`


### PR DESCRIPTION
- Add sections for invalid/valid examples
- Set example code language based on the plugin the rule is for