### PR TITLE
refactor(semantic): make SemanticBuilder opaque

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -12,7 +12,7 @@ use oxc_span::{GetSpan, SourceType};
 
 use crate::{scope::ScopeFlags, symbol::SymbolFlags, SemanticBuilder};
 
-pub trait Binder<'a> {
+pub(crate) trait Binder<'a> {
     #[allow(unused_variables)]
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {}
 }

--- a/crates/oxc_semantic/src/counter.rs
+++ b/crates/oxc_semantic/src/counter.rs
@@ -16,7 +16,7 @@ use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug)]
-pub struct Counter {
+pub(crate) struct Counter {
     pub nodes_count: usize,
     pub scopes_count: usize,
     pub symbols_count: usize,


### PR DESCRIPTION
change visibility of building-related methods and properties of SemanticBuilder
from `pub` to `pub(crate)`.