### PR TITLE
refactor(ast): replace `AstBuilder::move_statement_vec` with `move_vec`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -83,11 +83,6 @@ impl<'a> AstBuilder<'a> {
     }
 
     #[inline]
-    pub fn move_statement_vec(self, stmts: &mut Vec<'a, Statement<'a>>) -> Vec<'a, Statement<'a>> {
-        mem::replace(stmts, self.vec())
-    }
-
-    #[inline]
     pub fn move_assignment_target(self, target: &mut AssignmentTarget<'a>) -> AssignmentTarget<'a> {
         let dummy = self.simple_assignment_target_identifier_reference(Span::default(), "");
         mem::replace(target, dummy.into())
@@ -103,6 +98,11 @@ impl<'a> AstBuilder<'a> {
         );
         let empty_decl = Declaration::VariableDeclaration(self.alloc(empty_decl));
         mem::replace(decl, empty_decl)
+    }
+
+    #[inline]
+    pub fn move_vec<T>(self, vec: &mut Vec<'a, T>) -> Vec<'a, T> {
+        mem::replace(vec, self.vec())
     }
 
     /* ---------- Constructors ---------- */

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -37,7 +37,7 @@ impl<'a> TypeScript<'a> {
         // every time a namespace declaration is encountered.
         let mut new_stmts = self.ctx.ast.vec();
 
-        for stmt in self.ctx.ast.move_statement_vec(&mut program.body) {
+        for stmt in self.ctx.ast.move_vec(&mut program.body) {
             match stmt {
                 Statement::TSModuleDeclaration(decl) => {
                     if !decl.declare {


### PR DESCRIPTION
Replace `AstBuilder::move_statement_vec` with a general `move_vec` method which handles any kind of `Vec`.