### PR TITLE
feat(transformer): add methods to `BoundIdentifier`

### DIFF
--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -81,6 +81,49 @@ impl<'a> BoundIdentifier<'a> {
         span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, ReferenceFlag::Read)
+        self.create_spanned_reference(span, ReferenceFlag::Read, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_reference(&self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+        self.create_spanned_write_reference(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_reference(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlag::Write, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_reference(
+        &self,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_read_write_reference(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_reference(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlag::Read | ReferenceFlag::Write, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, with specified `Span` and `ReferenceFlag`
+    pub fn create_spanned_reference(
+        &self,
+        span: Span,
+        flag: ReferenceFlag,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> IdentifierReference<'a> {
+        ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, flag)
     }
 }


### PR DESCRIPTION
`BoundIdentifier` helper previously only had methods to create a read-only `IdentifierReference`. Add methods to also create write-only or read-write `IdentifierReference`s.