### PR TITLE
refactor(linter): remove meaningless `span0`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -6,10 +6,10 @@ use regex::{Regex, RegexBuilder};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn default_case_diagnostic(span0: Span) -> OxcDiagnostic {
+fn default_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require default cases in switch statements.")
         .with_help("Add a default case.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/default_case_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case_last.rs
@@ -5,9 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn default_case_last_diagnostic(span0: Span) -> OxcDiagnostic {
+fn default_case_last_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce default clauses in switch statements to be last")
-        .with_label(span0.label("Default clause should be the last clause."))
+        .with_label(span.label("Default clause should be the last clause."))
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/default_param_last.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_param_last.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn default_param_last_diagnostic(span0: Span) -> OxcDiagnostic {
+fn default_param_last_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Default parameters should be last")
         .with_help("Enforce default parameters to be last.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -18,10 +18,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn getter_return_diagnostic(span0: Span) -> OxcDiagnostic {
+fn getter_return_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected to always return a value in getter.")
         .with_help("Return a value from all code paths in getter.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
+++ b/crates/oxc_linter/src/rules/eslint/guard_for_in.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn guard_for_in_diagnostic(span0: Span) -> OxcDiagnostic {
+fn guard_for_in_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require `for-in` loops to include an `if` statement")
         .with_help("The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_array_constructor_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_array_constructor_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow `Array` constructors")
         .with_help("Use array literal instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_async_promise_executor_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Promise executor functions should not be `async`.").with_label(span0)
+fn no_async_promise_executor_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Promise executor functions should not be `async`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_await_in_loop_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected `await` inside a loop.").with_label(span0)
+fn no_await_in_loop_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected `await` inside a loop.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_caller.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_caller.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_caller_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_caller_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow the use of arguments.caller or arguments.callee")
         .with_help("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_case_declarations_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected lexical declaration in case block.").with_label(span0)
+fn no_case_declarations_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected lexical declaration in case block.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_cond_assign_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_cond_assign_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a conditional expression and instead saw an assignment")
         .with_help("Consider wrapping the assignment in additional parentheses")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_console_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected console statement.").with_label(span0)
+fn no_console_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected console statement.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -62,16 +62,16 @@ fn constant_binary_operand(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
         .with_label(span2)
 }
 
-fn constant_always_new(span0: Span) -> OxcDiagnostic {
+fn constant_always_new(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected comparison to newly constructed object")
         .with_help("These two values can never be equal")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn constant_both_always_new(span0: Span) -> OxcDiagnostic {
+fn constant_both_always_new(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected comparison of two newly constructed objects")
         .with_help("These two values can never be equal")
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for NoConstantBinaryExpression {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{ast_util::IsConstant, context::LintContext, rule::Rule, AstNode};
 
-fn no_constant_condition_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_constant_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected constant condition")
         .with_help("Constant expression as a test condition is not allowed")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_continue_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_continue_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of `continue` statement.")
         .with_help("Do not use the `continue` statement.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_debugger_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`debugger` statement is not allowed").with_label(span0)
+fn no_debugger_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`debugger` statement is not allowed").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -6,8 +6,8 @@ use oxc_syntax::operator::UnaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_delete_var_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("variables should not be deleted").with_label(span0)
+fn no_delete_var_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("variables should not be deleted").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_div_regex.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_div_regex_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_div_regex_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("A regular expression literal can be confused with '/='.")
         .with_help("Rewrite `/=` into `/[=]`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -8,10 +8,10 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_character_class_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_empty_character_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Empty character class")
         .with_help("Try to remove empty character class `[]` in regexp literal")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_function_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_empty_function_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty functions")
         .with_help("Unexpected empty function block")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_static_block_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_empty_static_block_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty static blocks")
         .with_help("Unexpected empty static block.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eq_null.rs
@@ -8,10 +8,10 @@ use oxc_syntax::operator::BinaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_eq_null_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_eq_null_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use '===' to compare with null")
         .with_help("Disallow `null` comparisons without type-checking operators.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -7,8 +7,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_eval_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eval can be harmful.").with_label(span0)
+fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("eval can be harmful.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_ex_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_label(span0)
+fn no_ex_assign_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not assign to the exception parameter.").with_help("If a catch clause in a try statement accidentally (or purposely) assigns another value to the exception parameter, it is impossible to refer to the error from that point on. Since there is no arguments object to offer alternative access to this data, assignment of the parameter is absolutely destructive.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -7,16 +7,16 @@ use oxc_syntax::operator::{LogicalOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_extra_double_negation_cast_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_extra_double_negation_cast_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Redundant double negation")
         .with_help("Remove the double negation as it will already be coerced to a boolean")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn no_extra_boolean_cast_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_extra_boolean_cast_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Redundant Boolean call")
         .with_help("Remove the Boolean call as it will already be coerced to a boolean")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -8,10 +8,10 @@ use phf::phf_set;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_import_assign_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_import_assign_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("do not assign to imported bindings")
         .with_help("imported bindings are readonly")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -4,10 +4,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_irregular_whitespace_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_irregular_whitespace_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected irregular whitespace")
         .with_help("Try to remove the irregular whitespace")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_iterator.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_iterator.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_iterator_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_iterator_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Reserved name '__iterator__'")
         .with_help("Disallow the use of the `__iterator__` property.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -7,8 +7,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_loss_of_precision_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This number literal will lose precision at runtime.").with_label(span0)
+fn no_loss_of_precision_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This number literal will lose precision at runtime.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -6,8 +6,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_multi_str_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected multi string.").with_label(span0)
+fn no_multi_str_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected multi string.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -5,8 +5,8 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_new_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use 'new' for side effects.").with_label(span0)
+fn no_new_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use 'new' for side effects.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_proto.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_proto.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_proto_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_proto_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The '__proto__' property is deprecated")
         .with_help("Disallow the use of the `__proto__` property.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -9,10 +9,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_regex_spaces_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_regex_spaces_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Spaces are hard to count.")
         .with_help("Use a quantifier, e.g. {2}")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_script_url_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_script_url_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Script URL is a form of eval")
         .with_help("Disallow `javascript:` urls")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -13,8 +13,8 @@ use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_self_assign_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("this expression is assigned to itself").with_label(span0)
+fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("this expression is assigned to itself").with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_setter_return_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Setter cannot return a value").with_label(span0)
+fn no_setter_return_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Setter cannot return a value").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_template_curly_in_string_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_template_curly_in_string_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected template string expression")
         .with_help("Disallow template literal placeholder syntax in regular strings")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_ternary_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_ternary_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of ternary expression")
         .with_help("Do not use the ternary expression.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -15,10 +15,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_this_before_super_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_this_before_super_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected to always call super() before this/super property access.")
         .with_help("Call super() before this/super property access.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -8,10 +8,10 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[derive(Debug, Default, Clone)]
 pub struct NoUndefined;
 
-fn no_undefined_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow the use of `undefined` as an identifier")
         .with_help("Unexpected use of undefined.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 declare_oxc_lint!(
@@ -58,9 +58,9 @@ declare_oxc_lint!(
     restriction,
 );
 
-fn diagnostic_undefined_keyword(name: &str, span0: Span, ctx: &LintContext) {
+fn diagnostic_undefined_keyword(name: &str, span: Span, ctx: &LintContext) {
     if name == "undefined" {
-        ctx.diagnostic(no_undefined_diagnostic(span0));
+        ctx.diagnostic(no_undefined_diagnostic(span));
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unsafe_finally_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unsafe_finally_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe finally block")
         .with_help("Control flow inside try or catch blocks will be overwritten by this statement")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -9,16 +9,16 @@ use oxc_syntax::operator::LogicalOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unsafe_optional_chaining_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unsafe_optional_chaining_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe usage of optional chaining")
         .with_help("If this short-circuits with 'undefined' the evaluation will throw TypeError")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn no_unsafe_arithmetic_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unsafe_arithmetic_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe arithmetic operation on optional chaining")
         .with_help("This can result in NaN.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -12,10 +12,10 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[derive(Debug, Default, Clone)]
 pub struct NoUselessConcat;
 
-fn no_useless_concat_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_useless_concat_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected string concatenation of literals.")
         .with_help("Rewrite into one string literal")
-        .with_label(span0)
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -8,12 +8,12 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_useless_rename_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_useless_rename_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Disallow renaming import, export, and destructured assignments to the same name",
     )
     .with_help("Either remove the renaming or rename the variable.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_var_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_var_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected var, use let or const instead.")
         .with_help("Replace var with let or const")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_void.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_void.rs
@@ -6,10 +6,10 @@ use oxc_syntax::operator::UnaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_void_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_void_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow `void` operators")
         .with_help("Expected 'undefined' and instead saw 'void'.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_with_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_with_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected use of `with` statement.")
         .with_help("Do not use the `with` statement.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -11,8 +11,8 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct PreferExponentiationOperator;
 
-fn prefer_exponentian_operator_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `**` over `Math.pow`.").with_label(span0)
+fn prefer_exponentian_operator_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `**` over `Math.pow`.").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -15,8 +15,8 @@ use crate::{
     AstNode,
 };
 
-fn prefer_numeric_literals_diagnostic(span0: Span, x0: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use {x0} literals instead of parseInt().")).with_label(span0)
+fn prefer_numeric_literals_diagnostic(span: Span, x0: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use {x0} literals instead of parseInt().")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -8,21 +8,21 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn missing_parameters(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing parameters.").with_label(span0)
+fn missing_parameters(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing parameters.").with_label(span)
 }
 
-fn missing_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing radix parameter.").with_label(span0)
+fn missing_radix(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing radix parameter.").with_label(span)
 }
 
-fn redundant_radix(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Redundant radix parameter.").with_label(span0)
+fn redundant_radix(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Redundant radix parameter.").with_label(span)
 }
 
-fn invalid_radix(span0: Span) -> OxcDiagnostic {
+fn invalid_radix(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid radix parameter, must be an integer between 2 and 36.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -13,8 +13,8 @@ use crate::{context::LintContext, rule::Rule, AstNode};
 #[derive(Debug, Default, Clone)]
 pub struct RequireAwait;
 
-fn require_await_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Async function has no 'await' expression.").with_label(span0)
+fn require_await_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Async function has no 'await' expression.").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn require_yield_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This generator function does not have 'yield'").with_label(span0)
+fn require_yield_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This generator function does not have 'yield'").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -23,15 +23,15 @@ fn unexpected_syntax_order_diagnostic(
     OxcDiagnostic::warn(format!("Expected '{x0}' syntax before '{x1}' syntax.")).with_label(span2)
 }
 
-fn sort_imports_alphabetically_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span0)
+fn sort_imports_alphabetically_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span)
 }
 
-fn sort_members_alphabetically_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
+fn sort_members_alphabetically_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Member '{x0}' of the import declaration should be sorted alphabetically."
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -4,16 +4,16 @@ use oxc_span::{Span, SPAN};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn unexpected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
+fn unexpected_unicode_bom_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected Unicode BOM (Byte Order Mark)")
         .with_help("File must not begin with the Unicode BOM")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn expected_unicode_bom_diagnostic(span0: Span) -> OxcDiagnostic {
+fn expected_unicode_bom_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected Unicode BOM (Byte Order Mark)")
         .with_help("File must begin with the Unicode BOM")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -9,24 +9,24 @@ use oxc_syntax::operator::BinaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn comparison_with_na_n(span0: Span) -> OxcDiagnostic {
+fn comparison_with_na_n(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help("Use the isNaN function to compare with NaN.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn switch_na_n(span0: Span) -> OxcDiagnostic {
+fn switch_na_n(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help(
             "'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.",
         )
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn case_na_n(span0: Span) -> OxcDiagnostic {
+fn case_na_n(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Requires calls to isNaN() when checking for NaN")
         .with_help("'case NaN' can never match. Use Number.isNaN before the switch.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 fn index_of_na_n(x0: &str, span1: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -8,8 +8,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_export(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("No named exports found in module '{x1}'")).with_label(span0)
+fn no_named_export(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("No named exports found in module '{x1}'")).with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md>

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -12,24 +12,24 @@ use oxc_syntax::module_record::{ExportExportName, ExportImportName, ImportImport
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_export(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1:?} not found in imported namespace {x2:?}.")).with_label(span0)
+fn no_export(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{x1:?} not found in imported namespace {x2:?}.")).with_label(span)
 }
 
-fn no_export_in_deeply_imported_namespace(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn no_export_in_deeply_imported_namespace(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("{x1:?} not found in deeply imported namespace {x2:?}."))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn computed_reference(span0: Span, x1: &str) -> OxcDiagnostic {
+fn computed_reference(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Unable to validate computed reference to imported namespace {x1:?}."
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
-fn assignment(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Assignment to member of namespace {x1:?}.'")).with_label(span0)
+fn assignment(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Assignment to member of namespace {x1:?}.'")).with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md>

--- a/crates/oxc_linter/src/rules/import/no_amd.rs
+++ b/crates/oxc_linter/src/rules/import/no_amd.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_amd_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_amd_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use AMD `require` and `define` calls.")
         .with_help(format!("Expected imports instead of AMD {x1}()"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -11,10 +11,10 @@ use oxc_syntax::{
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_cycle_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_cycle_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Dependency cycle detected")
         .with_help(format!("These paths form a cycle: \n{x1}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md>

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -4,8 +4,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_default_export_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer named exports").with_label(span0)
+fn no_default_export_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer named exports").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -5,10 +5,10 @@ use oxc_syntax::module_record::ImportImportName;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_as_default_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn no_named_as_default_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Module {x2:?} has named export {x1:?}"))
         .with_help(format!("Using default import as {x1:?} can be confusing. Use another name for default import to avoid confusion."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md>

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -11,15 +11,10 @@ use rustc_hash::FxHashMap;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_as_default_member_dignostic(
-    span0: Span,
-    x1: &str,
-    x2: &str,
-    x3: &str,
-) -> OxcDiagnostic {
+fn no_named_as_default_member_dignostic(span: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("{x1:?} also has a named export {x2:?}"))
         .with_help(format!("Check if you meant to write `import {{{x2:}}} from {x3:?}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md>

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -4,8 +4,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_self_import_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("module importing itself is not allowed").with_label(span0)
+fn no_self_import_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("module importing itself is not allowed").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_unused_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_unused_modules.rs
@@ -3,9 +3,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_exports_found(span0: Span) -> OxcDiagnostic {
+fn no_exports_found(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No exports found")
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unused-modules.md>

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -9,10 +9,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_named_as_default_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
+fn no_named_as_default_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unexpected `!` in `{x0}`."))
         .with_help("Do not use import syntax to configure webpack loaders")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -16,16 +16,16 @@ use crate::{
     },
 };
 
-fn consistent_method(x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
+fn consistent_method(x1: &str, x2: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce `test` and `it` usage conventions")
         .with_help(format!("Prefer using {x1:?} instead of {x2:?}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn consistent_method_within_describe(x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
+fn consistent_method_within_describe(x1: &str, x2: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce `test` and `it` usage conventions")
         .with_help(format!("Prefer using {x1:?} instead of {x2:?} within describe"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -18,10 +18,10 @@ use crate::{
     },
 };
 
-fn expect_expect_diagnostic(span0: Span) -> OxcDiagnostic {
+fn expect_expect_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Test has no assertions")
         .with_help("Add assertion(s) in this Test")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -13,10 +13,10 @@ use crate::{
     },
 };
 
-fn exceeded_max_depth(current: usize, max: usize, span0: Span) -> OxcDiagnostic {
+fn exceeded_max_depth(current: usize, max: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforces a maximum depth to nested describe calls.")
         .with_help(format!("Too many nested describe calls ({current}) - maximum allowed is {max}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -6,10 +6,10 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_commented_out_tests_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_commented_out_tests_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Some tests seem to be commented")
         .with_help("Remove or uncomment this comment")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -14,10 +14,10 @@ use crate::{
     },
 };
 
-fn no_conditional_expect_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_conditional_expect_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected conditional expect")
         .with_help("Avoid calling `expect` conditionally`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -9,10 +9,10 @@ use crate::{
     utils::{is_type_of_jest_fn_call, JestFnKind, PossibleJestNode},
 };
 
-fn no_conditional_in_test(span0: Span) -> OxcDiagnostic {
+fn no_conditional_in_test(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow conditional logic in tests")
         .with_help("Avoid having conditionals in tests.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -12,19 +12,19 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_jest_fn_call, PossibleJestNode},
 };
 
-fn no_global_set_timeout_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`jest.setTimeout` should be call in `global` scope").with_label(span0)
+fn no_global_set_timeout_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`jest.setTimeout` should be call in `global` scope").with_label(span)
 }
 
-fn no_multiple_set_timeouts_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_multiple_set_timeouts_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not call `jest.setTimeout` multiple times")
         .with_help("Only the last call to `jest.setTimeout` will have an effect.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn no_unorder_set_timeout_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unorder_set_timeout_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`jest.setTimeout` should be placed before any other jest methods")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -15,16 +15,16 @@ use crate::{
     },
 };
 
-fn no_done_callback(span0: Span) -> OxcDiagnostic {
+fn no_done_callback(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Function parameter(s) use the `done` argument")
         .with_help("Return a Promise instead of relying on callback parameter")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn use_await_instead_of_callback(span0: Span) -> OxcDiagnostic {
+fn use_await_instead_of_callback(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Function parameter(s) use the `done` argument")
         .with_help("Use await instead of callback in async functions")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -15,10 +15,10 @@ use crate::{
     },
 };
 
-fn no_duplicate_hooks_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
+fn no_duplicate_hooks_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow duplicate setup and teardown hooks.")
         .with_help(format!("Duplicate {x0:?} in describe block."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -4,10 +4,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::is_jest_file};
 
-fn no_export_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_export_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not export from a test file.")
         .with_help("If you want to share code between tests, move it into a separate file and import it from there.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -12,10 +12,10 @@ use crate::{
     },
 };
 
-fn no_focused_tests_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_focused_tests_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected focused test.")
         .with_help("Remove focus from test.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -12,8 +12,8 @@ use crate::{
     },
 };
 
-fn unexpected_hook_diagonsitc(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Disallow setup and teardown hooks.").with_label(span0)
+fn unexpected_hook_diagonsitc(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Disallow setup and teardown hooks.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -19,16 +19,16 @@ use crate::{
     AstNode,
 };
 
-fn describe_repeat(span0: Span) -> OxcDiagnostic {
+fn describe_repeat(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Describe block title is used multiple times in the same describe block.")
         .with_help("Change the title of describe block.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn test_repeat(span0: Span) -> OxcDiagnostic {
+fn test_repeat(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Test title is used multiple times in the same describe block.")
         .with_help("Change the title of test.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -9,10 +9,10 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
-fn no_interpolation_in_snapshots_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_interpolation_in_snapshots_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use string interpolation inside of snapshots")
         .with_help("Remove string interpolation from snapshots")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -16,18 +16,18 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
-fn no_snapshot(x0: usize, span0: Span) -> OxcDiagnostic {
+fn no_snapshot(x0: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow large snapshots.")
         .with_help(format!("`{x0:?}`s should begin with lowercase"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn too_long_snapshots(x0: usize, x1: usize, span0: Span) -> OxcDiagnostic {
+fn too_long_snapshots(x0: usize, x1: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow large snapshots.")
         .with_help(format!(
             "Expected Jest snapshot to be smaller than {x0:?} lines but was {x1:?} lines long"
         ))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -7,10 +7,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_mocks_import_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_mocks_import_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Mocks should not be manually imported from a `__mocks__` directory.")
         .with_help("Instead use `jest.mock` and import from the original module path.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-mocks-import.md>

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -17,10 +17,10 @@ use crate::{
     AstNode,
 };
 
-fn no_standalone_expect_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_standalone_expect_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expect must be inside of a test block.")
         .with_help("Did you forget to wrap `expect` in a `test` or `it` block?")
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md>

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -14,8 +14,8 @@ use crate::{
     utils::{is_type_of_jest_fn_call, JestFnKind, JestGeneralFnKind, PossibleJestNode},
 };
 
-fn no_test_return_statement_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Jest tests should not return a value").with_label(span0)
+fn no_test_return_statement_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Jest tests should not return a value").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -9,16 +9,16 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
-fn use_to_be_called_with(span0: Span) -> OxcDiagnostic {
+fn use_to_be_called_with(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
         .with_help("Prefer toBeCalledWith(/* expected args */)")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn use_have_been_called_with(span0: Span) -> OxcDiagnostic {
+fn use_have_been_called_with(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
         .with_help("Prefer toHaveBeenCalledWith(/* expected args */)")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -13,10 +13,10 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
-fn use_equality_matcher_diagnostic(span0: Span) -> OxcDiagnostic {
+fn use_equality_matcher_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using the built-in equality matchers.")
         .with_help("Prefer using one of the equality matchers instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -16,10 +16,10 @@ use crate::{
     },
 };
 
-fn expect_resolves(span0: Span) -> OxcDiagnostic {
+fn expect_resolves(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `await expect(...).resolves` over `expect(await ...)` syntax.")
         .with_help("Use `await expect(...).resolves` instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -13,10 +13,10 @@ use crate::{
     },
 };
 
-fn reorder_hooks(x1: &str, x2: &str, span0: Span) -> OxcDiagnostic {
+fn reorder_hooks(x1: &str, x2: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer having hooks in a consistent order.")
         .with_help(format!("{x1:?} hooks should be before any {x2:?} hooks"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -15,10 +15,10 @@ use crate::{
     },
 };
 
-fn no_hook_on_top(span0: Span) -> OxcDiagnostic {
+fn no_hook_on_top(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest having hooks before any test cases.")
         .with_help("Hooks should come before test cases")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_jest_mocked.rs
@@ -9,10 +9,10 @@ use phf::{phf_set, Set};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn use_jest_mocked(span0: Span) -> OxcDiagnostic {
+fn use_jest_mocked(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `jest.mocked()` over `fn as jest.Mock`.")
         .with_help("Prefer `jest.mocked()`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_spy_on.rs
@@ -17,10 +17,10 @@ use crate::{
     utils::{get_node_name, parse_general_jest_fn_call, PossibleJestNode},
 };
 
-fn use_jest_spy_on(span0: Span) -> OxcDiagnostic {
+fn use_jest_spy_on(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using `jest.spyOn()`.")
         .with_help("Use jest.spyOn() instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -9,10 +9,10 @@ use crate::{
     utils::{collect_possible_jest_call_node, parse_expect_jest_fn_call, PossibleJestNode},
 };
 
-fn use_to_strict_equal(span0: Span) -> OxcDiagnostic {
+fn use_to_strict_equal(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Suggest using `toStrictEqual()`.")
         .with_help("Use `toStrictEqual()` instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -15,24 +15,24 @@ use crate::{
     },
 };
 
-fn use_to_be(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use `toBe` when expecting primitive literals.").with_label(span0)
+fn use_to_be(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBe` when expecting primitive literals.").with_label(span)
 }
 
-fn use_to_be_undefined(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use `toBeUndefined` instead.").with_label(span0)
+fn use_to_be_undefined(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeUndefined` instead.").with_label(span)
 }
 
-fn use_to_be_defined(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use `toBeDefined` instead.").with_label(span0)
+fn use_to_be_defined(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeDefined` instead.").with_label(span)
 }
 
-fn use_to_be_null(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use `toBeNull` instead.").with_label(span0)
+fn use_to_be_null(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeNull` instead.").with_label(span)
 }
 
-fn use_to_be_na_n(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use `toBeNaN` instead.").with_label(span0)
+fn use_to_be_na_n(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeNaN` instead.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -15,8 +15,8 @@ use crate::{
     },
 };
 
-fn use_to_contain(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Suggest using `toContain()`.").with_label(span0)
+fn use_to_contain(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `toContain()`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -16,8 +16,8 @@ use crate::{
     },
 };
 
-fn use_to_have_length(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Suggest using `toHaveLength()`.").with_label(span0)
+fn use_to_have_length(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `toHaveLength()`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -16,12 +16,12 @@ use crate::{
     },
 };
 
-fn empty_test(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span0)
+fn empty_test(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span)
 }
 
-fn un_implemented_test_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span0)
+fn un_implemented_test_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `test.todo`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -17,10 +17,10 @@ use crate::{
     },
 };
 
-fn use_hook(span0: Span) -> OxcDiagnostic {
+fn use_hook(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require setup and teardown code to be within a hook.")
         .with_help("This should be done within a hook")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -15,24 +15,24 @@ use crate::{
     },
 };
 
-fn too_many_describes(max: usize, repeat: &str, span0: Span) -> OxcDiagnostic {
+fn too_many_describes(max: usize, repeat: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
         .with_help(format!(
             "There should not be more than {max:?} describe{repeat} at the top level."
         ))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn unexpected_test_case(span0: Span) -> OxcDiagnostic {
+fn unexpected_test_case(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
         .with_help("All test cases must be wrapped in a describe block.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn unexpected_hook(span0: Span) -> OxcDiagnostic {
+fn unexpected_hook(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
         .with_help("All hooks must be wrapped in a describe block.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -6,18 +6,18 @@ use rustc_hash::FxHashSet;
 
 use crate::{context::LintContext, rule::Rule, utils::should_ignore_as_internal};
 
-fn invalid_access_level(span0: Span) -> OxcDiagnostic {
+fn invalid_access_level(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid access level is specified or missing.")
         .with_help("Valid access levels are `package`, `private`, `protected`, and `public`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn redundant_access_tags(span0: Span) -> OxcDiagnostic {
+fn redundant_access_tags(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Mixing of @access with @public, @private, @protected, or @package on the same doc block.",
     )
     .with_help("There should be only one instance of access tag in a JSDoc comment.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -9,10 +9,10 @@ use crate::{
     utils::{should_ignore_as_internal, should_ignore_as_private},
 };
 
-fn no_root(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_root(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("No root defined for @property path.")
         .with_help(format!("@property path declaration `{x1}` appears before any real property."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -10,8 +10,8 @@ use crate::{
     utils::{should_ignore_as_internal, should_ignore_as_private},
 };
 
-fn check_tag_names_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Invalid tag name found.").with_help(x1.to_string()).with_label(span0)
+fn check_tag_names_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Invalid tag name found.").with_help(x1.to_string()).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -6,10 +6,10 @@ use serde::Deserialize;
 
 use crate::{context::LintContext, rule::Rule, utils::should_ignore_as_private};
 
-fn empty_tags_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn empty_tags_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expects the void tags to be empty of any content.")
         .with_help(format!("`@{x1}` tag should not have body."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -11,10 +11,10 @@ use crate::{
     AstNode,
 };
 
-fn implements_on_classes_diagnostic(span0: Span) -> OxcDiagnostic {
+fn implements_on_classes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`@implements` used on a non-constructor function")
         .with_help("Add `@class` tag or use ES6 class syntax.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -11,8 +11,8 @@ use crate::{
     AstNode,
 };
 
-fn no_defaults_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Defaults are not permitted.").with_help(x1.to_string()).with_label(span0)
+fn no_defaults_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Defaults are not permitted.").with_help(x1.to_string()).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn missing_type_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@param` description.")
         .with_help("Add description to `@param` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -10,10 +10,10 @@ use crate::{
     AstNode,
 };
 
-fn missing_name_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_name_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@param` name.")
         .with_help("Add name to `@param` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn missing_type_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@param` type.")
         .with_help("Add {type} to `@param` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -8,10 +8,10 @@ use crate::{
     utils::{should_ignore_as_internal, should_ignore_as_private},
 };
 
-fn require_property_description_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_property_description_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing description in @property tag.")
         .with_help("Add a description to this @property tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -8,10 +8,10 @@ use crate::{
     utils::{should_ignore_as_internal, should_ignore_as_private},
 };
 
-fn require_property_name_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_property_name_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing name in @property tag.")
         .with_help("Add a type name to this @property tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -8,10 +8,10 @@ use crate::{
     utils::{should_ignore_as_internal, should_ignore_as_private},
 };
 
-fn require_property_type_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_property_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing type in @property tag.")
         .with_help("Add a {type} to this @property tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -19,15 +19,15 @@ use crate::{
     },
 };
 
-fn missing_returns_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_returns_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@returns` declaration for function.")
         .with_help("Add `@returns` tag to the JSDoc comment.")
-        .with_label(span0)
+        .with_label(span)
 }
-fn duplicate_returns_diagnostic(span0: Span) -> OxcDiagnostic {
+fn duplicate_returns_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Duplicate `@returns` tags.")
         .with_help("Remove redundunt `@returns` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -10,10 +10,10 @@ use crate::{
     AstNode,
 };
 
-fn missing_description_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_description_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@returns` description.")
         .with_help("Add description comment to `@returns` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -10,10 +10,10 @@ use crate::{
     AstNode,
 };
 
-fn missing_type_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@returns` type.")
         .with_help("Add {type} to `@returns` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -16,22 +16,22 @@ use crate::{
     AstNode,
 };
 
-fn missing_yields(span0: Span) -> OxcDiagnostic {
+fn missing_yields(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing JSDoc `@yields` declaration for generator function.")
         .with_help("Add `@yields` tag to the JSDoc comment.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn duplicate_yields(span0: Span) -> OxcDiagnostic {
+fn duplicate_yields(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Duplicate `@yields` tags.")
         .with_help("Remove redundunt `@yields` tag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn missing_yields_with_generator(span0: Span) -> OxcDiagnostic {
+fn missing_yields_with_generator(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`@yields` tag is required when using `@generator` tag.")
         .with_help("Add `@yields` tag to the JSDoc comment.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -16,54 +16,54 @@ use crate::{
     AstNode,
 };
 
-fn missing_alt_prop(span0: Span) -> OxcDiagnostic {
+fn missing_alt_prop(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing `alt` attribute.")
         .with_help("Must have `alt` prop, either with meaningful text, or an empty string for decorative images.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn missing_alt_value(span0: Span) -> OxcDiagnostic {
+fn missing_alt_value(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid `alt` value.")
         .with_help(
             "Must have meaningful value for `alt` prop. Use alt=\"\" for presentational images.",
         )
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn aria_label_value(span0: Span) -> OxcDiagnostic {
+fn aria_label_value(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing value for `aria-label` attribute.")
         .with_help("Give `aria-label` a meaningful value. Prever the `alt` attribute over `aria-label` for images.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn aria_labelled_by_value(span0: Span) -> OxcDiagnostic {
+fn aria_labelled_by_value(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing value for `aria-labelledby` attribute.")
         .with_help("Give `aria-labelledby` an ID to a label element. Prefer the `alt` attribute over `aria-labelledby` for images.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn prefer_alt(span0: Span) -> OxcDiagnostic {
+fn prefer_alt(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("ARIA used where native HTML could suffice.")
         .with_help("Prefer alt=\"\" over presentational role. Native HTML attributes should be preferred for accessibility before resorting to ARIA attributes.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn object(span0: Span) -> OxcDiagnostic {
+fn object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing alternative text.")
         .with_help("Embedded <object> elements must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn area(span0: Span) -> OxcDiagnostic {
+fn area(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing alternative text.")
         .with_help("Each area of an image map must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn input_type_image(span0: Span) -> OxcDiagnostic {
+fn input_type_image(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing alternative text.")
         .with_help("<input> elements with type=\"image\" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` prop.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -17,10 +17,10 @@ use crate::{
     AstNode,
 };
 
-fn missing_content(span0: Span) -> OxcDiagnostic {
+fn missing_content(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing accessible content when using `a` elements.")
         .with_help("Provide screen reader accessible content when using `a` elements.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -16,22 +16,22 @@ use crate::{
     AstNode,
 };
 
-fn missing_href_attribute(span0: Span) -> OxcDiagnostic {
+fn missing_href_attribute(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing `href` attribute for the `a` element.")
         .with_help("Provide an href for the `a` element.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn incorrect_href(span0: Span) -> OxcDiagnostic {
+fn incorrect_href(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use an incorrect href for the 'a' element.")
         .with_help("Provide a correct href for the `a` element.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn cant_be_anchor(span0: Span) -> OxcDiagnostic {
+fn cant_be_anchor(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(" The a element has `href` and `onClick`.")
         .with_help("Use a `button` element instead of an `a` element.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -14,10 +14,10 @@ use crate::{
     AstNode,
 };
 
-fn aria_role_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn aria_role_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Elements with ARIA roles must use a valid, non-abstract ARIA role.")
         .with_help(format!("Set a valid, non-abstract ARIA role for element with ARIA{x1}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -37,10 +37,10 @@ declare_oxc_lint! {
 #[derive(Debug, Default, Clone)]
 pub struct AriaUnsupportedElements;
 
-fn aria_unsupported_elements_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn aria_unsupported_elements_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("This element does not support ARIA roles, states and properties.")
         .with_help(format!("Try removing the prop `{x1}`."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for AriaUnsupportedElements {

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -14,10 +14,10 @@ use crate::{
     AstNode,
 };
 
-fn click_events_have_key_events_diagnostic(span0: Span) -> OxcDiagnostic {
+fn click_events_have_key_events_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce a clickable non-interactive element has at least one keyboard event listener.")
         .with_help("Visible, non-interactive elements with click handlers must have one of keyup, keydown, or keypress listener.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -10,12 +10,12 @@ use crate::{
     AstNode,
 };
 
-fn heading_has_content_diagnostic(span0: Span) -> OxcDiagnostic {
+fn heading_has_content_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Headings must have content and the content must be accessible by a screen reader.",
     )
     .with_help("Provide screen reader accessible content when using heading elements.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -13,16 +13,16 @@ use crate::{
     AstNode,
 };
 
-fn missing_lang_prop(span0: Span) -> OxcDiagnostic {
+fn missing_lang_prop(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing lang attribute.")
         .with_help("Add a lang attribute to the html element whose value represents the primary language of document.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn missing_lang_value(span0: Span) -> OxcDiagnostic {
+fn missing_lang_value(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing value for lang attribute")
         .with_help("Must have meaningful value for `lang` prop.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn iframe_has_title_diagnostic(span0: Span) -> OxcDiagnostic {
+fn iframe_has_title_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing `title` attribute for the `iframe` element.")
         .with_help("Provide title property for iframe element.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -17,9 +17,9 @@ use crate::{
     AstNode,
 };
 
-fn img_redundant_alt_diagnostic(span0: Span) -> OxcDiagnostic {
+fn img_redundant_alt_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Redundant alt attribute.")
-        .with_help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.").with_label(span0)
+        .with_help("Provide no redundant alt text for image. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -14,10 +14,10 @@ use crate::{
     AstNode,
 };
 
-fn lang_diagnostic(span0: Span) -> OxcDiagnostic {
+fn lang_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Lang attribute must have a valid value.")
         .with_help("Set a valid value for lang attribute.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -11,10 +11,10 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule, utils::get_element_type, AstNode};
 
-fn media_has_caption_diagnostic(span0: Span) -> OxcDiagnostic {
+fn media_has_caption_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing <track> element with captions inside <audio> or <video> element")
         .with_help("Media elements such as <audio> and <video> must have a <track> for captions.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -11,16 +11,16 @@ use crate::{
     AstNode,
 };
 
-fn miss_on_focus(span0: Span, x1: &str) -> OxcDiagnostic {
+fn miss_on_focus(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("{x1} must be accompanied by onFocus for accessibility."))
         .with_help("Try to add onFocus.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn miss_on_blur(span0: Span, x1: &str) -> OxcDiagnostic {
+fn miss_on_blur(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("{x1} must be accompanied by onBlur for accessibility."))
         .with_help("Try to add onBlur.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case, AstNode};
 
-fn no_access_key_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_access_key_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No access key attribute allowed.")
         .with_help("Remove the accessKey attribute. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreaders and keyboard-only users create a11y complications.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_aria_hidden_on_focusable.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn no_aria_hidden_on_focusable_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_aria_hidden_on_focusable_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`aria-hidden` must not be true on focusable elements.")
         .with_help("Remove `aria-hidden=\"true\"` from focusable elements or modify the element to be not focusable.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -11,10 +11,10 @@ use crate::{
     AstNode,
 };
 
-fn no_autofocus_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_autofocus_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The `autofocus` attribute is found here, which can cause usability issues for sighted and non-sighted users")
         .with_help("Remove `autofocus` attribute")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -6,10 +6,10 @@ use oxc_span::Span;
 
 use crate::{rule::Rule, utils::get_element_type, LintContext};
 
-fn no_distracting_elements_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_distracting_elements_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use <marquee> or <blink> elements as they can create visual accessibility issues and are deprecated.")
         .with_help("Replace the <marquee> or <blink> element with alternative, more accessible ways to achieve your desired visual effects.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -47,16 +47,16 @@ declare_oxc_lint!(
 #[derive(Debug, Default, Clone)]
 pub struct RoleSupportsAriaProps;
 
-fn default(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn default(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("The attribute {x1} is not supported by the role {x2}."))
         .with_help(format!("Try to remove invalid attribute {x1}."))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn is_implicit_diagnostic(span0: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagnostic {
+fn is_implicit_diagnostic(span: Span, x1: &str, x2: &str, x3: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("The attribute {x1} is not supported by the role {x2}. This role is implicit on the element {x3}."))
         .with_help(format!("Try to remove invalid attribute {x1}."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for RoleSupportsAriaProps {

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -11,10 +11,10 @@ use crate::{
     AstNode,
 };
 
-fn scope_diagnostic(span0: Span) -> OxcDiagnostic {
+fn scope_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The scope prop can only be used on <th> elements")
         .with_help("Must use scope prop only on <th> elements")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -10,10 +10,10 @@ use crate::{
     AstNode,
 };
 
-fn tabindex_no_positive_diagnostic(span0: Span) -> OxcDiagnostic {
+fn tabindex_no_positive_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid positive integer values for tabIndex.")
         .with_help("Change the tabIndex prop to a non-negative value")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -10,18 +10,18 @@ use crate::{
     AstNode,
 };
 
-fn font_display_parameter_missing(span0: Span) -> OxcDiagnostic {
+fn font_display_parameter_missing(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "A font-display parameter is missing (adding `&display=optional` is recommended).",
     )
     .with_help("See https://nextjs.org/docs/messages/google-font-display")
-    .with_label(span0)
+    .with_label(span)
 }
 
-fn not_recommended_font_display_value(span0: Span, x1: &str) -> OxcDiagnostic {
+fn not_recommended_font_display_value(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("`{x1}` is not a recommended font-display value."))
         .with_help("See https://nextjs.org/docs/messages/google-font-display")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -10,10 +10,10 @@ use crate::{
     AstNode,
 };
 
-fn google_font_preconnect_diagnostic(span0: Span) -> OxcDiagnostic {
+fn google_font_preconnect_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(r#"`rel="preconnect"` is missing from Google Font."#)
         .with_help("See: https://nextjs.org/docs/messages/google-font-preconnect")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -9,12 +9,12 @@ use rustc_hash::FxHashSet;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn inline_script_id_diagnostic(span0: Span) -> OxcDiagnostic {
+fn inline_script_id_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "`next/script` components with inline content must specify an `id` attribute.",
     )
     .with_help("See https://nextjs.org/docs/messages/inline-script-id")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -16,12 +16,12 @@ use crate::{
     AstNode,
 };
 
-fn next_script_for_ga_diagnostic(span0: Span) -> OxcDiagnostic {
+fn next_script_for_ga_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Prefer `next/script` component when using the inline script for Google Analytics.",
     )
     .with_help("See https://nextjs.org/docs/messages/next-script-for-ga")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_assign_module_variable_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_assign_module_variable_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not assign to the variable `module`.")
         .with_help("See https://nextjs.org/docs/messages/no-assign-module-variable")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule};
 
-fn no_async_client_component_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_async_client_component_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent client components from being async functions.")
         .with_help("See: https://nextjs.org/docs/messages/no-async-client-component")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn no_before_interactive_script_outside_document_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_before_interactive_script_outside_document_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("next/script's `beforeInteractive` strategy should not be used outside of `pages/_document.js`")
         .with_help("See https://nextjs.org/docs/messages/no-before-interactive-script-outside-document")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::get_string_literal_prop_value, AstNode};
 
-fn no_css_tags_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_css_tags_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not include stylesheets manually.")
         .with_help("See https://nextjs.org/docs/messages/no-css-tags")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::is_document_page, AstNode};
 
-fn no_document_import_in_page_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-import-in-page").with_help("Prevent importing `next/document` outside of `pages/_document.js`.").with_label(span0)
+fn no_document_import_in_page_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`<Document />` from `next/document` should not be imported outside of `pages/_document.js`. See: https://nextjs.org/docs/messages/no-document-import-in-page").with_help("Prevent importing `next/document` outside of `pages/_document.js`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::is_in_app_dir, AstNode};
 
-fn no_head_element_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_head_element_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `<head>` element. Use `<Head />` from `next/head` instead.")
         .with_help("See https://nextjs.org/docs/messages/no-head-element")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_head_import_in_document_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_head_import_in_document_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `next/head` in `pages/_document.js`.")
         .with_help("See https://nextjs.org/docs/messages/no-head-import-in-document")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_img_element_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_img_element_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `<img>` element due to slower LCP and higher bandwidth.")
         .with_help("See https://nextjs.org/docs/messages/no-img-element")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -8,16 +8,16 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn not_added_in_document(span0: Span) -> OxcDiagnostic {
+fn not_added_in_document(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged.")
         .with_help("See: https://nextjs.org/docs/messages/no-page-custom-font")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn link_outside_of_head(span0: Span) -> OxcDiagnostic {
+fn link_outside_of_head(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using `<link />` outside of `<Head>` will disable automatic font optimization. This is discouraged.")
         .with_help("See: 'https://nextjs.org/docs/messages/no-page-custom-font")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_script_component_in_head_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_script_component_in_head_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `next/script` in `next/head` component.")
         .with_help("See https://nextjs.org/docs/messages/no-script-component-in-head")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_styled_jsx_in_document_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_styled_jsx_in_document_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`styled-jsx` should not be used in `pages/_document.js`")
         .with_help("Possible to fix it please see: https://nextjs.org/docs/messages/no-styled-jsx-in-document#possible-ways-to-fix-it")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -9,10 +9,10 @@ use rustc_hash::FxHashSet;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_sync_scripts_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_sync_scripts_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent synchronous scripts.")
         .with_help("See https://nextjs.org/docs/messages/no-sync-scripts")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_title_in_document_head_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_title_in_document_head_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prevent usage of `<title>` with `Head` component from `next/document`.")
         .with_help("See https://nextjs.org/docs/messages/no-title-in-document-head")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -9,10 +9,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn approx_constant_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn approx_constant_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Approximate value of `{x1}` found."))
         .with_help(format!("Use `Math.{x1}` instead"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -17,10 +17,10 @@ fn bad_bitwise_operator_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagno
         .with_label(span2)
 }
 
-fn bad_bitwise_or_operator_diagnostic(span0: Span) -> OxcDiagnostic {
+fn bad_bitwise_or_operator_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Bad bitwise operator")
         .with_help("Bitwise operator '|=' seems unintended. Consider using non-compound assignment and logical operator '||' instead.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_comparison_sequence.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn bad_comparison_sequence_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Bad comparison sequence").with_help("Comparison result should not be used directly as an operand of another comparison. If you need to compare three or more operands, you should connect each comparison operation with logical AND operator (`&&`)").with_label(span0)
+fn bad_comparison_sequence_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Bad comparison sequence").with_help("Comparison result should not be used directly as an operand of another comparison. If you need to compare three or more operands, you should connect each comparison operation with logical AND operator (`&&`)").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_object_literal_comparison.rs
@@ -6,18 +6,18 @@ use oxc_syntax::operator::BinaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn object_comparison(span0: Span, x1: bool) -> OxcDiagnostic {
+fn object_comparison(span: Span, x1: bool) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected object literal comparison.")
         .with_help(format!(
             "This comparison will always return {x1:?} as object literals are never equal to each other. Consider using `Object.entries()` of `Object.keys()` and comparing their lengths."
         ))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn array_comparison(span0: Span, x1: bool) -> OxcDiagnostic {
+fn array_comparison(span: Span, x1: bool) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected array literal comparison.")
         .with_help(format!("This comparison will always return {x1:?} as array literals are never equal to each other. Consider using `Array.length` if empty checking was intended."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -6,12 +6,12 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
-fn double_comparisons_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn double_comparisons_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected double comparisons.")
         .with_help(format!(
             "This logical expression can be simplified. Try using the `{x1}` operator instead."
         ))
-        .with_label(span0)
+        .with_label(span)
 }
 
 /// <https://rust-lang.github.io/rust-clippy/master/index.html#/double_comparisons>

--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -10,10 +10,10 @@ use oxc_syntax::operator::BinaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn erasing_op_diagnostic(span0: Span) -> OxcDiagnostic {
+fn erasing_op_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected erasing operation. This expression will always evaluate to zero.")
         .with_help("This is most likely not the intended outcome. Consider removing the operation, or directly assigning zero to the variable")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -15,12 +15,12 @@ use crate::{
     AstNode,
 };
 
-fn misrefactored_assign_op_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn misrefactored_assign_op_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Misrefactored assign op. Variable appears on both sides of an assignment operation",
     )
     .with_help(format!("Did you mean `{x1}`?"))
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/missing_throw.rs
+++ b/crates/oxc_linter/src/rules/oxc/missing_throw.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn missing_throw_diagnostic(span0: Span) -> OxcDiagnostic {
+fn missing_throw_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing throw")
         .with_help("The `throw` keyword seems to be missing in front of this 'new' expression")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_async_await_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_async_await_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected async/await")
         .with_help("Async/await is not allowed")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_const_enum_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_const_enum_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected const enum")
         .with_help("Const enums are not supported by bundlers and are incompatible with the isolatedModules mode. Their use can lead to import nonexistent values (because const enums are erased).")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -5,13 +5,13 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_optional_chaining_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_optional_chaining_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     if x1.is_empty() {
-        OxcDiagnostic::warn("Optional chaining is not allowed.").with_label(span0)
+        OxcDiagnostic::warn("Optional chaining is not allowed.").with_label(span)
     } else {
         OxcDiagnostic::warn("Optional chaining is not allowed.")
             .with_help(x1.to_owned())
-            .with_label(span0)
+            .with_label(span)
     }
 }
 

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_rest_spread_properties_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{x1} are not allowed. {x2}")).with_label(span0)
+fn no_rest_spread_properties_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{x1} are not allowed. {x2}")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -10,14 +10,14 @@ use crate::{
     ast_util::get_function_like_declaration, context::LintContext, fixer::Fix, rule::Rule, AstNode,
 };
 
-fn only_used_in_recursion_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn only_used_in_recursion_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Parameter `{x1}` is only used in recursive calls"
     ))
     .with_help(
         "Remove the argument and its usage. Alternatively, use the argument in the function body.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn avoid_new_promise_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid creating new promises").with_label(span0)
+fn avoid_new_promise_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid creating new promises").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::PROMISE_STATIC_METHODS, AstNode};
 
-fn static_promise_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{x0}`")).with_label(span0)
+fn static_promise_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Disallow calling `new` on a `Promise.{x0}`")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -9,10 +9,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::is_promise, AstNode};
 
-fn no_return_in_finally_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_return_in_finally_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't return in a finally callback")
         .with_help("Remove the return statement as nothing can consume the return value")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -9,9 +9,9 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn param_names_diagnostic(span0: Span, x0: &str) -> OxcDiagnostic {
+fn param_names_diagnostic(span: Span, x0: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Promise constructor parameters must be named to match `{x0}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -3,8 +3,8 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-fn prefer_wait_to_then_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer await to then()/catch()/finally()").with_label(span0)
+fn prefer_wait_to_then_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer await to then()/catch()/finally()").with_label(span)
 }
 
 use crate::{context::LintContext, rule::Rule, utils::is_promise, AstNode};

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -6,40 +6,36 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule, utils::is_promise, AstNode};
 
 fn zero_or_one_argument_required_diagnostic(
-    span0: Span,
+    span: Span,
     prop_name: &str,
     args_len: usize,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise.{prop_name}() requires 0 or 1 arguments, but received {args_len}"
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
 fn one_or_two_argument_required_diagnostic(
-    span0: Span,
+    span: Span,
     prop_name: &str,
     args_len: usize,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise.{prop_name}() requires 1 or 2 arguments, but received {args_len}"
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
-fn one_argument_required_diagnostic(
-    span0: Span,
-    prop_name: &str,
-    args_len: usize,
-) -> OxcDiagnostic {
+fn one_argument_required_diagnostic(span: Span, prop_name: &str, args_len: usize) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise.{prop_name}() requires 1 argument, but received {args_len}"
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
-fn valid_params_diagnostic(span0: Span, x0: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(x0.to_string()).with_label(span0)
+fn valid_params_diagnostic(span: Span, x0: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(x0.to_string()).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -16,16 +16,16 @@ use crate::{
     AstNode,
 };
 
-fn missing_type_prop(span0: Span) -> OxcDiagnostic {
+fn missing_type_prop(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`button` elements must have an explicit `type` attribute.")
         .with_help("Add a `type` attribute to the `button` element.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn invalid_type_prop(span0: Span) -> OxcDiagnostic {
+fn invalid_type_prop(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`button` elements must have a valid `type` attribute.")
         .with_help("Change the `type` attribute to one of the allowed values: `button`, `submit`, or `reset`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -10,18 +10,18 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::get_prop_value, AstNode};
 
-fn boolean_value_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
+fn boolean_value_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Value must be omitted for boolean attribute {x0:?}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn boolean_value_always_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Value must be set for boolean attribute {x0:?}")).with_label(span0)
+fn boolean_value_always_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Value must be set for boolean attribute {x0:?}")).with_label(span)
 }
 
-fn boolean_value_undefined_false_diagnostic(x0: &str, span0: Span) -> OxcDiagnostic {
+fn boolean_value_undefined_false_diagnostic(x0: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Value must be omitted for `false` attribute {x0:?}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -8,8 +8,8 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn missing_key_prop_for_element_in_array(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(r#"Missing "key" prop for element in array."#).with_label(span0)
+fn missing_key_prop_for_element_in_array(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(r#"Missing "key" prop for element in array."#).with_label(span)
 }
 
 fn missing_key_prop_for_element_in_iterator(span0: Span, span1: Span) -> OxcDiagnostic {
@@ -21,10 +21,10 @@ fn missing_key_prop_for_element_in_iterator(span0: Span, span1: Span) -> OxcDiag
         ])
 }
 
-fn key_prop_must_be_placed_before_spread(span0: Span) -> OxcDiagnostic {
+fn key_prop_must_be_placed_before_spread(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(r#""key" prop must be placed before any `{...spread}`"#)
         .with_help("To avoid conflicting with React's new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -7,9 +7,9 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn jsx_no_comment_textnodes_diagnostic(span0: Span) -> OxcDiagnostic {
+fn jsx_no_comment_textnodes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Comments inside children section of tag should be placed inside braces")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -13,22 +13,22 @@ use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn target_blank_without_noreferrer(span0: Span) -> OxcDiagnostic {
+fn target_blank_without_noreferrer(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using target=`_blank` without rel=`noreferrer` (which implies rel=`noopener`) is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
 .with_help("add rel=`noreferrer` to the element")
-.with_label(span0)
+.with_label(span)
 }
 
-fn target_blank_without_noopener(span0: Span) -> OxcDiagnostic {
+fn target_blank_without_noopener(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using target=`_blank` without rel=`noreferrer` or rel=`noopener` (the former implies the latter and is preferred due to wider support) is a security risk: see https://mathiasbynens.github.io/rel-noopener/#recommendations")
 .with_help("add rel=`noreferrer` or rel=`noopener` to the element")
-.with_label(span0)
+.with_label(span)
 }
 
-fn explicit_props_in_spread_attributes(span0: Span) -> OxcDiagnostic {
+fn explicit_props_in_spread_attributes(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("all spread attributes are treated as if they contain an unsafe combination of props, unless specifically overridden by props after the last spread attribute prop.")
 .with_help("add rel=`noreferrer` to the element")
-.with_label(span0)
+.with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -12,12 +12,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn needs_more_children(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span0)
+fn needs_more_children(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span)
 }
 
-fn child_of_html_element(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.").with_label(span0)
+fn child_of_html_element(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, utils::is_create_element_call, AstNode};
 
-fn no_children_prop_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_children_prop_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid passing children using a prop.")
         .with_help("The canonical way to pass children in React is to use JSX elements")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn no_danger_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_danger_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `dangerouslySetInnerHTML` prop")
         .with_help("`dangerouslySetInnerHTML` is a way to inject HTML into your React component. This is dangerous because it can easily lead to XSS vulnerabilities.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -13,10 +13,10 @@ use crate::{
     AstNode,
 };
 
-fn no_direct_mutation_state_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_direct_mutation_state_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("never mutate this.state directly.")
         .with_help("calling setState() afterwards may replace the mutation you made.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_find_dom_node_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_find_dom_node_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected call to `findDOMNode`.")
         .with_help("Replace `findDOMNode` with one of the alternatives documented at https://react.dev/reference/react-dom/findDOMNode#alternatives.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_is_mounted_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_is_mounted_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use isMounted")
         .with_help("isMounted is on its way to being officially deprecated. You can use a _isMounted property to track the mounted status yourself.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_render_return_value_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_render_return_value_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not depend on the return value from ReactDOM.render.")
         .with_help("Using the return value is a legacy feature.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -10,8 +10,8 @@ use crate::{
     AstNode,
 };
 
-fn no_set_state_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use setState").with_label(span0)
+fn no_set_state_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use setState").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -16,16 +16,16 @@ use crate::{
     AstNode,
 };
 
-fn this_refs_deprecated(span0: Span) -> OxcDiagnostic {
+fn this_refs_deprecated(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using this.refs is deprecated.")
         .with_help("Using this.xxx instead of this.refs.xxx")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn string_in_ref_deprecated(span0: Span) -> OxcDiagnostic {
+fn string_in_ref_deprecated(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Using string literals in ref attributes is deprecated.")
         .with_help("Using reference callback instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -6,8 +6,8 @@ use phf::{phf_map, Map};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unescaped_entities_diagnostic(span0: Span, x1: char, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("`{x1}` can be escaped with {x2}")).with_label(span0)
+fn no_unescaped_entities_diagnostic(span: Span, x1: char, x2: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{x1}` can be escaped with {x2}")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -16,30 +16,30 @@ use serde::Deserialize;
 
 use crate::{context::LintContext, rule::Rule, utils::get_jsx_attribute_name, AstNode};
 
-fn invalid_prop_on_tag(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn invalid_prop_on_tag(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid property found")
         .with_help(format!("Property '{x1}' is only allowed on: {x2}"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn data_lowercase_required(span0: Span, x1: &str) -> OxcDiagnostic {
+fn data_lowercase_required(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "React does not recognize data-* props with uppercase characters on a DOM element",
     )
     .with_help(format!("Use '{x1}' instead"))
-    .with_label(span0)
+    .with_label(span)
 }
 
-fn unknown_prop_with_standard_name(span0: Span, x1: &str) -> OxcDiagnostic {
+fn unknown_prop_with_standard_name(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unknown property found")
         .with_help(format!("Use '{x1}' instead"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn unknown_prop(span0: Span) -> OxcDiagnostic {
+fn unknown_prop(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unknown property found")
         .with_help("Remove unknown property")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -10,12 +10,12 @@ use crate::{
     AstNode,
 };
 
-fn unexpected_es6_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use createClass instead of ES6 class.").with_label(span0)
+fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Components should use createClass instead of ES6 class.").with_label(span)
 }
 
-fn expected_es6_class_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use es6 class instead of createClass.").with_label(span0)
+fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Components should use es6 class instead of createClass.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn react_in_jsx_scope_diagnostic(span0: Span) -> OxcDiagnostic {
+fn react_in_jsx_scope_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'React' must be in scope when using JSX")
         .with_help("When using JSX, `<a />` expands to `React.createElement(\"a\")`. Therefore the `React` variable must be in scope.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -14,10 +14,10 @@ use crate::{
     AstNode,
 };
 
-fn require_render_return_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_render_return_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Your render method should have a return statement")
         .with_help("When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the return statement is missing.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
+++ b/crates/oxc_linter/src/rules/tree_shaking/no_side_effects_in_initialization/mod.rs
@@ -18,8 +18,8 @@ fn assignment(x0: &str, span1: Span) -> OxcDiagnostic {
         .with_label(span1)
 }
 
-fn mutate(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Cannot determine side-effects of mutating").with_label(span0)
+fn mutate(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Cannot determine side-effects of mutating").with_label(span)
 }
 
 fn mutate_with_name(x0: &str, span1: Span) -> OxcDiagnostic {
@@ -27,33 +27,33 @@ fn mutate_with_name(x0: &str, span1: Span) -> OxcDiagnostic {
         .with_label(span1)
 }
 
-fn mutate_function_return_value(span0: Span) -> OxcDiagnostic {
+fn mutate_function_return_value(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of mutating function return value")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn mutate_parameter(span0: Span) -> OxcDiagnostic {
+fn mutate_parameter(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of mutating function parameter")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn mutate_of_this(span0: Span) -> OxcDiagnostic {
+fn mutate_of_this(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of mutating unknown this value")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn mutate_import(span0: Span) -> OxcDiagnostic {
+fn mutate_import(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of mutating imported variable")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn call(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Cannot determine side-effects of calling").with_label(span0)
+fn call(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Cannot determine side-effects of calling").with_label(span)
 }
 
-fn call_return_value(span0: Span) -> OxcDiagnostic {
+fn call_return_value(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of calling function return value")
-        .with_label(span0)
+        .with_label(span)
 }
 
 fn call_global(x0: &str, span1: Span) -> OxcDiagnostic {
@@ -61,32 +61,31 @@ fn call_global(x0: &str, span1: Span) -> OxcDiagnostic {
         .with_label(span1)
 }
 
-fn call_parameter(span0: Span) -> OxcDiagnostic {
+fn call_parameter(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of calling function parameter")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn call_import(span0: Span) -> OxcDiagnostic {
+fn call_import(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of calling imported function")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn call_member(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Cannot determine side-effects of calling member function")
-        .with_label(span0)
+fn call_member(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Cannot determine side-effects of calling member function").with_label(span)
 }
 
-fn debugger(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Debugger statements are side-effects").with_label(span0)
+fn debugger(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Debugger statements are side-effects").with_label(span)
 }
 
-fn delete(span0: Span) -> OxcDiagnostic {
+fn delete(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Cannot determine side-effects of deleting anything but a MemberExpression")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn throw(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Throwing an error is a side-effect").with_label(span0)
+fn throw(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Throwing an error is a side-effect").with_label(span)
 }
 
 /// <https://github.com/lukastaegert/eslint-plugin-tree-shaking/blob/master/src/rules/no-side-effects-in-initialization.ts>

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -10,21 +10,21 @@ fn type_diagnostic(x0: &str, x1: &str, span2: Span) -> OxcDiagnostic {
         .with_label(span2)
 }
 
-fn type_literal(span0: Span) -> OxcDiagnostic {
+fn type_literal(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer explicitly define the object shape")
         .with_help("This type means \"any non-nullish value\", which is slightly better than 'unknown', but it's still a broad type")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn function(span0: Span) -> OxcDiagnostic {
+fn function(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't use `Function` as a type")
         .with_help("The `Function` type accepts any function-like value")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn object(span0: Span) -> OxcDiagnostic {
+fn object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'The `Object` type actually means \"any non-nullish value\"")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -32,8 +32,8 @@ fn type_over_value_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn some_imports_are_only_types_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Imports {x1} are only used as type.")).with_label(span0)
+fn some_imports_are_only_types_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Imports {x1} are only used as type.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -109,10 +109,10 @@ declare_oxc_lint!(
     restriction,
 );
 
-fn explicit_function_return_type_diagnostic(span0: Span) -> OxcDiagnostic {
+fn explicit_function_return_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Missing return type on function.")
         .with_help("Require explicit return types on functions and class methods.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for ExplicitFunctionReturnType {

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -27,10 +27,10 @@ declare_oxc_lint!(
     restriction,
 );
 
-fn no_dynamic_delete_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_dynamic_delete_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not delete dynamically computed property keys.")
         .with_help("Disallow using the `delete` operator on computed key expressions")
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for NoDynamicDelete {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -6,13 +6,13 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_empty_interface_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span0)
+fn no_empty_interface_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span)
 }
 
-fn no_empty_interface_extend_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_empty_interface_extend_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("an interface declaring no members is equivalent to its supertype")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -6,10 +6,10 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_explicit_any_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_explicit_any_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected any. Specify a different type.")
         .with_help("Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_extra_non_null_assertion_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("extra non-null assertion").with_label(span0)
+fn no_extra_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("extra non-null assertion").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
 
-fn no_import_type_side_effects_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_import_type_side_effects_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("TypeScript will only remove the inline type specifiers which will leave behind a side effect import at runtime.")
         .with_help("Convert this to a top-level type qualifier to properly remove the entire import.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -8,16 +8,16 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_misused_new_interface_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_misused_new_interface_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Interfaces cannot be constructed, only classes.")
         .with_help("Consider removing this method from your interface.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn no_misused_new_class_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_misused_new_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Class cannot have method named `new`.")
         .with_help("This method name is confusing, consider renaming the method to `constructor`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_namespace_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_namespace_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("ES2015 module syntax is preferred over namespaces.")
         .with_help("Replace the namespace with an ES2015 module or use `declare module`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -27,10 +27,10 @@ declare_oxc_lint!(
     restriction,
 );
 
-fn no_non_null_asserted_nullish_coalescing_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_non_null_asserted_nullish_coalescing_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'Disallow non-null assertions in the left operand of a nullish coalescing operator")
         .with_help("The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for NoNonNullAssertedNullishCoalescing {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -25,10 +25,10 @@ declare_oxc_lint!(
     restriction,
 );
 
-fn no_non_null_assertion_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Forbidden non-null assertion.")
         .with_help("Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 impl Rule for NoNonNullAssertion {

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -10,18 +10,18 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_this_alias_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_this_alias_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected aliasing of 'this' to local variable.")
         .with_help("Assigning a variable to this instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not managing scope well.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn no_this_destructure_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_this_destructure_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected aliasing of members of 'this' to local variables.")
         .with_help(
             "Disabling destructuring of this is not a default, consider allowing destructuring",
         )
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_useless_empty_export.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_useless_empty_export_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_useless_empty_export_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow empty exports that don't change anything in a module file")
         .with_help("Empty export does nothing and can be removed.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{ast_util::is_global_require_call, context::LintContext, rule::Rule, AstNode};
 
-fn no_var_requires_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_var_requires_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require statement not part of import statement.")
         .with_help("Use ES6 style imports or import instead.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_wrapper_object_types(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use wrapper object types.").with_label(span0)
+fn no_wrapper_object_types(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use wrapper object types.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_as_const_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_as_const_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Expected a `const` assertion instead of a literal type annotation.")
         .with_help("You should use `as const` instead of type annotation.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_for_of.rs
@@ -12,12 +12,12 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator, Up
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_for_of_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_for_of_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Expected a `for-of` loop instead of a `for` loop with this simple iteration.",
     )
     .with_help("Consider using a for-of loop for this simple iteration.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -6,12 +6,12 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_literal_enum_member_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_literal_enum_member_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Explicit enum value must only be a literal value (string, number, boolean, etc).",
     )
     .with_help("Require all enum members to be literal values.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn prefer_ts_expect_error_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_ts_expect_error_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce using `@ts-expect-error` over `@ts-ignore`")
         .with_help("Use \"@ts-expect-error\" to ensure an error is actually being suppressed.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn empty_brace_spaces_diagnostic(span0: Span) -> OxcDiagnostic {
+fn empty_brace_spaces_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("No spaces inside empty pair of braces allowed")
         .with_help("There should be no spaces or new lines inside a pair of empty braces as it affects the overall readability of the code.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -12,12 +12,12 @@ fn missing_message(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Pass a message to the {x0:1} constructor.")).with_label(span1)
 }
 
-fn empty_message(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Error message should not be an empty string.").with_label(span0)
+fn empty_message(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Error message should not be an empty string.").with_label(span)
 }
 
-fn not_string(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Error message should be a string.").with_label(span0)
+fn not_string(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Error message should be a string.").with_label(span)
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -10,9 +10,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn escape_case_diagnostic(span0: Span) -> OxcDiagnostic {
+fn escape_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use uppercase characters for the value of the escape sequence.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -16,21 +16,21 @@ use crate::{
     AstNode,
 };
 
-fn none_zero(span0: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
+fn none_zero(span: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
     let mut d = OxcDiagnostic::warn(format!("Use `.{x1} {x2}` when checking {x1} is not zero."))
-        .with_label(span0);
+        .with_label(span);
     if let Some(x) = x3 {
         d = d.with_help(x);
     }
     d
 }
 
-fn zero(span0: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
+fn zero(span: Span, x1: &str, x2: &str, x3: Option<String>) -> OxcDiagnostic {
     let mut d = OxcDiagnostic::warn(format!("Use `.{x1} {x2}` when checking {x1} is zero."));
     if let Some(x) = x3 {
         d = d.with_help(x);
     }
-    d.with_label(span0)
+    d.with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -6,8 +6,8 @@ use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn filename_case_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Filename should not be in {x1} case")).with_label(span0)
+fn filename_case_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Filename should not be in {x1} case")).with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -10,12 +10,12 @@ use phf::phf_set;
 
 use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
 
-fn enforce(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `new {x1}()` instead of `{x1}()`")).with_label(span0)
+fn enforce(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `new {x1}()` instead of `{x1}()`")).with_label(span)
 }
 
-fn disallow(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `{x1}()` instead of `new {x1}()`")).with_label(span0)
+fn disallow(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `{x1}()` instead of `new {x1}()`")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -4,12 +4,12 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, disable_directives::DisableRuleComment, rule::Rule};
 
-fn no_abusive_eslint_disable_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_abusive_eslint_disable_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Unexpected `eslint-disable` comment that does not specify any rules to disable.",
     )
     .with_help("Specify the rules you want to disable.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_anonymous_default_export_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_anonymous_default_export_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow anonymous functions and classes as the default export")
         .with_help(format!("The {x1} should be named."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -9,10 +9,10 @@ use phf::phf_set;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn no_array_for_each_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_array_for_each_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `Array#forEach`")
         .with_help("Replace it with a for` loop. For loop is faster, more readable, and you can use `break` or `return` to exit early.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -11,12 +11,12 @@ use crate::{
     AstNode,
 };
 
-fn no_array_reduce_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_array_reduce_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.",
     )
     .with_help("Refactor your code to use `for` loops instead.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_expression_member.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_await_expression_member_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_await_expression_member_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow member access from await expression")
         .with_help("When accessing a member from an await expression, the await expression has to be parenthesized, which is not readable.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn no_await_in_promise_methods_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_await_in_promise_methods_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Promise in `Promise.{x1}()` should not be awaited."))
         .with_help("Remove the `await`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -11,10 +11,10 @@ use crate::{
     rule::Rule, AstNode,
 };
 
-fn no_document_cookie_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_document_cookie_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `document.cookie` directly")
         .with_help("Use the Cookie Store API or a cookie library instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -7,10 +7,10 @@ use crate::{
     context::LintContext, partial_loader::LINT_PARTIAL_LOADER_EXT, rule::Rule, utils::is_empty_stmt,
 };
 
-fn no_empty_file_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_empty_file_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Empty files are not allowed.")
         .with_help("Delete this file or add some code to it.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -8,8 +8,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_hex_escape_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use Unicode escapes instead of hexadecimal escapes.").with_label(span0)
+fn no_hex_escape_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use Unicode escapes instead of hexadecimal escapes.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_array.rs
@@ -6,10 +6,10 @@ use oxc_syntax::operator::BinaryOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_instanceof_array_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_instanceof_array_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Array.isArray()` instead of `instanceof Array`.")
         .with_help("The instanceof Array check doesn't work across realms/contexts, for example, frames/windows in browsers or the vm module in Node.js.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn no_magic_array_flat_map_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_magic_array_flat_map_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Magic number for `Array.prototype.flat` depth is not allowed.")
         .with_help("Add a comment explaining the depth.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -9,10 +9,10 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_negated_condition_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_negated_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected negated condition.")
         .with_help("Remove the negation operator and switch the consequent and alternate branches.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -7,7 +7,7 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_negation_in_equality_check_diagnostic(
-    span0: Span,
+    span: Span,
     current_operator: BinaryOperator,
     suggested_operator: BinaryOperator,
 ) -> OxcDiagnostic {
@@ -17,7 +17,7 @@ fn no_negation_in_equality_check_diagnostic(
             suggested_operator.as_str(),
             current_operator.as_str()
         ))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_nested_ternary.rs
@@ -5,16 +5,16 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn unparenthesized_nested_ternary(span0: Span) -> OxcDiagnostic {
+fn unparenthesized_nested_ternary(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected nested ternary expression without parentheses.")
         .with_help("Add parentheses around the nested ternary expression.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn deeply_nested_ternary(span0: Span) -> OxcDiagnostic {
+fn deeply_nested_ternary(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected deeply nested ternary expression.")
         .with_help("Avoid nesting ternary expressions for more than one level.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_new_array_diagnostic(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use `new Array(singleArgument)`.").with_help(r"It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.").with_label(span0)
+fn no_new_array_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use `new Array(singleArgument)`.").with_help(r"It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_new_buffer_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_new_buffer_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Buffer.alloc()` or `Buffer.from()` instead of the deprecated `new Buffer()` constructor.")
         .with_help("`new Buffer()` is deprecated, use `Buffer.alloc()` or `Buffer.from()` instead.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -8,13 +8,13 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn identifier(span0: Span, x1: &str) -> OxcDiagnostic {
+fn identifier(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use an object literal as default for parameter `{x1}`."))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn non_identifier(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use an object literal as default").with_label(span0)
+fn non_identifier(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use an object literal as default").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn no_process_exit_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_process_exit_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow `process.exit()`.")
         .with_help("Only use `process.exit()` in CLI apps. Throw an error instead.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_static_only_class_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_static_only_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow classes that only have static members.")
         .with_help("A class with only static members could just be an object instead.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -12,22 +12,22 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn object(span0: Span) -> OxcDiagnostic {
+fn object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not add `then` to an object.")
         .with_help("If an object is defined as 'thenable', once it's accidentally used in an await expression, it may cause problems")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn export(span0: Span) -> OxcDiagnostic {
+fn export(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not export `then`.")
         .with_help("If an object is defined as 'thenable', once it's accidentally used in an await expression, it may cause problems")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn class(span0: Span) -> OxcDiagnostic {
+fn class(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not add `then` to a class.")
         .with_help("If an object is defined as 'thenable', once it's accidentally used in an await expression, it may cause problems")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_this_assignment_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn no_this_assignment_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not assign `this` to `{x1}`"))
         .with_help("Reference `this` directly instead of assigning it to a variable.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -6,9 +6,9 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{ast_util::get_declaration_of_variable, context::LintContext, rule::Rule, AstNode};
 
-fn no_typeof_undefined_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_typeof_undefined_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Compare with `undefined` directly instead of using `typeof`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unnecessary_await_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unnecessary_await_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow awaiting non-promise values")
         .with_help("consider to remove the `await`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -6,10 +6,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unreadable_array_destructuring_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unreadable_array_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Disallow unreadable array destructuring")
         .with_help("Array destructuring may not contain consecutive ignored values.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn no_unreadable_iife_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_unreadable_iife_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("IIFE with parenthesized arrow function body is considered unreadable.")
         .with_help("Rewrite the IIFE to avoid having a parenthesized arrow function body.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -12,20 +12,20 @@ use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn some(span0: Span) -> OxcDiagnostic {
+fn some(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Found a useless array length check")
         .with_help(
             "The non-empty check is useless as `Array#some()` returns `false` for an empty array.",
         )
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn every(span0: Span) -> OxcDiagnostic {
+fn every(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Found a useless array length check")
         .with_help(
             "The empty check is useless as `Array#every()` returns `true` for an empty array.",
         )
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -14,16 +14,16 @@ use crate::{
     AstNode,
 };
 
-fn resolve(span0: Span, x1: &str) -> OxcDiagnostic {
+fn resolve(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `{x1} value` over `{x1} Promise.resolve(value)`."))
         .with_help("Wrapping the return value in `Promise.Resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn reject(span0: Span, x1: &str) -> OxcDiagnostic {
+fn reject(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `throw error` over `{x1} Promise.reject(error)`."))
         .with_help("Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::is_empty_stmt, AstNode};
 
-fn no_useless_switch_case_diagnostic(span0: Span) -> OxcDiagnostic {
+fn no_useless_switch_case_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Useless case in switch statement.")
         .with_help("Consider removing this case or removing the `default` case.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -11,8 +11,8 @@ fn warn() -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use useless `undefined`.")
         .with_help("Consider removing `undefined` or using `null` instead.")
 }
-fn no_useless_undefined_diagnostic(span0: Span) -> OxcDiagnostic {
-    warn().with_label(span0)
+fn no_useless_undefined_diagnostic(span: Span) -> OxcDiagnostic {
+    warn().with_label(span)
 }
 fn no_useless_undefined_diagnostic_spans(spans: Vec<Span>) -> OxcDiagnostic {
     warn().with_labels(spans)

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -5,16 +5,16 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn zero_fraction(span0: Span, x1: &str) -> OxcDiagnostic {
+fn zero_fraction(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't use a zero fraction in the number.")
         .with_help(format!("Replace the number literal with `{x1}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn dangling_dot(span0: Span, x1: &str) -> OxcDiagnostic {
+fn dangling_dot(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Don't use a dangling dot in the number.")
         .with_help(format!("Replace the number literal with `{x1}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -5,32 +5,32 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn uppercase_prefix(span0: Span, x1: &str) -> OxcDiagnostic {
+fn uppercase_prefix(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected number literal prefix in uppercase.")
         .with_help(format!("Use lowercase for the number literal prefix `{x1}`."))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn uppercase_exponential_notation(span0: Span) -> OxcDiagnostic {
+fn uppercase_exponential_notation(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected exponential notation in uppercase.")
         .with_help("Use lowercase for `e` in exponential notations.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn lowercase_hexadecimal_digits(span0: Span) -> OxcDiagnostic {
+fn lowercase_hexadecimal_digits(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected hexadecimal digits in lowercase.")
         .with_help("Use uppercase for hexadecimal digits.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn uppercase_prefix_and_lowercase_hexadecimal_digits(span0: Span, x1: &str) -> OxcDiagnostic {
+fn uppercase_prefix_and_lowercase_hexadecimal_digits(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Unexpected number literal prefix in uppercase and hexadecimal digits in lowercase.",
     )
     .with_help(format!(
         "Use lowercase for the number literal prefix `{x1}` and uppercase for hexadecimal digits."
     ))
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -10,10 +10,10 @@ use regex::Regex;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn numeric_separators_style_diagnostic(span0: Span) -> OxcDiagnostic {
+fn numeric_separators_style_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid group length in numeric value.")
         .with_help("Group digits with numeric separators (_) so longer numbers are easier to read.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -5,9 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_add_event_listener_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_add_event_listener_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `addEventListener()` over their `on`-function counterparts.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -19,10 +19,10 @@ use crate::{
     AstNode,
 };
 
-fn prefer_array_flat_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_array_flat_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer Array#flat() over legacy techniques to flatten arrays.")
         .with_help(r"Call `.flat()` on the array instead.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{ast_util::is_method_call, context::LintContext, fixer::Fix, rule::Rule, AstNode};
 
-fn prefer_array_flat_map_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_array_flat_map_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`Array.flatMap` performs `Array.map` and `Array.flat` in one step.")
         .with_help("Prefer `.flatMap(…)` over `.map(…).flat()`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -15,13 +15,13 @@ use crate::{
     AstNode,
 };
 
-fn over_method(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `.some(…)` over `.find(…)`or `.findLast(…)`.").with_label(span0)
+fn over_method(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `.some(…)` over `.find(…)`or `.findLast(…)`.").with_label(span)
 }
 
-fn non_zero_filter(span0: Span) -> OxcDiagnostic {
+fn non_zero_filter(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `.some(…)` over non-zero length check from `.filter(…)`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -5,9 +5,9 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_blob_reading_methods_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn prefer_blob_reading_methods_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `Blob#{x1}()` over `FileReader#{x2}(blob)`."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_code_point_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn prefer_code_point_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`"))
         .with_help(format!("Unicode is better supported in `{x1}` than `{x2}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -9,22 +9,22 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_date_now(span0: Span) -> OxcDiagnostic {
+fn prefer_date_now(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `Date.now()` over `new Date()`")
         .with_help("Change to `Date.now()`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn prefer_date_now_over_methods(span0: Span, x1: &str) -> OxcDiagnostic {
+fn prefer_date_now_over_methods(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `Date.now()` over `new Date().{x1}()`"))
         .with_help("Change to `Date.now()`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn prefer_date_now_over_number_date_object(span0: Span) -> OxcDiagnostic {
+fn prefer_date_now_over_number_date_object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `Date.now()` over `Number(new Date())`")
         .with_help("Change to `Date.now()`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_dom_node_append_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_dom_node_append_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `Node#append()` over `Node#appendChild()` for DOM nodes.")
         .with_help("Replace `Node#appendChild()` with `Node#append()`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -5,30 +5,30 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn set(span0: Span, x1: &str) -> OxcDiagnostic {
+fn set(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `setAttribute`.")
         .with_help(format!("Access the `.dataset` object directly: `element.dataset.{x1} = ...;`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn get(span0: Span, x1: &str) -> OxcDiagnostic {
+fn get(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `getAttribute`.")
         .with_help(format!("Access the `.dataset` object directly: `element.dataset.{x1}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn has(span0: Span, x1: &str) -> OxcDiagnostic {
+fn has(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `hasAttribute`.")
         .with_help(format!(
             "Check the `dataset` object directly: `Object.hasOwn(element.dataset, '{x1}')"
         ))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn remove(span0: Span, x1: &str) -> OxcDiagnostic {
+fn remove(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using `dataset` over `removeAttribute`.")
         .with_help(format!("Access the `.dataset` object directly: `delete element.dataset.{x1};"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -10,10 +10,10 @@ use crate::{
     AstNode,
 };
 
-fn prefer_dom_node_remove_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_dom_node_remove_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.")
         .with_help("Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_dom_node_text_content_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_dom_node_text_content_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `.textContent` over `.innerText`.")
         .with_help("Replace `.innerText` with `.textContent`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_event_target_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_event_target_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `EventTarget` over `EventEmitter`")
         .with_help("Change `EventEmitter` to `EventTarget`. EventEmitters are only available in Node.js, while EventTargets are also available in browsers.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -11,11 +11,11 @@ use crate::{
     AstNode,
 };
 
-fn prefer_includes_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_includes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Prefer `includes()` over `indexOf()` when checking for existence or non-existence.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -6,10 +6,10 @@ use oxc_syntax::operator::UnaryOperator;
 
 use crate::{context::LintContext, rule::Rule, utils::is_same_reference, AstNode};
 
-fn prefer_logical_operator_over_ternary_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_logical_operator_over_ternary_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using a logical operator over a ternary.")
         .with_help("Switch to \"||\" or \"??\" operator")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -6,9 +6,8 @@ use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_math_trunc_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `Math.trunc()` over instead of `{x1} 0`."))
-        .with_label(span0)
+fn prefer_math_trunc_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `Math.trunc()` over instead of `{x1} 0`.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -11,16 +11,16 @@ use crate::{
     ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_same_reference, AstNode,
 };
 
-fn prefer_math_abs(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `Math.abs(x)` over alternatives").with_label(span0)
+fn prefer_math_abs(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `Math.abs(x)` over alternatives").with_label(span)
 }
 
-fn prefer_math_hypot(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `Math.hypot(…)` over alternatives").with_label(span0)
+fn prefer_math_hypot(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `Math.hypot(…)` over alternatives").with_label(span)
 }
 
-fn prefer_math_log_n(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `Math.{x1}(x)` over `{x2}`")).with_label(span0)
+fn prefer_math_log_n(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `Math.{x1}(x)` over `{x2}`")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -9,14 +9,14 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, utils::get_first_parameter_name, AstNode};
 
-fn function(span0: Span, x1: &str) -> OxcDiagnostic {
+fn function(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("The function is equivalent to `{x1}`. Call `{x1}` directly."))
-        .with_label(span0)
+        .with_label(span)
 }
 
-fn array_callback(span0: Span) -> OxcDiagnostic {
+fn array_callback(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The arrow function in the callback of the array is equivalent to `Boolean`. Replace the callback with `Boolean`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -9,10 +9,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_node_protocol_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn prefer_node_protocol_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer using the `node:` protocol when importing Node.js builtin modules.")
         .with_help(format!("Prefer `node:{x1}` over `{x1}`."))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -8,10 +8,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule, AstNode};
 
-fn prefer_number_properties_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn prefer_number_properties_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `Number.{x1}` instead of the global `{x1}`"))
         .with_help(format!("Replace it with `Number.{x1}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -8,9 +8,9 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_optional_catch_binding_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_optional_catch_binding_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer omitting the catch binding parameter if it is unused")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -11,12 +11,12 @@ use crate::{
     AstNode,
 };
 
-fn known_method(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer using `{x1}.prototype.{x2}`.")).with_label(span0)
+fn known_method(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer using `{x1}.prototype.{x2}`.")).with_label(span)
 }
 
-fn unknown_method(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer using method from `{x1}.prototype`.")).with_label(span0)
+fn unknown_method(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer using method from `{x1}.prototype`.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_reflect_apply_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_reflect_apply_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer Reflect.apply() over Function#apply()")
         .with_help("Reflect.apply() is less verbose and easier to understand.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -8,10 +8,10 @@ use oxc_span::Span;
 
 use crate::{ast_util::outermost_paren_parent, context::LintContext, rule::Rule, AstNode};
 
-fn prefer_regexp_test_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_regexp_test_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer RegExp#test() over String#match() and RegExp#exec()")
         .with_help("RegExp#test() exclusively returns a boolean and therefore is more efficient")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -10,11 +10,11 @@ use crate::{
     ast_util::get_declaration_of_variable, context::LintContext, fixer::Fix, rule::Rule, AstNode,
 };
 
-fn prefer_set_size_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_set_size_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Use `Set#size` instead of converting a `Set` to an array and using its `length` property.",
     )
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -9,10 +9,10 @@ use phf::phf_set;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_spread_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
+fn prefer_spread_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer the spread operator (`...`) over {x1}"))
         .with_help("The spread operator (`...`) is more concise and readable.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -10,13 +10,13 @@ use oxc_span::GetSpan;
 
 use crate::{ast_util::extract_regex_flags, context::LintContext, rule::Rule, AstNode};
 
-fn string_literal(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("This pattern can be replaced with `{x1}`.")).with_label(span0)
+fn string_literal(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("This pattern can be replaced with `{x1}`.")).with_label(span)
 }
 
-fn use_replace_all(span0: Span) -> OxcDiagnostic {
+fn use_replace_all(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `String#replaceAll()` over `String#replace()` when using a regex with the global flag.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -5,8 +5,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_string_slice_diagnostic(span0: Span, x1: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer String#slice() over String#{x1}()")).with_label(span0)
+fn prefer_string_slice_diagnostic(span: Span, x1: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer String#slice() over String#{x1}()")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -13,12 +13,12 @@ use crate::{
     AstNode,
 };
 
-fn starts_with(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer String#startsWith over a regex with a caret.").with_label(span0)
+fn starts_with(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer String#startsWith over a regex with a caret.").with_label(span)
 }
 
-fn ends_with(span0: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer String#endsWith over a regex with a dollar sign.").with_label(span0)
+fn ends_with(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer String#endsWith over a regex with a dollar sign.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -5,10 +5,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_string_trim_start_end_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+fn prefer_string_trim_start_end_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`"))
         .with_help(format!("Replace with `{x1}`"))
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -7,10 +7,10 @@ use oxc_span::Span;
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 
-fn prefer_structured_clone_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_structured_clone_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `structuredClone(…)` to create a deep clone.")
         .with_help("Switch to `structuredClone(…)`.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -9,12 +9,12 @@ use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn prefer_type_error_diagnostic(span0: Span) -> OxcDiagnostic {
+fn prefer_type_error_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Prefer throwing a `TypeError` over a generic `Error` after a type checking if-statement",
     )
     .with_help("Change to `throw new TypeError(...)`")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -8,10 +8,10 @@ use crate::{
     AstNode,
 };
 
-fn require_array_join_separator_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_array_join_separator_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforce using the separator argument with Array#join()")
         .with_help("Missing the separator argument.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -5,10 +5,10 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn require_number_to_fixed_digits_argument_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_number_to_fixed_digits_argument_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Number method .toFixed() should have an argument")
         .with_help("It's better to make it clear what the value of the digits argument is when calling Number#toFixed(), instead of relying on the default value of 0.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -5,12 +5,12 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn switch_case_braces_diagnostic(span0: Span) -> OxcDiagnostic {
+fn switch_case_braces_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         " Empty switch case shouldn't have braces and not-empty case should have braces around it.",
     )
     .with_help("There is less visual clutter for empty cases and proper scope for non-empty cases.")
-    .with_label(span0)
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -9,8 +9,8 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn text_encoding_identifier_case_diagnostic(span0: Span, x1: &str, x2: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`.")).with_label(span0)
+fn text_encoding_identifier_case_diagnostic(span: Span, x1: &str, x2: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `{x1}` over `{x2}`.")).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -15,10 +15,10 @@ use crate::{
     AstNode,
 };
 
-fn throw_new_error_diagnostic(span0: Span) -> OxcDiagnostic {
+fn throw_new_error_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require `new` when throwing an error.")
         .with_help("While it's possible to create a new error without using the `new` keyword, it's better to be explicit.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
@@ -12,10 +12,10 @@ use crate::{
     },
 };
 
-fn no_conditional_tests(span0: Span) -> OxcDiagnostic {
+fn no_conditional_tests(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Avoid having conditionals in tests")
         .with_help("Remove the surrounding if statement.")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -4,10 +4,10 @@ use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule};
 
-fn no_import_node_test(span0: Span) -> OxcDiagnostic {
+fn no_import_node_test(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("disallow importing `node:test`".to_string())
         .with_help("Import from `vitest` instead of `node:test`")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -39,10 +39,10 @@ fn is_test_or_describe_node(member_expr: &MemberExpression) -> bool {
     false
 }
 
-fn require_local_test_context_for_concurrent_snapshots_diagnostic(span0: Span) -> OxcDiagnostic {
+fn require_local_test_context_for_concurrent_snapshots_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require local Test Context for concurrent snapshot tests")
         .with_help("Use local Test Context instead")
-        .with_label(span0)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
              Yes. Those were added due to a code mod. the number suffixes were to avoid name collisions.

_Originally posted by @DonIsaac in https://github.com/oxc-project/oxc/pull/5203#discussion_r1730578314_
            