### PR TITLE
refactor(syntax)!: rename `ReferenceFlag` to `ReferenceFlags`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -14,7 +14,7 @@ use oxc_syntax::{
     operator::{
         AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
     },
-    reference::{ReferenceFlag, ReferenceId},
+    reference::{ReferenceFlags, ReferenceId},
     scope::ScopeId,
     symbol::SymbolId,
 };
@@ -242,10 +242,10 @@ pub struct IdentifierReference<'a> {
     /// Flags indicating how the reference is used.
     ///
     /// This gets set in the bind step of semantic analysis, and will always be
-    /// [`ReferenceFlag::None`] immediately after parsing.
+    /// [`ReferenceFlags::None`] immediately after parsing.
     #[serde(skip)]
     #[clone_in(default)]
-    pub reference_flag: ReferenceFlag,
+    pub reference_flag: ReferenceFlags,
 }
 
 /// `x` in `const x = 0;`

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -6,7 +6,7 @@ use oxc_allocator::{Box, FromIn, Vec};
 use oxc_span::{Atom, GetSpan, SourceType, Span};
 use oxc_syntax::{
     operator::UnaryOperator,
-    reference::{ReferenceFlag, ReferenceId},
+    reference::{ReferenceFlags, ReferenceId},
     scope::ScopeFlags,
 };
 
@@ -330,7 +330,12 @@ impl<'a> Hash for IdentifierReference<'a> {
 
 impl<'a> IdentifierReference<'a> {
     pub fn new(span: Span, name: Atom<'a>) -> Self {
-        Self { span, name, reference_id: Cell::default(), reference_flag: ReferenceFlag::default() }
+        Self {
+            span,
+            name,
+            reference_id: Cell::default(),
+            reference_flag: ReferenceFlags::default(),
+        }
     }
 
     pub fn new_read(span: Span, name: Atom<'a>, reference_id: Option<ReferenceId>) -> Self {
@@ -338,7 +343,7 @@ impl<'a> IdentifierReference<'a> {
             span,
             name,
             reference_id: Cell::new(reference_id),
-            reference_flag: ReferenceFlag::Read,
+            reference_flag: ReferenceFlags::Read,
         }
     }
 

--- a/crates/oxc_minifier/src/node_util/check_for_state_change.rs
+++ b/crates/oxc_minifier/src/node_util/check_for_state_change.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::*;
 
-use oxc_semantic::ReferenceFlag;
+use oxc_semantic::ReferenceFlags;
 use oxc_syntax::operator::UnaryOperator;
 
 /// A "simple" operator is one whose children are expressions, has no direct side-effects.
@@ -33,7 +33,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for Expression<'a> {
                 .expressions
                 .iter()
                 .any(|expr| expr.check_for_state_change(check_for_new_objects)),
-            Self::Identifier(ident) => ident.reference_flag == ReferenceFlag::Write,
+            Self::Identifier(ident) => ident.reference_flag == ReferenceFlags::Write,
             Self::UnaryExpression(unary_expr) => {
                 unary_expr.check_for_state_change(check_for_new_objects)
             }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -39,7 +39,7 @@ pub use oxc_syntax::{
 use rustc_hash::FxHashSet;
 
 pub use crate::{
-    reference::{Reference, ReferenceFlag, ReferenceId},
+    reference::{Reference, ReferenceFlags, ReferenceId},
     scope::ScopeTree,
     symbol::SymbolTable,
 };
@@ -300,101 +300,105 @@ mod tests {
         let typescript = SourceType::default().with_typescript(true).with_module(true);
         let sources = [
             // simple cases
-            (SourceType::default(), "let a = 1; a = 2", ReferenceFlag::write()),
-            (SourceType::default(), "let a = 1, b; b = a", ReferenceFlag::read()),
-            (SourceType::default(), "let a = 1, b; b[a]", ReferenceFlag::read()),
-            (SourceType::default(), "let a = 1, b = 1, c; c = a + b", ReferenceFlag::read()),
-            (SourceType::default(), "function a() { return }; a()", ReferenceFlag::read()),
-            (SourceType::default(), "class a {}; new a()", ReferenceFlag::read()),
-            (SourceType::default(), "let a; function foo() { return a }", ReferenceFlag::read()),
+            (SourceType::default(), "let a = 1; a = 2", ReferenceFlags::write()),
+            (SourceType::default(), "let a = 1, b; b = a", ReferenceFlags::read()),
+            (SourceType::default(), "let a = 1, b; b[a]", ReferenceFlags::read()),
+            (SourceType::default(), "let a = 1, b = 1, c; c = a + b", ReferenceFlags::read()),
+            (SourceType::default(), "function a() { return }; a()", ReferenceFlags::read()),
+            (SourceType::default(), "class a {}; new a()", ReferenceFlags::read()),
+            (SourceType::default(), "let a; function foo() { return a }", ReferenceFlags::read()),
             // pattern assignment
-            (SourceType::default(), "let a = 1, b; b = { a }", ReferenceFlag::read()),
-            (SourceType::default(), "let a, b; ({ b } = { a })", ReferenceFlag::read()),
-            (SourceType::default(), "let a, b; ({ a } = { b })", ReferenceFlag::write()),
-            (SourceType::default(), "let a, b; ([ b ] = [ a ])", ReferenceFlag::read()),
-            (SourceType::default(), "let a, b; ([ a ] = [ b ])", ReferenceFlag::write()),
+            (SourceType::default(), "let a = 1, b; b = { a }", ReferenceFlags::read()),
+            (SourceType::default(), "let a, b; ({ b } = { a })", ReferenceFlags::read()),
+            (SourceType::default(), "let a, b; ({ a } = { b })", ReferenceFlags::write()),
+            (SourceType::default(), "let a, b; ([ b ] = [ a ])", ReferenceFlags::read()),
+            (SourceType::default(), "let a, b; ([ a ] = [ b ])", ReferenceFlags::write()),
             // property access/mutation
-            (SourceType::default(), "let a = { b: 1 }; a.b = 2", ReferenceFlag::read()),
-            (SourceType::default(), "let a = { b: 1 }; a.b += 2", ReferenceFlag::read()),
+            (SourceType::default(), "let a = { b: 1 }; a.b = 2", ReferenceFlags::read()),
+            (SourceType::default(), "let a = { b: 1 }; a.b += 2", ReferenceFlags::read()),
             // parens are pass-through
-            (SourceType::default(), "let a = 1, b; b = (a)", ReferenceFlag::read()),
-            (SourceType::default(), "let a = 1, b; b = ++(a)", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a = 1, b; b = ++((((a))))", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a = 1, b; b = ((++((a))))", ReferenceFlag::read_write()),
+            (SourceType::default(), "let a = 1, b; b = (a)", ReferenceFlags::read()),
+            (SourceType::default(), "let a = 1, b; b = ++(a)", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a = 1, b; b = ++((((a))))", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a = 1, b; b = ((++((a))))", ReferenceFlags::read_write()),
             // simple binops/calls for sanity check
-            (SourceType::default(), "let a, b; a + b", ReferenceFlag::read()),
-            (SourceType::default(), "let a, b; b(a)", ReferenceFlag::read()),
-            (SourceType::default(), "let a, b; a = 5", ReferenceFlag::write()),
+            (SourceType::default(), "let a, b; a + b", ReferenceFlags::read()),
+            (SourceType::default(), "let a, b; b(a)", ReferenceFlags::read()),
+            (SourceType::default(), "let a, b; a = 5", ReferenceFlags::write()),
             // unary op counts as write, but checking continues up tree
-            (SourceType::default(), "let a = 1, b; b = ++a", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a = 1, b; b = --a", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a = 1, b; b = a++", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a = 1, b; b = a--", ReferenceFlag::read_write()),
+            (SourceType::default(), "let a = 1, b; b = ++a", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a = 1, b; b = --a", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a = 1, b; b = a++", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a = 1, b; b = a--", ReferenceFlags::read_write()),
             // assignment expressions count as read-write
-            (SourceType::default(), "let a = 1, b; b = a += 5", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a = 1; a += 5", ReferenceFlag::read_write()),
+            (SourceType::default(), "let a = 1, b; b = a += 5", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a = 1; a += 5", ReferenceFlags::read_write()),
             // note: we consider a to be written, and the read of `1` propagates upwards
-            (SourceType::default(), "let a, b; b = a = 1", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a, b; b = (a = 1)", ReferenceFlag::read_write()),
-            (SourceType::default(), "let a, b, c; b = c = a", ReferenceFlag::read()),
+            (SourceType::default(), "let a, b; b = a = 1", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a, b; b = (a = 1)", ReferenceFlags::read_write()),
+            (SourceType::default(), "let a, b, c; b = c = a", ReferenceFlags::read()),
             // sequences return last read_write in sequence
-            (SourceType::default(), "let a, b; b = (0, a++)", ReferenceFlag::read_write()),
+            (SourceType::default(), "let a, b; b = (0, a++)", ReferenceFlags::read_write()),
             // loops
             (
                 SourceType::default(),
                 "var a, arr = [1, 2, 3]; for(a in arr) { break }",
-                ReferenceFlag::write(),
+                ReferenceFlags::write(),
             ),
             (
                 SourceType::default(),
                 "var a, obj = { }; for(a of obj) { break }",
-                ReferenceFlag::write(),
+                ReferenceFlags::write(),
             ),
-            (SourceType::default(), "var a; for(; false; a++) { }", ReferenceFlag::read_write()),
-            (SourceType::default(), "var a = 1; while(a < 5) { break }", ReferenceFlag::read()),
+            (SourceType::default(), "var a; for(; false; a++) { }", ReferenceFlags::read_write()),
+            (SourceType::default(), "var a = 1; while(a < 5) { break }", ReferenceFlags::read()),
             // if statements
-            (SourceType::default(), "let a; if (a) { true } else { false }", ReferenceFlag::read()),
+            (
+                SourceType::default(),
+                "let a; if (a) { true } else { false }",
+                ReferenceFlags::read(),
+            ),
             (
                 SourceType::default(),
                 "let a, b; if (a == b) { true } else { false }",
-                ReferenceFlag::read(),
+                ReferenceFlags::read(),
             ),
             (
                 SourceType::default(),
                 "let a, b; if (b == a) { true } else { false }",
-                ReferenceFlag::read(),
+                ReferenceFlags::read(),
             ),
             // identifiers not in last read_write are also considered a read (at
             // least, or now)
-            (SourceType::default(), "let a, b; b = (a, 0)", ReferenceFlag::read()),
-            (SourceType::default(), "let a, b; b = (--a, 0)", ReferenceFlag::read_write()),
+            (SourceType::default(), "let a, b; b = (a, 0)", ReferenceFlags::read()),
+            (SourceType::default(), "let a, b; b = (--a, 0)", ReferenceFlags::read_write()),
             // other reads after a is written
             // a = 1 writes, but the CallExpression reads the rhs (1) so a isn't read
             (
                 SourceType::default(),
                 "let a; function foo(a) { return a }; foo(a = 1)",
-                ReferenceFlag::read_write(),
+                ReferenceFlags::read_write(),
             ),
             // member expression
-            (SourceType::default(), "let a; a.b = 1", ReferenceFlag::read()),
-            (SourceType::default(), "let a; let b; b[a += 1] = 1", ReferenceFlag::read_write()),
+            (SourceType::default(), "let a; a.b = 1", ReferenceFlags::read()),
+            (SourceType::default(), "let a; let b; b[a += 1] = 1", ReferenceFlags::read_write()),
             (
                 SourceType::default(),
                 "let a; let b; let c; b[c[a = c['a']] = 'c'] = 'b'",
-                ReferenceFlag::read_write(),
+                ReferenceFlags::read_write(),
             ),
             (
                 SourceType::default(),
                 "let a; let b; let c; a[c[b = c['a']] = 'c'] = 'b'",
-                ReferenceFlag::read(),
+                ReferenceFlags::read(),
             ),
-            (SourceType::default(), "console.log;let a=0;a++", ReferenceFlag::write()),
+            (SourceType::default(), "console.log;let a=0;a++", ReferenceFlags::write()),
             // typescript
-            (typescript, "let a: number = 1; (a as any) = true", ReferenceFlag::write()),
-            (typescript, "let a: number = 1; a = true as any", ReferenceFlag::write()),
-            (typescript, "let a: number = 1; a = 2 as const", ReferenceFlag::write()),
-            (typescript, "let a: number = 1; a = 2 satisfies number", ReferenceFlag::write()),
-            (typescript, "let a: number; (a as any) = 1;", ReferenceFlag::write()),
+            (typescript, "let a: number = 1; (a as any) = true", ReferenceFlags::write()),
+            (typescript, "let a: number = 1; a = true as any", ReferenceFlags::write()),
+            (typescript, "let a: number = 1; a = 2 as const", ReferenceFlags::write()),
+            (typescript, "let a: number = 1; a = 2 satisfies number", ReferenceFlags::write()),
+            (typescript, "let a: number; (a as any) = 1;", ReferenceFlags::write()),
         ];
 
         for (source_type, source, flag) in sources {

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -1,7 +1,7 @@
 // Silence erroneous warnings from Rust Analyser for `#[derive(Tsify)]`
 #![allow(non_snake_case)]
 
-pub use oxc_syntax::reference::{ReferenceFlag, ReferenceId};
+pub use oxc_syntax::reference::{ReferenceFlags, ReferenceId};
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 #[cfg(feature = "serialize")]
@@ -11,8 +11,8 @@ use crate::{symbol::SymbolId, AstNodeId};
 
 /// Describes where and how a Symbol is used in the AST.
 ///
-/// References indicate how they are being used using [`ReferenceFlag`]. Refer
-/// to the documentation for [`ReferenceFlag`] for more information.
+/// References indicate how they are being used using [`ReferenceFlags`]. Refer
+/// to the documentation for [`ReferenceFlags`] for more information.
 ///
 /// ## Resolution
 /// References to symbols that could be resolved have their `symbol_id` field
@@ -45,13 +45,13 @@ pub struct Reference {
     symbol_id: Option<SymbolId>,
     /// Describes how this referenced is used by other AST nodes. References can
     /// be reads, writes, or both.
-    flag: ReferenceFlag,
+    flag: ReferenceFlags,
 }
 
 impl Reference {
     /// Create a new unresolved reference.
     #[inline]
-    pub fn new(node_id: AstNodeId, flag: ReferenceFlag) -> Self {
+    pub fn new(node_id: AstNodeId, flag: ReferenceFlags) -> Self {
         Self { node_id, symbol_id: None, flag }
     }
 
@@ -60,7 +60,7 @@ impl Reference {
     pub fn new_with_symbol_id(
         node_id: AstNodeId,
         symbol_id: SymbolId,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> Self {
         Self { node_id, symbol_id: Some(symbol_id), flag }
     }
@@ -91,12 +91,12 @@ impl Reference {
     }
 
     #[inline]
-    pub fn flag(&self) -> ReferenceFlag {
+    pub fn flag(&self) -> ReferenceFlags {
         self.flag
     }
 
     #[inline]
-    pub fn flag_mut(&mut self) -> &mut ReferenceFlag {
+    pub fn flag_mut(&mut self) -> &mut ReferenceFlags {
         &mut self.flag
     }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         "node": "VariableDeclarator(foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "foo",
             "node_id": 19
@@ -44,13 +44,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 3,
             "name": "a",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
                 "node": "CatchParameter",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "e",
                     "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "VariableDeclarator(outer1)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "outer1",
             "node_id": 14
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "VariableDeclarator(outer2)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer2",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 13
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
                 "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 13
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Bar",
             "node_id": 14
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Foo",
             "node_id": 22

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "node": "FormalParameter(printName)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "printName",
                     "node_id": 19
@@ -42,7 +42,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "node": "FormalParameter(printerName)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "printerName",
                     "node_id": 40

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
@@ -20,13 +20,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 26
                   },
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
                     "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
@@ -27,13 +27,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 26
                   },
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 3,
                     "name": "a",
                     "node_id": 41
@@ -95,7 +95,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 30
@@ -109,7 +109,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 2,
             "name": "Outer",
             "node_id": 38

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Function(f)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "f",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Function(f)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "f",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -38,19 +38,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 1,
             "name": "A",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "A",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "VariableDeclarator(outer1)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "outer1",
             "node_id": 16
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "VariableDeclarator(outer2)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer2",
             "node_id": 20

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
@@ -20,13 +20,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 28
                   },
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
                     "node_id": 33

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "VariableDeclarator(A)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
@@ -27,13 +27,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 28
                   },
                   {
-                    "flag": "ReferenceFlag(Read)",
+                    "flag": "ReferenceFlags(Read)",
                     "id": 3,
                     "name": "a",
                     "node_id": 43
@@ -95,7 +95,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 32
@@ -109,7 +109,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 2,
             "name": "Outer",
             "node_id": 40

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             "node": "Class(A)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "A",
                 "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
@@ -54,13 +54,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 10
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
             "node_id": 20

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/meth
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
@@ -54,13 +54,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
             "node_id": 19

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
@@ -68,25 +68,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
             "node_id": 19
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "decorator",
             "node_id": 24
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 3,
             "name": "decorator",
             "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "node": "VariableDeclarator(obj)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "obj",
             "node_id": 18
@@ -30,7 +30,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "node": "VariableDeclarator(b)",
         "references": [
           {
-            "flag": "ReferenceFlag(Write)",
+            "flag": "ReferenceFlags(Write)",
             "id": 1,
             "name": "b",
             "node_id": 22
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         "node": "VariableDeclarator(c)",
         "references": [
           {
-            "flag": "ReferenceFlag(Write)",
+            "flag": "ReferenceFlags(Write)",
             "id": 2,
             "name": "c",
             "node_id": 28

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
         "node": "VariableDeclarator(obj)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "obj",
             "node_id": 27

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.t
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "V",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.t
         "node": "VariableDeclarator(v)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inl
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
@@ -18,13 +18,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 25
               },
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
                 "node_id": 34
@@ -87,7 +87,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 29

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
                 "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
                 "node_id": 23
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
@@ -18,13 +18,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 25
               },
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
                 "node_id": 34
@@ -87,7 +87,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 29

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
                 "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
                 "node_id": 21
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
@@ -18,13 +18,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 27
               },
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
                 "node_id": 36
@@ -87,7 +87,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
                 "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
                 "node_id": 23
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "Function(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "Function(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 7
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.
         "node": "TSImportEqualsDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-al
         "node": "ImportSpecifier(t)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "t",
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "t",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
         "node": "ImportSpecifier(v)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespac
         "node": "ImportNamespaceSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 7
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlag(Type | TSTypeQuery)",
+            "flag": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "node": "ImportSpecifier(foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type | TSTypeQuery)",
+            "flag": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         "node": "ImportSpecifier(T)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "node": "ImportSpecifier(foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type | TSTypeQuery)",
+            "flag": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         "node": "ImportSpecifier(T)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 13
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 2,
                 "name": "T",
                 "node_id": 28
@@ -61,7 +61,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Foo",
             "node_id": 24
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         "node": "Class(Bar)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 3,
             "name": "Bar",
             "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "node": "FormalParameter(value)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "value",
                 "node_id": 19
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 31
@@ -75,13 +75,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         "node": "Function(makeBox)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 2,
             "name": "makeBox",
             "node_id": 27
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 4,
             "name": "makeBox",
             "node_id": 36

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-s
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.ts
         "node": "VariableDeclarator(child)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "child",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         "node": "VariableDeclarator(X)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "X",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.t
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-ch
         "node": "VariableDeclarator(child)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "child",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-typ
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
             "node": "FormalParameter(props)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 3,
                 "name": "props",
                 "node_id": 57
@@ -67,7 +67,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 2,
             "name": "FooProps",
             "node_id": 45
@@ -81,13 +81,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Foo",
             "node_id": 24

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
@@ -16,31 +16,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expressi
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 7
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
             "node_id": 14
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "x",
             "node_id": 21
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 3,
             "name": "x",
             "node_id": 28
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 4,
             "name": "x",
             "node_id": 35

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 10
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/externa
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
             "node": "TSEnumMember",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-
             "node": "TSEnumMember",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-re
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -32,13 +32,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 2,
             "name": "Foo",
             "node_id": 20

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 11
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 11
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Write)",
+            "flag": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Write)",
+            "flag": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
@@ -16,7 +16,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | Write)",
+            "flag": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 11
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
@@ -22,7 +22,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                     "node": "TSTypeParameter(U)",
                     "references": [
                       {
-                        "flag": "ReferenceFlag(Type)",
+                        "flag": "ReferenceFlags(Type)",
                         "id": 5,
                         "name": "U",
                         "node_id": 33
@@ -43,7 +43,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "U",
                     "node_id": 19
@@ -64,13 +64,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 9
               },
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 23

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(V)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "V",
                     "node_id": 15
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
                     "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(I)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
                     "node_id": 21
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(I)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
                     "node_id": 19
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -20,7 +20,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(I)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
                     "node_id": 31
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
@@ -31,13 +31,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(dual)",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "dual",
             "node_id": 12
           },
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 1,
             "name": "dual",
             "node_id": 16

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 16
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 20

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 13
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
@@ -31,13 +31,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 16
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 20

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 13
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
@@ -31,13 +31,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(arg)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 0,
             "name": "arg",
             "node_id": 15

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
                 "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
                 "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
                 "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Param",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -52,7 +52,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "K",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(k)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 1,
             "name": "k",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(Id)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "Id",
                     "node_id": 28
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14
@@ -69,7 +69,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "X",
             "node_id": 25

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Parent",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Color",
             "node_id": 24
@@ -52,7 +52,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Quantity",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
@@ -18,25 +18,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
                 "node_id": 14
               },
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 21
               },
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 5,
                 "name": "T",
                 "node_id": 28
               },
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 7,
                 "name": "T",
                 "node_id": 35
@@ -64,7 +64,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 8,
             "name": "EnthusiasticGreeting",
             "node_id": 40

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "VerticalAlignment",
             "node_id": 28
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "HorizontalAlignment",
             "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
@@ -27,13 +27,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(k)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "k",
                     "node_id": 17
                   },
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 3,
                     "name": "k",
                     "node_id": 24
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(k)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "k",
                     "node_id": 21
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -25,7 +25,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 14
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
@@ -31,13 +31,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
                     "node_id": 15
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 19

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
@@ -39,13 +39,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 19

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 14
@@ -53,13 +53,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 21
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
             "node_id": 25

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlag(Type)",
+                    "flag": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "U",
                     "node_id": 21
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 17

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
@@ -39,13 +39,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 17
           },
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 14
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T1",
             "node_id": 14
@@ -52,7 +52,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T2",
             "node_id": 19

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
                 "node_id": 13
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 1,
             "name": "StyledPaymentProps",
             "node_id": 31
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "Function(div)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read)",
+            "flag": "ReferenceFlags(Read)",
             "id": 0,
             "name": "div",
             "node_id": 26

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 0,
             "name": "x",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -18,7 +18,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "FormalParameter(y)",
             "references": [
               {
-                "flag": "ReferenceFlag(Read)",
+                "flag": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "y",
                 "node_id": 19
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlag(Type)",
+                "flag": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 33
@@ -75,7 +75,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "Function(foo)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 2,
             "name": "foo",
             "node_id": 29

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlag(Read | TSTypeQuery)",
+            "flag": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 0,
             "name": "x",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
@@ -31,7 +31,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlag(Type)",
+            "flag": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 19

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -36,7 +36,7 @@ impl Serialize for ReferenceId {
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
 export type ReferenceId = number;
-export type ReferenceFlag = {
+export type ReferenceFlags = {
     None: 0,
     Read: 0b1,
     Write: 0b10,
@@ -73,12 +73,12 @@ bitflags! {
     /// type definitions and signatures. Types can never be re-assigned, so
     /// there is no read/write distinction for type references.
     ///
-    /// [`Read`]: ReferenceFlag::Read
-    /// [`Write`]: ReferenceFlag::Write
-    /// [`TSTypeQuery`]: ReferenceFlag::TSTypeQuery
+    /// [`Read`]: ReferenceFlags::Read
+    /// [`Write`]: ReferenceFlags::Write
+    /// [`TSTypeQuery`]: ReferenceFlags::TSTypeQuery
     #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, CloneIn)]
     #[cfg_attr(feature = "serialize", derive(Serialize))]
-    pub struct ReferenceFlag: u8 {
+    pub struct ReferenceFlags: u8 {
         const None = 0;
         /// A symbol is being read as a Value
         const Read = 1 << 0;
@@ -93,12 +93,12 @@ bitflags! {
         /// Note that this does not necessarily indicate the reference is used
         /// in a value context, since type queries are also flagged as [`Read`]
         ///
-        /// [`Read`]: ReferenceFlag::Read
+        /// [`Read`]: ReferenceFlags::Read
         const Value = Self::Read.bits() | Self::Write.bits();
     }
 }
 
-impl ReferenceFlag {
+impl ReferenceFlags {
     #[inline]
     pub const fn read() -> Self {
         Self::Read

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::ast::*;
-use oxc_semantic::{ReferenceFlag, SymbolFlags};
+use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 use oxc_traverse::TraverseCtx;
@@ -117,7 +117,7 @@ impl<'a> ExponentiationOperator<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let ident_math =
-            ctx.create_reference_id(SPAN, ctx.ast.atom("Math"), None, ReferenceFlag::Read);
+            ctx.create_reference_id(SPAN, ctx.ast.atom("Math"), None, ReferenceFlags::Read);
         let object = ctx.ast.expression_from_identifier_reference(ident_math);
         let property = ctx.ast.identifier_name(SPAN, "pow");
         let callee =
@@ -308,7 +308,7 @@ impl<'a> ExponentiationOperator<'a> {
         }
 
         let ident =
-            ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlag::Read);
+            ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Read);
 
         // let ident = self.create_new_var_with_expression(&expr);
         // Add new reference `_name = name` to nodes

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -30,7 +30,7 @@
 
 use std::cell::Cell;
 
-use oxc_semantic::{ReferenceFlag, ScopeFlags, ScopeId, SymbolFlags};
+use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
 
 use oxc_allocator::{CloneIn, Vec};
@@ -117,7 +117,7 @@ impl<'a> Traverse<'a> for NullishCoalescingOperator<'a> {
 
         let left =
             AssignmentTarget::from(ctx.ast.simple_assignment_target_from_identifier_reference(
-                ctx.clone_identifier_reference(&ident, ReferenceFlag::Write),
+                ctx.clone_identifier_reference(&ident, ReferenceFlags::Write),
             ));
 
         let reference = ctx.ast.expression_from_identifier_reference(ident);
@@ -183,7 +183,7 @@ impl<'a> NullishCoalescingOperator<'a> {
     fn clone_expression(expr: &Expression<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         match expr {
             Expression::Identifier(ident) => ctx.ast.expression_from_identifier_reference(
-                ctx.clone_identifier_reference(ident, ReferenceFlag::Read),
+                ctx.clone_identifier_reference(ident, ReferenceFlags::Read),
             ),
             _ => expr.clone_in(ctx.ast.allocator),
         }
@@ -211,7 +211,7 @@ impl<'a> NullishCoalescingOperator<'a> {
         let id = ctx.ast.binding_pattern_kind_from_binding_identifier(binding_identifier);
         let id = ctx.ast.binding_pattern(id, None::<TSTypeAnnotation<'_>>, false);
         let reference =
-            ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlag::Read);
+            ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Read);
 
         (id, reference)
     }

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -57,7 +57,7 @@ use std::cell::Cell;
 
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::ast::*;
-use oxc_semantic::{ReferenceFlag, SymbolFlags};
+use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
 use oxc_traverse::TraverseCtx;
@@ -117,7 +117,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
             .push(ctx.ast.variable_declarator(SPAN, kind, id, None, false));
 
         // _name = name
-        Some(ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlag::Write))
+        Some(ctx.create_reference_id(SPAN, symbol_name, Some(symbol_id), ReferenceFlags::Write))
     }
 
     pub fn transform_statements(

--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 use oxc_ast::ast::{BindingIdentifier, IdentifierReference};
 use oxc_span::{Atom, Span, SPAN};
 use oxc_syntax::{
-    reference::ReferenceFlag,
+    reference::ReferenceFlags,
     scope::ScopeId,
     symbol::{SymbolFlags, SymbolId},
 };
@@ -95,7 +95,7 @@ impl<'a> BoundIdentifier<'a> {
         span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        self.create_spanned_reference(span, ReferenceFlag::Read, ctx)
+        self.create_spanned_reference(span, ReferenceFlags::Read, ctx)
     }
 
     /// Create `IdentifierReference` referencing this binding, which is written to, with dummy `Span`
@@ -109,7 +109,7 @@ impl<'a> BoundIdentifier<'a> {
         span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        self.create_spanned_reference(span, ReferenceFlag::Write, ctx)
+        self.create_spanned_reference(span, ReferenceFlags::Write, ctx)
     }
 
     /// Create `IdentifierReference` referencing this binding, which is read from + written to,
@@ -128,14 +128,14 @@ impl<'a> BoundIdentifier<'a> {
         span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        self.create_spanned_reference(span, ReferenceFlag::Read | ReferenceFlag::Write, ctx)
+        self.create_spanned_reference(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
     }
 
-    /// Create `IdentifierReference` referencing this binding, with specified `Span` and `ReferenceFlag`
+    /// Create `IdentifierReference` referencing this binding, with specified `Span` and `ReferenceFlags`
     pub fn create_spanned_reference(
         &self,
         span: Span,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
         ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, flag)

--- a/crates/oxc_transformer/src/helpers/module_imports.rs
+++ b/crates/oxc_transformer/src/helpers/module_imports.rs
@@ -3,7 +3,7 @@ use std::cell::{Cell, RefCell};
 use indexmap::IndexMap;
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::{ast::*, AstBuilder};
-use oxc_semantic::ReferenceFlag;
+use oxc_semantic::ReferenceFlags;
 use oxc_span::{Atom, SPAN};
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::TraverseCtx;
@@ -123,7 +123,7 @@ impl<'a> ModuleImports<'a> {
         let var_kind = VariableDeclarationKind::Var;
         let symbol_id = ctx.scopes().get_root_binding("require");
         let ident =
-            ctx.create_reference_id(SPAN, Atom::from("require"), symbol_id, ReferenceFlag::read());
+            ctx.create_reference_id(SPAN, Atom::from("require"), symbol_id, ReferenceFlags::read());
         let callee = self.ast.expression_from_identifier_reference(ident);
 
         let args = {

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -5,7 +5,7 @@ use oxc_ast::{ast::*, AstBuilder};
 use oxc_span::{Atom, GetSpan, Span, SPAN};
 use oxc_syntax::{
     identifier::{is_irregular_whitespace, is_line_terminator},
-    reference::ReferenceFlag,
+    reference::ReferenceFlags,
     symbol::SymbolFlags,
     xml_entities::XML_ENTITIES,
 };
@@ -1018,7 +1018,7 @@ fn get_read_identifier_reference<'a>(
     ctx: &mut TraverseCtx<'a>,
 ) -> IdentifierReference<'a> {
     let reference_id =
-        ctx.create_reference_in_current_scope(name.to_compact_str(), ReferenceFlag::Read);
+        ctx.create_reference_in_current_scope(name.to_compact_str(), ReferenceFlags::Read);
     IdentifierReference::new_read(span, name, Some(reference_id))
 }
 

--- a/crates/oxc_transformer/src/react/refresh.rs
+++ b/crates/oxc_transformer/src/react/refresh.rs
@@ -4,7 +4,7 @@ use oxc_allocator::CloneIn;
 use oxc_ast::{
     ast::*, match_expression, match_member_expression, visit::walk::walk_variable_declarator, Visit,
 };
-use oxc_semantic::{ReferenceFlag, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
+use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{Atom, GetSpan, Span, SPAN};
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::{Ancestor, TraverseCtx};
@@ -55,7 +55,7 @@ impl<'a> ReactRefresh<'a> {
         let symbol_id = ctx.generate_uid_in_root_scope("c", SymbolFlags::FunctionScopedVariable);
         self.registrations.push((symbol_id, persistent_id));
         let name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
-        let ident = ctx.create_reference_id(SPAN, name, Some(symbol_id), ReferenceFlag::Write);
+        let ident = ctx.create_reference_id(SPAN, name, Some(symbol_id), ReferenceFlags::Write);
         let ident = ctx.ast.simple_assignment_target_from_identifier_reference(ident);
         ctx.ast.assignment_target_simple(ident)
     }
@@ -152,7 +152,7 @@ impl<'a> ReactRefresh<'a> {
             SPAN,
             id.name.clone(),
             id.symbol_id.get(),
-            ReferenceFlag::Read,
+            ReferenceFlags::Read,
         ))
     }
 
@@ -167,7 +167,7 @@ impl<'a> ReactRefresh<'a> {
             SPAN,
             id.name.clone(),
             id.symbol_id.get().unwrap(),
-            ReferenceFlag::Read,
+            ReferenceFlags::Read,
         );
         let right = ctx.ast.expression_from_identifier_reference(right);
         let expr = ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
@@ -198,7 +198,7 @@ impl<'a> ReactRefresh<'a> {
             SPAN,
             self.refresh_sig.clone(),
             Some(symbol_id),
-            ReferenceFlag::Read,
+            ReferenceFlags::Read,
         );
 
         // _s();
@@ -612,7 +612,7 @@ impl<'a> ReactRefresh<'a> {
                 SPAN,
                 self.refresh_reg.clone(),
                 Some(symbol_id),
-                ReferenceFlag::Read,
+                ReferenceFlags::Read,
             );
             let callee = ctx.ast.expression_from_identifier_reference(refresh_reg_ident);
             let mut arguments = ctx.ast.vec_with_capacity(2);
@@ -858,7 +858,7 @@ impl<'a, 'b> CalculateSignatureKey<'a, 'b> {
                     SPAN,
                     binding_name.clone(),
                     Some(symbol_id),
-                    ReferenceFlag::Read,
+                    ReferenceFlags::Read,
                 );
 
                 let mut expr = self.ctx.ast.expression_from_identifier_reference(ident);

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -9,7 +9,7 @@ use oxc_semantic::SymbolFlags;
 use oxc_span::{Atom, GetSpan, Span, SPAN};
 use oxc_syntax::{
     operator::AssignmentOperator,
-    reference::ReferenceFlag,
+    reference::ReferenceFlags,
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolId,
 };
@@ -594,7 +594,7 @@ struct Assignment<'a> {
 impl<'a> Assignment<'a> {
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
-        let reference_id = ctx.create_bound_reference(self.symbol_id, ReferenceFlag::Read);
+        let reference_id = ctx.create_bound_reference(self.symbol_id, ReferenceFlags::Read);
         let id = IdentifierReference::new_read(self.span, self.name.clone(), Some(reference_id));
 
         ctx.ast.statement_expression(

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -7,7 +7,7 @@ use oxc_syntax::{
     node::AstNodeId,
     number::{NumberBase, ToJsInt32, ToJsString},
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
-    reference::ReferenceFlag,
+    reference::ReferenceFlags,
     symbol::SymbolFlags,
 };
 use oxc_traverse::TraverseCtx;
@@ -134,7 +134,7 @@ impl<'a> TypeScriptEnum<'a> {
                 decl.id.span,
                 enum_name.clone(),
                 var_symbol_id,
-                ReferenceFlag::Read,
+                ReferenceFlags::Read,
             );
             let left = ast.expression_from_identifier_reference(left);
             let right = ast.expression_object(SPAN, ast.vec(), None);
@@ -156,7 +156,7 @@ impl<'a> TypeScriptEnum<'a> {
                 decl.id.span,
                 enum_name.clone(),
                 var_symbol_id,
-                ReferenceFlag::Write,
+                ReferenceFlags::Write,
             );
             let left = ast.simple_assignment_target_from_identifier_reference(left);
             let expr = ast.expression_assignment(SPAN, op, left.into(), call_expression);
@@ -202,7 +202,7 @@ impl<'a> TypeScriptEnum<'a> {
                 param.span,
                 param.name.clone(),
                 param.symbol_id.get(),
-                ReferenceFlag::Read,
+                ReferenceFlags::Read,
             );
             ctx.ast.expression_from_identifier_reference(ident)
         };

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
 use oxc_span::SPAN;
-use oxc_syntax::reference::ReferenceFlag;
+use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::TraverseCtx;
 
 use super::TypeScript;
@@ -86,10 +86,10 @@ impl<'a> TypeScript<'a> {
         match type_name {
             TSTypeName::IdentifierReference(ident) => {
                 let mut ident = ident.clone();
-                ident.reference_flag = ReferenceFlag::Read;
+                ident.reference_flag = ReferenceFlags::Read;
                 let reference_id = ident.reference_id.get().unwrap();
                 let reference = ctx.symbols_mut().get_reference_mut(reference_id);
-                *reference.flag_mut() = ReferenceFlag::Read;
+                *reference.flag_mut() = ReferenceFlags::Read;
                 self.ctx.ast.expression_from_identifier_reference(ident)
             }
             TSTypeName::QualifiedName(qualified_name) => self

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
 use oxc_semantic::{ScopeTree, SymbolTable};
 use oxc_span::{Atom, CompactStr, Span};
 use oxc_syntax::{
-    reference::{ReferenceFlag, ReferenceId},
+    reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
@@ -320,7 +320,7 @@ impl<'a> TraverseCtx<'a> {
     pub fn create_bound_reference(
         &mut self,
         symbol_id: SymbolId,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_bound_reference(symbol_id, flag)
     }
@@ -333,7 +333,7 @@ impl<'a> TraverseCtx<'a> {
         span: Span,
         name: Atom<'a>,
         symbol_id: SymbolId,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         self.scoping.create_bound_reference_id(span, name, symbol_id, flag)
     }
@@ -344,7 +344,7 @@ impl<'a> TraverseCtx<'a> {
     pub fn create_unbound_reference(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flag)
     }
@@ -356,7 +356,7 @@ impl<'a> TraverseCtx<'a> {
         &mut self,
         span: Span,
         name: Atom<'a>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         self.scoping.create_unbound_reference_id(span, name, flag)
     }
@@ -371,7 +371,7 @@ impl<'a> TraverseCtx<'a> {
         &mut self,
         name: CompactStr,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_reference(name, symbol_id, flag)
     }
@@ -387,7 +387,7 @@ impl<'a> TraverseCtx<'a> {
         span: Span,
         name: Atom<'a>,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         self.scoping.create_reference_id(span, name, symbol_id, flag)
     }
@@ -398,7 +398,7 @@ impl<'a> TraverseCtx<'a> {
     pub fn create_reference_in_current_scope(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_reference_in_current_scope(name, flag)
     }
@@ -413,7 +413,7 @@ impl<'a> TraverseCtx<'a> {
     pub fn clone_identifier_reference(
         &mut self,
         ident: &IdentifierReference<'a>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         self.scoping.clone_identifier_reference(ident, flag)
     }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
 use oxc_semantic::{AstNodeId, Reference, ScopeTree, SymbolTable};
 use oxc_span::{Atom, CompactStr, Span, SPAN};
 use oxc_syntax::{
-    reference::{ReferenceFlag, ReferenceId},
+    reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
@@ -269,7 +269,7 @@ impl TraverseScoping {
     pub fn create_bound_reference(
         &mut self,
         symbol_id: SymbolId,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         let reference = Reference::new_with_symbol_id(AstNodeId::DUMMY, symbol_id, flag);
         let reference_id = self.symbols.create_reference(reference);
@@ -283,7 +283,7 @@ impl TraverseScoping {
         span: Span,
         name: Atom<'a>,
         symbol_id: SymbolId,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference_id = self.create_bound_reference(symbol_id, flag);
         IdentifierReference {
@@ -298,7 +298,7 @@ impl TraverseScoping {
     pub fn create_unbound_reference(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         let reference = Reference::new(AstNodeId::DUMMY, flag);
         let reference_id = self.symbols.create_reference(reference);
@@ -311,7 +311,7 @@ impl TraverseScoping {
         &mut self,
         span: Span,
         name: Atom<'a>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference_id = self.create_unbound_reference(name.to_compact_str(), flag);
         IdentifierReference {
@@ -330,7 +330,7 @@ impl TraverseScoping {
         &mut self,
         name: CompactStr,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         if let Some(symbol_id) = symbol_id {
             self.create_bound_reference(symbol_id, flag)
@@ -348,7 +348,7 @@ impl TraverseScoping {
         span: Span,
         name: Atom<'a>,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         if let Some(symbol_id) = symbol_id {
             self.create_bound_reference_id(span, name, symbol_id, flag)
@@ -361,7 +361,7 @@ impl TraverseScoping {
     pub fn create_reference_in_current_scope(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> ReferenceId {
         let symbol_id = self.scopes.find_binding(self.current_scope_id, name.as_str());
         self.create_reference(name, symbol_id, flag)
@@ -375,7 +375,7 @@ impl TraverseScoping {
     pub fn clone_identifier_reference<'a>(
         &mut self,
         ident: &IdentifierReference<'a>,
-        flag: ReferenceFlag,
+        flag: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference =
             self.symbols().get_reference(ident.reference_id.get().unwrap_or_else(|| {

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -235,7 +235,7 @@ fn default_init_field(field: &FieldDef) -> bool {
             field!(scope_id: Cell<Option<ScopeId>>),
             field!(symbol_id: Cell<Option<SymbolId>>),
             field!(reference_id: Cell<Option<ReferenceId>>),
-            field!(reference_flag: ReferenceFlag),
+            field!(reference_flag: ReferenceFlags),
         ]);
     }
 

--- a/tasks/ast_tools/src/passes/calc_layout.rs
+++ b/tasks/ast_tools/src/passes/calc_layout.rs
@@ -358,7 +358,7 @@ lazy_static! {
         Cell<Option<SymbolId>>: { _ => Layout::known(4, 4, 0), },
         Cell<Option<ReferenceId>>: { _ => Layout::known(4, 4, 0), },
         // Unsupported: this is a `bitflags` generated type, we don't expand macros
-        ReferenceFlag: { _ => Layout::known(1, 1, 0), },
+        ReferenceFlags: { _ => Layout::known(1, 1, 0), },
         // Unsupported: this is a `bitflags` generated type, we don't expand macros
         RegExpFlags: { _ => Layout::known(1, 1, 0), },
     };


### PR DESCRIPTION
Part of #4991.