### PR TITLE
fix(linter): missing closing ticks in some example blocks

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// import thing from './__mocks__/index';
     /// require('./__mocks__/index');
     /// require('__mocks__');
-    ///
+    /// ```
     NoMocksImport,
     style
 );

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -62,7 +62,7 @@ declare_oxc_lint!(
     ///
     ///   // ...
     /// });
-    ///
+    /// ```
     NoRestrictedJestMethods,
     style,
 );


### PR DESCRIPTION
These broken example blocks breaks codegen for the upstream PR in this stack.