### PR TITLE
refactor(semantic): store all data in `PostTransformChecker` in transform checker

### DIFF
--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -9,7 +9,7 @@ use oxc::diagnostics::OxcDiagnostic;
 use oxc::minifier::CompressOptions;
 use oxc::parser::{ParseOptions, ParserReturn};
 use oxc::semantic::{
-    post_transform_checker::{PostTransformChecker, SemanticIds},
+    post_transform_checker::{check_semantic_after_transform, SemanticIds},
     SemanticBuilderReturn,
 };
 use oxc::span::{SourceType, Span};
@@ -32,8 +32,6 @@ pub struct Driver {
     pub panicked: bool,
     pub errors: Vec<OxcDiagnostic>,
     pub printed: String,
-    // states
-    pub checker: PostTransformChecker,
 }
 
 impl CompilerInterface for Driver {
@@ -93,7 +91,7 @@ impl CompilerInterface for Driver {
         transformer_return: &mut TransformerReturn,
     ) -> ControlFlow<()> {
         if self.check_semantic {
-            if let Some(errors) = self.checker.after_transform(
+            if let Some(errors) = check_semantic_after_transform(
                 &transformer_return.symbols,
                 &transformer_return.scopes,
                 program,

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -3,7 +3,7 @@ use std::{mem, ops::ControlFlow, path::Path};
 use oxc::{
     ast::ast::Program,
     diagnostics::OxcDiagnostic,
-    semantic::post_transform_checker::PostTransformChecker,
+    semantic::post_transform_checker::check_semantic_after_transform,
     span::SourceType,
     transformer::{TransformOptions, TransformerReturn},
     CompilerInterface,
@@ -13,7 +13,6 @@ pub struct Driver {
     options: TransformOptions,
     printed: String,
     errors: Vec<OxcDiagnostic>,
-    checker: PostTransformChecker,
 }
 
 impl CompilerInterface for Driver {
@@ -38,7 +37,7 @@ impl CompilerInterface for Driver {
         program: &mut Program<'_>,
         transformer_return: &mut TransformerReturn,
     ) -> ControlFlow<()> {
-        if let Some(errors) = self.checker.after_transform(
+        if let Some(errors) = check_semantic_after_transform(
             &transformer_return.symbols,
             &transformer_return.scopes,
             program,
@@ -52,12 +51,7 @@ impl CompilerInterface for Driver {
 
 impl Driver {
     pub fn new(options: TransformOptions) -> Self {
-        Self {
-            options,
-            printed: String::new(),
-            errors: vec![],
-            checker: PostTransformChecker::default(),
-        }
+        Self { options, printed: String::new(), errors: vec![] }
     }
 
     pub fn execute(


### PR DESCRIPTION
Pure refactor of transform checker. Store all scope data in `PostTransformChecker` so it doesn't need to be passed around. `SemanticData` contains a full set of all semantic data for semantic pass, so we have 2 instances of it for 1. after transform and 2. rebuilt semantic.