### PR TITLE
fix(linter/no-unused-vars): do not delete function expressions when fixing

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{ast::VariableDeclarator, AstKind};
+use oxc_ast::{
+    ast::{Expression, VariableDeclarator},
+    AstKind,
+};
 use oxc_semantic::{AstNode, AstNodeId};
 use oxc_span::CompactStr;
 use regex::Regex;
@@ -20,6 +23,10 @@ impl NoUnusedVars {
         decl: &VariableDeclarator<'a>,
         decl_id: AstNodeId,
     ) -> RuleFix<'a> {
+        if decl.init.as_ref().is_some_and(Expression::is_function) {
+            return fixer.noop();
+        }
+
         let Some(AstKind::VariableDeclaration(declaration)) =
             symbol.nodes().parent_node(decl_id).map(AstNode::kind)
         else {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -89,6 +89,20 @@ fn test_vars_simple() {
             None,
             FixKind::DangerousSuggestion,
         ),
+        // function expressions do not get changed
+        (r"const foo = () => {}", r"const foo = () => {}", None, FixKind::DangerousSuggestion),
+        (
+            r"const foo = function() {}",
+            r"const foo = function() {}",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        (
+            r"const foo = function foo() {}",
+            r"const foo = function foo() {}",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
         // vars with references get renamed
         ("let x = 1; x = 2;", "let _x = 1; _x = 2;", None, FixKind::DangerousFix),
         (
@@ -279,8 +293,10 @@ fn test_vars_destructure() {
     ];
 
     let fix = vec![
+        // single destructure
         ("const { a } = obj;", "", None, FixKind::DangerousSuggestion),
         ("const [a] = arr;", "", None, FixKind::DangerousSuggestion),
+        // multi destructure
         (
             "const { a, b } = obj; f(b)",
             "const { b } = obj; f(b)",
@@ -310,6 +326,13 @@ fn test_vars_destructure() {
         (
             "const { foo: fooBar, baz } = obj; f(baz);",
             "const { baz } = obj; f(baz);",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        // multi destructure with rename
+        (
+            "const { a: foo, b: bar } = obj; f(bar)",
+            "const { b: bar } = obj; f(bar)",
             None,
             FixKind::DangerousSuggestion,
         ),


### PR DESCRIPTION
`VariableDeclarator` fixer will no longer delete declarations that are initialized to function expressions.

```ts
// none of these get deleted
const unusedArrow = () => {}
const unusedAnon = function() {}
const unusedNamed = function foo() {}

// matches fixer behavior for function declarations
function unusedDecl() {}
```