### PR TITLE
feat(semantic,syntax): add SymbolFlags::ArrowFunction

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -19,7 +19,7 @@ pub(crate) trait Binder<'a> {
 
 impl<'a> Binder<'a> for VariableDeclarator<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let (includes, excludes) = match self.kind {
+        let (mut includes, excludes) = match self.kind {
             VariableDeclarationKind::Const => (
                 SymbolFlags::BlockScopedVariable | SymbolFlags::ConstVariable,
                 SymbolFlags::BlockScopedVariableExcludes,
@@ -31,6 +31,12 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                 (SymbolFlags::FunctionScopedVariable, SymbolFlags::FunctionScopedVariableExcludes)
             }
         };
+
+        if self.init.as_ref().is_some_and(|init| {
+            matches!(init.get_inner_expression(), Expression::ArrowFunctionExpression(_))
+        }) {
+            includes |= SymbolFlags::ArrowFunction;
+        }
 
         if self.kind.is_lexical() {
             self.id.bound_names(&mut |ident| {

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "arrow",
         "node": "VariableDeclarator(arrow)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(FunctionScopedVariable)",
+        "flag": "SymbolFlags(FunctionScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(FunctionScopedVariable)",
+        "flag": "SymbolFlags(FunctionScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -77,22 +77,28 @@ bitflags! {
         /// Is this symbol inside an export declaration
         const Export                  = 1 << 4;
         const Class                   = 1 << 5;
-        const CatchVariable           = 1 << 6; // try {} catch(catch_variable) {}
+        /// `try {} catch(catch_variable) {}`
+        const CatchVariable           = 1 << 6;
+        /// A function declaration or expression
         const Function                = 1 << 7;
-        const Import             = 1 << 8; // Imported ESM binding
-        const TypeImport              = 1 << 9; // Imported ESM type-only binding
+        /// A function or block-scoped variable initialized to an arrow function
+        const ArrowFunction           = 1 << 8;
+        /// Imported ESM binding
+        const Import                  = 1 << 9;
+        /// Imported ESM type-only binding
+        const TypeImport              = 1 << 10;
         // Type specific symbol flags
-        const TypeAlias               = 1 << 10;
-        const Interface               = 1 << 11;
-        const RegularEnum             = 1 << 12;
-        const ConstEnum               = 1 << 13;
-        const EnumMember              = 1 << 14;
-        const TypeLiteral             = 1 << 15;
-        const TypeParameter           = 1 << 16;
-        const NameSpaceModule         = 1 << 17;
-        const ValueModule             = 1 << 18;
+        const TypeAlias               = 1 << 11;
+        const Interface               = 1 << 12;
+        const RegularEnum             = 1 << 13;
+        const ConstEnum               = 1 << 14;
+        const EnumMember              = 1 << 15;
+        const TypeLiteral             = 1 << 16;
+        const TypeParameter           = 1 << 17;
+        const NameSpaceModule         = 1 << 18;
+        const ValueModule             = 1 << 19;
         // In a dts file or there is a declare flag
-        const Ambient                 = 1 << 19;
+        const Ambient                 = 1 << 20;
 
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
 
@@ -150,9 +156,23 @@ impl SymbolFlags {
         self.contains(Self::ConstVariable)
     }
 
+    /// Returns `true` if this symbol is a function declaration or expression.
+    ///
+    /// Use [`SymbolFlags::is_function_like`] to check if this symbol is a function or an arrow function.
     #[inline]
     pub fn is_function(&self) -> bool {
         self.contains(Self::Function)
+    }
+
+    #[inline]
+    pub fn is_arrow_function(&self) -> bool {
+        self.contains(Self::ArrowFunction)
+    }
+
+    /// Returns `true` if this symbol is an arrow function or a function declaration/expression.
+    #[inline]
+    pub fn is_function_like(&self) -> bool {
+        self.intersects(Self::Function | Self::ArrowFunction)
     }
 
     #[inline]


### PR DESCRIPTION
There are many cases in lint rules where we want to see if a symbol is a
function by checking its SymbolFlags. This is currently not fully possible,
since variables assigned to arrow functions are not distinguished from any other
kind of variable. This PR adds `SymbolFlags::ArrowFunction` for variables that
are initialized to arrow functions. Symbols that are re-assigned to arrow
functions will not have this flag, but this is acceptable for lint rules.