### PR TITLE
feat(vscode): provide config's schema to oxlint config files

### DIFF
--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// ::: danger NOTE
 ///
-/// Only the `.json` format is supported.
+/// Only the `.json` format is supported. You can use comments in configuration files.
 ///
 /// :::
 ///

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OxlintConfig",
-  "description": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\n::: danger NOTE\n\nOnly the `.json` format is supported.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json { \"env\": { \"browser\": true }, \"globals\": { \"foo\": \"readonly\" }, \"settings\": { }, \"rules\": { \"eqeqeq\": \"warn\" } } ```",
+  "description": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\n::: danger NOTE\n\nOnly the `.json` format is supported. You can use comments in configuration files.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json { \"env\": { \"browser\": true }, \"globals\": { \"foo\": \"readonly\" }, \"settings\": { }, \"rules\": { \"eqeqeq\": \"warn\" } } ```",
   "type": "object",
   "properties": {
     "env": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -101,7 +101,31 @@
           "description": "Path to ESlint configuration."
         }
       }
-    }
+    },
+    "jsonValidation": [
+      {
+        "fileMatch": [
+          "oxlintrc.json",
+          "oxlint.json",
+          ".oxlintrc.json",
+          ".oxlint.json",
+          ".oxlintrc"
+        ],
+        "url": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json"
+      }
+    ],
+    "languages": [
+      {
+        "id": "jsonc",
+        "filenames": [
+          "oxlintrc.json",
+          "oxlint.json",
+          ".oxlintrc.json",
+          ".oxlint.json",
+          ".oxlintrc"
+        ]
+      }
+    ]
   },
   "scripts": {
     "preinstall": "[ -f icon.png ] || curl https://cdn.jsdelivr.net/gh/oxc-project/oxc-assets/square.png --output icon.png",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OxlintConfig",
-  "description": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\n::: danger NOTE\n\nOnly the `.json` format is supported.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json { \"env\": { \"browser\": true }, \"globals\": { \"foo\": \"readonly\" }, \"settings\": { }, \"rules\": { \"eqeqeq\": \"warn\" } } ```",
+  "description": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\n::: danger NOTE\n\nOnly the `.json` format is supported. You can use comments in configuration files.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json { \"env\": { \"browser\": true }, \"globals\": { \"foo\": \"readonly\" }, \"settings\": { }, \"rules\": { \"eqeqeq\": \"warn\" } } ```",
   "type": "object",
   "properties": {
     "env": {

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -10,7 +10,7 @@ Usage: `oxlint -c oxlintrc.json`
 
 ::: danger NOTE
 
-Only the `.json` format is supported.
+Only the `.json` format is supported. You can use comments in configuration files.
 
 :::
 


### PR DESCRIPTION
Updates the VSCode plugin client to automatically provide our auto-generated
JSON schema to `\.?oxlint(rc)?(\.json)?` files.