### PR TITLE
refactor(traverse): remove unnecessary imports

### DIFF
--- a/crates/oxc_traverse/scripts/lib/ancestor.mjs
+++ b/crates/oxc_traverse/scripts/lib/ancestor.mjs
@@ -113,13 +113,7 @@ export default function generateAncestorsCode(types) {
         use oxc_allocator::{Box, Vec};
         #[allow(clippy::wildcard_imports)]
         use oxc_ast::ast::*;
-        use oxc_span::{Atom, SourceType, Span};
-        use oxc_syntax::{
-            operator::{
-                AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
-            },
-            scope::ScopeId,
-        };
+        use oxc_syntax::scope::ScopeId;
 
         /// Type of [\`Ancestor\`].
         /// Used in [\`crate::TraverseCtx::retag_stack\`].

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -17,13 +17,7 @@ use memoffset::offset_of;
 use oxc_allocator::{Box, Vec};
 #[allow(clippy::wildcard_imports)]
 use oxc_ast::ast::*;
-use oxc_span::{Atom, SourceType, Span};
-use oxc_syntax::{
-    operator::{
-        AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
-    },
-    scope::ScopeId,
-};
+use oxc_syntax::scope::ScopeId;
 
 /// Type of [`Ancestor`].
 /// Used in [`crate::TraverseCtx::retag_stack`].


### PR DESCRIPTION
`Atom`, `SourceType` and `Span` from `oxc_span`, and operators from `oxc_syntax` are now re-exported from `oxc_ast` crate. Remove unnecessary `use` statements by importing them all from `oxc_ast`.