### PR TITLE
refactor(ast_tools): remove support for `#[scope(if(...))]` attr

### DIFF
--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -438,21 +438,6 @@ impl<'a> VisitBuilder<'a> {
         let ident = visit_as.unwrap_or_else(|| struct_.ident());
         let scope_events =
             struct_.markers.scope.as_ref().map_or_else(Default::default, |markers| {
-                let cond = markers.r#if.as_ref().map(|cond| {
-                    let cond = cond.to_token_stream().replace_ident("self", &format_ident!("it"));
-                    quote!(let scope_events_cond = #cond;)
-                });
-                let maybe_conditional = |tk: TokenStream| {
-                    if cond.is_some() {
-                        quote! {
-                            if scope_events_cond {
-                                #tk
-                            }
-                        }
-                    } else {
-                        tk
-                    }
-                };
                 let flags = markers
                     .flags
                     .as_ref()
@@ -470,9 +455,8 @@ impl<'a> VisitBuilder<'a> {
                 } else {
                     flags
                 };
-                let mut enter = cond.as_ref().into_token_stream();
-                enter.extend(maybe_conditional(quote!(visitor.enter_scope(#flags, &it.scope_id);)));
-                let leave = maybe_conditional(quote!(visitor.leave_scope();));
+                let enter = quote!(visitor.enter_scope(#flags, &it.scope_id););
+                let leave = quote!(visitor.leave_scope(););
                 (enter, leave)
             });
 

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -93,7 +93,6 @@ impl From<&Ident> for CloneInAttribute {
 /// A struct representing the `#[scope(...)]` attribute.
 #[derive(Debug, Default)]
 pub struct ScopeAttribute {
-    pub r#if: Option<Expr>,
     pub flags: Option<Expr>,
     pub strict_if: Option<Expr>,
 }
@@ -104,7 +103,6 @@ impl Parse for ScopeAttribute {
         Ok(parsed.into_iter().fold(Self::default(), |mut acc, CommonAttribute { ident, args }| {
             let expr = parse2(args).expect("Invalid `#[scope]` input.");
             match ident.to_string().as_str() {
-                "if" => acc.r#if = Some(expr),
                 "flags" => acc.flags = Some(expr),
                 "strict_if" => acc.strict_if = Some(expr),
                 _ => {}


### PR DESCRIPTION
There are no longer any nodes with conditional scopes. Remove support for `#[scope(if(...))]` attr from `ast_tools` - it's no longer needed.