### PR TITLE
refactor(semantic): `UnresolvedReferencesStack` contain only `ReferenceId`

### DIFF
--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -2,10 +2,10 @@ use assert_unchecked::assert_unchecked;
 use oxc_span::Atom;
 use rustc_hash::FxHashMap;
 
-use oxc_syntax::reference::{ReferenceFlag, ReferenceId};
+use oxc_syntax::reference::ReferenceId;
 
 /// The difference with Scope's `UnresolvedReferences` is that this type uses Atom as the key. its clone is very cheap!
-type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, Vec<(ReferenceId, ReferenceFlag)>>;
+type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, Vec<ReferenceId>>;
 
 // Stack used to accumulate unresolved refs while traversing scopes.
 // Indexed by scope depth. We recycle `UnresolvedReferences` instances during traversal


### PR DESCRIPTION
Remove `ReferenceFlag` from `UnresolvedReferencesStack` to align with `root_unresolved_references`.