### PR TITLE
refactor(semantic)!: rename `Reference::flag` and `flag_mut` methods to plural

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -470,7 +470,7 @@ impl<'a> SemanticBuilder<'a> {
 
                 references.retain(|&reference_id| {
                     let reference = &mut self.symbols.references[reference_id];
-                    let flag = reference.flag();
+                    let flag = reference.flags();
                     if flag.is_type() && symbol_flag.can_be_referenced_by_type()
                         || flag.is_value() && symbol_flag.can_be_referenced_by_value()
                         || flag.is_ts_type_query() && symbol_flag.is_import()
@@ -478,18 +478,18 @@ impl<'a> SemanticBuilder<'a> {
                         // The non type-only ExportSpecifier can reference a type/value symbol,
                         // If the symbol is a value symbol and reference flag is not type-only, remove the type flag.
                         if symbol_flag.is_value() && !flag.is_type_only() {
-                            *reference.flag_mut() -= ReferenceFlags::Type;
+                            *reference.flags_mut() -= ReferenceFlags::Type;
                         } else {
                             // If the symbol is a type symbol and reference flag is not type-only, remove the value flag.
-                            *reference.flag_mut() -= ReferenceFlags::Value;
+                            *reference.flags_mut() -= ReferenceFlags::Value;
                         }
 
                         // import type { T } from './mod'; type A = typeof T
                         //                                                 ^ can reference type-only import
                         // If symbol is type-import, we need to replace the ReferenceFlags::Value with ReferenceFlags::Type
                         if flag.is_ts_type_query() && symbol_flag.is_type_import() {
-                            *reference.flag_mut() -= ReferenceFlags::Value;
-                            *reference.flag_mut() |= ReferenceFlags::Type;
+                            *reference.flags_mut() -= ReferenceFlags::Value;
+                            *reference.flags_mut() |= ReferenceFlags::Type;
                         }
 
                         reference.set_symbol_id(symbol_id);

--- a/crates/oxc_semantic/src/post_transform_checker.rs
+++ b/crates/oxc_semantic/src/post_transform_checker.rs
@@ -161,7 +161,7 @@ current  symbol {cur_symbol_id:?}: {cur_symbol_id:?}
         // Check whether references are valid
         for reference_id in current_collect.reference_ids.iter().copied() {
             let reference = current_symbols.get_reference(reference_id);
-            if reference.flag().is_empty() {
+            if reference.flags().is_empty() {
                 self.errors.push(OxcDiagnostic::error(format!(
                     "Expect ReferenceFlags for IdentifierReference({reference_id:?}) to not be empty",
                 )));

--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -91,12 +91,12 @@ impl Reference {
     }
 
     #[inline]
-    pub fn flag(&self) -> ReferenceFlags {
+    pub fn flags(&self) -> ReferenceFlags {
         self.flag
     }
 
     #[inline]
-    pub fn flag_mut(&mut self) -> &mut ReferenceFlags {
+    pub fn flags_mut(&mut self) -> &mut ReferenceFlags {
         &mut self.flag
     }
 

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -67,7 +67,7 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
                         }
                         let reference = &semantic.symbols().references[*reference_id];
                         result.push('{');
-                        result.push_str(format!("\"flag\": \"{:?}\",", reference.flag()).as_str());
+                        result.push_str(format!("\"flag\": \"{:?}\",", reference.flags()).as_str());
                         result.push_str(format!("\"id\": {},", reference_id.index()).as_str());
                         result.push_str(
                             format!("\"name\": {:?},", semantic.reference_name(reference)).as_str(),

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -37,7 +37,7 @@ impl<'a> ExponentiationOperator<'a> {
     ) -> IdentifierReference<'a> {
         let reference = ctx.symbols().get_reference(ident.reference_id.get().unwrap());
         let symbol_id = reference.symbol_id();
-        let flag = reference.flag();
+        let flag = reference.flags();
         ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
     }
 

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -80,7 +80,7 @@ impl<'a> LogicalAssignmentOperators<'a> {
     ) -> IdentifierReference<'a> {
         let reference = ctx.symbols().get_reference(ident.reference_id.get().unwrap());
         let symbol_id = reference.symbol_id();
-        let flag = reference.flag();
+        let flag = reference.flags();
         ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
     }
 

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -89,7 +89,7 @@ impl<'a> TypeScript<'a> {
                 ident.reference_flags = ReferenceFlags::Read;
                 let reference_id = ident.reference_id.get().unwrap();
                 let reference = ctx.symbols_mut().get_reference_mut(reference_id);
-                *reference.flag_mut() = ReferenceFlags::Read;
+                *reference.flags_mut() = ReferenceFlags::Read;
                 self.ctx.ast.expression_from_identifier_reference(ident)
             }
             TSTypeName::QualifiedName(qualified_name) => self


### PR DESCRIPTION
Part of #4991.