### PR TITLE
feat(linter) expand  jsx-props-no-spread-multi to catch member expressions

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -5,11 +5,21 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{Atom, Span};
 
-use crate::{context::LintContext, rule::Rule, AstNode};
+use itertools::Itertools;
 
-fn jsx_props_no_spread_multi_diagnostic(spans: Vec<Span>, prop_name: &str) -> OxcDiagnostic {
+use crate::{context::LintContext, rule::Rule, utils::is_same_member_expression, AstNode};
+
+fn jsx_props_no_spread_multiple_identifiers_diagnostic(
+    spans: Vec<Span>,
+    prop_name: &str,
+) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow JSX prop spreading the same identifier multiple times.")
         .with_help(format!("Prop '{prop_name}' is spread multiple times."))
+        .with_labels(spans)
+}
+
+fn jsx_props_no_spread_multiple_member_expressions_diagnostic(spans: Vec<Span>) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Disallow JSX prop spreading the same member expression multiple times.")
         .with_labels(spans)
 }
 
@@ -45,11 +55,14 @@ impl Rule for JsxPropsNoSpreadMulti {
                 jsx_opening_el.attributes.iter().filter_map(JSXAttributeItem::as_spread);
 
             let mut identifier_names: FxHashMap<&Atom, Span> = FxHashMap::default();
+            let mut member_expressions = Vec::new();
             let mut duplicate_spreads: FxHashMap<&Atom, Vec<Span>> = FxHashMap::default();
 
             for spread_attr in spread_attrs {
+                let argument_without_parenthesized = spread_attr.argument.without_parenthesized();
+
                 if let Some(identifier_name) =
-                    spread_attr.argument.get_identifier_reference().map(|arg| &arg.name)
+                    argument_without_parenthesized.get_identifier_reference().map(|arg| &arg.name)
                 {
                     identifier_names
                         .entry(identifier_name)
@@ -61,11 +74,29 @@ impl Rule for JsxPropsNoSpreadMulti {
                         })
                         .or_insert(spread_attr.span);
                 }
+                if let Some(member_expression) =
+                    argument_without_parenthesized.as_member_expression()
+                {
+                    member_expressions.push((member_expression, spread_attr.span));
+                }
             }
 
             for (identifier_name, spans) in duplicate_spreads {
-                ctx.diagnostic(jsx_props_no_spread_multi_diagnostic(spans, identifier_name));
+                ctx.diagnostic(jsx_props_no_spread_multiple_identifiers_diagnostic(
+                    spans,
+                    identifier_name,
+                ));
             }
+
+            member_expressions.iter().tuple_combinations().for_each(
+                |((left, left_span), (right, right_span))| {
+                    if is_same_member_expression(left, right, ctx) {
+                        ctx.diagnostic(jsx_props_no_spread_multiple_member_expressions_diagnostic(
+                            vec![*left_span, *right_span],
+                        ));
+                    }
+                },
+            );
         }
     }
 }
@@ -84,12 +115,28 @@ fn test() {
           const b = {};
           <App {...a} {...b} />
         ",
+        "
+        const props = {};
+        <App {...props.x} {...props.foo} />
+      ",
+        "
+        const props = {};
+        <App {...(props.foo).baz} {...(props.y.baz)} />
+      ",
     ];
 
     let fail = vec![
         "
           const props = {};
           <App {...props} {...props} />
+        ",
+        "
+          const props = {};
+          <App {...props.foo} {...props.foo} />
+        ",
+        "
+          const props = {};
+          <App {...(props.foo).baz} {...(props.foo.baz)} />
         ",
         r#"
           const props = {};

--- a/crates/oxc_linter/src/snapshots/jsx_props_no_spread_multi.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_props_no_spread_multi.snap
@@ -10,6 +10,22 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Prop 'props' is spread multiple times.
 
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same member expression multiple times.
+   ╭─[jsx_props_no_spread_multi.tsx:3:16]
+ 2 │           const props = {};
+ 3 │           <App {...props.foo} {...props.foo} />
+   ·                ────────────── ──────────────
+ 4 │         
+   ╰────
+
+  ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same member expression multiple times.
+   ╭─[jsx_props_no_spread_multi.tsx:3:16]
+ 2 │           const props = {};
+ 3 │           <App {...(props.foo).baz} {...(props.foo.baz)} />
+   ·                ──────────────────── ────────────────────
+ 4 │         
+   ╰────
+
   ⚠ eslint-plugin-react(jsx-props-no-spread-multi): Disallow JSX prop spreading the same identifier multiple times.
    ╭─[jsx_props_no_spread_multi.tsx:3:16]
  2 │           const props = {};

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -236,10 +236,18 @@ pub fn is_same_member_expression(
         MemberExpression::ComputedMemberExpression(right),
     ) = (left, right)
     {
-        if !is_same_reference(&left.expression, &right.expression, ctx) {
+        if !is_same_reference(
+            left.expression.without_parenthesized(),
+            right.expression.without_parenthesized(),
+            ctx,
+        ) {
             return false;
         }
     }
 
-    return is_same_reference(left.object(), right.object(), ctx);
+    return is_same_reference(
+        left.object().without_parenthesized(),
+        right.object().without_parenthesized(),
+        ctx,
+    );
 }


### PR DESCRIPTION
closes #4894