### PR TITLE
fix(linter) fix bug in fixer for prefer-function-type when interface is exported

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -206,8 +206,10 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
 
                                     Fix::new(
                                         format!(
-                                            "type {} = {};",
-                                            &interface_decl.id.name, &suggestion
+                                            "{} {} = {};",
+                                            if is_parent_exported { "export type" } else { "type" },
+                                            &interface_decl.id.name,
+                                            &suggestion
                                         ),
                                         Span::new(node_start, node_end),
                                     )
@@ -716,6 +718,11 @@ type X = {} & { (): void; };
             r"
 type X = {} & (() => void);
                       ",
+            None,
+        ),
+        (
+            "export interface AnyFn { (...args: any[]): any }",
+            "export type AnyFn = (...args: any[]) => any;",
             None,
         ),
     ];


### PR DESCRIPTION
part of https://github.com/oxc-project/oxc/issues/5103