### PR TITLE
fix(transformer-optional-catch-binding): the `unused` binding is not in the correct scope

### DIFF
--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -58,8 +58,13 @@ impl<'a> Traverse<'a> for OptionalCatchBinding<'a> {
         if clause.param.is_some() {
             return;
         }
-        let symbol_id =
-            ctx.generate_uid("unused", ctx.scoping.current_scope_id(), SymbolFlags::CatchVariable);
+
+        let block_scope_id = clause.body.scope_id.get().unwrap();
+        let symbol_id = ctx.generate_uid(
+            "unused",
+            block_scope_id,
+            SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
+        );
         let name = ctx.ast.atom(ctx.symbols().get_name(symbol_id));
         let binding_identifier =
             BindingIdentifier { span: SPAN, symbol_id: Cell::new(Some(symbol_id)), name };

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,8 +1,9 @@
 commit: 12619ffe
 
-Passed: 338/953
+Passed: 340/953
 
 # All Passed:
+* babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-react-display-name
 * babel-plugin-transform-react-jsx-source
 
@@ -1664,46 +1665,6 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
   x Reference flags mismatch:
   | after transform: ReferenceId(2): ReferenceFlags(Write)
   | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
-
-
-
-# babel-plugin-transform-optional-catch-binding (2/4)
-* optional-catch-bindings/try-catch-block-no-binding/input.js
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["_unused"]
-  | rebuilt        : ScopeId(0): []
-
-  x Bindings mismatch:
-  | after transform: ScopeId(3): []
-  | rebuilt        : ScopeId(3): ["_unused"]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(CatchVariable)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable |
-  | CatchVariable)
-
-  x Symbol scope ID mismatch:
-  | after transform: SymbolId(0): ScopeId(0)
-  | rebuilt        : SymbolId(0): ScopeId(3)
-
-
-* optional-catch-bindings/try-catch-finally-no-binding/input.js
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["_unused"]
-  | rebuilt        : ScopeId(0): []
-
-  x Bindings mismatch:
-  | after transform: ScopeId(3): []
-  | rebuilt        : ScopeId(3): ["_unused"]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(CatchVariable)
-  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable |
-  | CatchVariable)
-
-  x Symbol scope ID mismatch:
-  | after transform: SymbolId(0): ScopeId(0)
-  | rebuilt        : SymbolId(0): ScopeId(3)
 
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,30 +1,9 @@
 commit: 12619ffe
 
-Passed: 8/35
+Passed: 9/35
 
 # All Passed:
-
-
-
-# babel-plugin-transform-optional-catch-binding (0/1)
-* try-catch-shadow/input.js
-  x Bindings mismatch:
-  | after transform: ScopeId(0): ["_unused", "_unused2"]
-  | rebuilt        : ScopeId(0): ["_unused"]
-
-  x Bindings mismatch:
-  | after transform: ScopeId(3): []
-  | rebuilt        : ScopeId(3): ["_unused2"]
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(CatchVariable)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable |
-  | CatchVariable)
-
-  x Symbol scope ID mismatch:
-  | after transform: SymbolId(1): ScopeId(0)
-  | rebuilt        : SymbolId(1): ScopeId(3)
-
+* babel-plugin-transform-optional-catch-binding
 
 
 # babel-plugin-transform-typescript (2/7)


### PR DESCRIPTION
Blocked by #5008

In the SemanticBuilder, we insert all CatchClause parameters in the BlockStatement scope, a child-scope of CatchClause

https://github.com/oxc-project/oxc/blob/858f510d59cb9ea29cca36c31fdf037b0d627f2c/crates/oxc_semantic/src/builder.rs#L709-L718

So we should do the same thing in this plugin, but because CatchClause has no parameters, SemanticBuilder doesn't create scope for `CatchClause`. This cause we cannot find the `BlockStatement` scope_id.

This PR has changed to the correct logic. Just to wait #5008 solved 