### PR TITLE
fix: comments gen regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "pico-args",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -33,10 +33,7 @@ impl Comment {
 
     pub fn real_span_start(&self) -> u32 {
         match self.kind {
-            // length of `//`
-            CommentKind::SingleLine => self.span.start - 2,
-            // length of `/*`
-            CommentKind::MultiLine => self.span.start - 2,
+            CommentKind::SingleLine | CommentKind::MultiLine => self.span.start - 2,
         }
     }
 }

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -22,6 +22,23 @@ impl Comment {
         let span = Span::new(start, end);
         Self { kind, span }
     }
+
+    pub fn real_span_end(&self) -> u32 {
+        match self.kind {
+            CommentKind::SingleLine => self.span.end,
+            // length of `*/`
+            CommentKind::MultiLine => self.span.end + 2,
+        }
+    }
+
+    pub fn real_span_start(&self) -> u32 {
+        match self.kind {
+            // length of `//`
+            CommentKind::SingleLine => self.span.start - 2,
+            // length of `/*`
+            CommentKind::MultiLine => self.span.start - 2,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -28,10 +28,11 @@ oxc_sourcemap = { workspace = true }
 oxc_mangler   = { workspace = true }
 oxc_index     = { workspace = true }
 
-bitflags  = { workspace = true }
-nonmax    = { workspace = true }
-once_cell = { workspace = true }
-daachorse = { workspace = true }
+bitflags   = { workspace = true }
+nonmax     = { workspace = true }
+once_cell  = { workspace = true }
+daachorse  = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 oxc_parser = { workspace = true }

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -14,7 +14,7 @@ use pico_args::Arguments;
 fn main() -> std::io::Result<()> {
     let mut args = Arguments::from_env();
     let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
-    let twice = false || args.contains("--twice");
+    let twice = args.contains("--twice");
     let minify = args.contains("--minify");
 
     let path = Path::new(&name);

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -14,7 +14,7 @@ use pico_args::Arguments;
 fn main() -> std::io::Result<()> {
     let mut args = Arguments::from_env();
     let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
-    let twice = args.contains("--twice");
+    let twice = false || args.contains("--twice");
     let minify = args.contains("--minify");
 
     let path = Path::new(&name);

--- a/crates/oxc_codegen/src/annotation_comment.rs
+++ b/crates/oxc_codegen/src/annotation_comment.rs
@@ -62,7 +62,7 @@ impl<'a> Codegen<'a> {
                 let comment_end = comment.real_span_end();
                 let range_content =
                     &self.source_text[comment_end as usize..latest_comment_start as usize];
-                let all_whitespace = range_content.chars().all(|c| c.is_whitespace());
+                let all_whitespace = range_content.chars().all(char::is_whitespace);
                 latest_comment_start = comment.real_span_start();
                 all_whitespace
             })
@@ -131,7 +131,6 @@ impl<'a> Codegen<'a> {
             return;
         }
         let mut annotation_kind_set = AnnotationKind::empty();
-        dbg!(&node_start);
         if let Some(comments) = self.try_take_moved_comment(node_start) {
             self.print_comments(&comments, &mut annotation_kind_set);
         }

--- a/crates/oxc_codegen/src/annotation_comment.rs
+++ b/crates/oxc_codegen/src/annotation_comment.rs
@@ -1,3 +1,4 @@
+use bitflags::Flags;
 use daachorse::DoubleArrayAhoCorasick;
 use once_cell::sync::Lazy;
 use oxc_ast::{Comment, CommentKind};
@@ -53,7 +54,23 @@ impl<'a> Codegen<'a> {
         if !self.comment_options.preserve_annotate_comments {
             return vec![];
         }
-        self.get_leading_comments(self.latest_consumed_comment_end, node_start)
+        dbg!(&node_start);
+        let mut latest_comment_start = node_start;
+        let mut ret = self
+            .get_leading_comments(0, node_start)
+            .rev()
+            // each comment should be separated by whitespaces
+            .take_while(|comment| {
+                dbg!(&comment);
+                let comment_end = comment.real_span_end();
+                let range_content =
+                    &self.source_text[comment_end as usize..latest_comment_start as usize];
+                println!("`{}`", range_content);
+                let all_whitespace = range_content.chars().all(|c| c.is_whitespace());
+                dbg!(&all_whitespace);
+                latest_comment_start = comment.real_span_start();
+                all_whitespace
+            })
             .filter_map(|comment| {
                 let source_code = self.source_text;
                 let comment_content =
@@ -68,7 +85,9 @@ impl<'a> Codegen<'a> {
                 }
                 None
             })
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+        ret.reverse();
+        ret
     }
 
     pub(crate) fn print_comment(&mut self, comment: AnnotationComment) {
@@ -86,9 +105,10 @@ impl<'a> Codegen<'a> {
         // share the same leading comment. since they both are call expr and has same span start, we need to avoid print the same comment multiple times.
         let comment_span = comment.span();
 
-        if self.latest_consumed_comment_end >= comment_span.end {
+        if self.latest_consumed_comment_end >= comment.comment.real_span_end() {
             return;
         }
+        self.update_last_consumed_comment_end(comment.comment.real_span_end());
         let real_comment_end = match comment.kind() {
             CommentKind::SingleLine => {
                 self.print_str("//");
@@ -109,7 +129,6 @@ impl<'a> Codegen<'a> {
                 comment_span.end + 2
             }
         };
-        self.update_last_consumed_comment_end(real_comment_end);
         // FIXME: esbuild function `restoreExprStartFlags`
         self.start_of_default_export = self.code_len();
     }
@@ -118,25 +137,28 @@ impl<'a> Codegen<'a> {
         if !self.comment_options.preserve_annotate_comments {
             return;
         }
-        let annotation_kind_set = AnnotationKind::empty();
-
+        let mut annotation_kind_set = AnnotationKind::empty();
+        dbg!(&node_start);
+        if let Some(comments) = self.try_take_moved_comment(node_start) {
+            self.print_comments(&comments, &mut annotation_kind_set);
+        }
         let leading_annotate_comments = self.get_leading_annotate_comments(node_start);
-        self.print_comments(&leading_annotate_comments, annotation_kind_set);
+        self.print_comments(&leading_annotate_comments, &mut annotation_kind_set);
     }
 
     #[inline]
     pub(crate) fn print_comments(
         &mut self,
         leading_annotate_comment: &Vec<AnnotationComment>,
-        mut annotation_kind_set: AnnotationKind,
+        annotation_kind_set: &mut AnnotationKind,
     ) {
         for &comment in leading_annotate_comment {
             let kind = comment.annotation_kind();
-            if !annotation_kind_set.intersects(kind) {
+            if !annotation_kind_set.contains(kind) {
+                dbg!(&kind);
                 annotation_kind_set.insert(kind);
                 self.print_comment(comment);
             }
-            self.update_last_consumed_comment_end(comment.span().end);
         }
     }
 

--- a/crates/oxc_codegen/src/annotation_comment.rs
+++ b/crates/oxc_codegen/src/annotation_comment.rs
@@ -57,7 +57,7 @@ impl<'a> Codegen<'a> {
         dbg!(&node_start);
         let mut latest_comment_start = node_start;
         let mut ret = self
-            .get_leading_comments(0, node_start)
+            .get_leading_comments(self.latest_consumed_comment_end, node_start)
             .rev()
             // each comment should be separated by whitespaces
             .take_while(|comment| {
@@ -155,7 +155,6 @@ impl<'a> Codegen<'a> {
         for &comment in leading_annotate_comment {
             let kind = comment.annotation_kind();
             if !annotation_kind_set.contains(kind) {
-                dbg!(&kind);
                 annotation_kind_set.insert(kind);
                 self.print_comment(comment);
             }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -155,10 +155,6 @@ impl<'a> Gen for Statement<'a> {
                 p.print_semicolon_after_statement();
             }
         }
-
-        // if p.comment_options.preserve_annotate_comments {
-        //     p.update_last_consumed_comment_end(self.span().end);
-        // }
     }
 }
 
@@ -879,9 +875,7 @@ impl<'a> Gen for ExportNamedDeclaration<'a> {
                             let leading_annotate_comments =
                                 p.get_leading_annotate_comments(self.span.start);
                             if !leading_annotate_comments.is_empty() {
-                                dbg!(&leading_annotate_comments);
                                 p.move_comments(init.span().start, leading_annotate_comments);
-                                dbg!(&p.move_comment_map);
                             }
                         }
                     }
@@ -1080,9 +1074,6 @@ impl<'a> GenExpr for Expression<'a> {
             Self::TSNonNullExpression(e) => e.gen_expr(p, precedence, ctx),
             Self::TSInstantiationExpression(e) => e.gen_expr(p, precedence, ctx),
         }
-        // if p.comment_options.preserve_annotate_comments {
-        //     p.update_last_consumed_comment_end(self.span().end);
-        // }
     }
 }
 
@@ -1423,12 +1414,9 @@ impl<'a> GenExpr for CallExpression<'a> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let mut wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
         let annotate_comments = p.get_leading_annotate_comments(self.span.start);
-        dbg!(&precedence);
         if !annotate_comments.is_empty() && precedence >= Precedence::Postfix {
             wrap = true;
         }
-        dbg!(&annotate_comments);
-        dbg!(&wrap);
         p.wrap(wrap, |p| {
             p.print_comments(&annotate_comments, &mut AnnotationKind::empty());
             p.add_source_mapping(self.span.start);

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -547,7 +547,6 @@ impl<'a> Codegen<'a> {
     ///  }, b = 10000;
     /// ```
     fn move_comments(&mut self, position: u32, full_comment_infos: Vec<AnnotationComment>) {
-        dbg!(&full_comment_infos,);
         match self.move_comment_map.entry(position) {
             Entry::Occupied(mut occ) => {
                 occ.get_mut().extend(full_comment_infos);


### PR DESCRIPTION
try to fix: https://github.com/rolldown/rolldown/issues/2013
1. Before we only considering the ast is untouched, but considering the scenario.
```js

const a = /*__PURE__*/ test(),
//    ^^^              ^^^^^^ is removed during transform
	b = a();

```
Then according to the previous algorithm, `PURE` will attach to `b = a()`
2. Now, we try to attach comments as much as possible unless the comments are separated by comments, for the case above, `PURE` will not be attached to `a()` since the content between `b = a()` and `/* __PURE__*/` is not all whitespace.
3. we added back `MoveMap`, for the special case 
```js
/*__NODE_SIDE_EFFECTS__*/ export const c = 100;
// ^^^^^^^^^^^^^^^^^^^^^         should be attached to first declarator,
//                        ^^^^^^ are not whitespace

```