### PR TITLE
fix(linter/unicorn): improve diagnostic message for `no-null`

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_null.snap
+++ b/crates/oxc_linter/src/snapshots/no_null.snap
@@ -1,256 +1,256 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:13]
  1 │ const foo = null
    ·             ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:5]
  1 │ foo(null)
    ·     ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:12]
  1 │ if (foo == null) {}
    ·            ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:12]
  1 │ if (foo != null) {}
    ·            ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:5]
  1 │ if (null == foo) {}
    ·     ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:5]
  1 │ if (null != foo) {}
    ·     ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:2:20]
  1 │ function foo() {
  2 │             return null;
    ·                    ────
  3 │             }
    ╰────
-  help: Remove the `null` literal.
+  help: Delete this code.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:11]
  1 │ let foo = null;
    ·           ────
    ╰────
-  help: Remove the `null` literal.
+  help: Delete this code.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:11]
  1 │ var foo = null;
    ·           ────
    ╰────
-  help: Remove the `null` literal.
+  help: Delete this code.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:20]
  1 │ var foo = 1, bar = null, baz = 2;
    ·                    ────
    ╰────
-  help: Remove the `null` literal.
+  help: Delete this code.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:13]
  1 │ const foo = null;
    ·             ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:13]
  1 │ if (foo === null) {}
    ·             ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:5]
  1 │ if (null === foo) {}
    ·     ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:13]
  1 │ if (foo !== null) {}
    ·             ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:5]
  1 │ if (null !== foo) {}
    ·     ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:19]
  1 │ new Object.create(null)
    ·                   ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:27]
  1 │ new foo.insertBefore(bar, null)
    ·                           ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:8]
  1 │ create(null)
    ·        ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:19]
  1 │ insertBefore(bar, null)
    ·                   ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:18]
  1 │ Object['create'](null)
    ·                  ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:26]
  1 │ foo['insertBefore'](bar, null)
    ·                          ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:16]
  1 │ Object[create](null)
    ·                ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:24]
  1 │ foo[insertBefore](bar, null)
    ·                        ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:8]
  1 │ Object[null](null)
    ·        ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:14]
  1 │ Object[null](null)
    ·              ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:18]
  1 │ Object.notCreate(null)
    ·                  ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:26]
  1 │ foo.notInsertBefore(foo, null)
    ·                          ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:18]
  1 │ NotObject.create(null)
    ·                  ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:19]
  1 │ lib.Object.create(null)
    ·                   ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:19]
  1 │ Object.create(...[null])
    ·                   ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:15]
  1 │ Object.create(null, bar, extraArgument)
    ·               ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:18]
  1 │ foo.insertBefore(null)
    ·                  ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:23]
  1 │ foo.insertBefore(foo, null, bar)
    ·                       ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:28]
  1 │ foo.insertBefore(...[foo], null)
    ·                            ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:18]
  1 │ foo.insertBefore(null, bar)
    ·                  ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.
 
-  ⚠ eslint-plugin-unicorn(no-null): Disallow the use of the `null` literal
+  ⚠ eslint-plugin-unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:20]
  1 │ Object.create(bar, null)
    ·                    ────
    ╰────
-  help: Replace the `null` literal with `undefined`.
+  help: Replace `null` with `undefined`.


### PR DESCRIPTION
This stack was made because of shortcomings I noticed while running `oxlint-eccosystem-ci` tests locally