### PR TITLE
feat(linter/jsx-a11y): add fixer for anchor-has-content

### DIFF
--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -145,6 +145,16 @@ macro_rules! impl_from {
 // but this breaks when implementing `From<RuleFix<'a>> for CompositeFix<'a>`.
 impl_from!(CompositeFix<'a>, Fix<'a>, Option<Fix<'a>>, Vec<Fix<'a>>);
 
+impl<'a> FromIterator<Fix<'a>> for RuleFix<'a> {
+    fn from_iter<T: IntoIterator<Item = Fix<'a>>>(iter: T) -> Self {
+        Self {
+            kind: FixKind::SafeFix,
+            message: None,
+            fix: iter.into_iter().collect::<Vec<_>>().into(),
+        }
+    }
+}
+
 impl<'a> From<RuleFix<'a>> for CompositeFix<'a> {
     #[inline]
     fn from(val: RuleFix<'a>) -> Self {

--- a/crates/oxc_linter/src/snapshots/anchor_has_content.snap
+++ b/crates/oxc_linter/src/snapshots/anchor_has_content.snap
@@ -17,8 +17,29 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jsx-a11y(anchor-has-content): Missing accessible content when using `a` elements.
    ╭─[anchor_has_content.tsx:1:1]
+ 1 │ <a><Bar aria-hidden="true" /></a>
+   · ─────────────────────────────────
+   ╰────
+  help: Provide screen reader accessible content when using `a` elements.
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-has-content): Missing accessible content when using `a` elements.
+   ╭─[anchor_has_content.tsx:1:1]
+ 1 │ <a><input type="hidden" /></a>
+   · ──────────────────────────────
+   ╰────
+  help: Provide screen reader accessible content when using `a` elements.
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-has-content): Missing accessible content when using `a` elements.
+   ╭─[anchor_has_content.tsx:1:1]
  1 │ <a>{undefined}</a>
    · ──────────────────
+   ╰────
+  help: Provide screen reader accessible content when using `a` elements.
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-has-content): Missing accessible content when using `a` elements.
+   ╭─[anchor_has_content.tsx:1:1]
+ 1 │ <a>{null}</a>
+   · ─────────────
    ╰────
   help: Provide screen reader accessible content when using `a` elements.
 


### PR DESCRIPTION
Add a conditional fix that removes `aria-hidden` from an anchor's child if there
is only a single child. This PR also fixes a false positive on hidden anchors.
It should report visible anchors with hidden content, not hidden anchors.