### PR TITLE
refactor(ast): remove `#[non_exhaustive]` attr from `AstBuilder`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -14,7 +14,6 @@ use crate::ast::*;
 
 /// AST builder for creating AST nodes
 #[derive(Clone, Copy)]
-#[non_exhaustive]
 pub struct AstBuilder<'a> {
     pub allocator: &'a Allocator,
 }

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -57,7 +57,6 @@ impl Generator for AstBuilderGenerator {
                 ///@@line_break
                 /// AST builder for creating AST nodes
                 #[derive(Clone, Copy)]
-                #[non_exhaustive]
                 pub struct AstBuilder<'a> {
                     pub allocator: &'a Allocator,
                 }


### PR DESCRIPTION
Partially revert #4925. That PR's description gave no explanation of why this attribute is desirable.