### PR TITLE
refactor(semantic)!: rename `SymbolTable::get_flag` to `get_flags`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 impl Rule for NoClassAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_class() {
+        if symbol_table.get_flags(symbol_id).is_class() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_class_assign_diagnostic(

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 impl Rule for NoConstAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_const_variable() {
+        if symbol_table.get_flags(symbol_id).is_const_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_const_assign_diagnostic(

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 impl Rule for NoExAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_catch_variable() {
+        if symbol_table.get_flags(symbol_id).is_catch_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_ex_assign_diagnostic(

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -52,7 +52,7 @@ const REFLECT_MUTATION_METHODS: phf::Set<&'static str> =
 impl Rule for NoImportAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flag(symbol_id).is_import() {
+        if symbol_table.get_flags(symbol_id).is_import() {
             let kind = ctx.nodes().kind(symbol_table.get_declaration(symbol_id));
             let is_namespace_specifier = matches!(kind, AstKind::ImportNamespaceSpecifier(_));
             for reference in symbol_table.get_resolved_references(symbol_id) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -28,7 +28,7 @@ impl PartialEq for Symbol<'_, '_> {
 // constructor and simple getters
 impl<'s, 'a> Symbol<'s, 'a> {
     pub fn new(semantic: &'s Semantic<'a>, symbol_id: SymbolId) -> Self {
-        let flags = semantic.symbols().get_flag(symbol_id);
+        let flags = semantic.symbols().get_flags(symbol_id);
         Self { semantic, id: symbol_id, flags, span: OnceCell::new() }
     }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -47,7 +47,7 @@ impl Rule for NoDuplicateHead {
             return;
         }
 
-        let flags = symbols.get_flag(symbol_id);
+        let flags = symbols.get_flags(symbol_id);
         if !flags.is_import() {
             return;
         }

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -101,7 +101,7 @@ impl Rule for OnlyUsedInRecursion {
                     && !ctx
                         .semantic()
                         .symbols()
-                        .get_flag(function_id.symbol_id.get().expect("`symbol_id` should be set"))
+                        .get_flags(function_id.symbol_id.get().expect("`symbol_id` should be set"))
                         .is_export()
                 {
                     ctx.diagnostic_with_dangerous_fix(

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -200,7 +200,7 @@ fn collect_ids_referenced_to_import<'a>(
         .resolved_references
         .iter_enumerated()
         .filter_map(|(symbol_id, reference_ids)| {
-            if ctx.symbols().get_flag(symbol_id).is_import() {
+            if ctx.symbols().get_flags(symbol_id).is_import() {
                 let id = ctx.symbols().get_declaration(symbol_id);
                 let Some(AstKind::ImportDeclaration(import_decl)) = ctx.nodes().parent_kind(id)
                 else {

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -201,7 +201,7 @@ pub fn get_parent_es5_component<'a, 'b>(
 
 pub fn get_parent_es6_component<'a, 'b>(ctx: &'b LintContext<'a>) -> Option<&'b AstNode<'a>> {
     ctx.semantic().symbols().iter_rev().find_map(|symbol| {
-        let flags = ctx.semantic().symbols().get_flag(symbol);
+        let flags = ctx.semantic().symbols().get_flags(symbol);
         if flags.contains(SymbolFlags::Class) {
             let node = ctx.semantic().symbol_declaration(symbol);
             if is_es6_component(node) {

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -198,7 +198,7 @@ impl Mangler {
     ) -> Vec<SlotFrequency> {
         let mut frequencies = vec![SlotFrequency::default(); total_number_of_slots];
         for (symbol_id, slot) in slots.iter_enumerated() {
-            let symbol_flags = symbol_table.get_flag(symbol_id);
+            let symbol_flags = symbol_table.get_flags(symbol_id);
             // omit renaming `export { x }`
             if !symbol_flags.is_variable() || symbol_flags.is_export() {
                 continue;

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -410,7 +410,7 @@ impl<'a> SemanticBuilder<'a> {
         let symbol_id = self.scope.get_binding(scope_id, name).or_else(|| {
             self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(name).copied())
         })?;
-        if report_error && self.symbols.get_flag(symbol_id).intersects(excludes) {
+        if report_error && self.symbols.get_flags(symbol_id).intersects(excludes) {
             let symbol_span = self.symbols.get_span(symbol_id);
             self.error(redeclaration(name, symbol_span, span));
         }
@@ -464,7 +464,7 @@ impl<'a> SemanticBuilder<'a> {
             // If unresolved, transfer it to parent scope's unresolved references.
             let bindings = self.scope.get_bindings(self.current_scope_id);
             if let Some(symbol_id) = bindings.get(name.as_str()).copied() {
-                let symbol_flags = self.symbols.get_flag(symbol_id);
+                let symbol_flags = self.symbols.get_flags(symbol_id);
 
                 let resolved_references = &mut self.symbols.resolved_references[symbol_id];
 
@@ -1996,7 +1996,7 @@ impl<'a> SemanticBuilder<'a> {
     fn make_all_namespaces_valuelike(&mut self) {
         for symbol_id in &self.namespace_stack {
             // Ambient modules cannot be value modules
-            if self.symbols.get_flag(*symbol_id).intersects(SymbolFlags::Ambient) {
+            if self.symbols.get_flags(*symbol_id).intersects(SymbolFlags::Ambient) {
                 continue;
             }
             self.symbols.union_flag(*symbol_id, SymbolFlags::ValueModule);

--- a/crates/oxc_semantic/src/post_transform_checker.rs
+++ b/crates/oxc_semantic/src/post_transform_checker.rs
@@ -113,7 +113,7 @@ current  scope {cur_scope_id:?}: {current_bindings:?}
     ) {
         // Check whether symbols are valid
         for symbol_id in current_collect.symbol_ids.iter().copied() {
-            if current_symbols.get_flag(symbol_id).is_empty() {
+            if current_symbols.get_flags(symbol_id).is_empty() {
                 let name = current_symbols.get_name(symbol_id);
                 self.errors.push(OxcDiagnostic::error(format!(
                     "Expect non-empty SymbolFlags for BindingIdentifier({name})"

--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -98,7 +98,7 @@ impl SymbolTable {
     }
 
     #[inline]
-    pub fn get_flag(&self, symbol_id: SymbolId) -> SymbolFlags {
+    pub fn get_flags(&self, symbol_id: SymbolId) -> SymbolFlags {
         self.flags[symbol_id]
     }
 

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -122,7 +122,7 @@ impl<'a> SymbolTester<'a> {
     pub fn contains_flags(mut self, flags: SymbolFlags) -> Self {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
-                let found_flags = self.semantic.symbols().get_flag(symbol_id);
+                let found_flags = self.semantic.symbols().get_flags(symbol_id);
                 if found_flags.contains(flags) {
                     Ok(symbol_id)
                 } else {
@@ -140,7 +140,7 @@ impl<'a> SymbolTester<'a> {
     pub fn intersects_flags(mut self, flags: SymbolFlags) -> Self {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
-                let found_flags = self.semantic.symbols().get_flag(symbol_id);
+                let found_flags = self.semantic.symbols().get_flags(symbol_id);
                 if found_flags.intersects(flags) {
                     Ok(symbol_id)
                 } else {
@@ -214,7 +214,7 @@ impl<'a> SymbolTester<'a> {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
                 let binding = self.target_symbol_name.clone();
-                if self.semantic.symbols().get_flag(symbol_id).is_export() {
+                if self.semantic.symbols().get_flags(symbol_id).is_export() {
                     Ok(symbol_id)
                 } else {
                     Err(OxcDiagnostic::error(format!(
@@ -238,7 +238,7 @@ impl<'a> SymbolTester<'a> {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
                 let binding = self.target_symbol_name.clone();
-                if self.semantic.symbols().get_flag(symbol_id).contains(SymbolFlags::Export) {
+                if self.semantic.symbols().get_flags(symbol_id).contains(SymbolFlags::Export) {
                     Err(OxcDiagnostic::error(format!(
                         "Expected {binding} to not be exported. Symbol has export flag."
                     )))

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -39,7 +39,7 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
             }
             result.push('{');
             result.push_str(
-                format!("\"flag\": \"{:?}\",", semantic.symbols().get_flag(*symbol_id)).as_str(),
+                format!("\"flag\": \"{:?}\",", semantic.symbols().get_flags(*symbol_id)).as_str(),
             );
             result.push_str(format!("\"id\": {},", symbol_id.index()).as_str());
             result.push_str(format!("\"name\": {name:?},").as_str());

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -568,7 +568,7 @@ impl<'a> TypeScriptAnnotations<'a> {
             // If the symbol is still a value symbol after SymbolFlags::Import is removed, then it's a value redeclaration.
             // That means the import is shadowed, and we can safely remove the import.
             let has_value_redeclaration =
-                (ctx.symbols().get_flag(symbol_id) - SymbolFlags::Import).is_value();
+                (ctx.symbols().get_flags(symbol_id) - SymbolFlags::Import).is_value();
             if has_value_redeclaration {
                 return false;
             }

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -325,7 +325,7 @@ impl Oxc {
                     scope_text.push_str(&format!("{binding_space}Bindings: {{"));
                 }
                 bindings.iter().for_each(|(name, symbol_id)| {
-                    let symbol_flags = semantic.symbols().get_flag(*symbol_id);
+                    let symbol_flags = semantic.symbols().get_flags(*symbol_id);
                     scope_text.push_str(&format!("\n{binding_space}  {name} ({symbol_flags:?})",));
                 });
                 if !bindings.is_empty() {


### PR DESCRIPTION
Part of #4991.