### PR TITLE
test(linter/no-unused-vars): add ignored destructuring test cases

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -567,6 +567,19 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_rest_siblings_only() {
+        let rule: NoUnusedVarsOptions = json!([
+            {
+                "ignoreRestSiblings": true,
+            }
+        ])
+        .into();
+        assert!(rule.ignore_rest_siblings);
+        // an options object is provided, so no default pattern is set.
+        assert!(rule.vars_ignore_pattern.is_none());
+    }
+
+    #[test]
     fn test_options_from_null() {
         let opts = NoUnusedVarsOptions::from(json!(null));
         let default = NoUnusedVarsOptions::default();

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -5,28 +5,6 @@ use crate::{tester::Tester, FixKind, RuleMeta as _};
 use serde_json::json;
 
 #[test]
-fn test_debug() {
-    let pass: Vec<&'static str> = vec![];
-    let fail = vec![];
-    let fix = vec![
-        // (
-        //     "const { foo: fooBar, baz } = obj; f(baz);",
-        //     "const { baz } = obj; f(baz);",
-        //     None,
-        //     FixKind::DangerousSuggestion,
-        // ),
-        ("const [a, b] = arr; f(a)", "const [a] = arr; f(a)", None, FixKind::DangerousSuggestion),
-        // (
-        //     "let x = 1; x = 2;",
-        //     "let x = 1; x = 2;",
-        //     Some(json!( [{ "varsIgnorePattern": "^tooCompli[cated]" }] )),
-        //     FixKind::DangerousFix,
-        // ),
-    ];
-    Tester::new(NoUnusedVars::NAME, pass, fail).expect_fix(fix).test();
-}
-
-#[test]
 fn test_vars_simple() {
     let pass = vec![
         ("let a = 1; console.log(a)", None),
@@ -281,14 +259,39 @@ fn test_vars_reassignment() {
 #[test]
 fn test_vars_destructure() {
     let pass = vec![
-        // ("const { a, ...rest } = obj; console.log(rest)", Some(json![{ "ignoreRestSiblings": true }]))
+        (
+            "const { a, ...rest } = obj; console.log(rest)",
+            Some(json![[{ "ignoreRestSiblings": true }]]),
+        ),
+        (
+            "const { a, ...rest } = obj; console.log(rest)",
+            Some(json!( [{ "ignoreRestSiblings": true, "vars": "all" }] )),
+        ),
+        (
+            "const { a, ...rest } = obj; console.log(rest)",
+            Some(json!( [{ "ignoreRestSiblings": true, "vars": "all" }] )),
+        ),
+        // https://github.com/oxc-project/oxc/issues/4888
+        (
+            "const { text, ...dbEntry } = entry; return doSomething({ ...dbEntry, someOtherProp });",
+            Some(json!([{
+                "args": "none",
+                "caughtErrors": "none",
+                "ignoreRestSiblings": true,
+                "vars": "all"
+            }]))
+        )
     ];
     let fail = vec![
-        ("const { a, ...rest } = obj", Some(json![{ "ignoreRestSiblings": true }])),
-        ("const [a, ...rest] = arr", Some(json![{ "ignoreRestSiblings": true }])),
+        ("const { a, ...rest } = obj", Some(json!( [{ "ignoreRestSiblings": true }] ))),
+        ("const [a, ...rest] = arr", Some(json!( [{ "ignoreRestSiblings": true }] ))),
         (
             "const { a: { b }, ...rest } = obj; console.log(a)",
-            Some(json![{ "ignoreRestSiblings": true }]),
+            Some(json!( [{ "ignoreRestSiblings": true }] )),
+        ),
+        (
+            "const { a: { b }, ...rest } = obj; console.log(rest)",
+            Some(json!( [{ "ignoreRestSiblings": true }] )),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-destructure.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-vars-destructure.snap
@@ -1,14 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-unused-vars): Variable 'a' is declared but never used.
-   ╭─[no_unused_vars.tsx:1:9]
- 1 │ const { a, ...rest } = obj
-   ·         ┬
-   ·         ╰── 'a' is declared here
-   ╰────
-  help: Consider removing this declaration.
-
   ⚠ eslint(no-unused-vars): Variable 'rest' is declared but never used.
    ╭─[no_unused_vars.tsx:1:15]
  1 │ const { a, ...rest } = obj
@@ -46,5 +38,13 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const { a: { b }, ...rest } = obj; console.log(a)
    ·                      ──┬─
    ·                        ╰── 'rest' is declared here
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable 'b' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:14]
+ 1 │ const { a: { b }, ...rest } = obj; console.log(rest)
+   ·              ┬
+   ·              ╰── 'b' is declared here
    ╰────
   help: Consider removing this declaration.


### PR DESCRIPTION
Add test cases that cover #4888. I can't reproduce the issue this way, so I'll try running oxlint as a CLI instead. These test cases will be useful to have in our repo anyways.