### PR TITLE
feat(transform_conformance): show printed output alongside with errors

### DIFF
--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 381/953
+Passed: 383/953
 
 # All Passed:
 * babel-preset-react
@@ -1864,29 +1864,7 @@ preset-env: unknown field `shippedProposals`, expected `targets` or `bugfixes`
 
 
 
-# babel-plugin-transform-typescript (49/151)
-* class/accessor-allowDeclareFields-false/input.ts
-  x TS(18010): An accessibility modifier cannot be used with a private
-  | identifier.
-   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/accessor-allowDeclareFields-false/input.ts:8:3]
- 7 |   abstract accessor prop6: number;
- 8 |   private accessor #p: any;
-   :   ^^^^^^^
- 9 | 
-   `----
-
-
-* class/accessor-allowDeclareFields-true/input.ts
-  x TS(18010): An accessibility modifier cannot be used with a private
-  | identifier.
-   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/accessor-allowDeclareFields-true/input.ts:8:3]
- 7 |   abstract accessor prop6: number;
- 8 |   private accessor #p: any;
-   :   ^^^^^^^
- 9 | 
-   `----
-
-
+# babel-plugin-transform-typescript (51/151)
 * class/head/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(1): ["T"]

--- a/tasks/transform_conformance/babel_exec.snap.md
+++ b/tasks/transform_conformance/babel_exec.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 20/23
+Passed: 18/23
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -8,7 +8,6 @@ Passed: 20/23
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
-* babel-plugin-transform-react-jsx-source
 
 
 # babel-preset-env (8/11)
@@ -19,6 +18,14 @@ exec failed
 exec failed
 
 * sanity/check-es2015-constants/exec.js
+exec failed
+
+
+# babel-plugin-transform-react-jsx-source (0/2)
+* react-source/basic-sample/exec.js
+exec failed
+
+* react-source/with-source/exec.js
 exec failed
 
 

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -10,6 +10,7 @@ use oxc::{
 };
 
 pub struct Driver {
+    filtered: bool,
     options: TransformOptions,
     printed: String,
     errors: Vec<OxcDiagnostic>,
@@ -43,28 +44,34 @@ impl CompilerInterface for Driver {
             program,
         ) {
             self.errors.extend(errors);
-            return ControlFlow::Break(());
+            if !self.filtered {
+                return ControlFlow::Break(());
+            }
         }
         ControlFlow::Continue(())
     }
 }
 
 impl Driver {
-    pub fn new(options: TransformOptions) -> Self {
-        Self { options, printed: String::new(), errors: vec![] }
+    pub fn new(filtered: bool, options: TransformOptions) -> Self {
+        Self { filtered, options, printed: String::new(), errors: vec![] }
+    }
+
+    pub fn errors(&mut self) -> Vec<OxcDiagnostic> {
+        mem::take(&mut self.errors)
+    }
+
+    pub fn printed(&mut self) -> String {
+        mem::take(&mut self.printed)
     }
 
     pub fn execute(
-        &mut self,
+        mut self,
         source_text: &str,
         source_type: SourceType,
         source_path: &Path,
-    ) -> Result<String, Vec<OxcDiagnostic>> {
+    ) -> Self {
         self.compile(source_text, source_type, source_path);
-        if self.errors.is_empty() {
-            Ok(mem::take(&mut self.printed))
-        } else {
-            Err(mem::take(&mut self.errors))
-        }
+        self
     }
 }

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -158,11 +158,11 @@ pub trait TestCase {
         false
     }
 
-    fn transform(&self, path: &Path) -> Result<String, Vec<OxcDiagnostic>> {
+    fn transform(&self, path: &Path, filtered: bool) -> Result<Driver, OxcDiagnostic> {
         let transform_options = match self.transform_options() {
             Ok(transform_options) => transform_options,
             Err(json_err) => {
-                return Err(vec![OxcDiagnostic::error(format!("{json_err:?}"))]);
+                return Err(OxcDiagnostic::error(format!("{json_err:?}")));
             }
         };
 
@@ -178,7 +178,12 @@ pub trait TestCase {
             source_type = source_type.with_typescript(true);
         }
 
-        Driver::new(transform_options.clone()).execute(&source_text, source_type, path)
+        let driver = Driver::new(filtered, transform_options.clone()).execute(
+            &source_text,
+            source_type,
+            path,
+        );
+        Ok(driver)
     }
 }
 
@@ -257,22 +262,21 @@ impl TestCase for ConformanceTestCase {
         match self.transform_options() {
             Ok(options) => {
                 transform_options.replace(options.clone());
-                match Driver::new(options.clone()).execute(&input, source_type, &self.path) {
-                    Ok(printed) => {
-                        transformed_code = printed;
-                    }
-                    Err(errors) => {
-                        let source = NamedSource::new(
-                            self.path.strip_prefix(project_root).unwrap().to_string_lossy(),
-                            input.to_string(),
-                        );
-                        let error = errors
-                            .into_iter()
-                            .map(|err| format!("{:?}", err.with_source_code(source.clone())))
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        actual_errors = get_babel_error(&error);
-                    }
+                let mut driver =
+                    Driver::new(filtered, options.clone()).execute(&input, source_type, &self.path);
+                transformed_code = driver.printed();
+                let errors = driver.errors();
+                if !errors.is_empty() {
+                    let source = NamedSource::new(
+                        self.path.strip_prefix(project_root).unwrap().to_string_lossy(),
+                        input.to_string(),
+                    );
+                    let error = errors
+                        .into_iter()
+                        .map(|err| format!("{:?}", err.with_source_code(source.clone())))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    actual_errors = get_babel_error(&error);
                 }
             }
             Err(json_err) => {
@@ -401,14 +405,11 @@ impl TestCase for ExecTestCase {
             println!("Input:\n{}\n", fs::read_to_string(&self.path).unwrap());
         }
 
-        let result = match self.transform(&self.path) {
-            Ok(result) => result,
+        let result = match self.transform(&self.path, filtered) {
+            Ok(mut driver) => driver.printed(),
             Err(error) => {
                 if filtered {
-                    println!(
-                        "Transform Errors:\n{}\n",
-                        error.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n")
-                    );
+                    println!("Transform Errors:\n{error:?}\n",);
                 }
                 return;
             }


### PR DESCRIPTION
closes #5098

```
cargo run -p oxc_transform_conformance -- --filter logical-assignment/arrow-functions-transform/input.js

Input:

var a;
a ||= () => {};
a &&= () => {};
a ??= () => {};


Expected:

var a;
a || (a = () => {});
a && (a = () => {});
a ?? (a = () => {});


Transformed:

var a;
a || (a = () => {});
a && (a = () => {});
a ?? (a = () => {});

Errors:

  x Symbol reference IDs mismatch:
  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
  | ReferenceId(6), ReferenceId(7), ReferenceId(8)]
  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]

  x Reference flags mismatch:
  | after transform: ReferenceId(4): ReferenceFlags(Write)
  | rebuilt        : ReferenceId(1): ReferenceFlags(Read | Write)

  x Reference flags mismatch:
  | after transform: ReferenceId(6): ReferenceFlags(Write)
  | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Write)

  x Reference flags mismatch:
  | after transform: ReferenceId(8): ReferenceFlags(Write)
  | rebuilt        : ReferenceId(5): ReferenceFlags(Read | Write)


Passed: true
```