### PR TITLE
fix(linter): bug in fixer for prefer-to-have-length

### DIFF
--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -55,7 +55,7 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
     // NOTE(@DonIsaac): Internal methods shouldn't use `T: Into<Foo>` generics to optimize binary
     // size. Only use such generics in public APIs.
-    fn new_fix(&self, fix: CompositeFix<'a>, message: Option<Cow<'a, str>>) -> RuleFix<'a> {
+    pub fn new_fix(&self, fix: CompositeFix<'a>, message: Option<Cow<'a, str>>) -> RuleFix<'a> {
         RuleFix::new(self.kind, message, fix)
     }
 

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -55,7 +55,7 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
     // NOTE(@DonIsaac): Internal methods shouldn't use `T: Into<Foo>` generics to optimize binary
     // size. Only use such generics in public APIs.
-    pub fn new_fix(&self, fix: CompositeFix<'a>, message: Option<Cow<'a, str>>) -> RuleFix<'a> {
+    fn new_fix(&self, fix: CompositeFix<'a>, message: Option<Cow<'a, str>>) -> RuleFix<'a> {
         RuleFix::new(self.kind, message, fix)
     }
 

--- a/crates/oxc_linter/src/snapshots/prefer_to_have_length.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_to_have_length.snap
@@ -6,67 +6,75 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(files["length"]).toBe(1);
    ·                         ────
    ╰────
-  help: Replace `expect(files["length"]).toBe` with `expect(files).toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:25]
  1 │ expect(files["length"]).toBe(1,);
    ·                         ────
    ╰────
-  help: Replace `expect(files["length"]).toBe` with `expect(files).toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:32]
  1 │ expect(files["length"])["not"].toBe(1);
    ·                                ────
    ╰────
-  help: Replace `expect(files["length"])["not"].toBe` with `expect(files)["not"].toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:25]
  1 │ expect(files["length"])["toBe"](1);
    ·                         ──────
    ╰────
-  help: Replace `expect(files["length"])["toBe"]` with `expect(files).toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:29]
  1 │ expect(files["length"]).not["toBe"](1);
    ·                             ──────
    ╰────
-  help: Replace `expect(files["length"]).not["toBe"]` with `expect(files).not.toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:32]
  1 │ expect(files["length"])["not"]["toBe"](1);
    ·                                ──────
    ╰────
-  help: Replace `expect(files["length"])["not"]["toBe"]` with `expect(files)["not"].toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:22]
  1 │ expect(files.length).toBe(1);
    ·                      ────
    ╰────
-  help: Replace `expect(files.length).toBe` with `expect(files).toHaveLength`.
+  help: Use `toHaveLength` instead of `toBe`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:22]
  1 │ expect(files.length).toEqual(1);
    ·                      ───────
    ╰────
-  help: Replace `expect(files.length).toEqual` with `expect(files).toHaveLength`.
+  help: Use `toHaveLength` instead of `toEqual`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:22]
  1 │ expect(files.length).toStrictEqual(1);
    ·                      ─────────────
    ╰────
-  help: Replace `expect(files.length).toStrictEqual` with `expect(files).toHaveLength`.
+  help: Use `toHaveLength` instead of `toStrictEqual`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:26]
  1 │ expect(files.length).not.toStrictEqual(1);
    ·                          ─────────────
    ╰────
-  help: Replace `expect(files.length).not.toStrictEqual` with `expect(files).not.toHaveLength`.
+  help: Use `toHaveLength` instead of `toStrictEqual`.
+
+  ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
+   ╭─[prefer_to_have_length.tsx:1:55]
+ 1 │ expect((meta.get('pages') as YArray<unknown>).length).toBe(
+   ·                                                       ────
+ 2 │   (originalMeta.get('pages') as YArray<unknown>).length
+   ╰────
+  help: Use `toHaveLength` instead of `toBe`.

--- a/crates/oxc_linter/src/snapshots/prefer_to_have_length.snap
+++ b/crates/oxc_linter/src/snapshots/prefer_to_have_length.snap
@@ -6,75 +6,74 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(files["length"]).toBe(1);
    ·                         ────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files["length"]).toBe` with `expect(files).toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:25]
  1 │ expect(files["length"]).toBe(1,);
    ·                         ────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files["length"]).toBe` with `expect(files).toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:32]
  1 │ expect(files["length"])["not"].toBe(1);
    ·                                ────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files["length"])["not"].toBe` with `expect(files)["not"].toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:25]
  1 │ expect(files["length"])["toBe"](1);
    ·                         ──────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files["length"])["toBe"]` with `expect(files).toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:29]
  1 │ expect(files["length"]).not["toBe"](1);
    ·                             ──────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files["length"]).not["toBe"]` with `expect(files).not.toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:32]
  1 │ expect(files["length"])["not"]["toBe"](1);
    ·                                ──────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files["length"])["not"]["toBe"]` with `expect(files)["not"].toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:22]
  1 │ expect(files.length).toBe(1);
    ·                      ────
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect(files.length).toBe` with `expect(files).toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:22]
  1 │ expect(files.length).toEqual(1);
    ·                      ───────
    ╰────
-  help: Use `toHaveLength` instead of `toEqual`.
+  help: Replace `expect(files.length).toEqual` with `expect(files).toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:22]
  1 │ expect(files.length).toStrictEqual(1);
    ·                      ─────────────
    ╰────
-  help: Use `toHaveLength` instead of `toStrictEqual`.
+  help: Replace `expect(files.length).toStrictEqual` with `expect(files).toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:26]
  1 │ expect(files.length).not.toStrictEqual(1);
    ·                          ─────────────
    ╰────
-  help: Use `toHaveLength` instead of `toStrictEqual`.
+  help: Replace `expect(files.length).not.toStrictEqual` with `expect(files).not.toHaveLength`.
 
   ⚠ eslint-plugin-jest(prefer-to-have-length): Suggest using `toHaveLength()`.
    ╭─[prefer_to_have_length.tsx:1:55]
- 1 │ expect((meta.get('pages') as YArray<unknown>).length).toBe(
+ 1 │ expect((meta.get('pages') as YArray<unknown>).length).toBe((originalMeta.get('pages') as YArray<unknown>).length);
    ·                                                       ────
- 2 │   (originalMeta.get('pages') as YArray<unknown>).length
    ╰────
-  help: Use `toHaveLength` instead of `toBe`.
+  help: Replace `expect((meta.get('pages') as YArray<unknown>).length).toBe` with `expect((meta.get('pages') as YArray<unknown>)).toHaveLength`.


### PR DESCRIPTION
closes #5132 

I exposed the `new_fix` of `RuleFixer` to support custom multi-step fixes, and I'm not sure if this is allowed.