### PR TITLE
feat(transformer): always pass in symbols and scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,6 +1905,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_isolated_declarations",
  "oxc_parser",
+ "oxc_semantic",
  "oxc_sourcemap",
  "oxc_span",
  "oxc_transformer",

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -4,6 +4,7 @@ use std::{env, path::Path};
 use oxc_allocator::Allocator;
 use oxc_codegen::CodeGenerator;
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_transformer::{
     ArrowFunctionsOptions, ES2015Options, ReactOptions, TransformOptions, Transformer,
@@ -47,6 +48,12 @@ fn main() {
         },
         ..Default::default()
     };
+
+    let (symbols, scopes) = SemanticBuilder::new(&source_text, source_type)
+        .build(&program)
+        .semantic
+        .into_symbol_table_and_scope_tree();
+
     let _ = Transformer::new(
         &allocator,
         path,
@@ -55,7 +62,7 @@ fn main() {
         ret.trivias.clone(),
         transform_options,
     )
-    .build(&mut program);
+    .build_with_symbols_and_scopes(symbols, scopes, &mut program);
 
     let printed = CodeGenerator::new().build(&program).source_text;
     println!("Transformed:\n");

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -36,7 +36,7 @@ use es2021::ES2021;
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::{ast::*, Trivias};
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::{ScopeTree, SemanticBuilder, SymbolTable};
+use oxc_semantic::{ScopeTree, SymbolTable};
 use oxc_span::SourceType;
 use oxc_traverse::{traverse_mut, Traverse, TraverseCtx};
 
@@ -100,16 +100,6 @@ impl<'a> Transformer<'a> {
             x2_es2016: ES2016::new(options.es2016, Rc::clone(&ctx)),
             x3_es2015: ES2015::new(options.es2015, ctx),
         }
-    }
-
-    pub fn build(mut self, program: &mut Program<'a>) -> TransformerReturn {
-        let (symbols, scopes) = SemanticBuilder::new(self.ctx.source_text, self.ctx.source_type)
-            .build(program)
-            .semantic
-            .into_symbol_table_and_scope_tree();
-        let allocator: &'a Allocator = self.ctx.ast.allocator;
-        let (symbols, scopes) = traverse_mut(&mut self, allocator, program, symbols, scopes);
-        TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes }
     }
 
     pub fn build_with_symbols_and_scopes(

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -241,6 +241,10 @@ impl Oxc {
         }
 
         if run_options.transform() {
+            let (symbols, scopes) = SemanticBuilder::new(source_text, source_type)
+                .build(program)
+                .semantic
+                .into_symbol_table_and_scope_tree();
             let options = TransformOptions::default();
             let result = Transformer::new(
                 &allocator,
@@ -250,7 +254,7 @@ impl Oxc {
                 ret.trivias.clone(),
                 options,
             )
-            .build(program);
+            .build_with_symbols_and_scopes(symbols, scopes, program);
             if !result.errors.is_empty() {
                 let errors = result.errors.into_iter().map(Error::from).collect::<Vec<_>>();
                 self.save_diagnostics(errors);

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -30,6 +30,7 @@ oxc_parser                = { workspace = true }
 oxc_span                  = { workspace = true }
 oxc_sourcemap             = { workspace = true }
 oxc_transformer           = { workspace = true }
+oxc_semantic              = { workspace = true }
 
 napi        = { workspace = true }
 napi-derive = { workspace = true }

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -109,7 +109,7 @@ codspeed_napi = ["criterion2/codspeed", "dep:serde", "dep:serde_json"]
 # e.g. `cargo build --release -p oxc_benchmark --bench parser --no-default-features --features parser`
 lexer = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
 parser = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
-transformer = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common", "dep:oxc_transformer"]
+transformer = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common", "dep:oxc_transformer", "dep:oxc_semantic"]
 semantic = ["dep:oxc_allocator", "dep:oxc_parser", "dep:oxc_semantic", "dep:oxc_span", "dep:oxc_tasks_common"]
 minifier = ["dep:oxc_allocator", "dep:oxc_minifier", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
 codegen = ["dep:oxc_allocator", "dep:oxc_codegen", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use oxc_parser::{Parser, ParserReturn};
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFiles;
 use oxc_transformer::{TransformOptions, Transformer};
@@ -23,6 +24,10 @@ fn bench_transformer(criterion: &mut Criterion) {
                     Parser::new(&allocator, source_text, source_type).parse();
                 let transform_options = TransformOptions::default();
                 let program = allocator.alloc(program);
+                let (symbols, scopes) = SemanticBuilder::new(source_text, source_type)
+                    .build(program)
+                    .semantic
+                    .into_symbol_table_and_scope_tree();
                 Transformer::new(
                     &allocator,
                     Path::new(&file.file_name),
@@ -31,7 +36,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                     trivias,
                     transform_options,
                 )
-                .build(program);
+                .build_with_symbols_and_scopes(symbols, scopes, program);
                 allocator
             });
         });


### PR DESCRIPTION
We no longer need to build semantic data inside the transformer.

The caller should be responsible for handling semantic data and its
errors.

The best way to achieve this in via `CompilerInterface`.

closes #3565