### PR TITLE
refactor(ast): `AstBuilder::move_identifier_reference` do not allocate empty string

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -75,7 +75,7 @@ impl<'a> AstBuilder<'a> {
         self,
         expr: &mut IdentifierReference<'a>,
     ) -> IdentifierReference<'a> {
-        let dummy = self.identifier_reference(expr.span(), "");
+        let dummy = self.identifier_reference(expr.span(), Atom::empty());
         mem::replace(expr, dummy)
     }
 


### PR DESCRIPTION
#4920 introduced `AstBuilder::move_identifier_reference`. Make this slightly cheaper by using a static empty `Atom` rather than relying on `"".into_in(allocator)` which allocates an empty string into arena.