### PR TITLE
refactor(semantic)!: `Reference::flag` method return `ReferenceFlag`

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -470,7 +470,7 @@ impl<'a> SemanticBuilder<'a> {
 
                 references.retain(|&reference_id| {
                     let reference = &mut self.symbols.references[reference_id];
-                    let flag = *reference.flag();
+                    let flag = reference.flag();
                     if flag.is_type() && symbol_flag.can_be_referenced_by_type()
                         || flag.is_value() && symbol_flag.can_be_referenced_by_value()
                         || flag.is_ts_type_query() && symbol_flag.is_import()

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -91,8 +91,8 @@ impl Reference {
     }
 
     #[inline]
-    pub fn flag(&self) -> &ReferenceFlag {
-        &self.flag
+    pub fn flag(&self) -> ReferenceFlag {
+        self.flag
     }
 
     #[inline]

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -38,7 +38,7 @@ impl<'a> ExponentiationOperator<'a> {
         let reference = ctx.symbols().get_reference(ident.reference_id.get().unwrap());
         let symbol_id = reference.symbol_id();
         let flag = reference.flag();
-        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, *flag)
+        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
     }
 
     fn clone_expression(expr: &Expression<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -81,7 +81,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
         let reference = ctx.symbols().get_reference(ident.reference_id.get().unwrap());
         let symbol_id = reference.symbol_id();
         let flag = reference.flag();
-        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, *flag)
+        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
     }
 
     pub fn maybe_generate_memoised(


### PR DESCRIPTION
Closes #4992.