### PR TITLE
refactor(codegen): rename vars

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -18,11 +18,13 @@ use crate::{
 };
 
 pub trait Gen {
-    fn gen(&self, _p: &mut Codegen, _ctx: Context) {}
+    #[allow(unused_variables)]
+    fn gen(&self, p: &mut Codegen, ctx: Context) {}
 }
 
 pub trait GenExpr {
-    fn gen_expr(&self, _p: &mut Codegen, _precedence: Precedence, _ctx: Context) {}
+    #[allow(unused_variables)]
+    fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {}
 }
 
 impl<'a, T> Gen for Box<'a, T>


### PR DESCRIPTION
Rename function params in default methods of `Codegen`. Makes no material difference, just nicer hints in IDE.