### PR TITLE
chore: alias `new-typescript-rule` to `new-ts-rule`

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,6 +9,7 @@ _default:
 alias r := ready
 alias c := coverage
 alias f := fix
+alias new-typescript-rule := new-ts-rule
 
 # Make sure you have cargo-binstall installed.
 # You can download the pre-compiled binary from <https://github.com/cargo-bins/cargo-binstall#installation>


### PR DESCRIPTION
This is the command suggested to users on our `typescript-eslint` mega-issue #2180.
This should help reduce confusion.