### PR TITLE
refactor(semantic): rename `Reference::flag` field to `flags`

### DIFF
--- a/crates/oxc_semantic/src/reference.rs
+++ b/crates/oxc_semantic/src/reference.rs
@@ -45,14 +45,14 @@ pub struct Reference {
     symbol_id: Option<SymbolId>,
     /// Describes how this referenced is used by other AST nodes. References can
     /// be reads, writes, or both.
-    flag: ReferenceFlags,
+    flags: ReferenceFlags,
 }
 
 impl Reference {
     /// Create a new unresolved reference.
     #[inline]
-    pub fn new(node_id: AstNodeId, flag: ReferenceFlags) -> Self {
-        Self { node_id, symbol_id: None, flag }
+    pub fn new(node_id: AstNodeId, flags: ReferenceFlags) -> Self {
+        Self { node_id, symbol_id: None, flags }
     }
 
     /// Create a new resolved reference on a symbol.
@@ -60,9 +60,9 @@ impl Reference {
     pub fn new_with_symbol_id(
         node_id: AstNodeId,
         symbol_id: SymbolId,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> Self {
-        Self { node_id, symbol_id: Some(symbol_id), flag }
+        Self { node_id, symbol_id: Some(symbol_id), flags }
     }
 
     /// Get the id of the node that is referencing the symbol.
@@ -92,31 +92,31 @@ impl Reference {
 
     #[inline]
     pub fn flags(&self) -> ReferenceFlags {
-        self.flag
+        self.flags
     }
 
     #[inline]
     pub fn flags_mut(&mut self) -> &mut ReferenceFlags {
-        &mut self.flag
+        &mut self.flags
     }
 
     /// Returns `true` if the identifier value was read. This is not mutually
     /// exclusive with [`#is_write`]
     #[inline]
     pub fn is_read(&self) -> bool {
-        self.flag.is_read()
+        self.flags.is_read()
     }
 
     /// Returns `true` if the identifier was written to. This is not mutually
     /// exclusive with [`#is_read`]
     #[inline]
     pub fn is_write(&self) -> bool {
-        self.flag.is_write()
+        self.flags.is_write()
     }
 
     /// Returns `true` if this reference is used in a type context.
     #[inline]
     pub fn is_type(&self) -> bool {
-        self.flag.is_type() || self.flag.is_ts_type_query()
+        self.flags.is_type() || self.flags.is_ts_type_query()
     }
 }


### PR DESCRIPTION
Part of #4991.