### PR TITLE
feat(transformer/nullish-coalescing-operator): handles nullish coalescing expression in the FormalParamter

### DIFF
--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1308,12 +1308,7 @@ Symbols mismatch after transform
 ReferenceId mismatch after transform
 
 * assumption-noDocumentAll/transform-in-default-param/input.js
-Bindings Mismatch:
-previous scope ScopeId(0): ["bar", "foo"]
-current  scope ScopeId(0): ["_foo$bar", "bar", "foo"]
-Bindings Mismatch:
-previous scope ScopeId(1): ["_foo$bar", "foo", "qux"]
-current  scope ScopeId(1): ["foo", "qux"]
+Scopes mismatch after transform
 Symbols mismatch after transform
 ReferenceId mismatch after transform
 
@@ -1332,12 +1327,7 @@ Symbols mismatch after transform
 ReferenceId mismatch after transform
 
 * nullish-coalescing/transform-in-default-param/input.js
-Bindings Mismatch:
-previous scope ScopeId(0): ["bar", "foo"]
-current  scope ScopeId(0): ["_foo$bar", "bar", "foo"]
-Bindings Mismatch:
-previous scope ScopeId(1): ["_foo$bar", "foo", "qux"]
-current  scope ScopeId(1): ["foo", "qux"]
+Scopes mismatch after transform
 Symbols mismatch after transform
 ReferenceId mismatch after transform
 


### PR DESCRIPTION
### What I did in this PR
1. Replace `self.clone_identifier_reference` with `ctx.clone_identifier.reference`
2. Remove the usage of `ast.copy`
3. Handle below example correctly

### Example

```js
// Input
var foo = object.foo ?? "default";

// Output
var _object$foo;
var foo =
(_object$foo = object.foo) !== null && _object$foo !== void 0
  ? _object$foo
  : "default";
```