### PR TITLE
fix(parser): Span for invalid regex flags

### DIFF
--- a/crates/oxc_parser/src/lexer/regex.rs
+++ b/crates/oxc_parser/src/lexer/regex.rs
@@ -63,11 +63,17 @@ impl<'a> Lexer<'a> {
         {
             self.consume_char();
             let Ok(flag) = RegExpFlags::try_from(b) else {
-                self.error(diagnostics::reg_exp_flag(b as char, self.current_offset()));
+                self.error(diagnostics::reg_exp_flag(
+                    b as char,
+                    self.current_offset().expand_left(1),
+                ));
                 continue;
             };
             if flags.contains(flag) {
-                self.error(diagnostics::reg_exp_flag_twice(b as char, self.current_offset()));
+                self.error(diagnostics::reg_exp_flag_twice(
+                    b as char,
+                    self.current_offset().expand_left(1),
+                ));
                 continue;
             }
             flags |= flag;

--- a/tasks/coverage/parser_babel.snap
+++ b/tasks/coverage/parser_babel.snap
@@ -3438,9 +3438,9 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   help: Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.
 
   × Flag i is mentioned twice in regular expression literal
-   ╭─[babel/packages/babel-parser/test/fixtures/es2015/regex/duplicate-flags/input.js:1:7]
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/regex/duplicate-flags/input.js:1:6]
  1 │ /./gii;
-   ·       ▲
+   ·      ─
    ╰────
 
   × Unexpected token

--- a/tasks/coverage/parser_test262.snap
+++ b/tasks/coverage/parser_test262.snap
@@ -20531,17 +20531,17 @@ Negative Passed: 4220/4220 (100.00%)
     ╰────
 
   × Unexpected flag G in regular expression literal
-    ╭─[test262/test/language/literals/regexp/early-err-bad-flag.js:18:5]
+    ╭─[test262/test/language/literals/regexp/early-err-bad-flag.js:18:4]
  17 │ 
  18 │ /./G;
-    ·     ▲
+    ·    ─
     ╰────
 
   × Flag g is mentioned twice in regular expression literal
-    ╭─[test262/test/language/literals/regexp/early-err-dup-flag.js:18:7]
+    ╭─[test262/test/language/literals/regexp/early-err-dup-flag.js:18:6]
  17 │ 
  18 │ /./gig;
-    ·       ▲
+    ·      ─
     ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none

--- a/tasks/coverage/parser_typescript.snap
+++ b/tasks/coverage/parser_typescript.snap
@@ -10378,90 +10378,90 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFro
    ╰────
 
   × Unexpected flag a in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:12]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:11]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·               ▲
+   ·              ─
  4 │     // Pattern modifiers
    ╰────
 
   × Unexpected flag l in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:13]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:12]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                ▲
+   ·               ─
  4 │     // Pattern modifiers
    ╰────
 
   × Flag s is mentioned twice in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:14]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:13]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                 ▲
+   ·                ─
  4 │     // Pattern modifiers
    ╰────
 
   × Unexpected flag t in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:15]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:14]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                  ▲
+   ·                 ─
  4 │     // Pattern modifiers
    ╰────
 
   × Flag u is mentioned twice in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:16]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:15]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                   ▲
+   ·                  ─
  4 │     // Pattern modifiers
    ╰────
 
   × Flag i is mentioned twice in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:18]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:17]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                     ▲
+   ·                    ─
  4 │     // Pattern modifiers
    ╰────
 
   × Unexpected flag o in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:19]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:18]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                      ▲
+   ·                     ─
  4 │     // Pattern modifiers
    ╰────
 
   × Unexpected flag c in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:20]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:19]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                       ▲
+   ·                      ─
  4 │     // Pattern modifiers
    ╰────
 
   × Unexpected flag o in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:21]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:20]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                        ▲
+   ·                       ─
  4 │     // Pattern modifiers
    ╰────
 
   × Flag d is mentioned twice in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:22]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:21]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                         ▲
+   ·                        ─
  4 │     // Pattern modifiers
    ╰────
 
   × Unexpected flag e in regular expression literal
-   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:23]
+   ╭─[typescript/tests/cases/compiler/regularExpressionScanning.ts:3:22]
  2 │     // Flags
  3 │     /foo/visualstudiocode,
-   ·                          ▲
+   ·                         ─
  4 │     // Pattern modifiers
    ╰────
 
@@ -20391,9 +20391,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFro
   help: Try insert a semicolon here
 
   × Unexpected flag a in regular expression literal
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts:1:17]
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts:1:16]
  1 │ if (1) /regexp/a.foo();
-   ·                 ▲
+   ·                ─
    ╰────
 
   × Unterminated regular expression


### PR DESCRIPTION
### Before
```
  x Flag u is mentioned twice in regular expression literal
   ,-[1:20]
 1 | const a = /\2(.)/uuxig;
   :                    ^
 2 | debugger;
   `----

  x Unexpected flag x in regular expression literal
   ,-[1:21]
 1 | const a = /\2(.)/uuxig;
   :                     ^
 2 | debugger;
   `----
```

### After
```
  x Flag u is mentioned twice in regular expression literal
   ,-[1:19]
 1 | const a = /\2(.)/uuxig;
   :                   ^
 2 | debugger;
   `----

  x Unexpected flag x in regular expression literal
   ,-[1:20]
 1 | const a = /\2(.)/uuxig;
   :                    ^
 2 | debugger;
   `----
```