### PR TITLE
refactor(syntax): inline trivial bitflags methods

### DIFF
--- a/crates/oxc_syntax/src/class.rs
+++ b/crates/oxc_syntax/src/class.rs
@@ -20,18 +20,22 @@ bitflags! {
 }
 
 impl ElementKind {
+    #[inline]
     pub fn is_property(self) -> bool {
         self.contains(Self::Property)
     }
 
+    #[inline]
     pub fn is_method(self) -> bool {
         self.contains(Self::Method)
     }
 
+    #[inline]
     pub fn is_accessor(self) -> bool {
         self.contains(Self::Accessor)
     }
 
+    #[inline]
     pub fn is_setter_or_getter(self) -> bool {
         self.intersects(Self::Setter | Self::Getter)
     }

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -99,57 +99,69 @@ bitflags! {
 }
 
 impl ReferenceFlag {
+    #[inline]
     pub const fn read() -> Self {
         Self::Read
     }
 
+    #[inline]
     pub const fn write() -> Self {
         Self::Write
     }
 
+    #[inline]
     pub const fn read_write() -> Self {
         Self::Value
     }
 
     /// The identifier is read from. It may also be written to.
+    #[inline]
     pub const fn is_read(&self) -> bool {
         self.intersects(Self::Read)
     }
 
     /// The identifier is only read from.
+    #[inline]
     pub const fn is_read_only(&self) -> bool {
         self.contains(Self::Read)
     }
 
     /// The identifier is written to. It may also be read from.
+    #[inline]
     pub const fn is_write(&self) -> bool {
         self.intersects(Self::Write)
     }
 
     /// The identifier is only written to. It is not read from in this reference.
+    #[inline]
     pub const fn is_write_only(&self) -> bool {
         self.contains(Self::Write)
     }
 
     /// The identifier is both read from and written to, e.g `a += 1`.
+    #[inline]
     pub fn is_read_write(&self) -> bool {
         self.contains(Self::Read | Self::Write)
     }
 
     /// The identifier is used in a type referenced
+    #[inline]
     pub fn is_ts_type_query(&self) -> bool {
         self.contains(Self::TSTypeQuery)
     }
 
     /// The identifier is used in a type definition.
+    #[inline]
     pub const fn is_type(&self) -> bool {
         self.contains(Self::Type)
     }
 
+    #[inline]
     pub const fn is_type_only(self) -> bool {
         matches!(self, Self::Type)
     }
 
+    #[inline]
     pub const fn is_value(&self) -> bool {
         self.intersects(Self::Value)
     }

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -81,6 +81,7 @@ bitflags! {
 
 impl ScopeFlags {
     #[must_use]
+    #[inline]
     pub fn with_strict_mode(self, yes: bool) -> Self {
         if yes {
             self | Self::StrictMode
@@ -89,50 +90,62 @@ impl ScopeFlags {
         }
     }
 
+    #[inline]
     pub fn is_strict_mode(&self) -> bool {
         self.contains(Self::StrictMode)
     }
 
+    #[inline]
     pub fn is_block(&self) -> bool {
         self.is_empty() || *self == Self::StrictMode
     }
 
+    #[inline]
     pub fn is_top(&self) -> bool {
         self.contains(Self::Top)
     }
 
+    #[inline]
     pub fn is_function(&self) -> bool {
         self.contains(Self::Function)
     }
 
+    #[inline]
     pub fn is_arrow(&self) -> bool {
         self.contains(Self::Arrow)
     }
 
+    #[inline]
     pub fn is_constructor(&self) -> bool {
         self.contains(Self::Constructor)
     }
 
+    #[inline]
     pub fn is_class_static_block(&self) -> bool {
         self.contains(Self::ClassStaticBlock)
     }
 
+    #[inline]
     pub fn is_ts_module_block(&self) -> bool {
         self.contains(Self::TsModuleBlock)
     }
 
+    #[inline]
     pub fn is_var(&self) -> bool {
         self.intersects(Self::Var)
     }
 
+    #[inline]
     pub fn is_set_accessor(&self) -> bool {
         self.contains(Self::SetAccessor)
     }
 
+    #[inline]
     pub fn is_set_or_get_accessor(&self) -> bool {
         self.intersects(Self::SetAccessor | Self::GetAccessor)
     }
 
+    #[inline]
     pub fn is_catch_clause(&self) -> bool {
         self.contains(Self::CatchClause)
     }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -123,78 +123,96 @@ bitflags! {
 }
 
 impl SymbolFlags {
+    #[inline]
     pub fn is_variable(&self) -> bool {
         self.intersects(Self::Variable)
     }
 
+    #[inline]
     pub fn is_type_parameter(&self) -> bool {
         self.contains(Self::TypeParameter)
     }
 
     /// If true, then the symbol is a type, such as a TypeAlias, Interface, or Enum
+    #[inline]
     pub fn is_type(&self) -> bool {
         self.intersects((Self::TypeImport | Self::Type) - Self::Value)
     }
 
     /// If true, then the symbol is a value, such as a Variable, Function, or Class
+    #[inline]
     pub fn is_value(&self) -> bool {
         self.intersects(Self::Value | Self::Import | Self::Function)
     }
 
+    #[inline]
     pub fn is_const_variable(&self) -> bool {
         self.contains(Self::ConstVariable)
     }
 
+    #[inline]
     pub fn is_function(&self) -> bool {
         self.contains(Self::Function)
     }
 
+    #[inline]
     pub fn is_class(&self) -> bool {
         self.contains(Self::Class)
     }
 
+    #[inline]
     pub fn is_interface(&self) -> bool {
         self.contains(Self::Interface)
     }
 
+    #[inline]
     pub fn is_type_alias(&self) -> bool {
         self.contains(Self::TypeAlias)
     }
 
+    #[inline]
     pub fn is_enum(&self) -> bool {
         self.intersects(Self::Enum)
     }
 
+    #[inline]
     pub fn is_enum_member(&self) -> bool {
         self.contains(Self::EnumMember)
     }
 
+    #[inline]
     pub fn is_catch_variable(&self) -> bool {
         self.contains(Self::CatchVariable)
     }
 
+    #[inline]
     pub fn is_function_scoped_declaration(&self) -> bool {
         self.contains(Self::FunctionScopedVariable)
     }
 
+    #[inline]
     pub fn is_export(&self) -> bool {
         self.contains(Self::Export)
     }
 
+    #[inline]
     pub fn is_import(&self) -> bool {
         self.intersects(Self::Import | Self::TypeImport)
     }
 
+    #[inline]
     pub fn is_type_import(&self) -> bool {
         self.contains(Self::TypeImport)
     }
 
     /// If true, then the symbol can be referenced by a type
+    #[inline]
     pub fn can_be_referenced_by_type(&self) -> bool {
         self.intersects(Self::Type | Self::TypeImport | Self::Import)
     }
 
     /// If true, then the symbol can be referenced by a value
+    #[inline]
     pub fn can_be_referenced_by_value(&self) -> bool {
         self.intersects(Self::Value | Self::Import | Self::Function)
     }


### PR DESCRIPTION
Add `#[inline]` to trivial bitflags methods. Very likely this makes no difference within Oxc, as we compile with LTO enabled, but for external consumers of Oxc who don't use LTO, this will enable cross-crate inlining.