### PR TITLE
fix(linter/no-unused-vars): function expression in implicit arrow function return

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -52,7 +52,15 @@ impl<'s, 'a> Symbol<'s, 'a> {
                 AstKind::AssignmentExpression(assignment) if assignment.right.span().contains_inclusive(self.span()) => {
                     return self != &assignment.left;
                 }
+                AstKind::ExpressionStatement(_) => {
+                    // implicit return in arrow function expression
+                    let Some(AstKind::FunctionBody(body)) = self.nodes().parent_kind(parent.id()) else {
+                        return false;
+                    };
+                    return body.span.contains_inclusive(self.span()) && body.statements.len() == 1 && !self.get_snippet(body.span).starts_with('{')
+                }
                 _ => {
+                    parent.kind().debug_name();
                     return false;
                 }
             }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -459,9 +459,15 @@ fn test_functions() {
                 };
             });
         ",
+        "const foo = () => function bar() { }\nfoo()",
+        "module.exports.foo = () => function bar() { }"
     ];
 
-    let fail = vec!["function foo() {}", "function foo() { foo() }"];
+    let fail = vec![
+        "function foo() {}",
+        "function foo() { foo() }",
+        "const foo = () => { function bar() { } }\nfoo()",
+    ];
 
     let fix = vec![
         // function declarations are never removed

--- a/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-functions.snap
+++ b/crates/oxc_linter/src/snapshots/no_unused_vars@oxc-functions.snap
@@ -16,3 +16,12 @@ source: crates/oxc_linter/src/tester.rs
    ·           ╰── 'foo' is declared here
    ╰────
   help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable 'bar' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:30]
+ 1 │ const foo = () => { function bar() { } }
+   ·                              ─┬─
+   ·                               ╰── 'bar' is declared here
+ 2 │ foo()
+   ╰────
+  help: Consider removing this declaration.


### PR DESCRIPTION
Fixes cases such as:
```ts
export const foo = () => function bar() {}
```