### PR TITLE
refactor(transformer): TS annotations transform use `move_expression`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -69,33 +69,11 @@ impl<'a> AstBuilder<'a> {
         unsafe { std::mem::transmute_copy(src) }
     }
 
-    /// Moves the identifier reference out by replacing it with a dummy identifier reference.
-    #[inline]
-    pub fn move_identifier_reference(
-        self,
-        expr: &mut IdentifierReference<'a>,
-    ) -> IdentifierReference<'a> {
-        let dummy = self.identifier_reference(expr.span(), Atom::empty());
-        mem::replace(expr, dummy)
-    }
-
     /// Moves the expression out by replacing it with a null expression.
     #[inline]
     pub fn move_expression(self, expr: &mut Expression<'a>) -> Expression<'a> {
         let null_expr = self.expression_null_literal(expr.span());
         mem::replace(expr, null_expr)
-    }
-
-    /// Moves the member expression out by replacing it with a dummy expression.
-    #[inline]
-    pub fn move_member_expression(self, expr: &mut MemberExpression<'a>) -> MemberExpression<'a> {
-        let dummy = self.member_expression_computed(
-            expr.span(),
-            self.expression_null_literal(expr.span()),
-            self.expression_null_literal(expr.span()),
-            false,
-        );
-        mem::replace(expr, dummy)
     }
 
     #[inline]


### PR DESCRIPTION
Follow on after #4920. #4920 removed a usage of `AstBuilder::copy` and replaced with 2 new methods `AstBuilder::move_identifier_reference` and `AstBuilder:: move_member_expression`.

We can instead use `AstBuilder::move_expression` earlier and then unpack the enum again. Hopefully the compiler can see that the 2 `unreachable!()` branches are indeed unreachable and elide them.

`move_expression` is preferable to `move_member_expression` as it only creates 1 temporary `Box<Expression::NullLiteral>` instead of 2.

