### PR TITLE
feat(transformer/arrow-functions): the output that uses `this` inside blocks doesn't match Babel

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 
 pub use arrow_functions::{ArrowFunctions, ArrowFunctionsOptions};
 pub use options::ES2015Options;
-use oxc_allocator::Vec;
 use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
 
@@ -34,15 +33,21 @@ impl<'a> ES2015<'a> {
 }
 
 impl<'a> Traverse<'a> for ES2015<'a> {
-    fn enter_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+    fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.arrow_function.is_some() {
-            self.arrow_functions.enter_statements(stmts, ctx);
+            self.arrow_functions.exit_program(program, ctx);
         }
     }
 
-    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+    fn enter_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.arrow_function.is_some() {
-            self.arrow_functions.exit_statements(stmts, ctx);
+            self.arrow_functions.enter_function(func, ctx);
+        }
+    }
+
+    fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.options.arrow_function.is_some() {
+            self.arrow_functions.exit_function(func, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -123,6 +123,7 @@ impl<'a> Traverse<'a> for Transformer<'a> {
     fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x1_react.transform_program_on_exit(program, ctx);
         self.x0_typescript.transform_program_on_exit(program, ctx);
+        self.x3_es2015.exit_program(program, ctx);
     }
 
     // ALPHASORT
@@ -202,8 +203,14 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x0_typescript.transform_formal_parameter(param);
     }
 
-    fn enter_function(&mut self, func: &mut Function<'a>, _ctx: &mut TraverseCtx<'a>) {
+    fn enter_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x0_typescript.transform_function(func);
+        self.x3_es2015.enter_function(func, ctx);
+    }
+
+    fn exit_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.x0_typescript.transform_function(func);
+        self.x3_es2015.exit_function(func, ctx);
     }
 
     fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, _ctx: &mut TraverseCtx<'a>) {
@@ -261,7 +268,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x2_es2021.enter_statements(stmts, ctx);
         self.x2_es2020.enter_statements(stmts, ctx);
         self.x2_es2016.enter_statements(stmts, ctx);
-        self.x3_es2015.enter_statements(stmts, ctx);
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
@@ -270,7 +276,6 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x2_es2021.exit_statements(stmts, ctx);
         self.x2_es2020.exit_statements(stmts, ctx);
         self.x2_es2016.exit_statements(stmts, ctx);
-        self.x3_es2015.exit_statements(stmts, ctx);
     }
 
     fn enter_tagged_template_expression(

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,9 +1,35 @@
 commit: 12619ffe
 
-Passed: 9/35
+Passed: 9/36
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
+
+
+# babel-plugin-transform-arrow-functions (0/1)
+* use-this-inside-blocks/input.js
+  x Bindings mismatch:
+  | after transform: ScopeId(1): []
+  | rebuilt        : ScopeId(1): ["_this"]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(3): ["_this"]
+  | rebuilt        : ScopeId(3): []
+
+  x Symbol scope ID mismatch:
+  | after transform: SymbolId(3): ScopeId(3)
+  | rebuilt        : SymbolId(1): ScopeId(1)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
+  | ArrowFunction)
+  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ArrowFunction)
+  | rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+
 
 
 # babel-plugin-transform-typescript (2/7)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-arrow-functions"]]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/use-this-inside-blocks/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/use-this-inside-blocks/input.js
@@ -1,0 +1,4 @@
+function foo() {
+  { let f = () => this; }
+  { let f2 = () => this; }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/use-this-inside-blocks/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/use-this-inside-blocks/output.js
@@ -1,0 +1,13 @@
+function foo() {
+	var _this = this;
+	{
+					let f = function() {
+									return _this;
+					};
+	}
+	{
+					let f2 = function() {
+									return _this;
+					};
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/blob/666282a13b172de849e251eb3b8417bfb19a79cb/crates/oxc_transformer/src/es2015/arrow_functions.rs#L35-L62