### PR TITLE
refactor(transformer): remove unnecessary type annotation

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -108,7 +108,7 @@ impl<'a> Transformer<'a> {
         scopes: ScopeTree,
         program: &mut Program<'a>,
     ) -> TransformerReturn {
-        let allocator: &'a Allocator = self.ctx.ast.allocator;
+        let allocator = self.ctx.ast.allocator;
         let (symbols, scopes) = traverse_mut(&mut self, allocator, program, symbols, scopes);
         TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes }
     }


### PR DESCRIPTION
Remove unnecessary type annotation introduced in #4925.