### PR TITLE
refactor(ast): rename `IdentifierReference::new_with_reference_id`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -325,11 +325,17 @@ impl<'a> Hash for IdentifierReference<'a> {
 }
 
 impl<'a> IdentifierReference<'a> {
+    #[inline]
     pub fn new(span: Span, name: Atom<'a>) -> Self {
         Self { span, name, reference_id: Cell::default() }
     }
 
-    pub fn new_read(span: Span, name: Atom<'a>, reference_id: Option<ReferenceId>) -> Self {
+    #[inline]
+    pub fn new_with_reference_id(
+        span: Span,
+        name: Atom<'a>,
+        reference_id: Option<ReferenceId>,
+    ) -> Self {
         Self { span, name, reference_id: Cell::new(reference_id) }
     }
 

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -1019,7 +1019,7 @@ fn get_read_identifier_reference<'a>(
 ) -> IdentifierReference<'a> {
     let reference_id =
         ctx.create_reference_in_current_scope(name.to_compact_str(), ReferenceFlags::Read);
-    IdentifierReference::new_read(span, name, Some(reference_id))
+    IdentifierReference::new_with_reference_id(span, name, Some(reference_id))
 }
 
 fn create_static_member_expression<'a>(

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -595,7 +595,11 @@ impl<'a> Assignment<'a> {
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
         let reference_id = ctx.create_bound_reference(self.symbol_id, ReferenceFlags::Read);
-        let id = IdentifierReference::new_read(self.span, self.name.clone(), Some(reference_id));
+        let id = IdentifierReference::new_with_reference_id(
+            self.span,
+            self.name.clone(),
+            Some(reference_id),
+        );
 
         ctx.ast.statement_expression(
             SPAN,


### PR DESCRIPTION
The old name `new_read` no longer makes sense as it doesn't set a read-only flag any more, since `flags` field was removed from `IdentifierReference`.