### PR TITLE
docs(transformer): add documentation for `logical-assignment-operators` plugin

### DIFF
--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -1,3 +1,58 @@
+//! ES2021: Logical Assignment Operators
+//!
+//! This plugin transform logical assignment operators `&&=`, `||=`, and `??=` to a series of logical expressions.
+//!
+//! > This plugin is included in `preset-env`, in ES2021
+//!
+//! ## Example
+//!
+//! Input:
+//! ```js
+//! a ||= b;
+//! obj.a.b ||= c;
+//!
+//! a &&= b;
+//! obj.a.b &&= c;
+//! ```
+//!
+//! Output:
+//! ```js
+//! var _obj$a, _obj$a2;
+//!
+//! a || (a = b);
+//! (_obj$a = obj.a).b || (_obj$a.b = c);
+//!
+//! a && (a = b);
+//! (_obj$a2 = obj.a).b && (_obj$a2.b = c);
+//! ```
+//!
+//! ### With Nullish Coalescing
+//!
+//! > While using the [nullish-coalescing-operator](https://github.com/oxc-project/oxc/blob/main/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs) plugin (included in `preset-env``)
+//!
+//! Input:
+//! ```js
+//! a ??= b;
+//! obj.a.b ??= c;
+//! ```
+//!
+//! Output:
+//! ```js
+//! var _a, _obj$a, _obj$a$b;
+//!
+//! (_a = a) !== null && _a !== void 0 ? _a : (a = b);
+//! (_obj$a$b = (_obj$a = obj.a).b) !== null && _obj$a$b !== void 0
+//! ? _obj$a$b
+//! : (_obj$a.b = c);
+//! ```
+//! ## Implementation
+//!
+//! Implementation based on [@babel/plugin-transform-logical-assignment-operators](https://babel.dev/docs/babel-plugin-transform-logical-assignment-operators).
+//!
+//! ## References:
+//! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-logical-assignment-operators>
+//! * Logical Assignment TC39 proposal: <https://github.com/tc39/proposal-logical-assignment>
+
 use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
@@ -9,11 +64,6 @@ use oxc_traverse::TraverseCtx;
 
 use crate::context::Ctx;
 
-/// ES2021: Logical Assignment Operators
-///
-/// References:
-/// * <https://babel.dev/docs/babel-plugin-transform-logical-assignment-operators>
-/// * <https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-logical-assignment-operators>
 pub struct LogicalAssignmentOperators<'a> {
     _ctx: Ctx<'a>,
     var_declarations: std::vec::Vec<Vec<'a, VariableDeclarator<'a>>>,


### PR DESCRIPTION
follow-up #4881
