### PR TITLE
fix(semantic): transform checker catch more scope flags mismatches

### DIFF
--- a/crates/oxc_semantic/src/post_transform_checker.rs
+++ b/crates/oxc_semantic/src/post_transform_checker.rs
@@ -292,10 +292,9 @@ impl<'s> PostTransformChecker<'s> {
                 (Some(scope_id_after_transform), Some(scope_id_rebuilt)) => {
                     let scope_ids = Pair::new(scope_id_after_transform, scope_id_rebuilt);
                     let bindings = self.get_pair(scope_ids, get_sorted_bindings);
-                    if bindings.is_match() {
-                        continue;
+                    if bindings.is_mismatch() {
+                        self.errors.push_mismatch("Bindings mismatch", scope_ids, bindings);
                     }
-                    self.errors.push_mismatch("Bindings mismatch", scope_ids, bindings);
                     scope_ids
                 }
                 (Some(scope_id), None) => {

--- a/tasks/coverage/semantic_babel.snap
+++ b/tasks/coverage/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 12619ffe
 
 semantic_babel Summary:
 AST Parsed     : 2101/2101 (100.00%)
-Positive Passed: 1853/2101 (88.20%)
+Positive Passed: 1845/2101 (87.82%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-import/input.js
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["spawn"]
@@ -363,6 +363,11 @@ Bindings mismatch:
 after transform: ScopeId(4): ["T", "x"]
 rebuilt        : ScopeId(4): ["x"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/const/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
@@ -377,6 +382,16 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-const/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-declare-const/input.ts
 semantic error: Bindings mismatch:
@@ -455,6 +470,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/expor
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "a", "b"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "b"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/nested-same-name/input.ts
 semantic error: Semantic Collector failed after transform
@@ -843,6 +861,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/i
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "I", "T"]
 rebuilt        : ScopeId(0): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/issue-7742/input.ts
 semantic error: Bindings mismatch:
@@ -879,6 +900,21 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/n
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals"]
 rebuilt        : ScopeId(0): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/enum-block-scoped/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-after/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-before/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-func-in-declare-module/input.ts
 semantic error: Bindings mismatch:
@@ -922,6 +958,22 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/module-declaration-var-2/input.js
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-constenum-constenum/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-enum/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-ambient-class/input.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/semantic_misc.snap
+++ b/tasks/coverage/semantic_misc.snap
@@ -40,7 +40,19 @@ after transform: ScopeId(0): ["BrowserWorkingCopyBackupTracker", "CancellationTo
 rebuilt        : ScopeId(0): ["BrowserWorkingCopyBackupTracker", "DisposableStore", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "ILifecycleService", "ILogService", "IWorkingCopyBackupService", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
 
 tasks/coverage/misc/pass/oxc-4449.ts
-semantic error: Bindings mismatch:
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
 after transform: ScopeId(5): ["E", "baz"]
 rebuilt        : ScopeId(5): ["E"]
 Scope flags mismatch:

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: d8086f14
 
 semantic_typescript Summary:
 AST Parsed     : 6456/6456 (100.00%)
-Positive Passed: 3815/6456 (59.09%)
+Positive Passed: 3810/6456 (59.01%)
 tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -3389,6 +3389,11 @@ rebuilt        : ReferenceId(0): None
 Reference mismatch:
 after transform: ReferenceId(1): Some("a")
 rebuilt        : ReferenceId(1): None
+
+tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/emptyIndexer.ts
 semantic error: Bindings mismatch:
@@ -10447,6 +10452,14 @@ tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Test", "UnNullify", "v"]
 rebuilt        : ScopeId(0): ["v"]
+
+tasks/coverage/typescript/tests/cases/compiler/overload2.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries.ts
 semantic error: Bindings mismatch:
@@ -18446,6 +18459,11 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "x"]
 rebuilt        : ScopeId(0): ["x"]
 
+tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+
 tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionAndTypeArgumentInES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -21287,6 +21305,14 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 
+tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardEnums.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "I1", "a", "b", "f1", "obj", "subType", "union", "union2", "union3"]
@@ -21301,6 +21327,9 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Tag", "Tag2", "value"]
 rebuilt        : ScopeId(0): ["Tag2", "value"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
 semantic error: Bindings mismatch:
@@ -21422,7 +21451,10 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voi
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithEnumType.ts
-semantic error: Bindings mismatch:
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
 after transform: ScopeId(2): ["", "A", "B", "ENUM1"]
 rebuilt        : ScopeId(2): ["ENUM1"]
 Scope flags mismatch:
@@ -23442,6 +23474,11 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["IsIndexer", "IsNumberIndexer", "IsStringIndexer", "None", "SignatureFlags"]
 rebuilt        : ScopeId(1): ["SignatureFlags"]
 Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+
+tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum3.ts
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 406/953
+Passed: 403/953
 
 # All Passed:
 * babel-preset-react
@@ -1745,7 +1745,7 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
 
 
 
-# babel-plugin-transform-typescript (61/151)
+# babel-plugin-transform-typescript (58/151)
 * class/accessor-allowDeclareFields-false/input.ts
   x TS(18010): An accessibility modifier cannot be used with a private
   | identifier.
@@ -1797,6 +1797,12 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
   | after transform: ScopeId(1): ["A", "E"]
   | rebuilt        : ScopeId(1): ["E"]
 
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+
+* enum/const/input.ts
   x Scope flags mismatch:
   | after transform: ScopeId(1): ScopeFlags(StrictMode)
   | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -1981,6 +1987,12 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
   | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 
 
+* enum/scoped/input.ts
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+
 * enum/string-value/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(1): ["A", "A2", "B", "B2", "E"]
@@ -2051,6 +2063,10 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
   | after transform: ScopeId(13): ScopeFlags(StrictMode)
   | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 
+  x Scope flags mismatch:
+  | after transform: ScopeId(16): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+
   x Reference mismatch:
   | after transform: ReferenceId(0): Some("x")
   | rebuilt        : ReferenceId(0): None
@@ -2066,6 +2082,12 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
   x Reference mismatch:
   | after transform: ReferenceId(11): Some("E")
   | rebuilt        : ReferenceId(3): None
+
+
+* exports/export-const-enums/input.ts
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 
 
 * exports/export-import=/input.ts


### PR DESCRIPTION
There was a bug previously where scope flags were only checked if there was also a bindings mismatch.