### PR TITLE
refactor(semantic): `root_unresolved_references` contain only `ReferenceId`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -52,7 +52,7 @@ impl Rule for NoJasmineGlobals {
             .filter(|(key, _)| NON_JASMINE_PROPERTY_NAMES.contains(&key.as_str()));
 
         for (name, reference_ids) in jasmine_references {
-            for &(reference_id, _) in reference_ids {
+            for &reference_id in reference_ids {
                 let reference = symbol_table.get_reference(reference_id);
                 if let Some((error, help)) = get_non_jasmine_property_messages(name) {
                     ctx.diagnostic(no_jasmine_globals_diagnostic(

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -48,7 +48,7 @@ impl Rule for NoMocksImport {
             return;
         };
 
-        for (reference_id, _) in require_reference_ids {
+        for reference_id in require_reference_ids {
             let reference = ctx.symbols().get_reference(*reference_id);
             let Some(parent) = ctx.nodes().parent_node(reference.node_id()) else {
                 return;

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
     },
     AstKind,
 };
-use oxc_semantic::{AstNode, ReferenceFlag, ReferenceId};
+use oxc_semantic::{AstNode, ReferenceId};
 use phf::phf_set;
 
 use crate::LintContext;
@@ -162,7 +162,7 @@ pub fn collect_possible_jest_call_node<'a, 'b>(
             collect_ids_referenced_to_global(ctx)
                 .iter()
                 // set the original of global test function to None
-                .map(|(id, _)| (*id, None)),
+                .map(|&id| (id, None)),
         );
     }
 
@@ -239,13 +239,13 @@ fn find_original_name<'a>(import_decl: &'a ImportDeclaration<'a>, name: &str) ->
     })
 }
 
-fn collect_ids_referenced_to_global(ctx: &LintContext) -> Vec<(ReferenceId, ReferenceFlag)> {
+fn collect_ids_referenced_to_global(ctx: &LintContext) -> Vec<ReferenceId> {
     ctx.scopes()
         .root_unresolved_references()
         .iter()
         .filter(|(name, _)| JEST_METHOD_NAMES.contains(name.as_str()))
         .flat_map(|(_, reference_ids)| reference_ids.clone())
-        .collect::<Vec<(ReferenceId, ReferenceFlag)>>()
+        .collect()
 }
 
 /// join name of the expression. e.g.

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -256,7 +256,7 @@ impl<'a> SemanticBuilder<'a> {
             .unresolved_references
             .into_root()
             .into_iter()
-            .map(|(k, v)| (k.into(), v))
+            .map(|(k, v)| (k.into(), v.into_iter().map(|(reference_id, _)| reference_id).collect()))
             .collect();
 
         let jsdoc = if self.build_jsdoc { self.jsdoc.build() } else { JSDocFinder::default() };

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -2,10 +2,10 @@ use assert_unchecked::assert_unchecked;
 use oxc_span::Atom;
 use rustc_hash::FxHashMap;
 
-use crate::scope::UnresolvedReference;
+use oxc_syntax::reference::{ReferenceFlag, ReferenceId};
 
 /// The difference with Scope's `UnresolvedReferences` is that this type uses Atom as the key. its clone is very cheap!
-type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, Vec<UnresolvedReference>>;
+type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, Vec<(ReferenceId, ReferenceFlag)>>;
 
 // Stack used to accumulate unresolved refs while traversing scopes.
 // Indexed by scope depth. We recycle `UnresolvedReferences` instances during traversal

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -302,7 +302,7 @@ impl TraverseScoping {
     ) -> ReferenceId {
         let reference = Reference::new(AstNodeId::DUMMY, flag);
         let reference_id = self.symbols.create_reference(reference);
-        self.scopes.add_root_unresolved_reference(name, (reference_id, flag));
+        self.scopes.add_root_unresolved_reference(name, reference_id);
         reference_id
     }
 


### PR DESCRIPTION
`ScopeTree::root_unresolved_references` does not need to record `ReferenceFlag` as well as `ReferenceId` - it's never read.