### PR TITLE
refactor(semantic): rewrite handling of label statement errors

### DIFF
--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -16,7 +16,7 @@ pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
 
     match kind {
         AstKind::Program(_) => {
-            js::check_labeled_statement(ctx);
+            // js::check_labeled_statement(ctx);
             js::check_duplicate_class_elements(ctx);
         }
         AstKind::BindingIdentifier(ident) => {
@@ -47,6 +47,7 @@ pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::BreakStatement(stmt) => js::check_break_statement(stmt, node, ctx),
         AstKind::ContinueStatement(stmt) => js::check_continue_statement(stmt, node, ctx),
         AstKind::LabeledStatement(stmt) => {
+            js::check_labeled_statement(stmt, node, ctx);
             js::check_function_declaration(&stmt.body, true, ctx);
         }
         AstKind::ForInStatement(stmt) => {

--- a/crates/oxc_semantic/src/label.rs
+++ b/crates/oxc_semantic/src/label.rs
@@ -1,156 +1,37 @@
-use oxc_ast::ast::LabeledStatement;
-use oxc_span::Span;
-use rustc_hash::FxHashSet;
-
 use crate::AstNodeId;
 
 #[derive(Debug)]
-pub struct Label<'a> {
-    pub id: AstNodeId,
+pub struct LabeledScope<'a> {
     pub name: &'a str,
-    pub span: Span,
-    used: bool,
-    /// depth is the number of nested labeled statements
-    pub depth: usize,
-    /// is accessible means that the label is accessible from the current position
-    is_accessible: bool,
-    /// is_inside_function_or_static_block means that the label is inside a function or static block
-    is_inside_function_or_static_block: bool,
+    pub used: bool,
+    pub parent: usize,
 }
 
-impl<'a> Label<'a> {
-    pub fn new(
-        id: AstNodeId,
-        name: &'a str,
-        span: Span,
-        depth: usize,
-        is_inside_function_or_static_block: bool,
-    ) -> Self {
-        Self {
-            id,
-            name,
-            span,
-            depth,
-            is_inside_function_or_static_block,
-            used: false,
-            is_accessible: true,
-        }
-    }
+#[derive(Debug, Default)]
+pub struct UnusedLabels<'a> {
+    pub scopes: Vec<LabeledScope<'a>>,
+    pub curr_scope: usize,
+    pub labels: Vec<AstNodeId>,
 }
 
-#[derive(Default)]
-pub struct LabelBuilder<'a> {
-    pub labels: Vec<Vec<Label<'a>>>,
-    depth: usize,
-    pub unused_node_ids: FxHashSet<AstNodeId>,
-}
-
-impl<'a> LabelBuilder<'a> {
-    pub fn enter(&mut self, stmt: &'a LabeledStatement<'a>, current_node_id: AstNodeId) {
-        let is_empty = self.labels.last().map_or(false, Vec::is_empty);
-
-        if !self.is_inside_labeled_statement() {
-            self.labels.push(vec![]);
-        }
-
-        self.depth += 1;
-
-        self.labels.last_mut().unwrap_or_else(|| unreachable!()).push(Label::new(
-            current_node_id,
-            stmt.label.name.as_str(),
-            stmt.label.span,
-            self.depth,
-            is_empty,
-        ));
+impl<'a> UnusedLabels<'a> {
+    pub fn add(&mut self, name: &'a str) {
+        self.scopes.push(LabeledScope { name, used: false, parent: self.curr_scope });
+        self.curr_scope = self.scopes.len() - 1;
     }
 
-    pub fn leave(&mut self) {
-        let depth = self.depth;
-
-        // Mark labels at the current depth as inaccessible
-        // ```ts
-        // label: {} // leave here, mark label as inaccessible
-        // break label // So we cannot find label here
-        // ```
-        for label in self.get_accessible_labels_mut() {
-            if depth == label.depth {
-                label.is_accessible = false;
-            }
-        }
-
-        // If depth is 0, move last labels to the front of `labels` and set `depth` to the length of the last labels.
-        // We need to do this because we're currently inside a function or static block
-        while self.depth == 0 {
-            if let Some(last_labels) = self.labels.pop() {
-                if !last_labels.is_empty() {
-                    self.labels.insert(0, last_labels);
-                }
-            }
-            self.depth = self.labels.last().unwrap().len();
-        }
-
-        self.depth -= 1;
-
-        // insert unused labels into `unused_node_ids`
-        if self.depth == 0 {
-            if let Some(labels) = self.labels.last() {
-                for label in labels {
-                    if !label.used {
-                        self.unused_node_ids.insert(label.id);
-                    }
-                }
-            }
+    pub fn reference(&mut self, name: &'a str) {
+        let scope = self.scopes.iter_mut().rev().find(|x| x.name == name);
+        if let Some(scope) = scope {
+            scope.used = true;
         }
     }
 
-    pub fn enter_function_or_static_block(&mut self) {
-        if self.is_inside_labeled_statement() {
-            self.depth = 0;
-            self.labels.push(vec![]);
+    pub fn mark_unused(&mut self, current_node_id: AstNodeId) {
+        let scope = &self.scopes[self.curr_scope];
+        if !scope.used {
+            self.labels.push(current_node_id);
         }
-    }
-
-    pub fn leave_function_or_static_block(&mut self) {
-        if self.is_inside_labeled_statement() {
-            let labels = self.labels.pop().unwrap_or_else(|| unreachable!());
-            if !labels.is_empty() {
-                self.labels.insert(0, labels);
-            }
-            self.depth = self.labels.last().map_or(0, Vec::len);
-        }
-    }
-
-    pub fn is_inside_labeled_statement(&self) -> bool {
-        self.depth != 0 || self.labels.last().is_some_and(Vec::is_empty)
-    }
-
-    pub fn is_inside_function_or_static_block(&self) -> bool {
-        self.labels
-            .last()
-            .is_some_and(|labels| labels.is_empty() || labels[0].is_inside_function_or_static_block)
-    }
-
-    pub fn get_accessible_labels(&self) -> impl DoubleEndedIterator<Item = &Label<'a>> {
-        return self.labels.last().unwrap().iter().filter(|label| label.is_accessible).rev();
-    }
-
-    pub fn get_accessible_labels_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Label<'a>> {
-        return self
-            .labels
-            .last_mut()
-            .unwrap()
-            .iter_mut()
-            .filter(|label| label.is_accessible)
-            .rev();
-    }
-
-    pub fn mark_as_used(&mut self, label: &oxc_ast::ast::LabelIdentifier) {
-        if self.is_inside_labeled_statement() {
-            let label = self.get_accessible_labels_mut().find(|x| x.name == label.name);
-
-            if let Some(label) = label {
-                label.used = true;
-            }
-        }
+        self.curr_scope = scope.parent;
     }
 }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -36,7 +36,6 @@ pub use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
-use rustc_hash::FxHashSet;
 
 pub use crate::{
     reference::{Reference, ReferenceFlags, ReferenceId},
@@ -83,7 +82,7 @@ pub struct Semantic<'a> {
     /// Parsed JSDoc comments.
     jsdoc: JSDocFinder<'a>,
 
-    unused_labels: FxHashSet<AstNodeId>,
+    unused_labels: Vec<AstNodeId>,
 
     /// Control flow graph. Only present if [`Semantic`] is built with cfg
     /// creation enabled using [`SemanticBuilder::with_cfg`].
@@ -150,7 +149,7 @@ impl<'a> Semantic<'a> {
         &self.symbols
     }
 
-    pub fn unused_labels(&self) -> &FxHashSet<AstNodeId> {
+    pub fn unused_labels(&self) -> &Vec<AstNodeId> {
         &self.unused_labels
     }
 

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -23861,7 +23861,7 @@ Negative Passed: 4220/4220 (100.00%)
  24 │     var y=2;
     ╰────
 
-  × Use of undefined label
+  × Jump target cannot cross function boundary.
     ╭─[test262/test/language/statements/break/S12.8_A5_T1.js:23:15]
  22 │             return;
  23 │         break LABEL_ANOTHER_LOOP;
@@ -23869,7 +23869,7 @@ Negative Passed: 4220/4220 (100.00%)
  24 │         LABEL_IN_2 : y++;
     ╰────
 
-  × Use of undefined label
+  × Jump target cannot cross function boundary.
     ╭─[test262/test/language/statements/break/S12.8_A5_T2.js:25:15]
  24 │             return;
  25 │         break IN_DO_FUNC;
@@ -23877,7 +23877,7 @@ Negative Passed: 4220/4220 (100.00%)
  26 │         LABEL_IN_2 : y++;
     ╰────
 
-  × Use of undefined label
+  × Jump target cannot cross function boundary.
     ╭─[test262/test/language/statements/break/S12.8_A5_T3.js:25:15]
  24 │             return;
  25 │         break LABEL_IN;
@@ -30352,7 +30352,7 @@ Negative Passed: 4220/4220 (100.00%)
  21 │   }
     ╰────
 
-  × Use of undefined label
+  × Jump target cannot cross function boundary.
     ╭─[test262/test/language/statements/class/static-init-invalid-undefined-break-target.js:22:13]
  21 │     x: while (false) {
  22 │       break y;
@@ -30360,7 +30360,7 @@ Negative Passed: 4220/4220 (100.00%)
  23 │     }
     ╰────
 
-  × Use of undefined label
+  × Jump target cannot cross function boundary.
     ╭─[test262/test/language/statements/class/static-init-invalid-undefined-continue-target.js:22:16]
  21 │     x: while (false) {
  22 │       continue y;

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -8118,15 +8118,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFro
    ╰────
   help: A `continue` statement can only be used within an enclosing `for`, `while` or `do while`
 
-  × Illegal continue statement: no surrounding iteration statement
-   ╭─[typescript/tests/cases/compiler/invalidContinueInDownlevelAsync.ts:3:9]
- 2 │     if (true) {
- 3 │         continue;
-   ·         ─────────
- 4 │     }
-   ╰────
-  help: A `continue` statement can only be used within an enclosing `for`, `while` or `do while`
-
   × Expected `;` but found `[`
    ╭─[typescript/tests/cases/compiler/invalidLetInForOfAndForIn_ES5.ts:5:13]
  4 │ var let = 10;
@@ -21438,7 +21429,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFro
  28 │             return toFixed()
     ╰────
 
-  × Use of undefined label
+  × Jump target cannot cross function boundary.
     ╭─[typescript/tests/cases/conformance/salsa/plainJSBinderErrors.ts:34:19]
  33 │             label: var x = 1
  34 │             break label


### PR DESCRIPTION
This reverts the previous changes to handling labels so that all tests can pass.

This passes all false postivies found in `monitor-oxc` (node_modules/flow-parser/flow_parser.js)

As it turns out this requires less code and produces better diagnostics.