### PR TITLE
refactor(semantic): do not reserve space in `resolved_references`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -466,10 +466,7 @@ impl<'a> SemanticBuilder<'a> {
             if let Some(symbol_id) = bindings.get(name.as_str()).copied() {
                 let symbol_flag = self.symbols.get_flag(symbol_id);
 
-                let resolved_references: &mut Vec<_> =
-                    self.symbols.resolved_references[symbol_id].as_mut();
-                // Reserve space for all references to avoid reallocations.
-                resolved_references.reserve(references.len());
+                let resolved_references = &mut self.symbols.resolved_references[symbol_id];
 
                 references.retain(|&reference_id| {
                     let reference = &mut self.symbols.references[reference_id];


### PR DESCRIPTION
While resolving references in `SemanticBuilder`, there is little benefit to reserving space in advance in `resolved_references` as it is not possible to avoid growing the `Vec`. The comment here says "Reserve space for all references to avoid reallocations", but `reserve()` itself may cause a reallocation.