### PR TITLE
fix(transformer): remove an `ast.copy` from `NullishCoalescingOperator` transform

### DIFF
--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -137,7 +137,7 @@ impl<'a> NullishCoalescingOperator<'a> {
 
         let op = BinaryOperator::StrictInequality;
         let null = ctx.ast.expression_null_literal(SPAN);
-        let left = ctx.ast.expression_binary(SPAN, ctx.ast.copy(&assignment), op, null);
+        let left = ctx.ast.expression_binary(SPAN, assignment, op, null);
         let right = ctx.ast.expression_binary(SPAN, ctx.ast.copy(&reference), op, ctx.ast.void_0());
         let test = ctx.ast.expression_logical(SPAN, left, LogicalOperator::And, right);
 


### PR DESCRIPTION
Remove one unnecessary `ast.copy` call from `NullishCoalescingOperator` transform (towards #3483).