### PR TITLE
refactor(traverse): remove support for `#[scope(if(...))]` attr

### DIFF
--- a/crates/oxc_traverse/scripts/lib/parse.mjs
+++ b/crates/oxc_traverse/scripts/lib/parse.mjs
@@ -187,8 +187,10 @@ function parseScopeArgs(lines, scopeArgs) {
     return parseScopeArgsStr(scopeArgsStr, scopeArgs, position);
 }
 
+const SCOPE_ARGS_KEYS = {flags: 'flags', strict_if: 'strictIf'};
+
 function parseScopeArgsStr(argsStr, args, position) {
-    if (!args) args = {flags: 'ScopeFlags::empty()', if: null, strictIf: null};
+    if (!args) args = {flags: 'ScopeFlags::empty()', strictIf: null, enterScopeBefore: null};
 
     if (!argsStr) return args;
 
@@ -201,9 +203,9 @@ function parseScopeArgsStr(argsStr, args, position) {
 
     try {
         while (true) {
-            let [key] = matchAndConsume(/^([a-z_]+)\(/);
-            key = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-            position.assert(Object.hasOwn(args, key), `Unexpected scope macro arg: ${key}`);
+            const [keyRaw] = matchAndConsume(/^([a-z_]+)\(/);
+            const key = SCOPE_ARGS_KEYS[keyRaw];
+            position.assert(key, `Unexpected scope macro arg: ${key}`);
 
             let bracketCount = 1,
                 index = 0;

--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -74,32 +74,15 @@ function generateWalkForStruct(type, types) {
         }
 
         // TODO: Maybe this isn't quite right. `scope_id` fields are `Cell<Option<ScopeId>>`,
-        // so visitor is able to alter the `scope_id` of a node higher up the tree,
+        // so visitor is able to alter the `scope_id` of a node from higher up the tree,
         // but we don't take that into account.
         // Visitor should not do that though, so maybe it's OK.
         // In final version, we should not make `scope_id` fields `Cell`s to prevent this.
-        if (scopeArgs.if) {
-            enterScopeCode = `
-                let mut previous_scope_id = None;
-                if let Some(scope_id) = (*(${makeFieldCode(scopeIdField)})).get() {
-                    previous_scope_id = Some(ctx.current_scope_id());
-                    ctx.set_current_scope_id(scope_id);
-                }
-            `;
-
-            exitScopeCode = `
-                if let Some(previous_scope_id) = previous_scope_id {
-                    ctx.set_current_scope_id(previous_scope_id);
-                }
-            `;
-        } else {
-            enterScopeCode = `
-                let previous_scope_id = ctx.current_scope_id();
-                ctx.set_current_scope_id((*(${makeFieldCode(scopeIdField)})).get().unwrap());
-            `;
-
-            exitScopeCode = `ctx.set_current_scope_id(previous_scope_id);`;
-        }
+        enterScopeCode = `
+            let previous_scope_id = ctx.current_scope_id();
+            ctx.set_current_scope_id((*(${makeFieldCode(scopeIdField)})).get().unwrap());
+        `;
+        exitScopeCode = `ctx.set_current_scope_id(previous_scope_id);`;
     }
 
     const fieldsCodes = visitedFields.map((field, index) => {


### PR DESCRIPTION
Closes #5008.

There are no longer any nodes with conditional scopes. Remove support for `#[scope(if(...))]` attr from `oxc_traverse` codegen - it's no longer needed.