### PR TITLE
refactor(transformer): rename `BoundIdentifier::new_uid_in_root_scope`

### DIFF
--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -56,7 +56,11 @@ impl<'a> BoundIdentifier<'a> {
     }
 
     /// Create `BoundIdentifier` for new binding in root scope
-    pub fn new_root_uid(name: &str, flags: SymbolFlags, ctx: &mut TraverseCtx<'a>) -> Self {
+    pub fn new_uid_in_root_scope(
+        name: &str,
+        flags: SymbolFlags,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Self {
         let scope_id = ctx.scopes().root_scope_id();
         Self::new_uid(name, scope_id, flags, ctx)
     }

--- a/crates/oxc_transformer/src/react/jsx_source.rs
+++ b/crates/oxc_transformer/src/react/jsx_source.rs
@@ -169,7 +169,7 @@ impl<'a> ReactJsxSource<'a> {
 
     fn get_filename_var(&mut self, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
         if self.filename_var.is_none() {
-            self.filename_var = Some(BoundIdentifier::new_root_uid(
+            self.filename_var = Some(BoundIdentifier::new_uid_in_root_scope(
                 FILE_NAME_VAR,
                 SymbolFlags::FunctionScopedVariable,
                 ctx,


### PR DESCRIPTION
Just renaming the method.