### PR TITLE
fix(transformer/arrow-functions): remove `SymbolFlags::ArrowFunction`

### DIFF
--- a/crates/oxc_semantic/src/symbol.rs
+++ b/crates/oxc_semantic/src/symbol.rs
@@ -102,6 +102,11 @@ impl SymbolTable {
     }
 
     #[inline]
+    pub fn get_flags_mut(&mut self, symbol_id: SymbolId) -> &mut SymbolFlags {
+        &mut self.flags[symbol_id]
+    }
+
+    #[inline]
     pub fn get_redeclarations(&self, symbol_id: SymbolId) -> &[Span] {
         if let Some(redeclaration_id) = self.redeclarations[symbol_id] {
             &self.redeclaration_spans[redeclaration_id]

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -207,6 +207,20 @@ impl<'a> Traverse<'a> for ArrowFunctions<'a> {
     fn exit_class(&mut self, _class: &mut Class<'a>, _ctx: &mut TraverseCtx<'a>) {
         self.stacks.pop();
     }
+
+    fn enter_variable_declarator(
+        &mut self,
+        node: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if !matches!(node.init, Some(Expression::ArrowFunctionExpression(_))) {
+            return;
+        }
+
+        let Some(id) = node.id.get_binding_identifier() else { return };
+        *ctx.symbols_mut().get_flags_mut(id.symbol_id.get().unwrap()) &=
+            !SymbolFlags::ArrowFunction;
+    }
 }
 
 impl<'a> ArrowFunctions<'a> {

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -331,6 +331,14 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x2_es2019.enter_catch_clause(clause, ctx);
     }
 
+    fn enter_variable_declarator(
+        &mut self,
+        node: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x3_es2015.enter_variable_declarator(node, ctx);
+    }
+
     fn enter_ts_export_assignment(
         &mut self,
         export_assignment: &mut TSExportAssignment<'a>,

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 281/953
+Passed: 282/953
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -1341,12 +1341,6 @@ Targets: The `esmodules` is not supported
 
 
 * preset-options/ios-6/input.mjs
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | ArrowFunction)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
 
 
 * preset-options/no-options/input.mjs
@@ -1419,12 +1413,6 @@ Targets: The `esmodules` is not supported
 
 
 * preset-options-babel-7/ios-6/input.mjs
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | ArrowFunction)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
 
 
 * preset-options-babel-7/loose-typeof-symbol/input.mjs
@@ -1916,53 +1904,20 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 
-# babel-plugin-transform-arrow-functions (0/6)
+# babel-plugin-transform-arrow-functions (1/6)
 * assumption-newableArrowFunctions-false/basic/input.js
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 
 
 * assumption-newableArrowFunctions-false/naming/input.js
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
-  | ConstVariable | ArrowFunction)
-  | rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable |
-  | ConstVariable)
 
 
 * assumption-newableArrowFunctions-false/self-referential/input.js
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 
 
 * spec/newableArrowFunction-default/input.js
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 
 * spec/newableArrowFunction-vs-spec-false/input.js
-  x Output mismatch
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-
-* spec/newableArrowFunction-vs-spec-true/input.js
-  x Symbol flags mismatch:
-  | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,23 +1,10 @@
 commit: 12619ffe
 
-Passed: 9/36
+Passed: 10/36
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
-
-
-# babel-plugin-transform-arrow-functions (0/1)
-* use-this-inside-blocks/input.js
-  x Symbol flags mismatch:
-  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-
-  x Symbol flags mismatch:
-  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
-  | ArrowFunction)
-  | rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-
+* babel-plugin-transform-arrow-functions
 
 
 # babel-plugin-transform-typescript (2/7)


### PR DESCRIPTION
`ArrowFunction` has been transforming to `FunctionExpression`, So we should remove `SymbolFlags::ArrowFunction`