### PR TITLE
fix(codegen): add missing `declare` to `PropertyDefinition`

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2535,6 +2535,9 @@ impl<'a, const MINIFY: bool> Gen<MINIFY> for PropertyDefinition<'a> {
     fn gen(&self, p: &mut Codegen<{ MINIFY }>, ctx: Context) {
         p.add_source_mapping(self.span.start);
         self.decorators.gen(p, ctx);
+        if self.declare {
+            p.print_str("declare ");
+        }
         if let Some(accessibility) = &self.accessibility {
             accessibility.gen(p, ctx);
         }


### PR DESCRIPTION
I'm seeing a broken test for 

```rust
    #[test]
    fn dts_class_decl_prop_test() {
        transform_dts_test(
            "export class Foo { declare a: string }",
            "export declare class Foo {
  a: string;
}",
        );
    }
```

can you double check @Dunqing ?