### PR TITLE
feat(linter)!: parse and display syntax errors for regular expressions

### DIFF
--- a/crates/oxc_linter/src/service.rs
+++ b/crates/oxc_linter/src/service.rs
@@ -256,6 +256,7 @@ impl Runtime {
     ) -> Vec<Message<'a>> {
         let ret = Parser::new(allocator, source_text, source_type)
             .with_options(ParseOptions {
+                parse_regular_expression: true,
                 allow_return_outside_function: true,
                 ..ParseOptions::default()
             })


### PR DESCRIPTION
cc @leaysgur shipping to production!

This is marked as breaking change because there may be false positives.