### PR TITLE
fix(minifier): handle `Object.definedPropert(exports` for @babel/types/lib/index.js

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/substitute_alternate_syntax.rs
@@ -4,7 +4,7 @@ use oxc_syntax::{
     number::NumberBase,
     operator::{BinaryOperator, UnaryOperator},
 };
-use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
+use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::{CompressOptions, CompressorPass};
 
@@ -56,10 +56,7 @@ impl<'a> Traverse<'a> for SubstituteAlternateSyntax<'a> {
         call_expr: &mut CallExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        // Check if this call expression is a top level `ExpressionStatement`.
-        // NB: 1 = global, 2 = Program, 3 = ExpressionStatement
-        if ctx.ancestors_depth() == 3
-            && matches!(ctx.parent(), Ancestor::ExpressionStatementExpression(_))
+        if ctx.parent().is_expression_statement()
             && Self::is_object_define_property_exports(call_expr)
         {
             self.in_define_export = true;

--- a/crates/oxc_minifier/tests/ast_passes/fold_constants.rs
+++ b/crates/oxc_minifier/tests/ast_passes/fold_constants.rs
@@ -19,16 +19,6 @@ fn test_same(source_text: &str) {
 
 #[test]
 fn cjs() {
-    // Export is undefined when `enumerable` is "!0".
-    // https://github.com/nodejs/cjs-module-lexer/issues/64
-    test_same(
-        "Object.defineProperty(exports, 'ConnectableObservable', {
-          enumerable: true,
-          get: function() {
-            return ConnectableObservable_1.ConnectableObservable;
-          }
-        });",
-    );
     // Bail `cjs-module-lexer`.
     test_same("0 && (module.exports = { version });");
 }

--- a/crates/oxc_minifier/tests/ast_passes/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/ast_passes/substitute_alternate_syntax.rs
@@ -7,6 +7,43 @@ fn test(source_text: &str, expected: &str) {
     crate::test(source_text, expected, options);
 }
 
+fn test_same(source_text: &str) {
+    test(source_text, source_text);
+}
+
+// Oxc
+
+#[test]
+fn cjs() {
+    // Bail `cjs-module-lexer`.
+    // Export is undefined when `enumerable` is "!0".
+    // https://github.com/nodejs/cjs-module-lexer/issues/64
+    test_same(
+        "Object.defineProperty(exports, 'ConnectableObservable', {
+          enumerable: true,
+          get: function() {
+            return ConnectableObservable_1.ConnectableObservable;
+          }
+        });",
+    );
+    // @babel/types/lib/index.js
+    test_same(
+        r#"Object.keys(_index6).forEach(function(key) {
+          if (key === "default" || key === "__esModule") return;
+          if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+          if (key in exports && exports[key] === _index6[key]) return;
+          Object.defineProperty(exports, key, {
+            enumerable: true,
+            get: function() {
+              return _index6[key];
+            }
+          });
+        });"#,
+    );
+}
+
+// Google Closure Compiler
+
 #[test]
 fn fold_return_result() {
     test("function f(){return !1;}", "function f(){return !1}");


### PR DESCRIPTION
Discoverd in `monitor-oxc`

```javascript
Object.keys(_index6).forEach(function(key) {
	if (key === "default" || key === "__esModule") return;
	if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
	if (key in exports && exports[key] === _index6[key]) return;
	Object.defineProperty(exports, key, {
		enumerable: true,
		get: function() {
			return _index6[key];
		}
	});
});
```

🙃 