### PR TITLE
refactor(ast)!: rename `IdentifierReference::reference_flags` field

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -245,7 +245,7 @@ pub struct IdentifierReference<'a> {
     /// [`ReferenceFlags::None`] immediately after parsing.
     #[serde(skip)]
     #[clone_in(default)]
-    pub reference_flag: ReferenceFlags,
+    pub reference_flags: ReferenceFlags,
 }
 
 /// `x` in `const x = 0;`

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -334,7 +334,7 @@ impl<'a> IdentifierReference<'a> {
             span,
             name,
             reference_id: Cell::default(),
-            reference_flag: ReferenceFlags::default(),
+            reference_flags: ReferenceFlags::default(),
         }
     }
 
@@ -343,7 +343,7 @@ impl<'a> IdentifierReference<'a> {
             span,
             name,
             reference_id: Cell::new(reference_id),
-            reference_flag: ReferenceFlags::Read,
+            reference_flags: ReferenceFlags::Read,
         }
     }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -71,7 +71,7 @@ const _: () = {
     assert!(offset_of!(IdentifierReference, span) == 0usize);
     assert!(offset_of!(IdentifierReference, name) == 8usize);
     assert!(offset_of!(IdentifierReference, reference_id) == 24usize);
-    assert!(offset_of!(IdentifierReference, reference_flag) == 28usize);
+    assert!(offset_of!(IdentifierReference, reference_flags) == 28usize);
 
     assert!(size_of::<BindingIdentifier>() == 32usize);
     assert!(align_of::<BindingIdentifier>() == 8usize);
@@ -1476,7 +1476,7 @@ const _: () = {
     assert!(offset_of!(IdentifierReference, span) == 0usize);
     assert!(offset_of!(IdentifierReference, name) == 8usize);
     assert!(offset_of!(IdentifierReference, reference_id) == 16usize);
-    assert!(offset_of!(IdentifierReference, reference_flag) == 20usize);
+    assert!(offset_of!(IdentifierReference, reference_flags) == 20usize);
 
     assert!(size_of::<BindingIdentifier>() == 20usize);
     assert!(align_of::<BindingIdentifier>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1509,7 +1509,7 @@ impl<'a> AstBuilder<'a> {
             span,
             name: name.into_in(self.allocator),
             reference_id: Default::default(),
-            reference_flag: Default::default(),
+            reference_flags: Default::default(),
         }
     }
 

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -182,7 +182,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'old_al
             span: self.span.clone_in(allocator),
             name: self.name.clone_in(allocator),
             reference_id: Default::default(),
-            reference_flag: Default::default(),
+            reference_flags: Default::default(),
         }
     }
 }

--- a/crates/oxc_minifier/src/node_util/check_for_state_change.rs
+++ b/crates/oxc_minifier/src/node_util/check_for_state_change.rs
@@ -33,7 +33,7 @@ impl<'a, 'b> CheckForStateChange<'a, 'b> for Expression<'a> {
                 .expressions
                 .iter()
                 .any(|expr| expr.check_for_state_change(check_for_new_objects)),
-            Self::Identifier(ident) => ident.reference_flag == ReferenceFlags::Write,
+            Self::Identifier(ident) => ident.reference_flags == ReferenceFlags::Write,
             Self::UnaryExpression(unary_expr) => {
                 unary_expr.check_for_state_change(check_for_new_objects)
             }

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -86,7 +86,7 @@ impl<'a> TypeScript<'a> {
         match type_name {
             TSTypeName::IdentifierReference(ident) => {
                 let mut ident = ident.clone();
-                ident.reference_flag = ReferenceFlags::Read;
+                ident.reference_flags = ReferenceFlags::Read;
                 let reference_id = ident.reference_id.get().unwrap();
                 let reference = ctx.symbols_mut().get_reference_mut(reference_id);
                 *reference.flag_mut() = ReferenceFlags::Read;

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -290,7 +290,7 @@ impl TraverseScoping {
             span,
             name,
             reference_id: Cell::new(Some(reference_id)),
-            reference_flag: flag,
+            reference_flags: flag,
         }
     }
 
@@ -318,7 +318,7 @@ impl TraverseScoping {
             span,
             name,
             reference_id: Cell::new(Some(reference_id)),
-            reference_flag: flag,
+            reference_flags: flag,
         }
     }
 

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -235,7 +235,7 @@ fn default_init_field(field: &FieldDef) -> bool {
             field!(scope_id: Cell<Option<ScopeId>>),
             field!(symbol_id: Cell<Option<SymbolId>>),
             field!(reference_id: Cell<Option<ReferenceId>>),
-            field!(reference_flag: ReferenceFlags),
+            field!(reference_flags: ReferenceFlags),
         ]);
     }
 


### PR DESCRIPTION
Part of #4991.