### PR TITLE
fix(parser): detect @flow in `/** @flow */ comment

### DIFF
--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -6,7 +6,7 @@ pub struct TriviaBuilder {
     // NOTE(lucab): This is a set of unique comments. Duplicated
     // comments could be generated in case of rewind; they are
     // filtered out at insertion time.
-    comments: Vec<Comment>,
+    pub(crate) comments: Vec<Comment>,
     irregular_whitespaces: Vec<Span>,
 }
 


### PR DESCRIPTION
Discovered in https://github.com/oxc-project/monitor-oxc

There are files with 

```
/**
 * @flow
 */
```

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/__mocks__/JSXAttributeMock.js#L1

So I changed the logic to checking the first comment instead.