### PR TITLE
fix(isolated_declarations): Class properties should still be lifted from private constructors

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -375,10 +375,6 @@ impl<'a> IsolatedDeclarations<'a> {
                     if self.report_property_key(&method.key, method.computed) {
                         continue;
                     }
-                    if method.accessibility.is_some_and(TSAccessibility::is_private) {
-                        elements.push(self.transform_private_modifier_method(method));
-                        continue;
-                    }
 
                     let inferred_accessor_types = self.collect_inferred_accessor_types(decl);
                     let function = &method.value;
@@ -405,6 +401,11 @@ impl<'a> IsolatedDeclarations<'a> {
                                 function, &params,
                             ),
                         );
+                    }
+
+                    if method.accessibility.is_some_and(TSAccessibility::is_private) {
+                        elements.push(self.transform_private_modifier_method(method));
+                        continue;
                     }
 
                     let return_type = match method.kind {

--- a/crates/oxc_isolated_declarations/tests/fixtures/class.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class.ts
@@ -35,3 +35,11 @@ export class Boo {
     readonly prop3: number = 1,
   ) {}
 }
+
+export class Bux {
+  private constructor(
+    public readonly prop: number = 0,
+    private readonly prop2: number = 1,
+    readonly prop3: number = 1,
+  ) {}
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -33,3 +33,9 @@ export declare class Boo {
 	readonly prop3: number;
 	constructor(prop?: number, prop2?: number, prop3?: number);
 }
+export declare class Bux {
+	readonly prop: number;
+	private readonly prop2;
+	readonly prop3: number;
+	private constructor();
+}


### PR DESCRIPTION
Before, this
```ts
export class Bux {
  private constructor(
    public readonly prop: number = 0,
    private readonly prop2: number = 1,
    readonly prop3: number = 1,
  ) {}
}
```
would be emitted as 
```ts
export declare class Bux {
	private constructor();
}
```

Now it will be emitted as
```ts
export declare class Bux {
	readonly prop: number;
	private readonly prop2;
	readonly prop3: number;
	private constructor();
}
```