### PR TITLE
fix(semantic): transform checker handle conditional scopes

### DIFF
--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1647,11 +1647,31 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
 
 # babel-plugin-transform-optional-catch-binding (2/4)
 * optional-catch-bindings/try-catch-block-no-binding/input.js
-  x Scopes mismatch after transform
+  x Bindings mismatch:
+  | previous ScopeId(0): ["_unused"]
+  | current  ScopeId(0): []
+
+  x Bindings mismatch:
+  | previous No scope
+  | current  ScopeId(2): []
+
+  x Bindings mismatch:
+  | previous ScopeId(2): []
+  | current  ScopeId(3): ["_unused"]
 
 
 * optional-catch-bindings/try-catch-finally-no-binding/input.js
-  x Scopes mismatch after transform
+  x Bindings mismatch:
+  | previous ScopeId(0): ["_unused"]
+  | current  ScopeId(0): []
+
+  x Bindings mismatch:
+  | previous No scope
+  | current  ScopeId(2): []
+
+  x Bindings mismatch:
+  | previous ScopeId(2): []
+  | current  ScopeId(3): ["_unused"]
 
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -8,7 +8,17 @@ Passed: 9/35
 
 # babel-plugin-transform-optional-catch-binding (0/1)
 * try-catch-shadow/input.js
-  x Scopes mismatch after transform
+  x Bindings mismatch:
+  | previous ScopeId(0): ["_unused", "_unused2"]
+  | current  ScopeId(0): ["_unused"]
+
+  x Bindings mismatch:
+  | previous No scope
+  | current  ScopeId(2): []
+
+  x Bindings mismatch:
+  | previous ScopeId(2): []
+  | current  ScopeId(3): ["_unused2"]
 
 
 
@@ -218,7 +228,9 @@ Passed: 9/35
 
 
 * refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
-  x Scopes mismatch after transform
+  x Bindings mismatch:
+  | previous No scope
+  | current  ScopeId(3): []
 
   x Reference mismatch:
   | previous ReferenceId(17): Some("_s2")
@@ -234,7 +246,13 @@ Passed: 9/35
 
 
 * refresh/includes-custom-hooks-into-the-signatures/input.jsx
-  x Scopes mismatch after transform
+  x Bindings mismatch:
+  | previous No scope
+  | current  ScopeId(2): []
+
+  x Bindings mismatch:
+  | previous No scope
+  | current  ScopeId(6): []
 
   x Reference mismatch:
   | previous ReferenceId(10): Some("_s")


### PR DESCRIPTION
Some scopes are conditional e.g. `ForStatement` only gets a scope when initializer has a binding (`for (let i = 0; ...)` vs `for (i = 0; ...)`).

Make transform compare this between post-transform and fresh semantics.