### PR TITLE
fix(isolated-declarations): declare modifier of PropertyDefinition should not be retained

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -98,7 +98,7 @@ impl<'a> IsolatedDeclarations<'a> {
             value,
             property.computed,
             property.r#static,
-            property.declare,
+            false,
             property.r#override,
             property.optional,
             property.definite,


### PR DESCRIPTION
related: #4937

There are no tests/snapshots updates and seems we don't have a way to test it until #4937 is merged. But I tested it locally and it worked!