### PR TITLE
chore: add default VSCode build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,49 @@
 {
 	"version": "2.0.0",
 	"tasks": [
+		// format code, then build tests (but do not run them).
+		{
+			"label": "rust: cargo test --no-run",
+			"type": "cargo",
+			"command": "test",
+			"args": [
+				"--no-run"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "silent",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": false,
+				"clear": true
+			},
+			"dependsOn": [
+				"rust: cargo fmt"
+			]
+		},
+		{
+			"type": "cargo",
+			"command": "fmt",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"presentation": {
+				"echo": true,
+				"reveal": "silent",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": false,
+				"clear": false
+			},
+			"label": "rust: cargo fmt"
+		},
 		{
 			"type": "npm",
 			"script": "compile",
@@ -18,19 +61,16 @@
 		{
 			"type": "shell",
 			"command": "cd ./editors/vscode && npm run watch",
-      "windows": {
-        "command": "cd ./editors/vscode; npm run watch",
-      },
-      "label": "watch",
-			"isBackground": true,
-			"group": {
-				"kind": "build",
-				"isDefault": true
+			"windows": {
+				"command": "cd ./editors/vscode; npm run watch"
 			},
+			"label": "watch",
+			"isBackground": true,
+			"group": "build",
 			"presentation": {
 				"panel": "dedicated",
 				"reveal": "never"
 			}
-		}
-	]
+		},
+	],
 }


### PR DESCRIPTION
Changes the default VSCode build command to run `cargo fmt` and `cargo test --no-run`. This can be easily run with `Cmd+B` (or `Ctrl+B` for Windows users).