### PR TITLE
fix(transformer): remove an `AstBuilder::copy` call for TS `AssignmentTarget` transform

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -626,6 +626,10 @@ impl<'a> AssignmentTarget<'a> {
     pub fn get_expression(&self) -> Option<&Expression<'a>> {
         self.as_simple_assignment_target().and_then(SimpleAssignmentTarget::get_expression)
     }
+
+    pub fn get_expression_mut(&mut self) -> Option<&mut Expression<'a>> {
+        self.as_simple_assignment_target_mut().and_then(SimpleAssignmentTarget::get_expression_mut)
+    }
 }
 
 impl<'a> SimpleAssignmentTarget<'a> {


### PR DESCRIPTION
Add `AssignmentTarget::get_expression_mut` method and use it to remove an unsound `AstBuilder::copy` call from TS transform for `AssignmentTarget`s.