### PR TITLE
refactor(linter, mangler, parser, semantic, transformer, traverse, wasm): rename various `flag` vars to `flags`

### DIFF
--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -47,8 +47,8 @@ impl Rule for NoDuplicateHead {
             return;
         }
 
-        let flag = symbols.get_flag(symbol_id);
-        if !flag.is_import() {
+        let flags = symbols.get_flag(symbol_id);
+        if !flags.is_import() {
             return;
         }
 

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -198,9 +198,9 @@ impl Mangler {
     ) -> Vec<SlotFrequency> {
         let mut frequencies = vec![SlotFrequency::default(); total_number_of_slots];
         for (symbol_id, slot) in slots.iter_enumerated() {
-            let symbol_flag = symbol_table.get_flag(symbol_id);
+            let symbol_flags = symbol_table.get_flag(symbol_id);
             // omit renaming `export { x }`
-            if !symbol_flag.is_variable() || symbol_flag.is_export() {
+            if !symbol_flags.is_variable() || symbol_flags.is_export() {
                 continue;
             }
             let index = *slot;

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -297,12 +297,12 @@ impl<'a> ParserImpl<'a> {
         let mut modifiers = self.ast.vec();
         while self.at_modifier() {
             let span = self.start_span();
-            let modifier_flag = self.cur_kind().into();
+            let modifier_flags = self.cur_kind().into();
             let kind = self.cur_kind();
             self.bump_any();
             let modifier = self.modifier(kind, self.end_span(span))?;
             self.check_for_duplicate_modifiers(flags, &modifier);
-            flags.set(modifier_flag, true);
+            flags.set(modifier_flags, true);
             modifiers.push(modifier);
         }
         Ok(Modifiers::new(modifiers, flags))

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -52,8 +52,8 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
 
         // Collect all scopes where variable hoisting can occur
         for scope_id in builder.scope.ancestors(target_scope_id) {
-            let flag = builder.scope.get_flags(scope_id);
-            if flag.is_var() {
+            let flags = builder.scope.get_flags(scope_id);
+            if flags.is_var() {
                 target_scope_id = scope_id;
                 break;
             }
@@ -181,10 +181,10 @@ impl<'a> Binder<'a> for Function<'a> {
         if let Some(AstKind::ObjectProperty(prop)) =
             builder.nodes.parent_kind(builder.current_node_id)
         {
-            let flag = builder.scope.get_flags_mut(current_scope_id);
+            let flags = builder.scope.get_flags_mut(current_scope_id);
             match prop.kind {
-                PropertyKind::Get => *flag |= ScopeFlags::GetAccessor,
-                PropertyKind::Set => *flag |= ScopeFlags::SetAccessor,
+                PropertyKind::Get => *flags |= ScopeFlags::GetAccessor,
+                PropertyKind::Set => *flags |= ScopeFlags::SetAccessor,
                 PropertyKind::Init => {}
             };
         }

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -144,13 +144,13 @@ impl SymbolTable {
         &mut self,
         span: Span,
         name: CompactStr,
-        flag: SymbolFlags,
+        flags: SymbolFlags,
         scope_id: ScopeId,
         node_id: AstNodeId,
     ) -> SymbolId {
         self.spans.push(span);
         self.names.push(name);
-        self.flags.push(flag);
+        self.flags.push(flags);
         self.scope_ids.push(scope_id);
         self.declarations.push(node_id);
         self.resolved_references.push(vec![]);

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -14,14 +14,14 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
         if index != 0 {
             result.push(',');
         }
-        let flag = semantic.scopes().get_flags(scope_id);
+        let flags = semantic.scopes().get_flags(scope_id);
         result.push('{');
         if let Some(child_ids) = semantic.scopes().get_child_ids(scope_id) {
             result.push_str("\"children\":");
             result.push_str(&get_scope_snapshot(semantic, child_ids.iter().copied()));
             result.push(',');
         }
-        result.push_str(format!("\"flag\": \"{flag:?}\",").as_str());
+        result.push_str(format!("\"flag\": \"{flags:?}\",").as_str());
         result.push_str(format!("\"id\": {},", scope_id.index()).as_str());
         result.push_str(
             format!(

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -37,8 +37,8 @@ impl<'a> ExponentiationOperator<'a> {
     ) -> IdentifierReference<'a> {
         let reference = ctx.symbols().get_reference(ident.reference_id.get().unwrap());
         let symbol_id = reference.symbol_id();
-        let flag = reference.flags();
-        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
+        let flags = reference.flags();
+        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flags)
     }
 
     fn clone_expression(expr: &Expression<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -80,8 +80,8 @@ impl<'a> LogicalAssignmentOperators<'a> {
     ) -> IdentifierReference<'a> {
         let reference = ctx.symbols().get_reference(ident.reference_id.get().unwrap());
         let symbol_id = reference.symbol_id();
-        let flag = reference.flags();
-        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
+        let flags = reference.flags();
+        ctx.create_reference_id(ident.span, ident.name.clone(), symbol_id, flags)
     }
 
     pub fn maybe_generate_memoised(

--- a/crates/oxc_transformer/src/helpers/bindings.rs
+++ b/crates/oxc_transformer/src/helpers/bindings.rs
@@ -135,9 +135,9 @@ impl<'a> BoundIdentifier<'a> {
     pub fn create_spanned_reference(
         &self,
         span: Span,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, flag)
+        ctx.create_bound_reference_id(span, self.name.clone(), self.symbol_id, flags)
     }
 }

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -320,9 +320,9 @@ impl<'a> TraverseCtx<'a> {
     pub fn create_bound_reference(
         &mut self,
         symbol_id: SymbolId,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
-        self.scoping.create_bound_reference(symbol_id, flag)
+        self.scoping.create_bound_reference(symbol_id, flags)
     }
 
     /// Create an `IdentifierReference` bound to a `SymbolId`.
@@ -333,9 +333,9 @@ impl<'a> TraverseCtx<'a> {
         span: Span,
         name: Atom<'a>,
         symbol_id: SymbolId,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        self.scoping.create_bound_reference_id(span, name, symbol_id, flag)
+        self.scoping.create_bound_reference_id(span, name, symbol_id, flags)
     }
 
     /// Create an unbound reference.
@@ -344,9 +344,9 @@ impl<'a> TraverseCtx<'a> {
     pub fn create_unbound_reference(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
-        self.scoping.create_unbound_reference(name, flag)
+        self.scoping.create_unbound_reference(name, flags)
     }
 
     /// Create an unbound `IdentifierReference`.
@@ -356,9 +356,9 @@ impl<'a> TraverseCtx<'a> {
         &mut self,
         span: Span,
         name: Atom<'a>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        self.scoping.create_unbound_reference_id(span, name, flag)
+        self.scoping.create_unbound_reference_id(span, name, flags)
     }
 
     /// Create a reference optionally bound to a `SymbolId`.
@@ -371,9 +371,9 @@ impl<'a> TraverseCtx<'a> {
         &mut self,
         name: CompactStr,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
-        self.scoping.create_reference(name, symbol_id, flag)
+        self.scoping.create_reference(name, symbol_id, flags)
     }
 
     /// Create an `IdentifierReference` optionally bound to a `SymbolId`.
@@ -387,9 +387,9 @@ impl<'a> TraverseCtx<'a> {
         span: Span,
         name: Atom<'a>,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        self.scoping.create_reference_id(span, name, symbol_id, flag)
+        self.scoping.create_reference_id(span, name, symbol_id, flags)
     }
 
     /// Create reference in current scope, looking up binding for `name`,
@@ -398,9 +398,9 @@ impl<'a> TraverseCtx<'a> {
     pub fn create_reference_in_current_scope(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
-        self.scoping.create_reference_in_current_scope(name, flag)
+        self.scoping.create_reference_in_current_scope(name, flags)
     }
 
     /// Clone `IdentifierReference` based on the original reference's `SymbolId` and name.
@@ -413,9 +413,9 @@ impl<'a> TraverseCtx<'a> {
     pub fn clone_identifier_reference(
         &mut self,
         ident: &IdentifierReference<'a>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        self.scoping.clone_identifier_reference(ident, flag)
+        self.scoping.clone_identifier_reference(ident, flags)
     }
 }
 

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -269,9 +269,9 @@ impl TraverseScoping {
     pub fn create_bound_reference(
         &mut self,
         symbol_id: SymbolId,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
-        let reference = Reference::new_with_symbol_id(AstNodeId::DUMMY, symbol_id, flag);
+        let reference = Reference::new_with_symbol_id(AstNodeId::DUMMY, symbol_id, flags);
         let reference_id = self.symbols.create_reference(reference);
         self.symbols.resolved_references[symbol_id].push(reference_id);
         reference_id
@@ -283,14 +283,14 @@ impl TraverseScoping {
         span: Span,
         name: Atom<'a>,
         symbol_id: SymbolId,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference_id = self.create_bound_reference(symbol_id, flag);
+        let reference_id = self.create_bound_reference(symbol_id, flags);
         IdentifierReference {
             span,
             name,
             reference_id: Cell::new(Some(reference_id)),
-            reference_flags: flag,
+            reference_flags: flags,
         }
     }
 
@@ -298,9 +298,9 @@ impl TraverseScoping {
     pub fn create_unbound_reference(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
-        let reference = Reference::new(AstNodeId::DUMMY, flag);
+        let reference = Reference::new(AstNodeId::DUMMY, flags);
         let reference_id = self.symbols.create_reference(reference);
         self.scopes.add_root_unresolved_reference(name, reference_id);
         reference_id
@@ -311,14 +311,14 @@ impl TraverseScoping {
         &mut self,
         span: Span,
         name: Atom<'a>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference_id = self.create_unbound_reference(name.to_compact_str(), flag);
+        let reference_id = self.create_unbound_reference(name.to_compact_str(), flags);
         IdentifierReference {
             span,
             name,
             reference_id: Cell::new(Some(reference_id)),
-            reference_flags: flag,
+            reference_flags: flags,
         }
     }
 
@@ -330,12 +330,12 @@ impl TraverseScoping {
         &mut self,
         name: CompactStr,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
         if let Some(symbol_id) = symbol_id {
-            self.create_bound_reference(symbol_id, flag)
+            self.create_bound_reference(symbol_id, flags)
         } else {
-            self.create_unbound_reference(name, flag)
+            self.create_unbound_reference(name, flags)
         }
     }
 
@@ -348,12 +348,12 @@ impl TraverseScoping {
         span: Span,
         name: Atom<'a>,
         symbol_id: Option<SymbolId>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         if let Some(symbol_id) = symbol_id {
-            self.create_bound_reference_id(span, name, symbol_id, flag)
+            self.create_bound_reference_id(span, name, symbol_id, flags)
         } else {
-            self.create_unbound_reference_id(span, name, flag)
+            self.create_unbound_reference_id(span, name, flags)
         }
     }
 
@@ -361,10 +361,10 @@ impl TraverseScoping {
     pub fn create_reference_in_current_scope(
         &mut self,
         name: CompactStr,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> ReferenceId {
         let symbol_id = self.scopes.find_binding(self.current_scope_id, name.as_str());
-        self.create_reference(name, symbol_id, flag)
+        self.create_reference(name, symbol_id, flags)
     }
 
     /// Clone `IdentifierReference` based on the original reference's `SymbolId` and name.
@@ -375,14 +375,14 @@ impl TraverseScoping {
     pub fn clone_identifier_reference<'a>(
         &mut self,
         ident: &IdentifierReference<'a>,
-        flag: ReferenceFlags,
+        flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference =
             self.symbols().get_reference(ident.reference_id.get().unwrap_or_else(|| {
                 unreachable!("IdentifierReference must have a reference_id");
             }));
         let symbol_id = reference.symbol_id();
-        self.create_reference_id(ident.span, ident.name.clone(), symbol_id, flag)
+        self.create_reference_id(ident.span, ident.name.clone(), symbol_id, flags)
     }
 }
 

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -314,19 +314,19 @@ impl Oxc {
             let space = " ".repeat(depth * 2);
 
             for scope_id in scope_ids {
-                let flag = semantic.scopes().get_flags(*scope_id);
+                let flags = semantic.scopes().get_flags(*scope_id);
                 let next_scope_ids = semantic.scopes().get_child_ids(*scope_id);
 
                 scope_text
-                    .push_str(&format!("{space}Scope{:?} ({flag:?}) {{\n", scope_id.index() + 1));
+                    .push_str(&format!("{space}Scope{:?} ({flags:?}) {{\n", scope_id.index() + 1));
                 let bindings = semantic.scopes().get_bindings(*scope_id);
                 let binding_space = " ".repeat((depth + 1) * 2);
                 if !bindings.is_empty() {
                     scope_text.push_str(&format!("{binding_space}Bindings: {{"));
                 }
                 bindings.iter().for_each(|(name, symbol_id)| {
-                    let symbol_flag = semantic.symbols().get_flag(*symbol_id);
-                    scope_text.push_str(&format!("\n{binding_space}  {name} ({symbol_flag:?})",));
+                    let symbol_flags = semantic.symbols().get_flag(*symbol_id);
+                    scope_text.push_str(&format!("\n{binding_space}  {name} ({symbol_flags:?})",));
                 });
                 if !bindings.is_empty() {
                     scope_text.push_str(&format!("\n{binding_space}}}\n"));


### PR DESCRIPTION
Part of #4991.