### PR TITLE
refactor(linter): avoid unnecessary temp `Vec`s

### DIFF
--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -160,9 +160,8 @@ pub fn collect_possible_jest_call_node<'a, 'b>(
     {
         reference_id_with_original_list.extend(
             collect_ids_referenced_to_global(ctx)
-                .iter()
                 // set the original of global test function to None
-                .map(|&id| (id, None)),
+                .map(|id| (id, None)),
         );
     }
 
@@ -239,13 +238,14 @@ fn find_original_name<'a>(import_decl: &'a ImportDeclaration<'a>, name: &str) ->
     })
 }
 
-fn collect_ids_referenced_to_global(ctx: &LintContext) -> Vec<ReferenceId> {
+fn collect_ids_referenced_to_global<'c>(
+    ctx: &'c LintContext,
+) -> impl Iterator<Item = ReferenceId> + 'c {
     ctx.scopes()
         .root_unresolved_references()
         .iter()
         .filter(|(name, _)| JEST_METHOD_NAMES.contains(name.as_str()))
-        .flat_map(|(_, reference_ids)| reference_ids.clone())
-        .collect()
+        .flat_map(|(_, reference_ids)| reference_ids.iter().copied())
 }
 
 /// join name of the expression. e.g.


### PR DESCRIPTION
Use iterator instead of collecting into temporary `Vec` which is then iterated over.