### PR TITLE
feat(transformer/nullish-coalescing-operator): generate the correct binding name

### DIFF
--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -75,14 +75,8 @@ impl<'a> NullishCoalescingOperator<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
         // Add `var name` to scope
-        let name = match expr {
-            Expression::Identifier(ident) => ident.name.as_str(),
-            // TODO: needs to port generateUidIdentifierBasedOnNode
-            // https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L543-L545
-            _ => "nullish_coalescing_operator",
-        };
-        let symbol_id =
-            ctx.generate_uid_in_current_scope(name, SymbolFlags::FunctionScopedVariable);
+        let symbol_id = ctx
+            .generate_uid_in_current_scope_based_on_node(expr, SymbolFlags::FunctionScopedVariable);
         let symbol_name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
 
         {

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1310,9 +1310,9 @@ ReferenceId mismatch after transform
 * assumption-noDocumentAll/transform-in-default-param/input.js
 Bindings Mismatch:
 previous scope ScopeId(0): ["bar", "foo"]
-current  scope ScopeId(0): ["_nullish_coalescing_operator", "bar", "foo"]
+current  scope ScopeId(0): ["_foo$bar", "bar", "foo"]
 Bindings Mismatch:
-previous scope ScopeId(1): ["_nullish_coalescing_operator", "foo", "qux"]
+previous scope ScopeId(1): ["_foo$bar", "foo", "qux"]
 current  scope ScopeId(1): ["foo", "qux"]
 Symbols mismatch after transform
 ReferenceId mismatch after transform
@@ -1334,9 +1334,9 @@ ReferenceId mismatch after transform
 * nullish-coalescing/transform-in-default-param/input.js
 Bindings Mismatch:
 previous scope ScopeId(0): ["bar", "foo"]
-current  scope ScopeId(0): ["_nullish_coalescing_operator", "bar", "foo"]
+current  scope ScopeId(0): ["_foo$bar", "bar", "foo"]
 Bindings Mismatch:
-previous scope ScopeId(1): ["_nullish_coalescing_operator", "foo", "qux"]
+previous scope ScopeId(1): ["_foo$bar", "foo", "qux"]
 current  scope ScopeId(1): ["foo", "qux"]
 Symbols mismatch after transform
 ReferenceId mismatch after transform


### PR DESCRIPTION
match Babel's [implementation](https://github.com/babel/babel/blob/440fe413330f19fdb2c5fa63ffab87e67383d12d/packages/babel-plugin-transform-nullish-coalescing-operator/src/index.ts#L40)