### PR TITLE
refactor(semantic): rename fields in snapshots from `flag` to `flags`

### DIFF
--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited-scope.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/inherited
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "BlockStatement",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "BlockStatement",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 0,
             "name": "i",
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 11
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
             ]
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "j",
             "node": "VariableDeclarator(j)",
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/block/scope.ts
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/call-expression.snap
@@ -7,30 +7,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "foo",
             "node_id": 19
@@ -38,19 +38,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "a",
             "node_id": 21

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters1.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression/type-parameters2.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/call-expression
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited-scope.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "BlockStatement",
         "symbols": []
@@ -16,12 +16,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "BlockStatement",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
                 "id": 1,
                 "name": "e",
                 "node": "CatchParameter",
@@ -30,24 +30,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/inherited
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode | CatchClause)",
+        "flags": "ScopeFlags(StrictMode | CatchClause)",
         "id": 2,
         "node": "CatchClause",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "BlockStatement",
         "symbols": []
@@ -16,18 +16,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "BlockStatement",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable | CatchVariable)",
                 "id": 0,
                 "name": "e",
                 "node": "CatchParameter",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "e",
                     "node_id": 8
@@ -35,7 +35,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
                 ]
               },
               {
-                "flag": "SymbolFlags(BlockScopedVariable)",
+                "flags": "SymbolFlags(BlockScopedVariable)",
                 "id": 1,
                 "name": "a",
                 "node": "VariableDeclarator(a)",
@@ -44,25 +44,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/catch/scope.ts
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode | CatchClause)",
+        "flags": "ScopeFlags(StrictMode | CatchClause)",
         "id": 2,
         "node": "CatchClause",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "dontReference2",
         "node": "VariableDeclarator(dontReference2)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-accessor-property.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract-property.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/abstract.snap
@@ -9,19 +9,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "b",
                 "node": "FormalParameter(b)",
@@ -30,18 +30,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property-type-annotation.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/accessor-property.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 15
@@ -32,14 +32,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/computed-member.snap
@@ -9,30 +9,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer1",
         "node": "VariableDeclarator(outer1)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "outer1",
             "node_id": 14
@@ -40,13 +40,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "outer2",
         "node": "VariableDeclarator(outer2)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer2",
             "node_id": 18
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 2,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends-generic.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -22,31 +22,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "Class(B)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 13
@@ -54,13 +54,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 3,
         "name": "B",
         "node": "Class(B)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/extends.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(B)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 7
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "B",
         "node": "Class(B)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-extends.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
                 "node_id": 11
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic-ref-implements.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "A",
                 "node_id": 12
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/generic.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
             "node": "TSTypeParameter(A)",
@@ -22,25 +22,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements-generic.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -22,31 +22,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "Class(B)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "A",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 13
@@ -54,13 +54,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 3,
         "name": "B",
         "node": "Class(B)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/implements.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(B)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "A",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 7
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "B",
         "node": "Class(B)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/index-signature.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Bar",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Bar",
             "node_id": 14
@@ -39,13 +39,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Foo",
             "node_id": 22

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method-param-default.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "printName",
                 "node": "FormalParameter(printName)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "printName",
                     "node_id": 19
@@ -31,18 +31,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
           },
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "printerName",
                 "node": "FormalParameter(printerName)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "printerName",
                     "node_id": 40
@@ -52,18 +52,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/method.snap
@@ -9,24 +9,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 26
                   },
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
                     "node_id": 31
@@ -34,35 +34,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 ]
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "b",
                 "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "c",
                 "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "d",
                 "node": "FormalParameter(d)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "e",
                 "node": "FormalParameter(e)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "f",
                 "node": "FormalParameter(f)",
@@ -71,32 +71,32 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 7,
         "name": "unresolved1",
         "node": "VariableDeclarator(unresolved1)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 8,
         "name": "unresolved2",
         "node": "VariableDeclarator(unresolved2)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/new.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/parameter-properties.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,24 +16,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 26
                   },
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 3,
                     "name": "a",
                     "node_id": 41
@@ -41,35 +41,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
                 ]
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "b",
                 "node": "FormalParameter(b)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "c",
                 "node": "FormalParameter(c)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "d",
                 "node": "FormalParameter(d)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 7,
                 "name": "e",
                 "node": "FormalParameter(e)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 8,
                 "name": "f",
                 "node": "FormalParameter(f)",
@@ -78,24 +78,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 30
@@ -103,13 +103,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Outer",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "Outer",
             "node_id": 38
@@ -117,14 +117,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 2,
         "name": "A",
         "node": "Class(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/private-identifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/private-identifier.snap
@@ -9,24 +9,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties-type-annotation.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/properties.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 15
@@ -32,14 +32,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-block.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-block.snap
@@ -9,24 +9,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | ClassStaticBlock)",
+            "flags": "ScopeFlags(StrictMode | ClassStaticBlock)",
             "id": 2,
             "node": "StaticBlock",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-external-ref.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(f)",
         "symbols": []
@@ -16,30 +16,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | ClassStaticBlock)",
+            "flags": "ScopeFlags(StrictMode | ClassStaticBlock)",
             "id": 3,
             "node": "StaticBlock",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "f",
         "node": "Function(f)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "f",
             "node_id": 11
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/static-with-constructor.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(f)",
         "symbols": []
@@ -16,37 +16,37 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | ClassStaticBlock)",
+            "flags": "ScopeFlags(StrictMode | ClassStaticBlock)",
             "id": 3,
             "node": "StaticBlock",
             "symbols": []
           },
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 4,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "f",
         "node": "Function(f)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "f",
             "node_id": 17
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declaration/type-reference.snap
@@ -7,50 +7,50 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 1,
             "name": "A",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "A",
             "node_id": 17
@@ -58,21 +58,21 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/declarati
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T1",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "T2",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "v",
         "node": "VariableDeclarator(v)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/computed-member.snap
@@ -9,30 +9,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer1",
         "node": "VariableDeclarator(outer1)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "outer1",
             "node_id": 16
@@ -40,13 +40,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "outer2",
         "node": "VariableDeclarator(outer2)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer2",
             "node_id": 20
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "A",
         "node": "VariableDeclarator(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/extends.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "A",
         "node": "Class(A)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 9
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "B",
         "node": "VariableDeclarator(B)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/method.snap
@@ -9,24 +9,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 1,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 28
                   },
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 1,
                     "name": "a",
                     "node_id": 33
@@ -34,35 +34,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 ]
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "b",
                 "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "c",
                 "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "d",
                 "node": "FormalParameter(d)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "e",
                 "node": "FormalParameter(e)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "f",
                 "node": "FormalParameter(f)",
@@ -71,32 +71,32 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "A",
         "node": "VariableDeclarator(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 7,
         "name": "unresolved1",
         "node": "VariableDeclarator(unresolved1)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 8,
         "name": "unresolved2",
         "node": "VariableDeclarator(unresolved2)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/new.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "A",
         "node": "VariableDeclarator(A)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "A",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/parameter-properties.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,24 +16,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 0,
                     "name": "a",
                     "node_id": 28
                   },
                   {
-                    "flag": "ReferenceFlags(Read)",
+                    "flags": "ReferenceFlags(Read)",
                     "id": 3,
                     "name": "a",
                     "node_id": 43
@@ -41,35 +41,35 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
                 ]
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "b",
                 "node": "FormalParameter(b)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "c",
                 "node": "FormalParameter(c)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 6,
                 "name": "d",
                 "node": "FormalParameter(d)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 7,
                 "name": "e",
                 "node": "FormalParameter(e)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 8,
                 "name": "f",
                 "node": "FormalParameter(f)",
@@ -78,24 +78,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 32
@@ -103,13 +103,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Outer",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "Outer",
             "node_id": 40
@@ -117,14 +117,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "A",
         "node": "VariableDeclarator(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/private-identifier.snap
@@ -9,24 +9,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "Foo",
         "node": "VariableDeclarator(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/properties.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 17
@@ -32,14 +32,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "A",
         "node": "VariableDeclarator(A)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expression/self-reference-super.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(A)",
         "symbols": [
           {
-            "flag": "SymbolFlags(Class)",
+            "flags": "SymbolFlags(Class)",
             "id": 1,
             "name": "A",
             "node": "Class(A)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "A",
                 "node_id": 7
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/class/expressio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "A",
         "node": "VariableDeclarator(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/accessor.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
@@ -16,19 +16,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | GetAccessor)",
+            "flags": "ScopeFlags(StrictMode | Function | GetAccessor)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": []
           },
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | SetAccessor)",
+            "flags": "ScopeFlags(StrictMode | Function | SetAccessor)",
             "id": 4,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "value",
                 "node": "FormalParameter(value)",
@@ -37,30 +37,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 10
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
             "node_id": 20
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/acce
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(deco)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 0,
             "name": "param",
             "node": "BindingRestElement",
@@ -22,18 +22,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-property.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 10
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 7
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/method.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/meth
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
@@ -16,30 +16,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/meth
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 10
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/meth
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter-property.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
@@ -16,19 +16,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Constructor)",
+            "flags": "ScopeFlags(StrictMode | Function | Constructor)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "b",
                 "node": "FormalParameter(b)",
@@ -37,30 +37,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
             "node_id": 19
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/parameter.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
@@ -16,33 +16,33 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "a",
                 "node": "FormalParameter(a)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 3,
                 "name": "b",
                 "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 4,
                 "name": "c",
                 "node": "FormalParameter(<destructure>)",
                 "references": []
               },
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 5,
                 "name": "d",
                 "node": "FormalParameter(d)",
@@ -51,42 +51,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(A)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "decorator",
             "node_id": 19
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "decorator",
             "node_id": 24
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "decorator",
             "node_id": 31
@@ -94,7 +94,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/para
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "A",
         "node": "Class(A)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/typeof-this.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(decorator)",
         "symbols": []
@@ -16,12 +16,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": [
               {
-                "flag": "SymbolFlags(FunctionScopedVariable)",
+                "flags": "SymbolFlags(FunctionScopedVariable)",
                 "id": 2,
                 "name": "baz",
                 "node": "FormalParameter(baz)",
@@ -30,24 +30,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "decorator",
         "node": "Function(decorator)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "decorator",
             "node_id": 7
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/type
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array-assignment.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "obj",
         "node": "VariableDeclarator(obj)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "obj",
             "node_id": 18
@@ -24,13 +24,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "b",
         "node": "VariableDeclarator(b)",
         "references": [
           {
-            "flag": "ReferenceFlags(Write)",
+            "flags": "ReferenceFlags(Write)",
             "id": 1,
             "name": "b",
             "node_id": 22
@@ -38,13 +38,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 2,
         "name": "c",
         "node": "VariableDeclarator(c)",
         "references": [
           {
-            "flag": "ReferenceFlags(Write)",
+            "flags": "ReferenceFlags(Write)",
             "id": 2,
             "name": "c",
             "node_id": 28

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/array.snap
@@ -5,54 +5,54 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/a
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "b",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "c",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "d",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 4,
         "name": "e",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 5,
         "name": "f",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 6,
         "name": "rest",
         "node": "VariableDeclarator(<destructure>)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object-assignment.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "obj",
         "node": "VariableDeclarator(obj)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "obj",
             "node_id": 27

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/object.snap
@@ -5,54 +5,54 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/destructuring/o
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "shorthand",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "value",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "world",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "a",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 4,
         "name": "b",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 5,
         "name": "c",
         "node": "VariableDeclarator(<destructure>)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 6,
         "name": "d",
         "node": "VariableDeclarator(<destructure>)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.snap
@@ -5,7 +5,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/all.ts
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default1
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(f)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Export | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Export | Function)",
         "id": 0,
         "name": "f",
         "node": "Function(f)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3.snap
@@ -5,7 +5,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default3
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4.snap
@@ -7,13 +7,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default4
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals1.
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.snap
@@ -5,7 +5,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals2.
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-type.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals3-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Foo",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-type.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/equals4-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-dual.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-du
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source1.snap
@@ -5,7 +5,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-so
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-source2.snap
@@ -5,7 +5,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-so
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-type1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named-ty
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Export | TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 0,
         "name": "X",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named1.t
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-type.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2-t
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Export | TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 0,
         "name": "A",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named2.t
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-type.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3-t
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Export | TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 0,
         "name": "V",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "V",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/named3.t
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
         "id": 0,
         "name": "v",
         "node": "VariableDeclarator(v)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inline.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type-inl
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/type.ts
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-body-shadow.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "VariableDeclarator(a)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-const.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-let.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested-body-shadow.snap
@@ -9,25 +9,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "VariableDeclarator(a)",
@@ -36,18 +36,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-nested.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -29,18 +29,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-param-shadow.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 12
@@ -35,19 +35,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/readable-ref-partial.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/default-params/writable-ref.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/inherited-scope.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "parentScoped",
         "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/no-body.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 0,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 8
@@ -28,7 +28,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/params.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 25
               },
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
                 "node_id": 34
@@ -32,42 +32,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "c",
             "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "d",
             "node": "FormalParameter(d)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "e",
             "node": "FormalParameter(e)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 6,
             "name": "f",
             "node": "FormalParameter(f)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 7,
             "name": "g",
             "node": "FormalParameter(g)",
@@ -76,18 +76,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 29
@@ -95,7 +95,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 8,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/scope.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "i",
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 16
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "j",
             "node": "VariableDeclarator(j)",
@@ -35,19 +35,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "arrow",
         "node": "VariableDeclarator(arrow)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/body-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 16
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             ]
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 2,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/return-value-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-parameters/type-parameter-declaration.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
@@ -22,25 +22,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts1.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -21,12 +21,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate-asserts2.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 2,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
                 "node_id": 18
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow/type-predicate2.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 2,
         "node": "ArrowFunctionExpression",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
                 "node_id": 23
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/arrow
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-body-shadow.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "VariableDeclarator(a)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 10
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-const.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 11
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-let.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 10
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested-body-shadow.snap
@@ -9,25 +9,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "VariableDeclarator(a)",
@@ -36,18 +36,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 14
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-nested.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -29,18 +29,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 14
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-param-shadow.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 10
@@ -35,19 +35,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/readable-ref-partial.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 11
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/default-params/writable-ref.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/inherited-scope.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "parentScoped",
         "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/name-shadowed-in-body.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
             "id": 1,
             "name": "Foo",
             "node": "VariableDeclarator(Foo)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "Foo",
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
         "node": "VariableDeclarator(usage)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/overload.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 0,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -29,18 +29,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 17
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -57,12 +57,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 2,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/params.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 25
               },
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
                 "node_id": 34
@@ -32,42 +32,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "b",
             "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "c",
             "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "d",
             "node": "FormalParameter(d)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 6,
             "name": "e",
             "node": "FormalParameter(e)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 7,
             "name": "f",
             "node": "FormalParameter(f)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 8,
             "name": "g",
             "node": "FormalParameter(g)",
@@ -76,18 +76,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 29
@@ -95,14 +95,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/scope.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "i",
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 14
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "j",
             "node": "VariableDeclarator(j)",
@@ -35,19 +35,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/body-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 2,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/return-value-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-parameters/type-parameter-declaration.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
@@ -22,25 +22,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts1.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -21,12 +21,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate-asserts2.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 16
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
                 "node_id": 16
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-declaration/type-predicate2.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
                 "node_id": 21
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 16
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/anonymous.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-body-shadow.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "VariableDeclarator(a)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-const.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-let.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 12
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested-body-shadow.snap
@@ -9,25 +9,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "VariableDeclarator(a)",
@@ -36,18 +36,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-nested.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 2,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -29,18 +29,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 16
@@ -48,7 +48,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-param-shadow.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 12
@@ -35,19 +35,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/readable-ref-partial.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
             "node_id": 13
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/default-params/writable-ref.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "b",
             "node": "FormalParameter(b)",
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/inherited-scope.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "parentScoped",
         "node": "VariableDeclarator(parentScoped)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "parentScoped",
             "node_id": 13
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/params.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 27
               },
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 2,
                 "name": "a",
                 "node_id": 36
@@ -32,42 +32,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "b",
             "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 4,
             "name": "c",
             "node": "FormalParameter(<destructure>)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "d",
             "node": "FormalParameter(d)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 6,
             "name": "e",
             "node": "FormalParameter(e)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 7,
             "name": "f",
             "node": "FormalParameter(f)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 8,
             "name": "g",
             "node": "FormalParameter(g)",
@@ -76,18 +76,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "outer",
         "node": "VariableDeclarator(outer)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "outer",
             "node_id": 31
@@ -95,14 +95,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 9,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/scope.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 1,
             "name": "i",
             "node": "VariableDeclarator(i)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "i",
                 "node_id": 16
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "j",
             "node": "VariableDeclarator(j)",
@@ -35,19 +35,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 3,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/body-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 16
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(BlockScopedVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable)",
             "id": 2,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/return-value-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-parameters/type-parameter-declaration.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
@@ -22,25 +22,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts1.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -21,12 +21,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate-asserts2.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 1,
             "name": "arg",
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "arg",
                 "node_id": 18
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/function-expression/type-predicate2.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(<anonymous>)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "arg",
             "node": "FormalParameter(arg)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "arg",
                 "node_id": 23
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/functions/funct
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "foo",
         "node": "VariableDeclarator(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/class.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/function.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(top)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "top",
         "node": "Function(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-const.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-let.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/module/variable-decl-var.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(FunctionScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(FunctionScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/class.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 6

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/function.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(top)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "top",
         "node": "Function(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-const.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-let.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(BlockScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resolution/script/variable-decl-var.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/global-resoluti
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+        "flags": "ScopeFlags(StrictMode | Function | Arrow)",
         "id": 1,
         "node": "ArrowFunctionExpression",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(FunctionScopedVariable | ArrowFunction)",
+        "flags": "SymbolFlags(FunctionScopedVariable | ArrowFunction)",
         "id": 0,
         "name": "top",
         "node": "VariableDeclarator(top)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "top",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implicit1.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/implicit/implic
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.snap
@@ -7,30 +7,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "v",
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 7
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
             "node_id": 12
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/default.
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals1.
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "foo",
         "node": "TSImportEqualsDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "foo",
             "node_id": 7

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 9
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
         ]
       },
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 1,
         "name": "foo",
         "node": "TSImportEqualsDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-alias.snap
@@ -7,30 +7,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-al
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "t",
         "node": "ImportSpecifier(t)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "t",
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "t",
             "node_id": 13
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named-al
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.snap
@@ -7,30 +7,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "v",
         "node": "ImportSpecifier(v)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 8
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
             "node_id": 13
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/named.ts
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespace.snap
@@ -7,30 +7,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespac
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "v",
         "node": "ImportNamespaceSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "v",
             "node_id": 7
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "v",
             "node_id": 12
@@ -38,7 +38,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/namespac
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default-value.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeImport)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "foo",
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 10
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-default.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeImport)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "T",
         "node": "ImportDefaultSpecifier",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 10
@@ -32,14 +32,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-def
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Ref",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline-value.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeImport)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "foo",
         "node": "ImportSpecifier(foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inline.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeImport)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "T",
         "node": "ImportSpecifier(T)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11
@@ -32,14 +32,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-inl
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Ref",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named-value.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeImport)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "foo",
         "node": "ImportSpecifier(foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type | TSTypeQuery)",
+            "flags": "ReferenceFlags(Type | TSTypeQuery)",
             "id": 0,
             "name": "foo",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-named.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeImport)",
+        "flags": "SymbolFlags(TypeImport)",
         "id": 0,
         "name": "T",
         "node": "ImportSpecifier(T)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11
@@ -32,14 +32,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/type-nam
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Ref",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 13
@@ -29,18 +29,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "Class(Bar)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 3,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 2,
                 "name": "T",
                 "node_id": 28
@@ -50,18 +50,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Foo",
             "node_id": 24
@@ -69,13 +69,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         ]
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 2,
         "name": "Bar",
         "node": "Class(Bar)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "Bar",
             "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-expressions/type-arguments2.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(makeBox)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -26,13 +26,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "value",
             "node": "FormalParameter(value)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "value",
                 "node_id": 19
@@ -43,18 +43,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 4,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 31
@@ -64,24 +64,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "makeBox",
         "node": "Function(makeBox)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 2,
             "name": "makeBox",
             "node_id": 27
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "makeBox",
             "node_id": 36
@@ -89,14 +89,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/instantiation-e
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 3,
         "name": "BoxFunc",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 5,
         "name": "makeStringBox",
         "node": "VariableDeclarator(makeStringBox)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-spread.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute-s
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
             "node_id": 17
@@ -24,7 +24,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/attribute.t
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "attr",
         "node": "VariableDeclarator(attr)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/children.ts
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "child",
         "node": "VariableDeclarator(child)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "child",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-intrinsic-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-intrinsic-name.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-i
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(div)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "div",
         "node": "Function(div)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced1.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "X",
         "node": "VariableDeclarator(X)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "X",
             "node_id": 21
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "Foo",
         "node": "VariableDeclarator(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-namespaced2.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(<anonymous>)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 21
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component-n
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "Foo",
         "node": "VariableDeclarator(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/component.t
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "Foo",
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxFragmentName.snap
@@ -5,19 +5,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportDefaultSpecifier",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 1,
         "name": "Fragment",
         "node": "ImportSpecifier(Fragment)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma-fragment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma-fragment.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportDefaultSpecifier",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/default-jsxPragma.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/def
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportDefaultSpecifier",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxFragmentName.snap
@@ -5,19 +5,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportDefaultSpecifier",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 1,
         "name": "Fragment",
         "node": "ImportSpecifier(Fragment)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma-jsxFragmentName.snap
@@ -5,26 +5,26 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportDefaultSpecifier",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 1,
         "name": "h",
         "node": "ImportSpecifier(h)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 2,
         "name": "Fragment",
         "node": "ImportSpecifier(Fragment)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsxPragma.snap
@@ -5,19 +5,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/factory/jsx
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportDefaultSpecifier",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 1,
         "name": "h",
         "node": "ImportSpecifier(h)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-children.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment-ch
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "child",
         "node": "VariableDeclarator(child)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "child",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.snap
@@ -5,7 +5,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/fragment.ts
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": []

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-type-param.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/generic-typ
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 13

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-attribute.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 5,
             "name": "props",
             "node": "FormalParameter(props)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 3,
                 "name": "props",
                 "node_id": 57
@@ -35,39 +35,39 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Import)",
+        "flags": "SymbolFlags(Import)",
         "id": 0,
         "name": "React",
         "node": "ImportNamespaceSpecifier",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "y",
         "node": "VariableDeclarator(y)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 3,
         "name": "FooProps",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "FooProps",
             "node_id": 45
@@ -75,19 +75,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/namespaced-
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 4,
         "name": "Foo",
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "Foo",
             "node_id": 24

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/text.tsx
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "Foo",
         "node": "VariableDeclarator(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
@@ -9,38 +9,38 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxide
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function | Arrow)",
+            "flags": "ScopeFlags(StrictMode | Function | Arrow)",
             "id": 2,
             "node": "ArrowFunctionExpression",
             "symbols": []
           },
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode | Function)",
+            "flags": "ScopeFlags(StrictMode | Function)",
             "id": 3,
             "node": "Function(<anonymous>)",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "React",
         "node": "VariableDeclarator(React)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 1,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expression/member-expression.snap
@@ -5,42 +5,42 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/member-expressi
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 7
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "x",
             "node_id": 14
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "x",
             "node_id": 21
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 3,
             "name": "x",
             "node_id": 28
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 4,
             "name": "x",
             "node_id": 35

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/new-expression.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class)",
+        "flags": "SymbolFlags(Class)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 10
@@ -32,13 +32,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "a",
         "node": "VariableDeclarator(a)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "a",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters1.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 11

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/type-parameters2.snap
@@ -5,12 +5,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/new-expression/
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "T",
         "node": "VariableDeclarator(T)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/external-ref.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/externa
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/externa
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 8

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member-ref.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 8
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
             ]
           },
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 2,
             "name": "b",
             "node": "TSEnumMember",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal-member.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
@@ -21,12 +21,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/literal
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-ref.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 0,
                 "name": "a",
                 "node_id": 8
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-
             ]
           },
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 2,
             "name": "b",
             "node": "TSEnumMember",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/member-
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.t
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
@@ -21,19 +21,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/scope.t
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-ref.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-re
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
             "references": []
           },
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 2,
             "name": "b",
             "node": "TSEnumMember",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-enum/self-re
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 9

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "Class(Foo)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 2,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Class | NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(Class | NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 16
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
         "node": "VariableDeclarator(usage)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(Foo)",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 2,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "Function(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 17
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
         "node": "VariableDeclarator(usage)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/namespace-variable.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | NameSpaceModule)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | NameSpaceModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "usage",
         "node": "VariableDeclarator(usage)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/global-augmentation.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/globa
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(global)",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | Ambient)",
+        "flags": "SymbolFlags(NameSpaceModule | Ambient)",
         "id": 0,
         "name": "global",
         "node": "TSModuleDeclaration(global)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/import.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/impor
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(Import)",
+            "flags": "SymbolFlags(Import)",
             "id": 1,
             "name": "bar",
             "node": "ImportSpecifier(bar)",
@@ -21,12 +21,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/impor
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | Ambient)",
+        "flags": "SymbolFlags(NameSpaceModule | Ambient)",
         "id": 0,
         "name": "foo",
         "node": "TSModuleDeclaration(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "Foo",
             "node": "VariableDeclarator(Foo)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 13
@@ -40,7 +40,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "usage",
         "node": "VariableDeclarator(usage)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -21,24 +21,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 2,
             "name": "Foo",
             "node_id": 20
@@ -46,7 +46,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -21,19 +21,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "unresolved",
         "node": "VariableDeclarator(unresolved)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 1,
         "node": "TSModuleDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
+            "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Export)",
             "id": 1,
             "name": "x",
             "node": "VariableDeclarator(x)",
@@ -21,18 +21,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 12

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-array-destructure.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(<destructure>)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 12
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-default.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-object-destructure.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(<destructure>)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 15
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter-rest.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "BindingRestElement",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/parameter.snap
@@ -7,19 +7,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "a",
             "node": "FormalParameter(a)",
@@ -28,18 +28,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "foo",
         "node": "Function(foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-array-destructure.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 10
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
         "node": "VariableDeclarator(<destructure>)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-const.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
         "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-let.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 1,
         "name": "x",
         "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-object-destructure.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "x",
         "node": "VariableDeclarator(<destructure>)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation/variable-var.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-annotation
         ]
       },
       {
-        "flag": "SymbolFlags(FunctionScopedVariable)",
+        "flags": "SymbolFlags(FunctionScopedVariable)",
         "id": 1,
         "name": "x",
         "node": "VariableDeclarator(x)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/angle-bracket.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 11
@@ -32,13 +32,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/as.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 11
@@ -32,13 +32,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/angle-bracket-assignment.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | Write)",
+            "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/as-assignment.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | Write)",
+            "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/assignment/non-null-assignment.snap
@@ -5,18 +5,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
 [
   {
     "children": [],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | Write)",
+            "flags": "ReferenceFlags(Read | Write)",
             "id": 0,
             "name": "x",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/satisfies.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 11
@@ -32,13 +32,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-assertion/
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 14

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional-nested.snap
@@ -11,18 +11,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "children": [
               {
                 "children": [],
-                "flag": "ScopeFlags(StrictMode)",
+                "flags": "ScopeFlags(StrictMode)",
                 "id": 3,
                 "node": "TSConditionalType",
                 "symbols": [
                   {
-                    "flag": "SymbolFlags(TypeParameter)",
+                    "flags": "SymbolFlags(TypeParameter)",
                     "id": 3,
                     "name": "U",
                     "node": "TSTypeParameter(U)",
                     "references": [
                       {
-                        "flag": "ReferenceFlags(Type)",
+                        "flags": "ReferenceFlags(Type)",
                         "id": 5,
                         "name": "U",
                         "node_id": 33
@@ -32,18 +32,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 ]
               }
             ],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "U",
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "U",
                     "node_id": 19
@@ -53,24 +53,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 9
               },
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 23
@@ -80,12 +80,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Test",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional1.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "V",
                 "node": "TSTypeParameter(V)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "V",
                     "node_id": 15
@@ -30,18 +30,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9
@@ -52,25 +52,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 3,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional2.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 1,
                 "name": "U",
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
                     "node_id": 10
@@ -30,32 +30,32 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional3.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "I",
                 "node": "TSTypeParameter(I)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
                     "node_id": 21
@@ -30,18 +30,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9
@@ -51,12 +51,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Test",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional4.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "I",
                 "node": "TSTypeParameter(I)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
                     "node_id": 19
@@ -30,18 +30,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9
@@ -51,12 +51,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Test",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/conditional5.snap
@@ -9,18 +9,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 2,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "I",
                 "node": "TSTypeParameter(I)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "I",
                     "node_id": 31
@@ -30,18 +30,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 9
@@ -51,12 +51,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Test",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/dual-type-value.snap
@@ -7,37 +7,37 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)",
         "id": 0,
         "name": "dual",
         "node": "VariableDeclarator(dual)",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "dual",
             "node_id": 12
           },
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 1,
             "name": "dual",
             "node_id": 16
@@ -45,14 +45,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "reference1",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 2,
         "name": "reference2",
         "node": "VariableDeclarator(reference2)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics1.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 16
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 20
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor-generics2.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 13
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/constructor.snap
@@ -7,37 +7,37 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics1.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 16
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 20
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function-generics2.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 13
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function1.snap
@@ -7,37 +7,37 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 17
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/function2.snap
@@ -7,24 +7,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "arg",
         "node": "VariableDeclarator(arg)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 0,
             "name": "arg",
             "node_id": 15
@@ -32,7 +32,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/array-pattern.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
                 "node_id": 14
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Fn",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/object-pattern.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
                 "node_id": 21
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Fn",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/function/params/rest-element.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "A",
             "node": "TSTypeParameter(A)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "A",
                 "node_id": 13
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Fn",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-qualifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-qualifier.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type-with-type-params.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Param",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Param",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/import-type.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access1.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access2.snap
@@ -7,38 +7,38 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -46,13 +46,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "K",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "K",
             "node_id": 21
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/index-access3.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 18
@@ -39,13 +39,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 1,
         "name": "k",
         "node": "VariableDeclarator(k)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 1,
             "name": "k",
             "node_id": 21
@@ -53,7 +53,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/infer-type-constraint.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,18 +16,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSConditionalType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 3,
                 "name": "Id",
                 "node": "TSTypeParameter(Id)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "Id",
                     "node_id": 28
@@ -37,18 +37,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 14
@@ -58,18 +58,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "X",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "X",
             "node_id": 25
@@ -77,7 +77,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Id",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage1.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "Parent",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Parent",
             "node_id": 6
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 1,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,18 +16,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSTypeAliasDeclaration",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode | TsModuleBlock)",
+        "flags": "ScopeFlags(StrictMode | TsModuleBlock)",
         "id": 2,
         "node": "TSModuleDeclaration(Member)",
         "symbols": [
           {
-            "flag": "SymbolFlags(Export | TypeAlias)",
+            "flags": "SymbolFlags(Export | TypeAlias)",
             "id": 2,
             "name": "unreferenced",
             "node": "TSTypeAliasDeclaration",
@@ -37,32 +37,32 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 4,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "unreferenced",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(NameSpaceModule)",
+        "flags": "SymbolFlags(NameSpaceModule)",
         "id": 1,
         "name": "Member",
         "node": "TSModuleDeclaration(Member)",
         "references": []
       },
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 3,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "A",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface2.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "A",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 7
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "B",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type1.snap
@@ -7,38 +7,38 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Color",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "Color",
             "node_id": 24
@@ -46,13 +46,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "Quantity",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "Quantity",
             "node_id": 21
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "SeussFish",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type2.snap
@@ -7,36 +7,36 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
                 "node_id": 14
               },
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 21
               },
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 5,
                 "name": "T",
                 "node_id": 28
               },
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 7,
                 "name": "T",
                 "node_id": 35
@@ -47,24 +47,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "EnthusiasticGreeting",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 8,
             "name": "EnthusiasticGreeting",
             "node_id": 40
@@ -72,7 +72,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "HELLO",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
@@ -7,26 +7,26 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 3,
         "node": "Function(setAlignment)",
         "symbols": [
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "value",
             "node": "FormalParameter(value)",
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "VerticalAlignment",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "VerticalAlignment",
             "node_id": 28
@@ -54,13 +54,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "HorizontalAlignment",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "HorizontalAlignment",
             "node_id": 31

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped-named.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,24 +16,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSMappedType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "k",
                 "node": "TSTypeParameter(k)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "k",
                     "node_id": 17
                   },
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 3,
                     "name": "k",
                     "node_id": 24
@@ -43,24 +43,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
             "node_id": 21
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/mapped.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,18 +16,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSMappedType",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "k",
                 "node": "TSTypeParameter(k)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 2,
                     "name": "k",
                     "node_id": 21
@@ -37,24 +37,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18
@@ -62,7 +62,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/qualified-name.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 11
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call-generics.snap
@@ -7,25 +7,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "U",
                 "node_id": 14
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18
@@ -54,7 +54,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/call.snap
@@ -7,37 +7,37 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18
@@ -45,7 +45,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct-generics.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,18 +16,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSConstructSignatureDeclaration",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "U",
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 0,
                     "name": "U",
                     "node_id": 15
@@ -37,24 +37,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 19
@@ -62,7 +62,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/construct.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,36 +16,36 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSConstructSignatureDeclaration",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 15
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 19
@@ -53,7 +53,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/index-sig.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 13
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,30 +16,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSMethodSignature",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 14
@@ -47,19 +47,19 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 21
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 2,
             "name": "T",
             "node_id": 25
@@ -67,7 +67,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-computed-name2.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
@@ -24,30 +24,30 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSMethodSignature",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 11
@@ -55,7 +55,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method-generics.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,18 +16,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSMethodSignature",
             "symbols": [
               {
-                "flag": "SymbolFlags(TypeParameter)",
+                "flags": "SymbolFlags(TypeParameter)",
                 "id": 2,
                 "name": "U",
                 "node": "TSTypeParameter(U)",
                 "references": [
                   {
-                    "flag": "ReferenceFlags(Type)",
+                    "flags": "ReferenceFlags(Type)",
                     "id": 1,
                     "name": "U",
                     "node_id": 21
@@ -37,24 +37,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 17
@@ -62,7 +62,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/method.snap
@@ -7,7 +7,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
@@ -16,36 +16,36 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "children": [
           {
             "children": [],
-            "flag": "ScopeFlags(StrictMode)",
+            "flags": "ScopeFlags(StrictMode)",
             "id": 3,
             "node": "TSMethodSignature",
             "symbols": []
           }
         ],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 17
           },
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 21
@@ -53,7 +53,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "x",
             "node_id": 14
@@ -39,13 +39,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T",
             "node_id": 18
@@ -53,7 +53,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property-computed-name2.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSEnumDeclaration(Foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(EnumMember)",
+            "flags": "SymbolFlags(EnumMember)",
             "id": 1,
             "name": "a",
             "node": "TSEnumMember",
@@ -22,24 +22,24 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(RegularEnum)",
+        "flags": "SymbolFlags(RegularEnum)",
         "id": 0,
         "name": "Foo",
         "node": "TSEnumDeclaration(Foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "Foo",
             "node_id": 11
@@ -47,7 +47,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/signatures/property.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 14
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled-rest.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 10
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-labelled.snap
@@ -7,38 +7,38 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 3,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T1",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T1",
             "node_id": 14
@@ -46,13 +46,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T2",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "T2",
             "node_id": 19
@@ -60,7 +60,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple-rest.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 9
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/tuple.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 9
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/body-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
@@ -22,18 +22,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 3,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
                 "node_id": 13
@@ -43,18 +43,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "A",
         "node": "TSInterfaceDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 9
@@ -62,7 +62,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 2,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration-extends.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/type-parameter-declaration.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSInterfaceDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
@@ -22,25 +22,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(Interface)",
+        "flags": "SymbolFlags(Interface)",
         "id": 0,
         "name": "Foo",
         "node": "TSInterfaceDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/tagged-template.snap
@@ -7,26 +7,26 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 2,
         "node": "Function(div)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": []
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 3,
             "name": "arg",
             "node": "FormalParameter(arg)",
@@ -35,18 +35,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "StyledPaymentProps",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 1,
             "name": "StyledPaymentProps",
             "node_id": 31
@@ -54,13 +54,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 1,
         "name": "div",
         "node": "Function(div)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "div",
             "node_id": 26
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 4,
         "name": "StyledPayment",
         "node": "VariableDeclarator(StyledPayment)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/body-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 8
@@ -28,12 +28,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Foo",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-param-reference.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Foo",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration-extends.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 10
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           },
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 2,
             "name": "U",
             "node": "TSTypeParameter(U)",
@@ -35,12 +35,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Foo",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/type-decl/type-parameter-declaration.snap
@@ -7,12 +7,12 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
@@ -22,25 +22,25 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "Foo",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-qualified.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 0,
             "name": "x",
             "node_id": 21
@@ -39,14 +39,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query-with-parameters.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode | Function)",
+        "flags": "ScopeFlags(StrictMode | Function)",
         "id": 1,
         "node": "Function(foo)",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 1,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 0,
                 "name": "T",
                 "node_id": 12
@@ -26,13 +26,13 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             ]
           },
           {
-            "flag": "SymbolFlags(FunctionScopedVariable)",
+            "flags": "SymbolFlags(FunctionScopedVariable)",
             "id": 2,
             "name": "y",
             "node": "FormalParameter(y)",
             "references": [
               {
-                "flag": "ReferenceFlags(Read)",
+                "flags": "ReferenceFlags(Read)",
                 "id": 1,
                 "name": "y",
                 "node_id": 19
@@ -43,18 +43,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": [
           {
-            "flag": "SymbolFlags(TypeParameter)",
+            "flags": "SymbolFlags(TypeParameter)",
             "id": 4,
             "name": "T",
             "node": "TSTypeParameter(T)",
             "references": [
               {
-                "flag": "ReferenceFlags(Type)",
+                "flags": "ReferenceFlags(Type)",
                 "id": 3,
                 "name": "T",
                 "node_id": 33
@@ -64,18 +64,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | Function)",
+        "flags": "SymbolFlags(BlockScopedVariable | Function)",
         "id": 0,
         "name": "foo",
         "node": "Function(foo)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 2,
             "name": "foo",
             "node_id": 29
@@ -83,7 +83,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(Export | TypeAlias)",
+        "flags": "SymbolFlags(Export | TypeAlias)",
         "id": 3,
         "name": "Foo",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-query.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
         "references": [
           {
-            "flag": "ReferenceFlags(Read | TSTypeQuery)",
+            "flags": "ReferenceFlags(Read | TSTypeQuery)",
             "id": 0,
             "name": "x",
             "node_id": 9
@@ -39,14 +39,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": []
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 2,
         "name": "Unresolved",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type1.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type1.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type2.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "A",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
             "node_id": 9
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "B",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type3.snap
@@ -7,31 +7,31 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       },
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 2,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",
         "references": [
           {
-            "flag": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "T",
             "node_id": 19
@@ -39,7 +39,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 1,
         "name": "A",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/typeof-import-type-with-qualifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/typeof-import-type-with-qualifier.snap
@@ -7,18 +7,18 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
     "children": [
       {
         "children": [],
-        "flag": "ScopeFlags(StrictMode)",
+        "flags": "ScopeFlags(StrictMode)",
         "id": 1,
         "node": "TSTypeAliasDeclaration",
         "symbols": []
       }
     ],
-    "flag": "ScopeFlags(StrictMode | Top)",
+    "flags": "ScopeFlags(StrictMode | Top)",
     "id": 0,
     "node": "Program",
     "symbols": [
       {
-        "flag": "SymbolFlags(TypeAlias)",
+        "flags": "SymbolFlags(TypeAlias)",
         "id": 0,
         "name": "T",
         "node": "TSTypeAliasDeclaration",

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -21,7 +21,7 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
             result.push_str(&get_scope_snapshot(semantic, child_ids.iter().copied()));
             result.push(',');
         }
-        result.push_str(format!("\"flag\": \"{flags:?}\",").as_str());
+        result.push_str(format!("\"flags\": \"{flags:?}\",").as_str());
         result.push_str(format!("\"id\": {},", scope_id.index()).as_str());
         result.push_str(
             format!(
@@ -39,7 +39,7 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
             }
             result.push('{');
             result.push_str(
-                format!("\"flag\": \"{:?}\",", semantic.symbols().get_flags(*symbol_id)).as_str(),
+                format!("\"flags\": \"{:?}\",", semantic.symbols().get_flags(*symbol_id)).as_str(),
             );
             result.push_str(format!("\"id\": {},", symbol_id.index()).as_str());
             result.push_str(format!("\"name\": {name:?},").as_str());
@@ -67,7 +67,8 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
                         }
                         let reference = &semantic.symbols().references[*reference_id];
                         result.push('{');
-                        result.push_str(format!("\"flag\": \"{:?}\",", reference.flags()).as_str());
+                        result
+                            .push_str(format!("\"flags\": \"{:?}\",", reference.flags()).as_str());
                         result.push_str(format!("\"id\": {},", reference_id.index()).as_str());
                         result.push_str(
                             format!("\"name\": {:?},", semantic.reference_name(reference)).as_str(),


### PR DESCRIPTION
Part of #4991.