### PR TITLE
fix(linter/no-unused-vars): `type` specifier not deleted for type imports

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
@@ -25,7 +25,10 @@ impl NoUnusedVars {
         if specifiers.len() == 1 {
             return fixer.delete(import).dangerously();
         }
-        let span = symbol.span();
+        let span = specifiers
+            .iter()
+            .find(|specifier| symbol == specifier)
+            .map_or_else(|| symbol.span(), GetSpan::span);
         let text_after = fixer.source_text()[(span.end as usize)..].chars();
         let span = span.expand_right(count_whitespace_or_commas(text_after));
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::VariableDeclarator;
+use oxc_ast::ast::{ImportDeclarationSpecifier, VariableDeclarator};
 use std::{cell::OnceCell, fmt};
 
 use oxc_ast::{
@@ -254,6 +254,12 @@ impl<'a> PartialEq<AssignmentTarget<'a>> for Symbol<'_, 'a> {
             AssignmentTarget::AssignmentTargetIdentifier(id) => self == id.as_ref(),
             _ => false,
         }
+    }
+}
+
+impl<'s, 'a> PartialEq<ImportDeclarationSpecifier<'a>> for Symbol<'s, 'a> {
+    fn eq(&self, import: &ImportDeclarationSpecifier<'a>) -> bool {
+        self == import.local()
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -533,6 +533,25 @@ fn test_imports() {
             None,
             FixKind::DangerousSuggestion,
         ),
+        // type imports
+        (
+            "import { type foo, bar } from './foo'; bar();",
+            "import { bar } from './foo'; bar();",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        (
+            "import { foo, type bar, baz } from './foo'; foo(baz);",
+            "import { foo, baz } from './foo'; foo(baz);",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        (
+            "import foo, { type bar } from './foo'; foo();",
+            "import foo, { } from './foo'; foo();",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
     ];
 
     Tester::new(NoUnusedVars::NAME, pass, fail)


### PR DESCRIPTION
fixes a bug in eslint/no-unused-vars where, when unused type imports were deleted, the `type` modifier was not.