### PR TITLE
refactor(ast_codegen): add line break to generated code

### DIFF
--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -2,6 +2,7 @@
 // To edit this generated file you have to edit `tasks/ast_codegen/src/generators/derive_clone_in.rs`
 
 #![allow(clippy::default_trait_access)]
+
 use oxc_allocator::{Allocator, CloneIn};
 
 #[allow(clippy::wildcard_imports)]

--- a/tasks/ast_codegen/src/generators/derive_clone_in.rs
+++ b/tasks/ast_codegen/src/generators/derive_clone_in.rs
@@ -38,6 +38,7 @@ impl Generator for DeriveCloneIn {
 
                 #![allow(clippy::default_trait_access)]
 
+                ///@@line_break
                 use oxc_allocator::{Allocator, CloneIn};
 
                 ///@@line_break


### PR DESCRIPTION
Follow-on after #4819. Style nit. Add a line break after `#![allow(...)]`.