### PR TITLE
refactor(semantic)!: always create a scope for `for` statements

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1345,7 +1345,7 @@ pub struct WhileStatement<'a> {
 
 /// For Statement
 #[ast(visit)]
-#[scope(if(self.init.as_ref().is_some_and(ForStatementInit::is_lexical_declaration)))]
+#[scope]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
@@ -1383,7 +1383,7 @@ pub enum ForStatementInit<'a> {
 
 /// For-In Statement
 #[ast(visit)]
-#[scope(if(self.left.is_lexical_declaration()))]
+#[scope]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
@@ -1419,7 +1419,7 @@ pub enum ForStatementLeft<'a> {
 }
 /// For-Of Statement
 #[ast(visit)]
-#[scope(if(self.left.is_lexical_declaration()))]
+#[scope]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -3504,16 +3504,11 @@ pub mod walk {
     pub fn walk_for_in_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForInStatement<'a>) {
         let kind = AstKind::ForInStatement(visitor.alloc(it));
         visitor.enter_node(kind);
-        let scope_events_cond = it.left.is_lexical_declaration();
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_for_statement_left(&it.left);
         visitor.visit_expression(&it.right);
         visitor.visit_statement(&it.body);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
@@ -3575,16 +3570,11 @@ pub mod walk {
     pub fn walk_for_of_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForOfStatement<'a>) {
         let kind = AstKind::ForOfStatement(visitor.alloc(it));
         visitor.enter_node(kind);
-        let scope_events_cond = it.left.is_lexical_declaration();
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_for_statement_left(&it.left);
         visitor.visit_expression(&it.right);
         visitor.visit_statement(&it.body);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
@@ -3592,11 +3582,7 @@ pub mod walk {
     pub fn walk_for_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatement<'a>) {
         let kind = AstKind::ForStatement(visitor.alloc(it));
         visitor.enter_node(kind);
-        let scope_events_cond =
-            it.init.as_ref().is_some_and(ForStatementInit::is_lexical_declaration);
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         if let Some(init) = &it.init {
             visitor.visit_for_statement_init(init);
         }
@@ -3607,9 +3593,7 @@ pub mod walk {
             visitor.visit_expression(update);
         }
         visitor.visit_statement(&it.body);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -3692,16 +3692,11 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ForInStatement;
         visitor.enter_node(kind);
-        let scope_events_cond = it.left.is_lexical_declaration();
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_for_statement_left(&mut it.left);
         visitor.visit_expression(&mut it.right);
         visitor.visit_statement(&mut it.body);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
@@ -3772,16 +3767,11 @@ pub mod walk_mut {
     ) {
         let kind = AstType::ForOfStatement;
         visitor.enter_node(kind);
-        let scope_events_cond = it.left.is_lexical_declaration();
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_for_statement_left(&mut it.left);
         visitor.visit_expression(&mut it.right);
         visitor.visit_statement(&mut it.body);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
@@ -3789,11 +3779,7 @@ pub mod walk_mut {
     pub fn walk_for_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ForStatement<'a>) {
         let kind = AstType::ForStatement;
         visitor.enter_node(kind);
-        let scope_events_cond =
-            it.init.as_ref().is_some_and(ForStatementInit::is_lexical_declaration);
-        if scope_events_cond {
-            visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        }
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         if let Some(init) = &mut it.init {
             visitor.visit_for_statement_init(init);
         }
@@ -3804,9 +3790,7 @@ pub mod walk_mut {
             visitor.visit_expression(update);
         }
         visitor.visit_statement(&mut it.body);
-        if scope_events_cond {
-            visitor.leave_scope();
-        }
+        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -945,11 +945,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_for_statement(&mut self, stmt: &ForStatement<'a>) {
         let kind = AstKind::ForStatement(self.alloc(stmt));
         self.enter_node(kind);
-        let is_lexical_declaration =
-            stmt.init.as_ref().is_some_and(ForStatementInit::is_lexical_declaration);
-        if is_lexical_declaration {
-            self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
-        }
+        self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
         if let Some(init) = &stmt.init {
             self.visit_for_statement_init(init);
         }
@@ -1007,19 +1003,14 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         });
         /* cfg */
 
-        if is_lexical_declaration {
-            self.leave_scope();
-        }
+        self.leave_scope();
         self.leave_node(kind);
     }
 
     fn visit_for_in_statement(&mut self, stmt: &ForInStatement<'a>) {
         let kind = AstKind::ForInStatement(self.alloc(stmt));
         self.enter_node(kind);
-        let is_lexical_declaration = stmt.left.is_lexical_declaration();
-        if is_lexical_declaration {
-            self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
-        }
+        self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
         self.visit_for_statement_left(&stmt.left);
 
@@ -1071,19 +1062,14 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         });
         /* cfg */
 
-        if is_lexical_declaration {
-            self.leave_scope();
-        }
+        self.leave_scope();
         self.leave_node(kind);
     }
 
     fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
         let kind = AstKind::ForOfStatement(self.alloc(stmt));
         self.enter_node(kind);
-        let is_lexical_declaration = stmt.left.is_lexical_declaration();
-        if is_lexical_declaration {
-            self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
-        }
+        self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
         self.visit_for_statement_left(&stmt.left);
 
@@ -1134,9 +1120,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         });
         /* cfg */
 
-        if is_lexical_declaration {
-            self.leave_scope();
-        }
+        self.leave_scope();
         self.leave_node(kind);
     }
 

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -539,27 +539,15 @@ impl<'a> Visit<'a> for ChildScopeCollector {
     }
 
     fn visit_for_statement(&mut self, stmt: &ForStatement<'a>) {
-        if let Some(scope_id) = stmt.scope_id.get() {
-            self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_for_statement(self, stmt);
-        }
+        self.scope_ids.push(stmt.scope_id.get().unwrap());
     }
 
     fn visit_for_in_statement(&mut self, stmt: &ForInStatement<'a>) {
-        if let Some(scope_id) = stmt.scope_id.get() {
-            self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_for_in_statement(self, stmt);
-        }
+        self.scope_ids.push(stmt.scope_id.get().unwrap());
     }
 
     fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
-        if let Some(scope_id) = stmt.scope_id.get() {
-            self.scope_ids.push(scope_id);
-        } else {
-            walk::walk_for_of_statement(self, stmt);
-        }
+        self.scope_ids.push(stmt.scope_id.get().unwrap());
     }
 
     fn visit_switch_statement(&mut self, stmt: &SwitchStatement<'a>) {

--- a/crates/oxc_traverse/src/walk.rs
+++ b/crates/oxc_traverse/src/walk.rs
@@ -1617,14 +1617,13 @@ pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_for_statement(&mut *node, ctx);
-    let mut previous_scope_id = None;
-    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_SCOPE_ID)
-        as *mut Cell<Option<ScopeId>>))
-        .get()
-    {
-        previous_scope_id = Some(ctx.current_scope_id());
-        ctx.set_current_scope_id(scope_id);
-    }
+    let previous_scope_id = ctx.current_scope_id();
+    ctx.set_current_scope_id(
+        (*((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
+    );
     ctx.push_stack(Ancestor::ForStatementInit(ancestor::ForStatementWithoutInit(node)));
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_INIT)
         as *mut Option<ForStatementInit>)
@@ -1650,9 +1649,7 @@ pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
         ctx,
     );
     ctx.pop_stack();
-    if let Some(previous_scope_id) = previous_scope_id {
-        ctx.set_current_scope_id(previous_scope_id);
-    }
+    ctx.set_current_scope_id(previous_scope_id);
     traverser.exit_for_statement(&mut *node, ctx);
 }
 
@@ -1723,14 +1720,13 @@ pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_for_in_statement(&mut *node, ctx);
-    let mut previous_scope_id = None;
-    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
-        as *mut Cell<Option<ScopeId>>))
-        .get()
-    {
-        previous_scope_id = Some(ctx.current_scope_id());
-        ctx.set_current_scope_id(scope_id);
-    }
+    let previous_scope_id = ctx.current_scope_id();
+    ctx.set_current_scope_id(
+        (*((node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
+    );
     ctx.push_stack(Ancestor::ForInStatementLeft(ancestor::ForInStatementWithoutLeft(node)));
     walk_for_statement_left(
         traverser,
@@ -1750,9 +1746,7 @@ pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
         ctx,
     );
     ctx.pop_stack();
-    if let Some(previous_scope_id) = previous_scope_id {
-        ctx.set_current_scope_id(previous_scope_id);
-    }
+    ctx.set_current_scope_id(previous_scope_id);
     traverser.exit_for_in_statement(&mut *node, ctx);
 }
 
@@ -1792,14 +1786,13 @@ pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_for_of_statement(&mut *node, ctx);
-    let mut previous_scope_id = None;
-    if let Some(scope_id) = (*((node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
-        as *mut Cell<Option<ScopeId>>))
-        .get()
-    {
-        previous_scope_id = Some(ctx.current_scope_id());
-        ctx.set_current_scope_id(scope_id);
-    }
+    let previous_scope_id = ctx.current_scope_id();
+    ctx.set_current_scope_id(
+        (*((node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap(),
+    );
     ctx.push_stack(Ancestor::ForOfStatementLeft(ancestor::ForOfStatementWithoutLeft(node)));
     walk_for_statement_left(
         traverser,
@@ -1819,9 +1812,7 @@ pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
         ctx,
     );
     ctx.pop_stack();
-    if let Some(previous_scope_id) = previous_scope_id {
-        ctx.set_current_scope_id(previous_scope_id);
-    }
+    ctx.set_current_scope_id(previous_scope_id);
     traverser.exit_for_of_statement(&mut *node, ctx);
 }
 

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -5076,8 +5076,8 @@ rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst17.ts
 semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(18)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(22)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(19), ScopeId(21)]
 
 tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
 semantic error: Unresolved references mismatch:
@@ -8449,8 +8449,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AB", "B", "C", "CD", "D", "x", "y"]
 rebuilt        : ScopeId(0): []
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("y")
 rebuilt        : ReferenceId(0): None
@@ -9596,20 +9596,20 @@ Bindings mismatch:
 after transform: ScopeId(3): ["A", "f", "i", "list"]
 rebuilt        : ScopeId(3): ["f", "i", "list"]
 Bindings mismatch:
-after transform: ScopeId(5): ["A", "ar", "f", "ret"]
-rebuilt        : ScopeId(5): ["ar", "f", "ret"]
+after transform: ScopeId(6): ["A", "ar", "f", "ret"]
+rebuilt        : ScopeId(6): ["ar", "f", "ret"]
 Bindings mismatch:
-after transform: ScopeId(8): ["A", "ar"]
-rebuilt        : ScopeId(8): ["ar"]
+after transform: ScopeId(9): ["A", "ar"]
+rebuilt        : ScopeId(9): ["ar"]
 Bindings mismatch:
-after transform: ScopeId(9): ["A", "B", "C", "f"]
-rebuilt        : ScopeId(9): ["f"]
+after transform: ScopeId(10): ["A", "B", "C", "f"]
+rebuilt        : ScopeId(10): ["f"]
 Bindings mismatch:
-after transform: ScopeId(12): ["A", "pred"]
-rebuilt        : ScopeId(12): ["pred"]
+after transform: ScopeId(13): ["A", "pred"]
+rebuilt        : ScopeId(13): ["pred"]
 Bindings mismatch:
-after transform: ScopeId(13): ["A", "pred", "where"]
-rebuilt        : ScopeId(13): ["pred", "where"]
+after transform: ScopeId(14): ["A", "pred", "where"]
+rebuilt        : ScopeId(14): ["pred", "where"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallableMembers.ts
 semantic error: Bindings mismatch:
@@ -19030,8 +19030,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19187,8 +19187,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43)]
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19308,8 +19308,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19438,8 +19438,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19604,8 +19604,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("console")
 rebuilt        : ReferenceId(8): None
@@ -19761,8 +19761,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43)]
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("console")
 rebuilt        : ReferenceId(8): None
@@ -19882,8 +19882,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -20012,8 +20012,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -26960,14 +26960,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "I", "a", "entries", "entries1", "entries2", "entries3", "entries4", "entries5", "entries6", "i", "o", "values", "values1", "values2", "values3", "values4", "values5", "values6", "x"]
 rebuilt        : ScopeId(0): ["E", "a", "entries", "entries1", "entries2", "entries3", "entries4", "entries5", "entries6", "i", "o", "values", "values1", "values2", "values3", "values4", "values5", "values6", "x"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
-after transform: ScopeId(2): ["A", "B", "E"]
-rebuilt        : ScopeId(2): ["E"]
+after transform: ScopeId(3): ["A", "B", "E"]
+rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
-after transform: ScopeId(2): ScopeFlags(0x0)
-rebuilt        : ScopeId(2): ScopeFlags(Function)
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
@@ -29582,7 +29582,7 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AOrArrA", "a", "arr", "x"]
 rebuilt        : ScopeId(0): ["a", "arr", "x"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["RegExp"]
@@ -30412,8 +30412,8 @@ rebuilt        : ScopeId(3): ["r1", "r2", "r3", "r4", "t", "u"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherValidOperation.ts
 semantic error: Bindings mismatch:
-after transform: ScopeId(3): ["T1", "T2", "resultIsT1", "x", "y"]
-rebuilt        : ScopeId(3): ["resultIsT1", "x", "y"]
+after transform: ScopeId(4): ["T1", "T2", "resultIsT1", "x", "y"]
+rebuilt        : ScopeId(4): ["resultIsT1", "x", "y"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandAnyType.ts
 semantic error: Unresolved references mismatch:
@@ -35463,8 +35463,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Point", "a", "declSpace", "fn", "p", "x"]
 rebuilt        : ScopeId(0): ["a", "declSpace", "fn", "p", "x"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
@@ -35544,8 +35544,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Point", "a", "declSpace", "fn", "p", "x"]
 rebuilt        : ScopeId(0): ["a", "declSpace", "fn", "p", "x"]
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(27), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
@@ -35642,8 +35642,8 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
 Bindings mismatch:
-after transform: ScopeId(9): ["T"]
-rebuilt        : ScopeId(9): []
+after transform: ScopeId(11): ["T"]
+rebuilt        : ScopeId(11): []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
 semantic error: Semantic Collector failed after transform
@@ -37701,7 +37701,7 @@ rebuilt        : ["tuple"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
 semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "x", "y"]


### PR DESCRIPTION
Part of #5008. Make scopes for `ForStatement`, `ForInStatement` and `ForOfStatement` unconditional. i.e. always create a scope, even if there is no lexical binding (e.g. `for (i of a) {}`).