### PR TITLE
chore: add support for labelling `A-ast-tools`.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,10 @@ A-ast:
 - changed-files:
   - any-glob-to-any-file: ['crates/oxc_ast/**']
 
+A-ast-tools:
+- changed-files:
+  - any-glob-to-any-file: ['tasks/ast_tools/**']
+
 A-cfg:
 - changed-files:
   - any-glob-to-any-file: ['crates/oxc_cfg/**']


### PR DESCRIPTION
Now that the name isn't confusing anymore we can add a label for this area.
I took the liberty of adding the said label; In case of rejection, Feel free to remove it.