### PR TITLE
(poc/RFC) perf(parser): record nodes, scopes, symbols, and references while parsing

### DIFF
--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -33,6 +33,7 @@ mod ast_builder_impl;
 mod ast_impl;
 mod ast_kind_impl;
 pub mod precedence;
+mod stats;
 pub mod syntax_directed_operations;
 mod trivia;
 
@@ -61,6 +62,7 @@ pub use num_bigint::BigUint;
 pub use crate::{
     ast_builder::AstBuilder,
     ast_kind::{AstKind, AstType},
+    stats::Statistics,
     trivia::{Comment, CommentKind, SortedComments, Trivias},
     visit::{Visit, VisitMut},
 };

--- a/crates/oxc_ast/src/stats.rs
+++ b/crates/oxc_ast/src/stats.rs
@@ -1,0 +1,215 @@
+use std::{
+    cell::Cell, marker::PhantomData, mem::ManuallyDrop, ops::Deref, panic::Location, ptr::NonNull,
+};
+
+/// Records the number of relevant features in the AST.
+#[derive(Debug, Default, Clone)]
+// should this be repr(align(8))?
+pub struct Statistics {
+    /// Number of symbols created in a program
+    symbols: Cell<u32>,
+    /// Number of AST nodes in a program
+    nodes: Cell<u32>,
+    /// Number of nodes creating a scope in a program
+    scopes: Cell<u32>,
+    references: Cell<u32>,
+    /// Set to [`Some`] when the statistics are taken out of a [`StatisticsCell`].
+    ///
+    /// The location of where statistics were taken from is stored to help with
+    /// debugging. If we wanted to, we could store an [`Option<bool>`] for
+    /// release builds.
+    taken: Cell<Option<&'static Location<'static>>>,
+}
+
+impl Statistics {
+    pub fn observe_symbol(&self) {
+        self.assert_not_taken();
+        self.symbols.set(self.symbols.get() + 1);
+    }
+
+    /// Increment the number of AST nodes seen.
+    pub fn observe_node(&self) {
+        self.assert_not_taken();
+        self.nodes.set(self.nodes.get() + 1);
+    }
+
+    /// Increment the number of scopes that have been created.
+    pub fn observe_scope(&self) {
+        self.assert_not_taken();
+        self.scopes.set(self.scopes.get() + 1);
+    }
+
+    /// Increment the number of symbol references that have been created.
+    pub fn observe_reference(&self) {
+        self.assert_not_taken();
+        self.references.set(self.references.get() + 1);
+    }
+
+    /// Get the number of symbols that have been created.
+    #[inline]
+    pub fn symbols(&self) -> u32 {
+        self.symbols.get()
+    }
+
+    /// Get the number of AST nodes in the traversed program.
+    #[inline]
+    pub fn nodes(&self) -> u32 {
+        self.nodes.get()
+    }
+
+    /// Get the number of created symbols.
+    #[inline]
+    pub fn scopes(&self) -> u32 {
+        self.scopes.get()
+    }
+
+    /// Get the number of symbol references created in a program.
+    #[inline]
+    pub fn references(&self) -> u32 {
+        self.references.get()
+    }
+
+    /// Have the contents of this [`Statistics`] been taken yet?
+    ///
+    /// See [`Statistics::take`]
+    #[inline]
+    fn is_taken(&self) -> bool {
+        self.taken.get().is_some()
+    }
+
+    /// Mark these [`Statistics`] as taken from the given [`Location`].
+    #[inline]
+    fn take(&mut self, location: &'static Location<'static>) {
+        self.taken.set(Some(location));
+    }
+
+    /// If Statistics have been taken, returns the [`Location`] where they were
+    /// taken from.
+    #[inline]
+    fn taken_from(&self) -> Option<&'static Location<'static>> {
+        self.taken.get()
+    }
+
+    /// Assert that the statistics have not been taken yet.
+    ///
+    /// Note that "take" semantics only apply to statistics stored in a
+    /// [`StatisticsCell`]. Statistics used directly can be checked by the
+    /// compiler.
+    ///
+    /// # Panics
+    /// If this [`Statistics`] has been taken already
+    #[inline]
+    fn assert_not_taken(&self) {
+        if let Some(location) = self.taken_from() {
+            panic!("Statistics became read-only after being taken at {location:?}");
+        }
+    }
+}
+
+/// A [`Cell`]-like type that holds a reference to a [`Statistics`] instance.
+///
+/// This structure acts as a safe way to share a reference to a
+/// mutable set of statistics while preserving [`Copy`] semantics. Once created,
+/// the underlying [`Statistics`] may be updated uding one of the various
+/// `observe_*` methods, such as [`Statistics::observe_symbol`]. When AST
+/// traversal is complete, you can call [`StatisticsCell::take`] to obtain the
+/// finalized [`Statistics`] instance.
+///
+/// ## Safety
+/// While this type is safe to use, it **will leak memory** if
+/// [`StatisticsCell::take`] is never called.
+/// In order to preserve [`Copy`], cells will not [`Drop`] their [`Statistics`]
+/// instances. The only way to prevent [`Statistics`] from leaking is to take it
+/// out of the cell.
+///
+/// The only valid way to use this type is in a situation like tree traversal,
+/// where you are 100% confident that all copies of a cell will be dropped after
+/// this cell has been passed to some method that uses it.
+///
+/// ```ignore
+/// struct CountVisitor {
+///   pub cell: StatisticsCell,
+/// }
+/// let ret = Parser::new(/* ... */).parse(/* ... */);
+/// let cell = StatisticsCell::default();
+/// l
+/// let visit = CountVisitor { cell };
+/// visit.visit_program(&ret.program);
+/// drop(visit);
+/// // At this point, `stats` must be no other copies of `stats` in existence.
+/// let statistics: Statistics = cell.take();
+/// ```
+///
+/// In order to prevent dereferences on freed memory, [`StatisticsCell::take`]
+/// may only be called a single time, and statistics may not be mutated after
+/// being taken.
+///
+/// ```ignore
+/// let cell = StatisticsCell::default();
+/// // fine, not taken yet
+/// cell.observe_node();
+/// let stats = cell.take();
+/// // these will panic
+/// cell.observe_node();
+/// let stats2 = cell.take();
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StatisticsCell<'s>(NonNull<ManuallyDrop<Statistics>>, PhantomData<&'s ()>);
+
+impl<'s> Deref for StatisticsCell<'s> {
+    type Target = Statistics;
+
+    fn deref(&self) -> &Statistics {
+        // SAFETY:
+        // 1. Pointer is created by a Box, so it is well-aligneda and initialized,
+        // 2. Meets the requirements for valid pointer reads
+        //   a. dereferenceable and non-null: created by Box
+        //   c. non-atomic: Statistics is not Send or Sync.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl Default for StatisticsCell<'_> {
+    #[must_use = "Dropping a newly-created StatisticsCell without taking it is a memory leak."]
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'s> StatisticsCell<'s> {
+    #[must_use = "Dropping a newly-created StatisticsCell without taking it is a memory leak."]
+    pub fn new() -> Self {
+        let stats = Box::default();
+        let stats = Box::leak(stats);
+        Self(NonNull::new(stats).unwrap(), PhantomData)
+    }
+
+    /// Take the [`Statistics`] out of this cell, consuming it.
+    ///
+    /// You _must_ call this method on the last copy of the cell in order to avoid
+    /// leaking memory.
+    ///
+    /// # Panics
+    /// - If the statistics have already been taken.
+    #[track_caller]
+    pub fn take(mut self) -> Statistics {
+        assert!(!self.is_taken(), "Statistics already taken at {:?}.", self.taken_from());
+        let location = Location::caller();
+        // SAFETY:
+        // - pointer is created from a Box, so it is well-aligned and
+        //   initialized.
+        // - The only other time a mutable reference exists to this pointer is
+        //   if this method is called on another StatisticsCell. If this
+        //   happened, the above assertion would have already failed.
+        unsafe { self.0.as_mut().take(location) };
+
+        // SAFETY:
+        // - Pointer is created from Box::leak, so it is valid.
+        // - It is impossible for Box::from_raw to have been called already on
+        //   this pointer, because if it had the statitiscs would already be
+        //   taken and the above assertion would have failed.
+        let boxed = unsafe { Box::from_raw(self.0.as_ptr()) };
+        ManuallyDrop::into_inner(*boxed)
+    }
+}

--- a/crates/oxc_semantic/src/counter.rs
+++ b/crates/oxc_semantic/src/counter.rs
@@ -2,7 +2,7 @@
 //! These counts can be used to pre-allocate sufficient capacity in `AstNodes`,
 //! `ScopeTree`, and `SymbolTable` to store info for all these items.
 
-use std::cell::Cell;
+use std::{cell::Cell, ops::Deref};
 
 use oxc_ast::{
     ast::{
@@ -10,63 +10,77 @@ use oxc_ast::{
         TSEnumMemberName, TSModuleDeclarationName,
     },
     visit::walk::{walk_ts_enum_member_name, walk_ts_module_declaration_name},
-    AstKind, Visit,
+    AstKind, Statistics, Visit,
 };
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 #[allow(clippy::struct_field_names)]
 #[derive(Default, Debug)]
 pub(crate) struct Counter {
-    pub nodes_count: usize,
-    pub scopes_count: usize,
-    pub symbols_count: usize,
-    pub references_count: usize,
+    statistics: Statistics,
+}
+impl Deref for Counter {
+    type Target = Statistics;
+    fn deref(&self) -> &Self::Target {
+        &self.statistics
+    }
+}
+impl Counter {
+    pub fn into_inner(self) -> Statistics {
+        self.statistics
+    }
 }
 
 impl<'a> Visit<'a> for Counter {
     #[inline]
     fn enter_node(&mut self, _: AstKind<'a>) {
-        self.nodes_count += 1;
+        self.observe_node();
     }
     #[inline]
     fn enter_scope(&mut self, _: ScopeFlags, _: &Cell<Option<ScopeId>>) {
-        self.scopes_count += 1;
+        // self.scopes_count += 1;
+        self.observe_scope();
     }
 
     #[inline]
     fn visit_binding_identifier(&mut self, _: &BindingIdentifier<'a>) {
-        self.nodes_count += 1;
-        self.symbols_count += 1;
+        // self.nodes_count += 1;
+        // self.symbols_count += 1;
+        self.observe_symbol();
+        self.observe_node();
     }
 
     #[inline]
     fn visit_identifier_reference(&mut self, _: &IdentifierReference<'a>) {
-        self.nodes_count += 1;
-        self.references_count += 1;
+        // self.nodes_count += 1;
+        // self.references_count += 1;
+        self.observe_node();
+        self.observe_reference();
     }
 
     #[inline]
     fn visit_jsx_member_expression_object(&mut self, it: &JSXMemberExpressionObject<'a>) {
-        self.nodes_count += 1;
+        // self.nodes_count += 1;
+        self.observe_node();
         match it {
             JSXMemberExpressionObject::MemberExpression(expr) => {
                 self.visit_jsx_member_expression(expr);
             }
             JSXMemberExpressionObject::Identifier(_) => {
-                self.nodes_count += 1;
-                self.references_count += 1;
+                self.observe_node();
+                self.observe_reference();
             }
         }
     }
 
     #[inline]
     fn visit_jsx_element_name(&mut self, it: &JSXElementName<'a>) {
-        self.nodes_count += 1;
+        self.observe_node();
         match it {
             JSXElementName::Identifier(ident) => {
-                self.nodes_count += 1;
+                self.observe_node();
                 if ident.name.chars().next().is_some_and(char::is_uppercase) {
-                    self.references_count += 1;
+                    self.observe_reference();
                 }
             }
             JSXElementName::NamespacedName(name) => self.visit_jsx_namespaced_name(name),
@@ -77,14 +91,14 @@ impl<'a> Visit<'a> for Counter {
     #[inline]
     fn visit_ts_enum_member_name(&mut self, it: &TSEnumMemberName<'a>) {
         if !it.is_expression() {
-            self.symbols_count += 1;
+            self.observe_symbol();
         }
         walk_ts_enum_member_name(self, it);
     }
 
     #[inline]
     fn visit_ts_module_declaration_name(&mut self, it: &TSModuleDeclarationName<'a>) {
-        self.symbols_count += 1;
+        self.observe_symbol();
         walk_ts_module_declaration_name(self, it);
     }
 }

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -162,6 +162,7 @@ impl<'a> SemanticTester<'a> {
         SemanticBuilder::new(self.source_text, self.source_type)
             .with_check_syntax_error(true)
             .with_trivias(parse.trivias)
+            .with_statistics(parse.statistics)
             .with_cfg(self.cfg)
             .build(program)
     }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -107,7 +107,7 @@ impl<'a> Transformer<'a> {
             .build(program)
             .semantic
             .into_symbol_table_and_scope_tree();
-        let allocator: &'a Allocator = self.ctx.ast.allocator;
+        let allocator = self.ctx.ast.allocator;
         let (symbols, scopes) = traverse_mut(&mut self, allocator, program, symbols, scopes);
         TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes }
     }
@@ -118,7 +118,7 @@ impl<'a> Transformer<'a> {
         scopes: ScopeTree,
         program: &mut Program<'a>,
     ) -> TransformerReturn {
-        let allocator: &'a Allocator = self.ctx.ast.allocator;
+        let allocator = self.ctx.ast.allocator;
         let (symbols, scopes) = traverse_mut(&mut self, allocator, program, symbols, scopes);
         TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes }
     }

--- a/tasks/ast_tools/src/schema/defs.rs
+++ b/tasks/ast_tools/src/schema/defs.rs
@@ -36,6 +36,13 @@ impl TypeDef {
         let generated_derives = self.generated_derives();
         generated_derives.iter().any(|it| it == derive)
     }
+
+    pub fn is_visitable(&self) -> bool {
+        match self {
+            Self::Struct(it) => it.visitable,
+            Self::Enum(it) => it.visitable,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/tasks/benchmark/benches/isolated_declarations.rs
+++ b/tasks/benchmark/benches/isolated_declarations.rs
@@ -19,7 +19,7 @@ fn bench_isolated_declarations(criterion: &mut Criterion) {
         b.iter_with_large_drop(|| {
             let allocator = Allocator::default();
             let ParserReturn { program, .. } =
-                Parser::new(&allocator, source_text, source_type).parse();
+                Parser::new(&allocator, source_text, source_type).record_statistics(false).parse();
             IsolatedDeclarations::new(&allocator).build(&program);
         });
     });

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -36,6 +36,7 @@ fn bench_linter(criterion: &mut Criterion) {
                     .with_trivias(ret.trivias)
                     .with_cfg(true)
                     .build_module_record(PathBuf::new(), program)
+                    .with_statistics(ret.statistics)
                     .build(program);
                 let filter = vec![
                     (AllowWarnDeny::Deny, "all".into()),

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -22,6 +22,7 @@ fn bench_semantic(criterion: &mut Criterion) {
                     SemanticBuilder::new(source_text, source_type)
                         .with_trivias(ret.trivias.clone())
                         .with_build_jsdoc(true)
+                        .with_statistics(ret.statistics.clone())
                         .build_module_record(PathBuf::new(), program)
                         .build(program)
                 });

--- a/tasks/benchmark/benches/sourcemap.rs
+++ b/tasks/benchmark/benches/sourcemap.rs
@@ -15,7 +15,8 @@ fn bench_sourcemap(criterion: &mut Criterion) {
         let source_type = SourceType::from_path(&file.file_name).unwrap();
         group.bench_with_input(id, &file.source_text, |b, source_text| {
             let allocator = Allocator::default();
-            let ret = Parser::new(&allocator, source_text, source_type).parse();
+            let ret =
+                Parser::new(&allocator, source_text, source_type).record_statistics(false).parse();
 
             let CodegenReturn { source_text: output_txt, .. } = CodeGenerator::new()
                 .enable_source_map(file.file_name.as_str(), source_text)

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -20,7 +20,9 @@ fn bench_transformer(criterion: &mut Criterion) {
             b.iter_with_large_drop(|| {
                 let allocator = Allocator::default();
                 let ParserReturn { trivias, program, .. } =
-                    Parser::new(&allocator, source_text, source_type).parse();
+                    Parser::new(&allocator, source_text, source_type)
+                        .record_statistics(false)
+                        .parse();
                 let transform_options = TransformOptions::default();
                 let program = allocator.alloc(program);
                 Transformer::new(

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -53,7 +53,7 @@ impl Driver {
 
     pub fn run(&mut self, source_text: &str, source_type: SourceType) {
         let allocator = Allocator::default();
-        let ParserReturn { mut program, errors, trivias, panicked } =
+        let ParserReturn { mut program, errors, trivias, panicked, .. } =
             Parser::new(&allocator, source_text, source_type)
                 .allow_return_outside_function(self.allow_return_outside_function)
                 .parse();


### PR DESCRIPTION
Add `Statistics` to `AstBuilder` and record how many AST nodes, symbols, scopes, and references were encountered during parsing.

I know @overlookmotel is considering passing around `&mut AstBuilder<'a>` in the parser, so I'm putting this here for conversation. It has the following benefits:
- AstBuilder stays `Copy`
- No breaking API changes

And has the following downsides:
- Uses a small amount of unsafe rust
- `StatisticsCell` can cause a memory leak if not used properly
- `StatisticsCell` implementation is somewhat esoteric

NOTE: tests are  failing because it does not record _quite_ the correct number of each statistic, yet the point of this PR remains.