### PR TITLE
fix(linter): change consistent-function-scoping back to correctness

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -139,7 +139,7 @@ declare_oxc_lint!(
     /// })();
     /// ```
     ConsistentFunctionScoping,
-    suspicious,
+    correctness,
     pending
 );
 


### PR DESCRIPTION
Note: This still causes ecosystem CI to fail. https://github.com/oxc-project/oxlint-ecosystem-ci/actions/runs/10475318051/job/29011822474