### PR TITLE
refactor(parser)!: remove builder pattern from `Parser` struct

### DIFF
--- a/crates/oxc_language_server/src/linter.rs
+++ b/crates/oxc_language_server/src/linter.rs
@@ -15,7 +15,7 @@ use oxc_linter::{
     },
     FixKind, Linter,
 };
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::SemanticBuilder;
 use oxc_span::{SourceType, VALID_EXTENSIONS};
 use ropey::Rope;
@@ -270,7 +270,10 @@ impl IsolatedLintHandler {
                 source;
             let allocator = Allocator::default();
             let ret = Parser::new(&allocator, javascript_source_text, source_type)
-                .allow_return_outside_function(true)
+                .with_options(ParseOptions {
+                    allow_return_outside_function: true,
+                    ..ParseOptions::default()
+                })
                 .parse();
 
             if !ret.errors.is_empty() {

--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -10,7 +10,7 @@ use std::{
 use dashmap::DashMap;
 use oxc_allocator::Allocator;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic};
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_resolver::Resolver;
 use oxc_semantic::{ModuleRecord, SemanticBuilder};
 use oxc_span::{SourceType, VALID_EXTENSIONS};
@@ -254,7 +254,10 @@ impl Runtime {
         tx_error: &DiagnosticSender,
     ) -> Vec<Message<'a>> {
         let ret = Parser::new(allocator, source_text, source_type)
-            .allow_return_outside_function(true)
+            .with_options(ParseOptions {
+                allow_return_outside_function: true,
+                ..ParseOptions::default()
+            })
             .parse();
 
         if !ret.errors.is_empty() {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -226,7 +226,7 @@ impl<'a> ParserImpl<'a> {
             )
         };
 
-        Ok(if self.preserve_parens {
+        Ok(if self.options.preserve_parens {
             self.ast.expression_parenthesized(paren_span, expression)
         } else {
             expression

--- a/crates/oxc_prettier/examples/prettier.rs
+++ b/crates/oxc_prettier/examples/prettier.rs
@@ -2,7 +2,7 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_prettier::{Prettier, PrettierOptions, TrailingComma};
 use oxc_span::SourceType;
 use pico_args::Arguments;
@@ -22,7 +22,9 @@ fn main() -> std::io::Result<()> {
     let source_text = std::fs::read_to_string(path)?;
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
-    let ret = Parser::new(&allocator, &source_text, source_type).preserve_parens(false).parse();
+    let ret = Parser::new(&allocator, &source_text, source_type)
+        .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+        .parse();
     let output = Prettier::new(
         &allocator,
         &source_text,

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -11,7 +11,7 @@ use oxc::{
     codegen::{CodeGenerator, WhitespaceRemover},
     diagnostics::Error,
     minifier::{CompressOptions, Minifier, MinifierOptions},
-    parser::Parser,
+    parser::{ParseOptions, Parser},
     semantic::{ScopeId, Semantic, SemanticBuilder},
     span::SourceType,
     transformer::{TransformOptions, Transformer},
@@ -169,7 +169,10 @@ impl Oxc {
         let source_type = SourceType::from_path(&path).unwrap_or_default();
 
         let ret = Parser::new(&allocator, source_text, source_type)
-            .allow_return_outside_function(parser_options.allow_return_outside_function)
+            .with_options(ParseOptions {
+                allow_return_outside_function: parser_options.allow_return_outside_function,
+                ..ParseOptions::default()
+            })
             .parse();
 
         self.comments = self.map_comments(&ret.trivias);
@@ -204,7 +207,10 @@ impl Oxc {
 
         if run_options.prettier_format() {
             let ret = Parser::new(&allocator, source_text, source_type)
-                .allow_return_outside_function(parser_options.allow_return_outside_function)
+                .with_options(ParseOptions {
+                    allow_return_outside_function: parser_options.allow_return_outside_function,
+                    ..ParseOptions::default()
+                })
                 .parse();
             let printed =
                 Prettier::new(&allocator, source_text, ret.trivias, PrettierOptions::default())
@@ -214,7 +220,10 @@ impl Oxc {
 
         if run_options.prettier_ir() {
             let ret = Parser::new(&allocator, source_text, source_type)
-                .allow_return_outside_function(parser_options.allow_return_outside_function)
+                .with_options(ParseOptions {
+                    allow_return_outside_function: parser_options.allow_return_outside_function,
+                    ..ParseOptions::default()
+                })
                 .parse();
             let prettier_doc = Prettier::new(
                 &allocator,

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -8,7 +8,7 @@ use oxc_allocator::Allocator;
 pub use oxc_ast::ast::Program;
 use oxc_ast::CommentKind;
 use oxc_diagnostics::{Error, NamedSource};
-use oxc_parser::{Parser, ParserReturn};
+use oxc_parser::{ParseOptions, Parser, ParserReturn};
 use oxc_span::SourceType;
 
 pub use crate::module_lexer::*;
@@ -64,7 +64,10 @@ fn parse<'a>(
         _ => source_type,
     };
     Parser::new(allocator, source_text, source_type)
-        .preserve_parens(options.preserve_parens.unwrap_or(true))
+        .with_options(ParseOptions {
+            preserve_parens: options.preserve_parens.unwrap_or(true),
+            ..ParseOptions::default()
+        })
         .parse()
 }
 

--- a/tasks/coverage/src/tools/prettier.rs
+++ b/tasks/coverage/src/tools/prettier.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use oxc::allocator::Allocator;
-use oxc::parser::{Parser, ParserReturn};
+use oxc::parser::{ParseOptions, Parser, ParserReturn};
 use oxc::span::SourceType;
 use oxc_prettier::{Prettier, PrettierOptions};
 
@@ -18,13 +18,14 @@ fn get_result(source_text: &str, source_type: SourceType) -> TestResult {
     let options = PrettierOptions::default();
 
     let allocator = Allocator::default();
+    let parse_options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
     let ParserReturn { program, trivias, .. } =
-        Parser::new(&allocator, source_text, source_type).preserve_parens(false).parse();
+        Parser::new(&allocator, source_text, source_type).with_options(parse_options).parse();
     let source_text1 = Prettier::new(&allocator, source_text, trivias, options).build(&program);
 
     let allocator = Allocator::default();
     let ParserReturn { program, trivias, .. } =
-        Parser::new(&allocator, &source_text1, source_type).preserve_parens(false).parse();
+        Parser::new(&allocator, &source_text1, source_type).with_options(parse_options).parse();
     let source_text2 = Prettier::new(&allocator, &source_text1, trivias, options).build(&program);
 
     if source_text1 == source_text2 {

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use oxc_allocator::Allocator;
-use oxc_parser::Parser;
+use oxc_parser::{ParseOptions, Parser};
 use oxc_prettier::{Prettier, PrettierOptions};
 use oxc_span::SourceType;
 use oxc_tasks_common::project_root;
@@ -382,7 +382,9 @@ impl TestRunner {
     fn prettier(path: &Path, source_text: &str, prettier_options: PrettierOptions) -> String {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).unwrap();
-        let ret = Parser::new(&allocator, source_text, source_type).preserve_parens(false).parse();
+        let ret = Parser::new(&allocator, source_text, source_type)
+            .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+            .parse();
         Prettier::new(&allocator, source_text, ret.trivias, prettier_options).build(&ret.program)
     }
 }


### PR DESCRIPTION
part of #4455

use `with_options(ParseOptions { ..ParseOptions::default() })` API instead.