### PR TITLE
chore(regular_expression): Update example to support RegExp constructor

### DIFF
--- a/crates/oxc_regular_expression/examples/parse_file.rs
+++ b/crates/oxc_regular_expression/examples/parse_file.rs
@@ -1,13 +1,15 @@
-#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stdout, clippy::cast_possible_truncation)]
 use std::{env, fs, path::Path, sync::Arc};
 
 use oxc_allocator::Allocator;
-use oxc_ast::AstKind;
+use oxc_ast::{ast, AstKind};
 use oxc_parser::Parser;
+use oxc_regular_expression::{FlagsParser, ParserOptions, PatternParser};
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 fn main() {
+    // 1. Get the file content and parse
     let name = env::args().nth(1).unwrap_or_else(|| "test.js".to_string());
     let path = Path::new(&name);
 
@@ -26,23 +28,31 @@ fn main() {
         return;
     }
 
+    // 2. Build the semantic to iteralate over the nodes
     let program = allocator.alloc(parser_ret.program);
     let semantic_ret = SemanticBuilder::new(&source_text, source_type).build(program);
     let semantic = semantic_ret.semantic;
 
+    // 3. Parse regular expressions
+    // - RegExpLiteral
+    // - new RegExp() with string or template literal if static
     for node in semantic.nodes().iter() {
         match node.kind() {
             AstKind::RegExpLiteral(re) => {
-                let literal = re.span.source_text(&source_text);
-                let parsed = oxc_regular_expression::Parser::new(
+                println!("🍀 {}", re.span.source_text(&source_text));
+
+                let parsed = PatternParser::new(
                     &allocator,
-                    literal,
-                    oxc_regular_expression::ParserOptions::default()
-                        .with_span_offset(re.span.start),
+                    re.regex.pattern.as_str(),
+                    ParserOptions {
+                        span_offset: re.span.start + 1,
+                        unicode_mode: re.regex.flags.contains(ast::RegExpFlags::U)
+                            || re.regex.flags.contains(ast::RegExpFlags::V),
+                        unicode_sets_mode: re.regex.flags.contains(ast::RegExpFlags::V),
+                    },
                 )
                 .parse();
 
-                println!("🍀 {literal}");
                 if let Err(error) = parsed {
                     let error = error.with_source_code(Arc::clone(&source_text));
                     println!("{error:?}");
@@ -51,18 +61,60 @@ fn main() {
                 println!("{parsed:#?}");
                 println!();
             }
-            AstKind::NewExpression(new_expr) => {
+            AstKind::NewExpression(new_expr)
                 if new_expr
                     .callee
                     .get_identifier_reference()
                     .filter(|ident| ident.name == "RegExp")
-                    .is_some()
-                {
-                    println!("👻 TODO: new RegExp(...)");
-                    println!();
+                    .is_some() =>
+            {
+                println!("🍀 {}", new_expr.span.source_text(&source_text));
+
+                let pattern = match new_expr.arguments.first() {
+                    Some(ast::Argument::StringLiteral(sl)) => &sl.value,
+                    Some(ast::Argument::TemplateLiteral(tl))
+                        if tl.is_no_substitution_template() =>
+                    {
+                        &tl.quasi().unwrap()
+                    }
+                    _ => {
+                        continue;
+                    }
+                };
+
+                let flags = match new_expr.arguments.get(1) {
+                    Some(ast::Argument::StringLiteral(sl)) => &sl.value,
+                    Some(ast::Argument::TemplateLiteral(tl))
+                        if tl.is_no_substitution_template() =>
+                    {
+                        &tl.quasi().unwrap()
+                    }
+                    _ => "",
+                };
+
+                let flags =
+                    FlagsParser::new(&allocator, flags, ParserOptions::default()).parse().unwrap();
+                let parsed = PatternParser::new(
+                    &allocator,
+                    pattern,
+                    ParserOptions {
+                        span_offset: new_expr.span.start + 12, // = "new RegExp(\"".len()
+                        unicode_mode: flags.unicode || flags.unicode_sets,
+                        unicode_sets_mode: flags.unicode_sets,
+                    },
+                )
+                .parse();
+
+                if let Err(error) = parsed {
+                    let error = error.with_source_code(Arc::clone(&source_text));
+                    println!("{error:?}");
+                    return;
                 }
+                println!("{parsed:#?}");
+                println!();
             }
             _ => {}
         }
     }
+    println!("✨ All parsed!");
 }

--- a/crates/oxc_regular_expression/examples/test.js
+++ b/crates/oxc_regular_expression/examples/test.js
@@ -1,3 +1,7 @@
-const re1 = /abc{1}/gsv;
-const re2 = new RegExp("ooo", "u");
-const re3 = /[\w--[v]]/gsv;
+// All of them should be the same result!
+[
+  /\1(.)\\"'`a/v,
+  new RegExp("\\1(.)\\\\\"'`\a","v"),
+  new RegExp('\\1(.)\\\\"\'`\a','v'),
+  new RegExp(`\\1(.)\\\\"'\`\a`,`v`),
+]


### PR DESCRIPTION
- Fix example to handle `new RegExp()` too
- Update NOTE comments

- - - 

Until I tried interacting with the actual AST parsed by `oxc_parser`, I thought that the current `oxc_regular_expression` lacked support for the `RegExp` constructor due to escape sequences.

This was because `"\""` remained `"\""` after reading the source text from `.js` files.

However, once it was parsed by `oxc_parser`, I found that everything was [resolved](https://github.com/oxc-project/oxc/blob/8ef85a43c019a1ce9aa50b61ec4dbb5dbaeb3b7b/crates/oxc_parser/src/lexer/string.rs)! (Wonderful work as usual. 👏🏻 )

Now there is nothing to worry about. 😌