### PR TITLE
refactor(semantic): remove `ScopeTree::child_ids`

### DIFF
--- a/crates/oxc_semantic/src/post_transform_checker.rs
+++ b/crates/oxc_semantic/src/post_transform_checker.rs
@@ -420,13 +420,6 @@ impl<'s> PostTransformChecker<'s> {
                 self.errors.push_mismatch("Scope parent mismatch", scope_ids, parent_ids);
             }
 
-            // Check children match
-            let child_ids = self
-                .get_pair(scope_ids, |data, scope_id| data.scopes.get_child_ids(scope_id).to_vec());
-            if self.remap_scope_ids_sets(&child_ids).is_mismatch() {
-                self.errors.push_mismatch("Scope children mismatch", scope_ids, child_ids);
-            }
-
             // NB: Skip checking node IDs match - transformer does not set `AstNodeId`s
         }
     }
@@ -592,29 +585,6 @@ impl<'s> PostTransformChecker<'s> {
         Pair::new(self.scope_ids_map.get(scope_ids.after_transform), Some(scope_ids.rebuilt))
     }
 
-    /// Remap pair of arrays of `ScopeId`s.
-    /// Map `after_transform` IDs to `rebuilt` IDs.
-    /// Sort both sets.
-    fn remap_scope_ids_sets<V: AsRef<Vec<ScopeId>>>(
-        &self,
-        scope_ids: &Pair<V>,
-    ) -> Pair<Vec<Option<ScopeId>>> {
-        let mut after_transform = scope_ids
-            .after_transform
-            .as_ref()
-            .iter()
-            .map(|&scope_id| self.scope_ids_map.get(scope_id))
-            .collect::<Vec<_>>();
-        let mut rebuilt =
-            scope_ids.rebuilt.as_ref().iter().copied().map(Option::Some).collect::<Vec<_>>();
-
-        after_transform.sort_unstable();
-        rebuilt.sort_unstable();
-
-        Pair::new(after_transform, rebuilt)
-    }
-
-    /// Remap pair of arrays of `SymbolId`s.
     /// Map `after_transform` IDs to `rebuilt` IDs.
     /// Sort both sets.
     fn remap_symbol_ids_sets<V: AsRef<Vec<SymbolId>>>(

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -28,8 +28,6 @@ pub type UnresolvedReferences = FxHashMap<CompactStr, Vec<ReferenceId>>;
 pub struct ScopeTree {
     /// Maps a scope to the parent scope it belongs in.
     parent_ids: IndexVec<ScopeId, Option<ScopeId>>,
-    /// Maps a scope to direct children scopes.
-    child_ids: IndexVec<ScopeId, Vec<ScopeId>>,
     /// Maps a scope to its node id.
     node_ids: IndexVec<ScopeId, AstNodeId>,
     flags: IndexVec<ScopeId, ScopeFlags>,
@@ -65,46 +63,6 @@ impl ScopeTree {
     /// guarantees the iterator will have at least 1 element.
     pub fn ancestors(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
         std::iter::successors(Some(scope_id), |scope_id| self.parent_ids[*scope_id])
-    }
-
-    /// Iterate over scopes contained by a scope in breadth-first order.
-    ///
-    /// Unlike [`ancestors`], this iterator will not include the scope itself.
-    ///
-    /// [`ancestors`]: ScopeTree::ancestors
-    pub fn descendants(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-        // Has to be a `fn` and pass arguments because we can't
-        // have recursive closures
-        fn add_to_list(
-            parent_id: ScopeId,
-            child_ids: &IndexVec<ScopeId, Vec<ScopeId>>,
-            items: &mut Vec<ScopeId>,
-        ) {
-            if let Some(children) = child_ids.get(parent_id) {
-                for child_id in children {
-                    items.push(*child_id);
-                    add_to_list(*child_id, child_ids, items);
-                }
-            }
-        }
-
-        let mut list = vec![];
-
-        add_to_list(scope_id, &self.child_ids, &mut list);
-
-        list.into_iter()
-    }
-
-    /// Get the child scopes of a scope
-    #[inline]
-    pub fn get_child_ids(&self, scope_id: ScopeId) -> &[ScopeId] {
-        &self.child_ids[scope_id]
-    }
-
-    /// Get a mutable reference to a scope's children
-    #[inline]
-    pub fn get_child_ids_mut(&mut self, scope_id: ScopeId) -> &mut Vec<ScopeId> {
-        &mut self.child_ids[scope_id]
     }
 
     pub fn descendants_from_root(&self) -> impl Iterator<Item = ScopeId> + '_ {
@@ -173,9 +131,6 @@ impl ScopeTree {
 
     pub fn set_parent_id(&mut self, scope_id: ScopeId, parent_id: Option<ScopeId>) {
         self.parent_ids[scope_id] = parent_id;
-        if let Some(parent_id) = parent_id {
-            self.child_ids[parent_id].push(scope_id);
-        }
     }
 
     /// Get a variable binding by name that was declared in the top-level scope
@@ -266,12 +221,7 @@ impl ScopeTree {
         node_id: AstNodeId,
         flags: ScopeFlags,
     ) -> ScopeId {
-        let scope_id = self.add_scope_impl(Some(parent_id), node_id, flags);
-
-        // Set this scope as child of parent scope
-        self.child_ids[parent_id].push(scope_id);
-
-        scope_id
+        self.add_scope_impl(Some(parent_id), node_id, flags)
     }
 
     /// Create the root [`Program`] scope.
@@ -295,7 +245,6 @@ impl ScopeTree {
         flags: ScopeFlags,
     ) -> ScopeId {
         let scope_id = self.parent_ids.push(parent_id);
-        self.child_ids.push(vec![]);
         self.flags.push(flags);
         self.bindings.push(Bindings::default());
         self.node_ids.push(node_id);
@@ -317,7 +266,6 @@ impl ScopeTree {
     /// Reserve memory for an `additional` number of scopes.
     pub fn reserve(&mut self, additional: usize) {
         self.parent_ids.reserve(additional);
-        self.child_ids.reserve(additional);
         self.flags.reserve(additional);
         self.bindings.reserve(additional);
         self.node_ids.reserve(additional);

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -24,10 +24,6 @@ fn test_only_program() {
     // ancestors
     assert_eq!(scopes.ancestors(root).count(), 1);
     assert!(scopes.get_parent_id(root).is_none());
-
-    // children
-    assert_eq!(scopes.descendants(root).count(), 0);
-    assert!(scopes.get_child_ids(root).is_empty());
 }
 
 #[test]

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -7,6 +7,7 @@ use oxc_semantic::{ScopeId, Semantic, SemanticBuilder};
 use oxc_span::SourceType;
 
 fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>) -> String {
+    let scope_tree = semantic.scopes();
     let mut result = String::default();
 
     result.push('[');
@@ -14,9 +15,15 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
         if index != 0 {
             result.push(',');
         }
-        let flags = semantic.scopes().get_flags(scope_id);
+        let flags = scope_tree.get_flags(scope_id);
         result.push('{');
-        let child_ids = semantic.scopes().get_child_ids(scope_id);
+        let child_ids = semantic
+            .scopes()
+            .descendants_from_root()
+            .filter(|id| {
+                scope_tree.get_parent_id(*id).is_some_and(|parent_id| parent_id == scope_id)
+            })
+            .collect::<Vec<_>>();
         result.push_str("\"children\":");
         result.push_str(&get_scope_snapshot(semantic, child_ids.iter().copied()));
         result.push(',');
@@ -25,12 +32,12 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
         result.push_str(
             format!(
                 "\"node\": {:?},",
-                semantic.nodes().kind(semantic.scopes().get_node_id(scope_id)).debug_name()
+                semantic.nodes().kind(scope_tree.get_node_id(scope_id)).debug_name()
             )
             .as_str(),
         );
         result.push_str("\"symbols\": ");
-        let bindings = semantic.scopes().get_bindings(scope_id);
+        let bindings = scope_tree.get_bindings(scope_id);
         result.push('[');
         bindings.iter().enumerate().for_each(|(index, (name, symbol_id))| {
             if index != 0 {

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -119,10 +119,6 @@ impl TraverseScoping {
     }
 
     fn insert_scope_below(&mut self, child_scope_ids: &[ScopeId], flags: ScopeFlags) -> ScopeId {
-        // Remove these scopes from parent's children
-        let current_child_scope_ids = self.scopes.get_child_ids_mut(self.current_scope_id);
-        current_child_scope_ids.retain(|scope_id| !child_scope_ids.contains(scope_id));
-
         // Create new scope as child of parent
         let new_scope_id = self.create_child_scope_of_current(flags);
 

--- a/crates/oxc_wasm/Cargo.toml
+++ b/crates/oxc_wasm/Cargo.toml
@@ -26,7 +26,7 @@ oxc_linter   = { workspace = true }
 oxc_prettier = { workspace = true }
 serde        = { workspace = true }
 
-wasm-bindgen       = { workspace = true }
-serde-wasm-bindgen = { workspace = true }
-tsify              = { workspace = true }
+wasm-bindgen             = { workspace = true }
+serde-wasm-bindgen       = { workspace = true }
+tsify                    = { workspace = true }
 console_error_panic_hook = "0.1.7"

--- a/tasks/coverage/semantic_babel.snap
+++ b/tasks/coverage/semantic_babel.snap
@@ -2,12 +2,7 @@ commit: 12619ffe
 
 semantic_babel Summary:
 AST Parsed     : 2100/2100 (100.00%)
-Positive Passed: 1735/2100 (82.62%)
-tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
+Positive Passed: 1768/2100 (84.19%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-import/input.js
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["spawn"]
@@ -21,11 +16,6 @@ rebuilt        : ScopeId(0): []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/opts/allowNewTargetOutsideFunction-true/input.js
 semantic error: Unexpected new.target expression
 Unexpected new.target expression
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-catch-hang-func/input.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/core/uncategorised/230/input.js
 semantic error: Binding symbols mismatch:
@@ -143,11 +133,6 @@ semantic error: Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/statement-if/migrated_0003/input.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["t"]
@@ -222,10 +207,7 @@ after transform: ["asserts"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-as-identifier/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["asserts"]
 rebuilt        : []
 
@@ -233,16 +215,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predi
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-var/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/declare-asserts-var-with-predicate/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/input.ts
 semantic error: Unresolved references mismatch:
@@ -306,31 +278,10 @@ semantic error: Unresolved references mismatch:
 after transform: ["A", "Error"]
 rebuilt        : []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/abstract/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(5): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/async-named-properties/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/async-optional-method/input.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["B", "Promise"]
 rebuilt        : ["B"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-modifier-names/input.ts
 semantic error: Multiple constructor implementations are not allowed.
@@ -394,41 +345,13 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/get-generic/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/get-generic-babel-7/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/implements/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["T", "X"]
 rebuilt        : []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/members-with-modifier-names/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/members-with-modifier-names-babel-7/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/members-with-reserved-names/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/method-computed/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
@@ -494,37 +417,12 @@ Bindings mismatch:
 after transform: ScopeId(8): ["T"]
 rebuilt        : ScopeId(8): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/method-no-body/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/method-with-newline-without-body/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-accessors/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-methods-async/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/modifiers-override/input.ts
 semantic error: Identifier `show` has already been declared
 Identifier `size` has already been declared
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties/input.ts
 semantic error: A required parameter cannot follow an optional parameter.
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-method-overload/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts
 semantic error: Identifier `x` has already been declared
@@ -533,17 +431,9 @@ Identifier `x` has already been declared
 Identifier `x` has already been declared
 Identifier `x` has already been declared
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/static/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/const/initializer-ambient-context/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/const/input.ts
@@ -562,25 +452,14 @@ Cannot assign to 'arguments' in strict mode
 Cannot assign to 'eval' in strict mode
 Cannot assign to 'arguments' in strict mode
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/function-rest-trailing-comma/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/interface/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/interface-new-line/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/let/input.ts
@@ -592,16 +471,10 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/patt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/pattern-parameters-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/var/input.ts
@@ -649,24 +522,15 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare-const/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare-new-line/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export/input.ts
@@ -688,9 +552,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-declare-const/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members/input.ts
@@ -752,16 +613,10 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/estree-compa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["hot-new-module"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "M", "N", "T", "_bar", "bar", "foo", "x"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/equals/input.ts
@@ -776,25 +631,16 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/expor
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/export-type-declaration/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "b"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/export-value-declaration/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "a", "b"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
@@ -846,28 +692,8 @@ Unresolved references mismatch:
 after transform: ["Generator"]
 rebuilt        : []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare-babel-7/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts
 semantic error: A required parameter cannot follow an optional parameter.
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/export-default/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/overloads/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals/input.ts
 semantic error: Semantic Collector failed after transform
@@ -939,9 +765,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/not-t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/type-asi/input.ts
 semantic error: Bindings mismatch:
@@ -957,48 +780,30 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/ca
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/call-signature-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/construct-signature/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/construct-signature-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/export/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/extends/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["X", "Z"]
@@ -1008,104 +813,65 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/fu
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/function-like-node-2/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/function-like-node-3/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/function-like-node-4/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/function-like-node-5/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/generic/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/generic-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set-ambiguous/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set-ambiguous-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set-methods/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set-methods-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/get-set-properties/input.ts
@@ -1115,16 +881,10 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/in
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-computed/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
@@ -1134,9 +894,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/me
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
@@ -1145,88 +902,55 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/me
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-generic-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-optional/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-optional-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-plain/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-plain-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/modifiers/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/pattern-parameters/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/pattern-parameters-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/properties/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/property-computed/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
@@ -1236,32 +960,20 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/pr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/reserved-method-name/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/reserved-method-name-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/separators/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Comma", "Newline", "Semi"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body/input.ts
@@ -1275,64 +987,40 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-names
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-nested/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-nested-declare/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/declare-shorthand/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/global-in-module/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "N", "m"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head-declare/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "N", "global", "m"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head-export/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/async-arrow-generic-9560/input.ts
@@ -1355,16 +1043,10 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/d
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnotherType", "MyType"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnotherType", "MyType"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/elision-arrow-destructuring-13636/input.ts
@@ -1376,9 +1058,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/i
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "I", "T"]
 rebuilt        : ScopeId(0): ["E"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -1390,24 +1069,15 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/i
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/issue-7742-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["this"]
@@ -1416,9 +1086,6 @@ rebuilt        : []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["var"]
@@ -1434,9 +1101,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/n
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B", "C", "D", "E", "F", "G"]
 rebuilt        : []
@@ -1445,22 +1109,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/n
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B", "C", "D", "E", "F", "G"]
 rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/callable-class/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/callable-class-ambient/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/enum-block-scoped/input.ts
 semantic error: Scope flags mismatch:
@@ -1471,18 +1122,12 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-declare-function-after/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["foo"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-declare-function-before/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["foo"]
 rebuilt        : []
 
@@ -1506,9 +1151,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["X", "Y"]
 rebuilt        : []
@@ -1517,32 +1159,20 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["~popsicle/dist/common"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-interface-after/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-interface-before/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-namespace/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["N"]
@@ -1552,44 +1182,22 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-type-before/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/function-type-before-declaration/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/function-type-before-declaration-optional-pattern/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/module-declaration-var/input.js
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/module-declaration-var-2/input.js
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-class-interface/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch:
@@ -1597,10 +1205,7 @@ after transform: SymbolId(0): [Span { start: 21, end: 22 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-const-type/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol redeclarations mismatch:
@@ -1636,10 +1241,7 @@ after transform: SymbolId(0): [Span { start: 17, end: 20 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-function-interface/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 Symbol redeclarations mismatch:
@@ -1647,10 +1249,7 @@ after transform: SymbolId(0): [Span { start: 26, end: 27 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-function-type/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 Symbol redeclarations mismatch:
@@ -1660,9 +1259,6 @@ rebuilt        : SymbolId(0): []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-ambient-class/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Something"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-equals-var/input.ts
@@ -1749,9 +1345,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redecl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Global", "a"]
 rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-type-var/input.ts
 semantic error: Symbol flags mismatch:
@@ -1833,17 +1426,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redecl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "test", "test/submodule"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-different-module-and-top-level/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSONSchema7", "T", "foo", "fooBar", "test/submodule", "test/submodule2"]
 rebuilt        : ScopeId(0): ["foo", "fooBar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -1852,15 +1439,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redecl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["test/sub1"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-interface-class/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch:
@@ -1871,10 +1452,7 @@ after transform: SymbolId(0): [Span { start: 21, end: 22 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-interface-function/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 Symbol span mismatch:
@@ -1888,15 +1466,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redecl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-interface-let/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch:
@@ -1907,10 +1479,7 @@ after transform: SymbolId(0): [Span { start: 19, end: 20 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-interface-var/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -1921,10 +1490,7 @@ after transform: SymbolId(0): [Span { start: 19, end: 20 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-let-interface/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch:
@@ -1932,10 +1498,7 @@ after transform: SymbolId(0): [Span { start: 17, end: 18 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-let-type/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch:
@@ -1943,10 +1506,7 @@ after transform: SymbolId(0): [Span { start: 17, end: 18 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-type-function/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
 Symbol span mismatch:
@@ -1957,10 +1517,7 @@ after transform: SymbolId(0): [Span { start: 26, end: 27 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-type-let/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch:
@@ -1971,10 +1528,7 @@ after transform: SymbolId(0): [Span { start: 21, end: 22 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-type-var/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -1985,10 +1539,7 @@ after transform: SymbolId(0): [Span { start: 21, end: 22 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-var-interface/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch:
@@ -1996,10 +1547,7 @@ after transform: SymbolId(0): [Span { start: 17, end: 18 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-var-type/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch:
@@ -2034,9 +1582,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-arg
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["C", "T", "f"]
 rebuilt        : ["C", "f"]
@@ -2055,40 +1600,25 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/d
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/export/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/generic/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/generic-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/generic-complex-tokens-true/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
@@ -2098,9 +1628,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/g
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -2108,9 +1635,6 @@ rebuilt        : []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/plain/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call/input.ts
@@ -2127,9 +1651,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-argumen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C1", "C2", "C3", "C4", "I", "bar", "x10", "x11", "x12", "x13", "x14", "x5", "x6", "yy"]
 rebuilt        : ScopeId(0): ["C", "C1", "C2", "C3", "C4", "bar", "x10", "x11", "x12", "x13", "x14", "x5", "x6", "yy"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 Unresolved references mismatch:
 after transform: ["f", "true"]
 rebuilt        : ["f"]
@@ -2284,25 +1805,14 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "b"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/conditional/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/conditional-infer/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Element"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/conditional-infer-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Element"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts
@@ -2352,9 +1862,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X3", "X4", "X5", "X6", "X7", "X8", "X9"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["MustBeNumber"]
 rebuilt        : []
@@ -2363,24 +1870,15 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-with-constraints-and-conditional-types-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-with-constraints-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X3", "X4", "X5", "X6", "X7", "X8", "X9"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["MustBeNumber"]
@@ -2390,22 +1888,13 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foo", "intrinsic"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["Foo", "X", "a", "x"]
 rebuilt        : ScopeId(1): ["a", "x"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["intrinsic"]
@@ -2414,9 +1903,6 @@ rebuilt        : []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["intrinsic"]
@@ -2442,17 +1928,9 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar", "x"]
 rebuilt        : ScopeId(0): ["x"]
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped-as/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MappedTypeWithNewKeys", "PickByValueType", "RemoveKindField"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "NewKeyType"]
@@ -2462,17 +1940,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MappedTypeWithNewKeys", "PickByValueType", "RemoveKindField"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "NewKeyType"]
 rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped-babel-7/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/object-shorthand/input.ts
 semantic error: Bindings mismatch:
@@ -2488,32 +1958,20 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/parent
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/parenthesized-object/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/pattern-parameters/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/pattern-parameters-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference/input.ts
@@ -2535,32 +1993,20 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncWithDescription"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-keyword-labeled-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncWithDescriptionBabel7"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-after-unlabeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B"]
@@ -2570,9 +2016,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B"]
 rebuilt        : []
@@ -2580,9 +2023,6 @@ rebuilt        : []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-after-labeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B"]
@@ -2592,22 +2032,9 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B"]
 rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/type-literal-get-set/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/type-literal-get-set-babel-7/input.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/type-operator/input.ts
 semantic error: Unresolved references mismatch:
@@ -2623,9 +2050,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["a"]
 rebuilt        : []
@@ -2633,9 +2057,6 @@ rebuilt        : []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-asi-false-parameters-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["a"]
@@ -2650,31 +2071,19 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/types-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["abstract", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/union-intersection/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "J", "K", "M", "N", "O", "intersection", "precedence1", "precedence2", "union"]
 rebuilt        : ScopeId(0): ["intersection", "precedence1", "precedence2", "union"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types-arrow-function/object-pattern-with-template/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types-arrow-function-babel-7/object-pattern-with-template/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 

--- a/tasks/coverage/semantic_misc.snap
+++ b/tasks/coverage/semantic_misc.snap
@@ -20,24 +20,15 @@ tasks/coverage/misc/pass/oxc-2087.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Helpers"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/misc/pass/oxc-2394.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/misc/pass/oxc-2592.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/misc/pass/oxc-3443.tsx
@@ -172,9 +163,6 @@ tasks/coverage/misc/pass/oxc-5177.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bang", "Foo"]
 rebuilt        : ScopeId(0): ["Bang"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Foo"]

--- a/tasks/coverage/semantic_test262.snap
+++ b/tasks/coverage/semantic_test262.snap
@@ -2,12 +2,9 @@ commit: a1587416
 
 semantic_test262 Summary:
 AST Parsed     : 46466/46466 (100.00%)
-Positive Passed: 46182/46466 (99.39%)
+Positive Passed: 46354/46466 (99.76%)
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
@@ -16,102 +13,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-dft-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-skip-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
@@ -120,102 +24,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-dft-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-skip-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
@@ -224,102 +35,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-dft-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-skip-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
@@ -328,102 +46,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-dft-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-skip-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
@@ -433,101 +58,8 @@ Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-dft-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-skip-param.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
@@ -536,92 +68,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
@@ -630,92 +79,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
@@ -724,92 +90,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
@@ -818,92 +101,9 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-block-scoping.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
@@ -912,86 +112,6 @@ rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 Unresolved reference IDs mismatch for "f":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-block-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-fn-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-fn-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-var-no-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-existing-var-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-init.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-no-skip-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-block.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-in.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-of.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-switch.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-try.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-update.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-exec.js
 semantic error: Invalid regular expression: Duplicated group name
@@ -1524,16 +644,6 @@ tasks/coverage/test262/test/language/module-code/top-level-await/module-import-r
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["resolved"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/test262/test/language/statements/if/S12.5_A10_T1.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-
-tasks/coverage/test262/test/language/statements/if/S12.5_A5.js
-semantic error: Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7)]
 
 tasks/coverage/test262/test/staging/built-ins/RegExp/named-groups/duplicate-named-groups-replace.js
 semantic error: Invalid regular expression: Duplicated group name

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: d8086f14
 
 semantic_typescript Summary:
 AST Parsed     : 6456/6456 (100.00%)
-Positive Passed: 3242/6456 (50.22%)
+Positive Passed: 3441/6456 (53.30%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -41,9 +41,6 @@ tasks/coverage/typescript/tests/cases/compiler/APISample_jsdoc.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Annotations", "console", "getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
 rebuilt        : ScopeId(0): ["getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(9), ScopeId(14), ScopeId(20), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(13), ScopeId(19), ScopeId(22), ScopeId(23)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(20), ReferenceId(22), ReferenceId(26), ReferenceId(34), ReferenceId(46), ReferenceId(48), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(65), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(80), ReferenceId(81), ReferenceId(83), ReferenceId(86), ReferenceId(89), ReferenceId(91), ReferenceId(97)]
 rebuilt        : SymbolId(0): [ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(44), ReferenceId(47), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(60), ReferenceId(62), ReferenceId(65), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(79)]
@@ -90,9 +87,6 @@ tasks/coverage/typescript/tests/cases/compiler/APISample_watcher.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["console", "currentDirectoryFiles", "fs", "path", "process", "ts", "watch"]
 rebuilt        : ScopeId(0): ["currentDirectoryFiles", "ts", "watch"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(23)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(2), ReferenceId(3), ReferenceId(7), ReferenceId(16), ReferenceId(21), ReferenceId(27), ReferenceId(29), ReferenceId(60), ReferenceId(79)]
 rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(55), ReferenceId(74)]
@@ -148,20 +142,11 @@ tasks/coverage/typescript/tests/cases/compiler/abstractInterfaceIdentifierName.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["abstract"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/abstractPropertyBasics.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): ["B", "C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
 semantic error: Semantic Collector failed after transform
@@ -181,25 +166,16 @@ tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "a", "kitty"]
 rebuilt        : ScopeId(0): ["a", "kitty"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "a", "kitty"]
 rebuilt        : ScopeId(0): ["a", "kitty"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExtendedMapper", "ExtendedMapper1", "ExtendedMapper2", "a", "a1", "a2", "a3", "b", "b1", "b2", "b3", "check", "check1", "check2", "check3", "test", "test1", "test2", "test3"]
 rebuilt        : ScopeId(0): ["check", "check1", "check2", "check3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/aliasUsageInAccessorsOfClass.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -259,148 +235,84 @@ tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/ambientClassOverloadForFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleReopen.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["fs"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithInternalImportDeclaration.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithoutInternalImportDeclaration.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientFundule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["f"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientModuleExports.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Foo2", "c", "c2"]
 rebuilt        : ScopeId(0): ["c", "c2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithClassDeclarationWithExtends.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithTemplateLiterals.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientModules.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientNameRestrictions.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/ambiguousCallsWhereReturnTypesAgree.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(8): [ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/ambiguousOverloadResolution.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -456,25 +368,16 @@ tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["P", "Q"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["P", "Q"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "myFunction"]
 rebuilt        : ScopeId(0): ["myFunction"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Array", "use"]
 rebuilt        : ["use"]
@@ -492,9 +395,6 @@ tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
 semantic error: Semantic Collector failed after transform
@@ -516,9 +416,6 @@ tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Fn", "doStuff"]
 rebuilt        : ScopeId(0): ["doStuff"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "T1", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
@@ -530,9 +427,6 @@ tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BooleanLogicExpression", "Expression", "evaluate"]
 rebuilt        : ScopeId(0): ["evaluate"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
 semantic error: Unresolved references mismatch:
@@ -558,9 +452,6 @@ tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Elephant", "Giraffe", "IAnimal", "arr", "bar", "foo"]
 rebuilt        : ScopeId(0): ["Elephant", "Giraffe", "arr", "bar", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -586,9 +477,6 @@ tasks/coverage/typescript/tests/cases/compiler/arrayTypeInSignatureOfInterfaceAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Data", "WinJS"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["WinJS"]
 rebuilt        : []
@@ -597,9 +485,6 @@ tasks/coverage/typescript/tests/cases/compiler/arrayconcat.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IOptions", "parser"]
 rebuilt        : ScopeId(0): ["parser"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInExpressionStatement2.ts
 semantic error: Semantic Collector failed after transform
@@ -661,16 +546,6 @@ semantic error: Unresolved references mismatch:
 after transform: ["Error"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/asiAmbientFunctionDeclaration.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "obj"]
@@ -683,9 +558,6 @@ tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDisc
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Cat", "Dog", "animal", "animalOrUndef"]
 rebuilt        : ScopeId(0): ["animal", "animalOrUndef"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["assertEqual", "const", "true"]
 rebuilt        : ["assertEqual"]
@@ -702,11 +574,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/assignmentCompatForEnums.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["One", "TokenType", "Two"]
@@ -722,10 +589,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/assignmentCompatOnNew.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): []
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
@@ -818,9 +682,6 @@ tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedRet
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyCallback", "increment", "increment2"]
 rebuilt        : ScopeId(0): ["increment", "increment2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11)]
 Unresolved references mismatch:
 after transform: ["Promise", "PromiseLike", "f", "g", "h"]
 rebuilt        : ["Promise", "f", "g", "h"]
@@ -837,9 +698,6 @@ tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Obj", "fAsync", "fAsyncExplicit", "fGenericIndexedTypeForAnyProp", "fGenericIndexedTypeForExplicitPromiseOfAnyProp", "fGenericIndexedTypeForExplicitPromiseOfKProp", "fGenericIndexedTypeForExplicitPromiseOfStringProp", "fGenericIndexedTypeForKProp", "fGenericIndexedTypeForPromiseOfAnyProp", "fGenericIndexedTypeForPromiseOfKProp", "fGenericIndexedTypeForPromiseOfStringProp", "fGenericIndexedTypeForStringProp", "fIndexedTypeForAnyProp", "fIndexedTypeForExplicitPromiseOfAnyProp", "fIndexedTypeForExplicitPromiseOfStringProp", "fIndexedTypeForPromiseOfAnyProp", "fIndexedTypeForPromiseOfStringProp", "fIndexedTypeForStringProp"]
 rebuilt        : ScopeId(0): ["fAsync", "fAsyncExplicit", "fGenericIndexedTypeForAnyProp", "fGenericIndexedTypeForExplicitPromiseOfAnyProp", "fGenericIndexedTypeForExplicitPromiseOfKProp", "fGenericIndexedTypeForExplicitPromiseOfStringProp", "fGenericIndexedTypeForKProp", "fGenericIndexedTypeForPromiseOfAnyProp", "fGenericIndexedTypeForPromiseOfKProp", "fGenericIndexedTypeForPromiseOfStringProp", "fGenericIndexedTypeForStringProp", "fIndexedTypeForAnyProp", "fIndexedTypeForExplicitPromiseOfAnyProp", "fIndexedTypeForExplicitPromiseOfStringProp", "fIndexedTypeForPromiseOfAnyProp", "fIndexedTypeForPromiseOfStringProp", "fIndexedTypeForStringProp"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
 Bindings mismatch:
 after transform: ScopeId(10): ["TObj", "obj"]
 rebuilt        : ScopeId(9): ["obj"]
@@ -875,9 +733,6 @@ tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Windows", "sample", "sample2"]
 rebuilt        : ScopeId(0): ["sample", "sample2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Promise", "Windows", "resolve1", "resolve2"]
 rebuilt        : ["resolve1", "resolve2"]
@@ -886,9 +741,6 @@ tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Author", "Book", "BookWithAuthor", "Result", "T", "U", "V", "authorPromise", "f", "g", "mapper"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("authorPromise")
 rebuilt        : ReferenceId(0): None
@@ -915,9 +767,6 @@ tasks/coverage/typescript/tests/cases/compiler/augmentArray.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -941,9 +790,6 @@ tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["e", "express"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -958,18 +804,12 @@ tasks/coverage/typescript/tests/cases/compiler/augmentedTypeBracketNamedProperty
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Function", "Object", "f", "o", "r1", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["f", "o", "r1", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/augmentedTypesExternalModule1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol redeclarations mismatch:
@@ -1009,9 +849,6 @@ tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpressionRetur
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Howl", "HowlErrorCallback", "HowlOptions", "instance"]
 rebuilt        : ScopeId(0): ["Howl", "instance"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
 semantic error: Bindings mismatch:
@@ -1031,9 +868,6 @@ tasks/coverage/typescript/tests/cases/compiler/awaitUnionPromise.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AsyncEnumeratorDone", "IAsyncEnumerator", "main"]
 rebuilt        : ScopeId(0): ["AsyncEnumeratorDone", "main"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(6)]
 rebuilt        : SymbolId(0): []
@@ -1053,9 +887,6 @@ tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Promise3", "PromiseBase", "T", "Thenable"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Awaited", "Element", "Error", "PromiseLike"]
 rebuilt        : []
@@ -1064,17 +895,9 @@ tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGood
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "goofus", "result"]
 rebuilt        : ScopeId(0): ["goofus", "result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(5): ["ARGS", "f"]
 rebuilt        : ScopeId(3): ["f"]
-
-tasks/coverage/typescript/tests/cases/compiler/badThisBinding.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/bangInModuleName.ts
 semantic error: Bindings mismatch:
@@ -1085,9 +908,6 @@ tasks/coverage/typescript/tests/cases/compiler/baseIndexSignatureResolution.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Foo", "FooOf", "x", "y"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -1099,9 +919,6 @@ tasks/coverage/typescript/tests/cases/compiler/baseTypeAfterDerivedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Base2", "Derived", "Derived2"]
 rebuilt        : ScopeId(0): ["Derived2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/baseTypeOrderChecking.ts
 semantic error: Bindings mismatch:
@@ -1144,31 +961,19 @@ tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeReturnStatement.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IPromise", "b", "d", "f"]
 rebuilt        : ScopeId(0): ["b", "d", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Contextual", "Ellement", "arr", "conditional", "contextualOr", "e", "obj"]
 rebuilt        : ScopeId(0): ["arr", "conditional", "contextualOr", "e", "obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithOptionalProperties.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "Z", "b1", "b2", "b3", "b4", "b5", "b6", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["b1", "b2", "b3", "b4", "b5", "b6", "x", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/bindingPatternContextualTypeDoesNotCauseWidening.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Pick", "pick"]
 rebuilt        : ["pick"]
 
@@ -1180,11 +985,6 @@ Missing ReferenceId: _Test
 Missing ReferenceId: Bug
 Missing ReferenceId: Test
 Missing ReferenceId: Test
-
-tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
 semantic error: Unresolved references mismatch:
@@ -1207,9 +1007,6 @@ tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ari", "Bullean", "BulleanConstructor", "anys", "foo", "foor", "foos", "realanys", "xs", "ys"]
 rebuilt        : ScopeId(0): ["foo", "foor", "foos", "xs", "ys"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("anys")
 rebuilt        : ReferenceId(0): None
@@ -1227,9 +1024,6 @@ tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IMenuWorkbenchToolBarOptions", "MenuWorkbenchToolBar"]
 rebuilt        : ScopeId(0): ["MenuWorkbenchToolBar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Unresolved references mismatch:
 after transform: ["ConstructorParameters", "InstanceType", "createInstance"]
 rebuilt        : ["createInstance"]
@@ -1263,17 +1057,11 @@ tasks/coverage/typescript/tests/cases/compiler/callExpressionWithTypeParameterCo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i", "y"]
 rebuilt        : ScopeId(0): ["i", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AddFirstParameterToFunctions", "ExtractParameters", "Q", "Q2", "X", "fn", "fn2"]
 rebuilt        : ScopeId(0): ["fn", "fn2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
@@ -1288,29 +1076,17 @@ tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Collection", "Combinators", "_", "c2", "r1a", "r1b", "r5a", "r5b", "rf1"]
 rebuilt        : ScopeId(0): ["_", "c2", "r1a", "r1b", "r5a", "r5b", "rf1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Temp1", "Temp2", "stringType1", "stringType2", "test"]
 rebuilt        : ScopeId(1): ["test"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(9): ["Messages", "messages", "test1"]
 rebuilt        : ScopeId(3): ["messages", "test1"]
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(20): ["C", "P1", "P2", "a"]
 rebuilt        : ScopeId(13): ["C", "a"]
-Scope children mismatch:
-after transform: ScopeId(20): [ScopeId(21), ScopeId(22)]
-rebuilt        : ScopeId(13): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(28), ReferenceId(32), ReferenceId(33), ReferenceId(36), ReferenceId(38), ReferenceId(43), ReferenceId(46), ReferenceId(49)]
 rebuilt        : SymbolId(1): [ReferenceId(24), ReferenceId(28), ReferenceId(31)]
@@ -1328,9 +1104,6 @@ tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["iobj", "sobj"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(10), ScopeId(14), ScopeId(17), ScopeId(20), ScopeId(24), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(38), ScopeId(41), ScopeId(44), ScopeId(47), ScopeId(53), ScopeId(57), ScopeId(61), ScopeId(65), ScopeId(68), ScopeId(71), ScopeId(75), ScopeId(79), ScopeId(82), ScopeId(85), ScopeId(89), ScopeId(92)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(13), ScopeId(16), ScopeId(19), ScopeId(23), ScopeId(27), ScopeId(30), ScopeId(33), ScopeId(37), ScopeId(40), ScopeId(43), ScopeId(46), ScopeId(52), ScopeId(56), ScopeId(60), ScopeId(64), ScopeId(67), ScopeId(70), ScopeId(74), ScopeId(78), ScopeId(81), ScopeId(84), ScopeId(88), ScopeId(91)]
 Reference symbol mismatch:
 after transform: ReferenceId(90): Some("sobj")
 rebuilt        : ReferenceId(90): None
@@ -1346,26 +1119,6 @@ rebuilt        : ReferenceId(94): None
 Unresolved references mismatch:
 after transform: ["use"]
 rebuilt        : ["iobj", "sobj", "use"]
-
-tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(7), ScopeId(12), ScopeId(17), ScopeId(21), ScopeId(25), ScopeId(30), ScopeId(35), ScopeId(39), ScopeId(43), ScopeId(48), ScopeId(53), ScopeId(58), ScopeId(63), ScopeId(67), ScopeId(71), ScopeId(76), ScopeId(81), ScopeId(85), ScopeId(89)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(11), ScopeId(16), ScopeId(20), ScopeId(24), ScopeId(29), ScopeId(34), ScopeId(38), ScopeId(42), ScopeId(47), ScopeId(52), ScopeId(57), ScopeId(62), ScopeId(66), ScopeId(70), ScopeId(75), ScopeId(80), ScopeId(84), ScopeId(88)]
-
-tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop3_ES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(7), ScopeId(12), ScopeId(17), ScopeId(21), ScopeId(25), ScopeId(30), ScopeId(35), ScopeId(39), ScopeId(43), ScopeId(48), ScopeId(53), ScopeId(58), ScopeId(63), ScopeId(67), ScopeId(71), ScopeId(76), ScopeId(81), ScopeId(85), ScopeId(89)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(11), ScopeId(16), ScopeId(20), ScopeId(24), ScopeId(29), ScopeId(34), ScopeId(38), ScopeId(42), ScopeId(47), ScopeId(52), ScopeId(57), ScopeId(62), ScopeId(66), ScopeId(70), ScopeId(75), ScopeId(80), ScopeId(84), ScopeId(88)]
-
-tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(17), ScopeId(33), ScopeId(45), ScopeId(51)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(32), ScopeId(44), ScopeId(50)]
-
-tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(17), ScopeId(33), ScopeId(45), ScopeId(51)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(32), ScopeId(44), ScopeId(50)]
 
 tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 semantic error: Bindings mismatch:
@@ -1418,15 +1171,9 @@ tasks/coverage/typescript/tests/cases/compiler/castNewObjectBug.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "xx"]
 rebuilt        : ScopeId(0): ["xx"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/castTest.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved reference IDs mismatch for "Point":
+semantic error: Unresolved reference IDs mismatch for "Point":
 after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(10)]
 rebuilt        : [ReferenceId(3)]
 
@@ -1448,25 +1195,16 @@ tasks/coverage/typescript/tests/cases/compiler/chainedSpecializationToObjectType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Sequence", "s", "s2", "s3"]
 rebuilt        : ScopeId(0): ["s", "s2", "s3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "IObservable", "ISubject", "values", "values2"]
 rebuilt        : ScopeId(0): ["values", "values2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IObservable", "ISubject", "fn"]
 rebuilt        : ScopeId(0): ["fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "values"]
 rebuilt        : ScopeId(1): ["values"]
@@ -1474,9 +1212,6 @@ rebuilt        : ScopeId(1): ["values"]
 tasks/coverage/typescript/tests/cases/compiler/checkInterfaceBases.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SecondEvent", "Third"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["JQueryEventObjectTest"]
@@ -1492,10 +1227,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/checkSwitchStatementIfCaseTypeIsString.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Array", "use"]
 rebuilt        : ["use"]
 
@@ -1503,17 +1235,11 @@ tasks/coverage/typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Loop"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/circularConstructorWithReturn.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Client", "applyModelsAndClientExtensions", "getPrismaClient"]
 rebuilt        : ScopeId(0): ["applyModelsAndClientExtensions", "getPrismaClient"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
@@ -1525,23 +1251,14 @@ tasks/coverage/typescript/tests/cases/compiler/circularContextualMappedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Func", "Mapped"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/circularGetAccessor.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["this"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Capitalize", "foo2"]
 rebuilt        : ["foo2"]
 
@@ -1557,9 +1274,6 @@ tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ComponentClass", "Connect", "InferableComponentEnhancerWithProps", "Omit", "Shared", "connect", "myStoreConnect"]
 rebuilt        : ScopeId(0): ["myStoreConnect"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(42): Some("connect")
 rebuilt        : ReferenceId(0): None
@@ -1590,9 +1304,6 @@ tasks/coverage/typescript/tests/cases/compiler/classExpressionWithResolutionOfNa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(1): []
@@ -1601,9 +1312,6 @@ tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperti
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arr", "console"]
 rebuilt        : ScopeId(0): ["arr"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(6): None
@@ -1615,9 +1323,6 @@ tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperti
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arr", "console"]
 rebuilt        : ScopeId(0): ["arr"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(6): None
@@ -1629,23 +1334,14 @@ tasks/coverage/typescript/tests/cases/compiler/classExpressions.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/classExtendingAbstractClassWithMemberCalledTheSameAsItsOwnTypeParam.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseObservable", "ConvenientObservable", "IObservable", "IObserver", "IReader"]
 rebuilt        : ScopeId(0): ["BaseObservable", "ConvenientObservable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "TChange"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(10): ["T", "TChange"]
 rebuilt        : ScopeId(3): []
@@ -1674,18 +1370,12 @@ tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved reference IDs mismatch for "Foo":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["A", "B", "console"]
 rebuilt        : ["B", "console"]
 Unresolved reference IDs mismatch for "B":
@@ -1696,9 +1386,6 @@ tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "I"]
 rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/classImplementsClass1.ts
 semantic error: Symbol reference IDs mismatch:
@@ -1727,9 +1414,6 @@ tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArg
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Settable"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record"]
 rebuilt        : []
@@ -1743,9 +1427,6 @@ tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaSc
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Greeter", "console"]
 rebuilt        : ScopeId(0): ["Greeter"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -1767,10 +1448,7 @@ after transform: SymbolId(2): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
@@ -1778,10 +1456,7 @@ after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 Bindings mismatch:
@@ -1845,9 +1520,6 @@ tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Block", "C", "CaseClause", "ClassExpression1", "ClassLike1", "ClassStatement1", "Declaration", "Expression", "FunctionDeclaration", "HasLocals", "Identifier", "Node", "Node1", "NodeArray", "Statement1", "SyntaxKind", "SyntaxKind1", "TypeNode", "bar", "f1", "f2", "f3", "foo", "maybeClassStatement", "statement", "types", "x"]
 rebuilt        : ScopeId(0): ["SyntaxKind", "SyntaxKind1", "bar", "f1", "f2", "f3", "foo", "maybeClassStatement", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(14): ["Block", "CaseClause", "FunctionDeclaration", "FunctionExpression", "Identifier", "SyntaxKind"]
 rebuilt        : ScopeId(6): ["SyntaxKind"]
@@ -1886,9 +1558,6 @@ tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AssertClause", "BindableOverloadBuilder", "BoundOverloadBuilder", "DISALLOW_DECORATORS", "Declaration", "Decorator", "DeprecationOptions", "Expression", "FinishableOverloadBuilder", "ImportClause", "ImportDeclaration", "Modifier", "Node", "OverloadBinder", "OverloadBinders", "OverloadBuilder", "OverloadDefinitions", "OverloadDeprecations", "OverloadFunction", "OverloadKeys", "OverloadParameters", "Statement", "SyntaxKind", "UnionToIntersection", "foo", "modifiers", "updateImportDeclaration"]
 rebuilt        : ScopeId(0): ["SyntaxKind", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(27): ["AssertClause", "Decorator", "ImportClause", "ImportDeclaration", "Modifier", "SyntaxKind"]
 rebuilt        : ScopeId(1): ["SyntaxKind"]
@@ -1924,9 +1593,6 @@ tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Decorator", "Modifier", "Node", "SyntaxKind", "foo", "modifiers"]
 rebuilt        : ScopeId(0): ["SyntaxKind", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Decorator", "Modifier", "SyntaxKind"]
 rebuilt        : ScopeId(1): ["SyntaxKind"]
@@ -1953,9 +1619,6 @@ tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SelectOptions", "SelectProps", "Thing", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Array", "select"]
 rebuilt        : ["select"]
@@ -1964,9 +1627,6 @@ tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DataProvider", "Message", "MessageList", "MsgConstructor", "f", "fetchMsg"]
 rebuilt        : ScopeId(0): ["DataProvider", "Message", "f", "fetchMsg"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(7)]
 Bindings mismatch:
 after transform: ScopeId(7): ["V", "protoCtor"]
 rebuilt        : ScopeId(3): ["protoCtor"]
@@ -1983,17 +1643,9 @@ Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsInType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["i1", "i12", "i1NoError", "i2", "i21", "i2NoError", "i3"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenEnumWithEnumMemberConflict.ts
@@ -2083,16 +1735,10 @@ tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbient
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m1", "m2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["exports", "m1", "m2", "require"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
@@ -2161,62 +1807,19 @@ tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninsta
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["exports", "foo", "foo2", "require"]
 rebuilt        : ScopeId(0): ["foo", "foo2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["exports", "require"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(21), ScopeId(25), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15)]
-Scope children mismatch:
-after transform: ScopeId(17): [ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(13): [ScopeId(14)]
-Scope children mismatch:
-after transform: ScopeId(21): [ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(15): [ScopeId(16)]
-
-tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassMethod.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(10), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-
-tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterFunctionExpressions.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-
-tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["i1", "i1NoError", "i2", "i2NoError", "i3"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterUnderscoreIUsage.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "_i", "console"]
 rebuilt        : ScopeId(0): ["Foo", "_i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -2224,37 +1827,13 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["console"]
 
-tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndNameResolution.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(19), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(19)]
-Scope children mismatch:
-after transform: ScopeId(23): [ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(19): [ScopeId(20), ScopeId(21)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(6): [ScopeId(7)]
-Scope children mismatch:
-after transform: ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(8): [ScopeId(9)]
-
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientVarInGlobal.ts
 semantic error: Bindings mismatch:
@@ -2278,16 +1857,6 @@ Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
 semantic error: Semantic Collector failed after transform
 Missing SymbolId: _this
@@ -2295,21 +1864,10 @@ Missing SymbolId: _this2
 Missing ReferenceId: _this
 Missing ReferenceId: _this
 
-tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndNameResolution.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Foo1", "Foo3", "console", "f1", "f3"]
 rebuilt        : ScopeId(0): ["Foo", "Foo1", "Foo3", "f1", "f3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(17), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(27), ScopeId(28), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(44), ScopeId(49), ScopeId(50)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(17), ScopeId(21), ScopeId(23), ScopeId(30)]
-Scope children mismatch:
-after transform: ScopeId(28): [ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(35), ScopeId(36)]
-rebuilt        : ScopeId(23): [ScopeId(24), ScopeId(27)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("console")
 rebuilt        : ReferenceId(1): None
@@ -2319,14 +1877,6 @@ rebuilt        : ReferenceId(3): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndPropertyNameAsConstuctorParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(9): [ScopeId(10)]
-Scope children mismatch:
-after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(13): [ScopeId(14)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
 semantic error: Semantic Collector failed after transform
@@ -2364,30 +1914,19 @@ Missing ReferenceId: _hello
 Missing ReferenceId: hello
 Missing ReferenceId: hello
 
-tasks/coverage/typescript/tests/cases/compiler/commentLeadingCloseBrace.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientClass1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
+semantic error: Unresolved references mismatch:
+after transform: ["C"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientVariable1.ts
@@ -2407,21 +1946,13 @@ after transform: []
 rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientfunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/commentOnDecoratedClassDeclaration.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+semantic error: Unresolved references mismatch:
+after transform: ["bar", "foo"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnElidedModule1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ElidedModule", "ElidedModule2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnExportEnumDeclaration.ts
@@ -2439,30 +1970,16 @@ tasks/coverage/typescript/tests/cases/compiler/commentOnInterface1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnParenthesizedExpressionOpenParen1.ts
 semantic error: Reference flags mismatch:
 after transform: ReferenceId(0): ReferenceFlags(Read | Write)
 rebuilt        : ReferenceId(0): ReferenceFlags(Write)
 
-tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
-
 tasks/coverage/typescript/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["Component", "_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -2483,9 +2000,6 @@ tasks/coverage/typescript/tests/cases/compiler/comparableRelationBidirectional.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Automation", "AutomationMode", "ExtensionData", "ThemePreset", "UserSettings", "getMockData"]
 rebuilt        : ScopeId(0): ["AutomationMode", "getMockData"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["AutomationMode", "LOCATION", "NONE", "SYSTEM", "TIME"]
 rebuilt        : ScopeId(1): ["AutomationMode"]
@@ -2503,9 +2017,6 @@ tasks/coverage/typescript/tests/cases/compiler/comparisonOfPartialDeepAndIndexed
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Collection", "Many", "PartialDeep", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -2514,9 +2025,6 @@ tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersections
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FormikConfig"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Exclude", "Extract", "Func", "Partial", "Pick", "Readonly"]
 rebuilt        : ["Func"]
@@ -2570,16 +2078,10 @@ tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatur
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Compute", "Equals", "EqualsTest", "Filter", "FooBar", "FooBarKey", "IndexObject", "OmitIndex", "WithIndex", "WithIndexKey", "WithoutIndex", "WithoutIndexKey"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals", "Foo", "ShouldBe0", "a", "b"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date"]
@@ -2589,21 +2091,10 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAnyUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["R", "Spec", "WithSpec"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/conditionalTypeBasedContextualTypeReturnTypeWidening.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeClassMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DS"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["MyRecord", "MySet"]
@@ -2613,35 +2104,20 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalTypeContextualTypeSimp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "bad", "good1", "good2"]
 rebuilt        : ScopeId(0): ["bad", "good1", "good2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(2): ["P", "attrs"]
 rebuilt        : ScopeId(1): ["attrs"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(6): ["P", "attrs"]
 rebuilt        : ScopeId(2): ["attrs"]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(9): ["P", "attrs"]
 rebuilt        : ScopeId(3): ["attrs"]
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10)]
-rebuilt        : ScopeId(3): []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BigUnion", "ChildrenOf", "DiscriminateUnion", "WithName", "makeThing"]
 rebuilt        : ScopeId(0): ["makeThing"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "children", "name"]
 rebuilt        : ScopeId(1): ["children", "name"]
@@ -2653,17 +2129,11 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalTypeGenericInSignature
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["H_inline1", "Result"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxingConstraintAssignability.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DeepPartial", "ElChildren", "Elem", "I", "Relax", "g"]
 rebuilt        : ScopeId(0): ["Elem", "g"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(7): ["C"]
 rebuilt        : ScopeId(1): []
@@ -2675,18 +2145,12 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AbstractSchema", "AnySchema", "AnySchemaType", "SchemaType"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSubclassExtendsTypeParam.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Field"]
 rebuilt        : []
 
@@ -2694,9 +2158,6 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExcludeWithDefault", "ExtractWithDefault", "TemplatedConditional", "fn1", "fn10", "fn11", "fn12", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8", "fn9", "x", "z", "zee"]
 rebuilt        : ScopeId(0): ["fn1", "fn10", "fn11", "fn12", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8", "fn9", "zee"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Params", "params"]
 rebuilt        : ScopeId(1): ["params"]
@@ -2741,13 +2202,7 @@ after transform: ["Exclude", "Extract", "Pick"]
 rebuilt        : ["z"]
 
 tasks/coverage/typescript/tests/cases/compiler/conditionallyDuplicateOverloadsCausedByOverloadResolution.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch:
@@ -2768,9 +2223,6 @@ rebuilt        : [ReferenceId(0)]
 tasks/coverage/typescript/tests/cases/compiler/constDeclarations-ambient.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "c1", "c2", "c3", "c4", "c5"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumExternalModule.ts
@@ -3004,9 +2456,6 @@ tasks/coverage/typescript/tests/cases/compiler/constIndexedAccess.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["indexAccess", "n", "n1", "n2", "n3", "numbers", "numbersNotConst", "s", "s1", "s2", "s3", "test"]
 rebuilt        : ScopeId(0): ["n", "n1", "n2", "n3", "numbers", "numbersNotConst", "s", "s1", "s2", "s3", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["numbers", "one", "zero"]
 rebuilt        : ScopeId(1): ["numbers"]
@@ -3027,10 +2476,7 @@ after transform: SymbolId(11): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 Symbol reference IDs mismatch:
@@ -3044,10 +2490,7 @@ after transform: SymbolId(3): [ReferenceId(5)]
 rebuilt        : SymbolId(3): []
 
 tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 Symbol reference IDs mismatch:
@@ -3078,9 +2521,6 @@ tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IImmutableMap", "IImmutableMap2", "ImmutableModel", "ImmutableModel2", "ImmutableTypes", "ImmutableTypes2", "Map", "isImmutableType"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(13)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/constraintPropagationThroughReturnTypes.ts
 semantic error: Bindings mismatch:
@@ -3094,9 +2534,6 @@ tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParamete
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "I4", "IComparable", "f", "foo"]
 rebuilt        : ScopeId(0): ["f", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["I", "T"]
 rebuilt        : ScopeId(1): []
@@ -3108,9 +2545,6 @@ tasks/coverage/typescript/tests/cases/compiler/constraintsThatReferenceOtherCont
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Object", "x"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U"]
 rebuilt        : ScopeId(1): []
@@ -3141,24 +2575,10 @@ tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Options", "Sub", "Super"]
 rebuilt        : ScopeId(0): ["Sub", "Super"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/constructorOverloads2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IArguments", "M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/constructorReturningAPrimitive.ts
@@ -3175,9 +2595,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextSensitiveReturnTypeInferen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DEPS", "IData"]
 rebuilt        : ScopeId(0): ["DEPS"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(18)]
@@ -3186,9 +2603,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualComputedNonBindableProp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mapped", "Original", "propSelector", "unexpectedlyFailingExample"]
 rebuilt        : ScopeId(0): ["propSelector", "unexpectedlyFailingExample"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Symbol flags mismatch:
 after transform: SymbolId(11): SymbolFlags(FunctionScopedVariable | TypeParameter)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
@@ -3206,9 +2620,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualExpressionTypecheckingD
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IValidationError", "Operation"]
 rebuilt        : ScopeId(0): ["Operation"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromArrayUnion.ts
 semantic error: Bindings mismatch:
@@ -3221,11 +2632,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["y"]
 
-tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE.ts
 semantic error: Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -3235,23 +2641,14 @@ tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["app"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["app"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualSigInstantiationRestParams.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["contextual", "toInstantiate"]
 rebuilt        : ["toInstantiate"]
 
@@ -3259,18 +2656,12 @@ tasks/coverage/typescript/tests/cases/compiler/contextualSignatureConditionalTyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ActionFunction", "TypegenDisabled", "TypegenEnabled"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["createMachine", "true"]
 rebuilt        : ["createMachine"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["K", "x", "y"]
 rebuilt        : ScopeId(1): ["x", "y"]
 Bindings mismatch:
@@ -3299,11 +2690,6 @@ Bindings mismatch:
 after transform: ScopeId(3): ["T", "x"]
 rebuilt        : ScopeId(3): ["x"]
 
-tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiationWithTypeParameterConstrainedToOuterTypeParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["V", "W", "f", "h", "x"]
@@ -3319,33 +2705,21 @@ tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationCo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Giraffe", "T", "TallThing", "f2", "g2", "h2"]
 rebuilt        : ScopeId(0): ["f2", "g2", "h2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/contextualSignature_objectLiteralMethodMayReturnNever.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeArrayReturnType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IBookStyle", "NamedTransform", "Transform3D", "style"]
 rebuilt        : ScopeId(0): ["style"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeCaching.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "CustomEvents", "Event", "Optimization", "P", "T", "WebpackPluginFunction", "WebpackPluginInstance", "applyOptimizationDefaults"]
 rebuilt        : ScopeId(0): ["applyOptimizationDefaults"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(20): Some("A")
 rebuilt        : ReferenceId(1): None
@@ -3354,10 +2728,7 @@ after transform: ["MyCompiler", "emit"]
 rebuilt        : ["A", "emit"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeIterableUnions.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["DMap", "Iterable", "true"]
 rebuilt        : ["DMap"]
 
@@ -3365,17 +2736,11 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypeObjectSpreadExpress
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i"]
 rebuilt        : ScopeId(0): ["i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Keys", "OptionsForKey", "g"]
 rebuilt        : ScopeId(0): ["g"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(5): ["K", "x", "y"]
 rebuilt        : ScopeId(2): ["x", "y"]
@@ -3384,9 +2749,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncOrGeneratorFunc", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Generator", "console"]
 rebuilt        : ["console"]
@@ -3395,9 +2757,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["OrGen", "g"]
 rebuilt        : ScopeId(0): ["g"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Generator", "console"]
 rebuilt        : ["console"]
@@ -3406,9 +2765,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["def", "narrow", "parse", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("parse")
 rebuilt        : ReferenceId(0): None
@@ -3420,9 +2776,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypeShouldBeLiteral.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LikeA", "LikeB", "TestGeneric", "TestObject", "TestString", "X", "X2", "X3", "Y", "Y2", "Y3", "foo", "foo2", "test", "xy", "xyz"]
 rebuilt        : ScopeId(0): ["foo", "foo2", "test", "xy", "xyz"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
 semantic error: Symbol reference IDs mismatch:
@@ -3439,14 +2792,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturning
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression.ts
 semantic error: Symbol reference IDs mismatch:
@@ -3457,17 +2802,11 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfLambdaWithMulti
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ActionsArray", "ActionsObject", "ActionsObjectOr", "Bar", "JSX", "Options", "Options2", "_jsxFileName", "_reactJsxRuntime", "a", "y"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "a", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(20), ScopeId(21), ScopeId(22)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Unresolved references mismatch:
 after transform: ["App4", "JSX", "app", "app2", "app3", "foo", "require", "undefined"]
 rebuilt        : ["App4", "app", "app2", "app3", "foo", "require", "undefined"]
@@ -3479,9 +2818,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ErrorRequestHandler", "IRouterHandler", "IRouterMatcher", "MyApp", "NextFunction", "Overload", "PathParams", "Request", "RequestHandler", "RequestHandlerParams", "Response", "app", "use"]
 rebuilt        : ScopeId(0): ["app", "use"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["RegExp"]
 rebuilt        : []
@@ -3490,9 +2826,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PropOfRaw", "getSpecsFromRaw"]
 rebuilt        : ScopeId(0): ["getSpecsFromRaw"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingTwoInstancesOfSameTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -3513,9 +2846,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeAsyncFunctionRetu
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LoadCallback", "cb1", "cb2", "cb3", "fn1"]
 rebuilt        : ScopeId(0): ["cb1", "cb2", "cb3", "fn1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
 Unresolved references mismatch:
 after transform: ["Promise", "Record", "StateMachine", "createMachine", "load"]
 rebuilt        : ["Promise", "createMachine", "load"]
@@ -3527,9 +2857,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeGeneratorReturnTy
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action", "Action2", "test1", "test2"]
 rebuilt        : ScopeId(0): ["test1", "test2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["AsyncGenerator", "Generator", "Promise"]
 rebuilt        : ["Promise"]
@@ -3538,9 +2865,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableU
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ADT", "invoke", "kind"]
 rebuilt        : ScopeId(0): ["invoke", "kind"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedGenericAssignment.ts
 semantic error: Bindings mismatch:
@@ -3551,9 +2875,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Elements", "Props", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Unresolved reference IDs mismatch for "Test":
 after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(13)]
 rebuilt        : [ReferenceId(2), ReferenceId(4), ReferenceId(6)]
@@ -3562,9 +2883,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DropdownMenu", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(6), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(22), ReferenceId(25), ReferenceId(26)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(12)]
@@ -3581,18 +2899,10 @@ Unresolved reference IDs mismatch for "DropdownMenu":
 after transform: [ReferenceId(7)]
 rebuilt        : [ReferenceId(1), ReferenceId(9)]
 
-tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedOptionalProperty.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["num", "test2", "test3"]
 rebuilt        : ScopeId(0): ["test2", "test3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("num")
 rebuilt        : ReferenceId(1): None
@@ -3604,15 +2914,9 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CanvasDirection", "GraphActions"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Record", "test"]
 rebuilt        : ["test"]
 
@@ -3625,9 +2929,6 @@ tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceAndTypeGuar
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FilterFn", "IteratorFn", "ListItem", "Test", "filter1", "list2", "x"]
 rebuilt        : ScopeId(0): ["filter1", "list2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "List":
 after transform: [ReferenceId(5), ReferenceId(11), ReferenceId(15), ReferenceId(21), ReferenceId(30), ReferenceId(36), ReferenceId(42), ReferenceId(46), ReferenceId(48), ReferenceId(56)]
 rebuilt        : [ReferenceId(0)]
@@ -3636,24 +2937,13 @@ tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Funcs", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Record", "foo"]
 rebuilt        : ["foo"]
 
-tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/compiler/contravariantTypeAliasInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Func1", "Func2", "f1", "f2", "g1", "g2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("f1")
@@ -3678,17 +2968,9 @@ after transform: ["bar", "foo"]
 rebuilt        : ["bar", "f1", "f2", "foo", "g1", "g2"]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["isBig", "true"]
 rebuilt        : ["isBig"]
-
-tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(18), ScopeId(21), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(20), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(33), ScopeId(34), ScopeId(35)]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
 semantic error: Bindings mismatch:
@@ -3709,26 +2991,15 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "value"]
 rebuilt        : ScopeId(1): ["value"]
 
-tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringLoop.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["NumVal", "StrVal", "Val", "foo", "isNumVal"]
 rebuilt        : ScopeId(0): ["foo", "isNumVal"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["obj1", "obj2", "obj3", "obj4"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("obj1")
 rebuilt        : ReferenceId(1): None
@@ -3785,9 +3056,6 @@ tasks/coverage/typescript/tests/cases/compiler/controlFlowForCatchAndFinally.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Browser", "Foo", "Page", "test"]
 rebuilt        : ScopeId(0): ["Foo", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(13), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
 Unresolved references mismatch:
 after transform: ["Aborter", "Promise", "test1", "test2", "undefined"]
 rebuilt        : ["Aborter", "test1", "test2", "undefined"]
@@ -3810,9 +3078,6 @@ tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceof.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "X", "Y", "ctor", "f1", "f2", "f3", "f4", "foo", "goo", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "f1", "f2", "f3", "f4", "foo", "goo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(22), ScopeId(23), ScopeId(25)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(36), ReferenceId(37), ReferenceId(38)]
 rebuilt        : SymbolId(8): [ReferenceId(28), ReferenceId(29)]
@@ -3836,15 +3101,9 @@ tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "PromiseConstructor", "SetConstructor", "X", "Y", "f1", "f2", "f3", "f4", "foo", "goo"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "f1", "f2", "f3", "f4", "foo", "goo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(28), ScopeId(29), ScopeId(30)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(23), ScopeId(24)]
 Bindings mismatch:
 after transform: ScopeId(16): ["T", "value"]
 rebuilt        : ScopeId(12): ["value"]
-Scope children mismatch:
-after transform: ScopeId(16): [ScopeId(17)]
-rebuilt        : ScopeId(12): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(8): [ReferenceId(32), ReferenceId(33)]
@@ -3906,9 +3165,6 @@ tasks/coverage/typescript/tests/cases/compiler/correctOrderOfPromiseMethod.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "countEverything", "expected"]
 rebuilt        : ScopeId(0): ["countEverything", "expected"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
 rebuilt        : [ReferenceId(0), ReferenceId(9)]
@@ -3928,17 +3184,11 @@ tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyN
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AB", "B", "ObjWithItems", "itemId", "itemOk1", "itemOk2", "itemWithTSError", "items", "objWithItems"]
 rebuilt        : ScopeId(0): ["itemId", "itemOk1", "itemOk2", "itemWithTSError", "items", "objWithItems"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/crashInResolveInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Q", "q1", "x"]
 rebuilt        : ScopeId(0): ["q1", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/crashInresolveReturnStatement.ts
 semantic error: Bindings mismatch:
@@ -3948,9 +3198,6 @@ rebuilt        : ScopeId(5): ["dialogType"]
 tasks/coverage/typescript/tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Hmm"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
@@ -4038,32 +3285,20 @@ tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithComposite.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationMerging1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationMerging2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["./a"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
@@ -4074,9 +3309,6 @@ tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["express"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "RegExp", "express"]
 rebuilt        : []
@@ -4085,39 +3317,21 @@ tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Baz", "Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declaredExternalModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["connect"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declaredExternalModuleWithExportAssignment.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["connect"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataConditionalType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(2): []
 Unresolved references mismatch:
 after transform: ["PropertyDecorator", "d", "true"]
 rebuilt        : ["d"]
@@ -4142,9 +3356,6 @@ tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataOnInferredType.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "console", "decorator"]
 rebuilt        : ScopeId(0): ["A", "B", "decorator"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -4189,9 +3400,6 @@ tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithConstructorT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "console", "decorator"]
 rebuilt        : ScopeId(0): ["A", "B", "decorator"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
@@ -4239,9 +3447,6 @@ tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "T"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(2): []
@@ -4250,9 +3455,6 @@ tasks/coverage/typescript/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "console", "dec"]
 rebuilt        : ScopeId(0): ["A", "dec"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -4264,18 +3466,12 @@ tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLiteralInters
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "R", "S", "T", "X", "_S", "a1", "a2", "b"]
 rebuilt        : ScopeId(0): ["a1", "a2", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial", "true"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch:
@@ -4286,10 +3482,7 @@ after transform: SymbolId(0): [Span { start: 32, end: 35 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch:
@@ -4300,10 +3493,7 @@ after transform: SymbolId(0): [Span { start: 25, end: 28 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch:
@@ -4314,10 +3504,7 @@ after transform: SymbolId(0): [Span { start: 30, end: 33 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch:
@@ -4331,9 +3518,6 @@ tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "And", "AndBit", "Bit", "Equals", "Extends", "FilterByStringValue", "FilteredRes1", "FilteredValuesMatchNever", "IsLiteral", "IsNumberLiteral", "Not", "Or", "T0", "T1", "T2", "T3", "T4", "T5", "T6", "TestBit", "TestBitRes", "Values"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(39), ScopeId(42)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
 rebuilt        : []
@@ -4341,9 +3525,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Add", "AddTest0", "AddTest1", "AddWithoutParentheses", "IsEqual", "NegativeInfinity", "PositiveInfinity"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7), ScopeId(10), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
@@ -4353,30 +3534,18 @@ tasks/coverage/typescript/tests/cases/compiler/deferredTypeReferenceWithinArrayW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TypeStructure"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Options"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AA", "BB", "Foo", "a", "b", "f"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("f")
@@ -4427,9 +3596,6 @@ rebuilt        : ["a", "b", "f"]
 tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AA", "BB", "Foo", "a", "b", "f", "g"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("f")
@@ -4517,9 +3683,6 @@ tasks/coverage/typescript/tests/cases/compiler/destructureOfVariableSameAsShorth
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AxiosResponse", "main"]
 rebuilt        : ScopeId(0): ["main"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Promise", "get"]
 rebuilt        : ["get"]
@@ -4528,33 +3691,21 @@ tasks/coverage/typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImpli
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "bar", "key", "lorem", "obj"]
 rebuilt        : ScopeId(1): ["bar", "key", "lorem", "obj"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/destructuringInitializerContextualTypeFromContext.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Child", "Parent", "Props", "SFC"]
 rebuilt        : ScopeId(0): ["Child", "Parent"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/destructuringTypeGuardFlow.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["aFoo", "bBar", "bar", "foo"]
 rebuilt        : ScopeId(0): ["aFoo", "bBar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/destructuringWithConstraint.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["P", "foo", "props"]
 rebuilt        : ScopeId(1): ["foo", "props"]
@@ -4577,25 +3728,16 @@ tasks/coverage/typescript/tests/cases/compiler/discriminableUnionWithIntersected
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantElementAccessCheck.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IfWithString", "IfWithTemplate", "SwitchWithString", "SwitchWithTemplate", "TypeA", "TypeB", "U", "assertNever"]
 rebuilt        : ScopeId(0): ["IfWithString", "IfWithTemplate", "SwitchWithString", "SwitchWithTemplate", "assertNever"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(10), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7), ScopeId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SomeRecord", "getImplicitAriaRole", "kPresentationInheritanceParents", "myObj2", "o"]
 rebuilt        : ScopeId(0): ["getImplicitAriaRole", "o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
 Reference symbol mismatch:
 after transform: ReferenceId(17): Some("kPresentationInheritanceParents")
 rebuilt        : ReferenceId(10): None
@@ -4613,9 +3755,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyCheck.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Additive", "AdditiveObj", "AllTests", "B", "BarEnum", "Base", "DoesNotWork", "Instance", "Item", "Item1", "Item2", "MapOfAllTests", "Multiplicative", "MultiplicativeObj", "NumType", "Obj", "StrType", "TestA", "TestB", "Type", "TypeA", "TypeB", "TypeBar1", "TypeBar2", "Types", "U", "UnionOfBar", "WorksProperly", "doTestingStuff", "f", "foo", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "func2", "func3", "goo1", "goo2", "onlyPlus", "u"]
 rebuilt        : ScopeId(0): ["BarEnum", "DoesNotWork", "Types", "WorksProperly", "doTestingStuff", "f", "foo", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "func2", "func3", "goo1", "goo2", "onlyPlus", "u"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(57), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(18), ScopeId(23), ScopeId(24), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(32), ScopeId(34), ScopeId(37)]
 Bindings mismatch:
 after transform: ScopeId(21): ["Num", "Str", "Types"]
 rebuilt        : ScopeId(17): ["Types"]
@@ -4648,9 +3787,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "Props"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
 after transform: ["f", "parseInt", "true", "undefined"]
 rebuilt        : ["f", "parseInt", "undefined"]
@@ -4659,17 +3795,11 @@ tasks/coverage/typescript/tests/cases/compiler/discriminantUsingEvaluatableTempl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N", "S"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantsAndNullOrUndefined.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "c", "never", "useA", "useB"]
 rebuilt        : ScopeId(0): ["never", "useA", "useB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("c")
 rebuilt        : ReferenceId(1): None
@@ -4693,9 +3823,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminantsAndPrimitives.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Disjunction", "EnumTypeNode", "Foo", "NodeA", "NodeBase", "Pattern", "f1", "f2", "f3", "f4", "n"]
 rebuilt        : ScopeId(0): ["EnumTypeNode", "f1", "f2", "f3", "f4", "n"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(13), ScopeId(14), ScopeId(15)]
 Bindings mismatch:
 after transform: ScopeId(15): ["Disjunction", "EnumTypeNode", "Pattern"]
 rebuilt        : ScopeId(13): ["EnumTypeNode"]
@@ -4713,25 +3840,16 @@ tasks/coverage/typescript/tests/cases/compiler/discriminantsAndTypePredicates.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "foo1", "foo2", "isA", "isB"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "isA", "isB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminateObjectTypesOnly.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Thing", "Thing2", "Thing3", "h", "k", "l", "q"]
 rebuilt        : ScopeId(0): ["h", "k", "l", "q"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["WeirdoBox", "WeirdoBox2", "weirdoBox", "weirdoBox2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(7), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("weirdoBox")
 rebuilt        : ReferenceId(0): None
@@ -4752,9 +3870,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty1
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "box"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("box")
 rebuilt        : ReferenceId(0): None
@@ -4769,9 +3884,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty2
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PromiseOrValue", "doubles", "items", "iterable", "mapAsyncIterable"]
 rebuilt        : ScopeId(0): ["doubles", "items", "iterable", "mapAsyncIterable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(17), ScopeId(18), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(2): ["R", "T", "U", "callback", "iterable", "iterator", "mapResult"]
 rebuilt        : ScopeId(1): ["callback", "iterable", "iterator", "mapResult"]
@@ -4786,9 +3898,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty3
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CoercedVariableValues", "ExecutionArgs", "ExecutionContext", "Maybe", "buildExecutionContext"]
 rebuilt        : ScopeId(0): ["buildExecutionContext"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Error", "GraphQLError", "ReadonlyArray", "getVariableValues"]
 rebuilt        : ["getVariableValues"]
@@ -4797,9 +3906,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MapOrSingleton", "UnionAltA", "UnionAltB", "ValueUnion", "withAsConst", "withoutAsConst"]
 rebuilt        : ScopeId(0): ["withAsConst", "withoutAsConst"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["const"]
 rebuilt        : []
@@ -4808,9 +3914,6 @@ tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPrope
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "A2", "B", "B2", "X", "Y", "opts", "testMethod"]
 rebuilt        : ScopeId(0): ["testMethod"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("opts")
 rebuilt        : ReferenceId(0): None
@@ -4825,9 +3928,6 @@ tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeNeverI
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Conflicted", "Ex1", "Ex2", "Ex3", "IsNumber"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
 rebuilt        : []
@@ -4836,23 +3936,14 @@ tasks/coverage/typescript/tests/cases/compiler/divergentAccessors1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["IHasGetSet", "ihgs", "r_ihgs_foo"]
 rebuilt        : ScopeId(1): ["ihgs", "r_ihgs_foo"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(5): ["T_HasGetSet", "r_t_hgs_foo", "t_hgs"]
 rebuilt        : ScopeId(2): ["r_t_hgs_foo", "t_hgs"]
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6)]
-rebuilt        : ScopeId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1", "Test2", "Test3"]
 rebuilt        : ScopeId(0): ["Test1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(11), ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(7), ScopeId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes3.ts
 semantic error: Bindings mismatch:
@@ -4907,9 +3998,6 @@ tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Combine", "EventHub", "Filter", "FilterFunction", "FilterQuery", "FilteredEvent", "L1Fragment", "Middleware", "PerformQuery", "QQ", "RunQuery", "Update", "matchFilter"]
 rebuilt        : ScopeId(0): ["EventHub", "matchFilter"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(4): ["Q", "U", "filter"]
 rebuilt        : ScopeId(1): ["filter"]
@@ -4930,17 +4018,11 @@ tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmitte
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "OData", "x"]
 rebuilt        : ScopeId(0): ["C", "x"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNodets.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "OData"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/doNotEmitTripleSlashCommentsOnNotEmittedNode.ts
 semantic error: Bindings mismatch:
@@ -4951,9 +4033,6 @@ tasks/coverage/typescript/tests/cases/compiler/doNotInferUnrelatedTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LiteralType", "alt", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("alt")
 rebuilt        : ReferenceId(1): None
@@ -4965,9 +4044,6 @@ tasks/coverage/typescript/tests/cases/compiler/doNotWidenAtObjectLiteralProperty
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IIntervalTreeNode", "ITestEventInterval", "test"]
 rebuilt        : ScopeId(0): ["test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/dottedModuleName2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -4999,9 +4075,6 @@ tasks/coverage/typescript/tests/cases/compiler/dottedSymbolResolution1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "JQuery", "JQueryStatic", "_setBarAndText", "each"]
 rebuilt        : ScopeId(0): ["Base", "_setBarAndText", "each"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(5)]
 rebuilt        : SymbolId(0): []
@@ -5010,9 +4083,6 @@ tasks/coverage/typescript/tests/cases/compiler/doubleMixinConditionalTypeBaseCla
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Constructor", "FooConstructor", "Mixin1", "Mixin2"]
 rebuilt        : ScopeId(0): ["C", "Mixin1", "Mixin2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(2): ["Base", "C"]
 rebuilt        : ScopeId(1): ["Base"]
@@ -5040,9 +4110,6 @@ tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Keys", "Properties", "Property2Type", "k", "ok", "partial"]
 rebuilt        : ScopeId(0): ["k", "ok", "partial"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial"]
 rebuilt        : []
@@ -5051,9 +4118,6 @@ tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["__foot", "_jsxFileName", "global", "thing"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "thing"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("__foot")
 rebuilt        : ReferenceId(1): None
@@ -5065,21 +4129,6 @@ tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst13.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst14.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst15.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-
-tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst17.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(22)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(19), ScopeId(21)]
 
 tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
 semantic error: Unresolved references mismatch:
@@ -5121,30 +4170,16 @@ tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/duplicateConstructorOverloadSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateConstructorOverloadSignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierShouldNotShortCircuitBaseTypeBinding.ts
 semantic error: Semantic Collector failed after transform
@@ -5159,9 +4194,6 @@ tasks/coverage/typescript/tests/cases/compiler/duplicateOverloadInTypeAugmentati
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "a", "r5"]
 rebuilt        : ScopeId(0): ["a", "r5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
 semantic error: Bindings mismatch:
@@ -5267,9 +4299,6 @@ Missing ReferenceId: Microsoft
 tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "OData"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/emptyAnonymousObjectNarrowing.ts
@@ -5390,16 +4419,10 @@ tasks/coverage/typescript/tests/cases/compiler/emptyIndexer.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "n", "x"]
 rebuilt        : ScopeId(0): ["n", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/emptyOptionalBindingPatternInDeclarationSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "T1", "T2", "val1", "val2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(13)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat4.ts
@@ -5443,17 +4466,11 @@ tasks/coverage/typescript/tests/cases/compiler/enumInitializersWithExponents.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/enumLiteralUnionNotWidened.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "List", "asList", "fn1", "fn2"]
 rebuilt        : ScopeId(0): ["A", "B", "List", "asList", "fn1", "fn2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "one", "two"]
 rebuilt        : ScopeId(1): ["A"]
@@ -5662,10 +4679,7 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/enumsWithMultipleDeclarations3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
@@ -5684,9 +4698,6 @@ rebuilt        : SymbolId(0): []
 tasks/coverage/typescript/tests/cases/compiler/errorConstructorSubtypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ErrorConstructor", "x"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("x")
@@ -7485,12 +6496,6 @@ tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClassWithConstructor", "BasicMonster", "ChildClassWithoutConstructor", "GetSetMonster", "IFoo", "ImplementsInterface", "OverloadedMonster", "PrototypeMonster", "SplatMonster", "Statics", "SuperChild", "SuperParent", "Visibility", "ccwc", "foo", "m1", "m2", "m3", "m4", "m5", "m6", "stat", "x", "y"]
 rebuilt        : ScopeId(0): ["BaseClassWithConstructor", "BasicMonster", "ChildClassWithoutConstructor", "GetSetMonster", "ImplementsInterface", "OverloadedMonster", "PrototypeMonster", "SplatMonster", "Statics", "SuperChild", "SuperParent", "Visibility", "ccwc", "foo", "m1", "m2", "m3", "m4", "m5", "m6", "stat", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(10), ScopeId(16), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(25), ScopeId(29), ScopeId(31), ScopeId(32), ScopeId(34), ScopeId(38), ScopeId(40)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(10), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(22), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(34), ScopeId(36)]
-Scope children mismatch:
-after transform: ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(10): [ScopeId(11), ScopeId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
 semantic error: Semantic Collector failed after transform
@@ -7500,10 +6505,7 @@ Missing ReferenceId: M
 Missing ReferenceId: M
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Point"]
 rebuilt        : []
 
@@ -7511,17 +6513,11 @@ tasks/coverage/typescript/tests/cases/compiler/es6ClassTest5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1T5", "C2T5", "bigClass"]
 rebuilt        : ScopeId(0): ["C1T5", "bigClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "M"]
 rebuilt        : ScopeId(0): ["Bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
 semantic error: Symbol reference IDs mismatch:
@@ -7699,9 +6695,6 @@ tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFu
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Args", "B", "EventMap"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "Record"]
 rebuilt        : []
@@ -7715,9 +6708,6 @@ tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithNestedArra
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BugRepro", "ValueAndKeyFields", "ValueOnlyFields", "repro"]
 rebuilt        : ScopeId(0): ["repro"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -7726,9 +6716,6 @@ tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckingIntersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "createDefaultExample"]
 rebuilt        : ScopeId(0): ["createDefaultExample"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["K", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -7745,9 +6732,6 @@ tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyComponent", "MyComponentProps", "StatelessComponent"]
 rebuilt        : ScopeId(0): ["MyComponent"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Partial"]
 rebuilt        : []
@@ -7756,9 +6740,6 @@ tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDyn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "bar", "foo", "mySymbol", "t"]
 rebuilt        : ScopeId(0): ["bar", "foo", "mySymbol", "t"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
@@ -7774,9 +6755,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportAssignValueAndType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["http", "server", "x"]
 rebuilt        : ScopeId(0): ["server", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Symbol flags mismatch:
 after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
@@ -7839,9 +6817,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithPrivacyError.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["connectexport", "connectmodule", "server"]
 rebuilt        : ScopeId(0): ["server"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(5)]
 rebuilt        : SymbolId(0): []
@@ -7863,9 +6838,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamesp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Q"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Function", "Q", "_try"]
 rebuilt        : ["Q"]
@@ -7879,41 +6851,26 @@ tasks/coverage/typescript/tests/cases/compiler/exportDefaultForNonInstantiatedMo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultImportedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a"]
 rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndFunctionOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndValue.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "x"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
 semantic error: Semantic Collector failed after transform
@@ -7931,10 +6888,7 @@ Missing ReferenceId: A
 Missing ReferenceId: A
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch:
@@ -7945,19 +6899,13 @@ tasks/coverage/typescript/tests/cases/compiler/exportDefaultVariable.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["io", "module"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualCallable.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualNamespaces.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface | NameSpaceModule | Ambient)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -7989,9 +6937,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportEqualsOfModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["popsicle", "popsicle-proxy-agent", "~popsicle/dist/common", "~popsicle/dist/request"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["proxy"]
 rebuilt        : []
@@ -8015,9 +6960,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "B"]
 rebuilt        : []
@@ -8029,10 +6971,7 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/exportRedeclarationTypeAliases.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
 Symbol span mismatch:
@@ -8046,9 +6985,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndExportedMemberD
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["X", "Y"]
 rebuilt        : []
@@ -8057,96 +6993,60 @@ tasks/coverage/typescript/tests/cases/compiler/exportStarForValues.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues10.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValuesInSystem.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportTwoInterfacesWithSameName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportVisibility.ts
@@ -8157,9 +7057,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 tasks/coverage/typescript/tests/cases/compiler/exportedInterfaceInaccessibleInCallbackInModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ProgressCallback"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["TPromise"]
@@ -8174,16 +7071,10 @@ tasks/coverage/typescript/tests/cases/compiler/exportsInAmbientModules1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportsInAmbientModules2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
@@ -8220,9 +7111,6 @@ tasks/coverage/typescript/tests/cases/compiler/extendConstructSignatureInInterfa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "CStatic", "E", "e"]
 rebuilt        : ScopeId(0): ["CStatic", "E", "e"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
@@ -8231,26 +7119,15 @@ tasks/coverage/typescript/tests/cases/compiler/extendedInterfaceGenericType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Alpha", "Beta", "alpha", "betaOfNumber"]
 rebuilt        : ScopeId(0): ["alpha", "betaOfNumber"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/externModuleClobber.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["EM", "ec", "x"]
 rebuilt        : ScopeId(0): ["ec", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved reference IDs mismatch for "EM":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(0)]
@@ -8274,9 +7151,6 @@ tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceDoubleUnde
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["__timezonecomplete/basics", "timezonecomplete"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceOfImportDeclarationWithExportModifier.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -8296,19 +7170,6 @@ tasks/coverage/typescript/tests/cases/compiler/externalModuleWithoutCompilerFlag
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
 semantic error: Semantic Collector failed after transform
@@ -8337,16 +7198,6 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["b"]
 
-tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctions.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(22), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(22)]
-
-tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctions.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOnConstructCalls.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -8359,35 +7210,16 @@ tasks/coverage/typescript/tests/cases/compiler/fixCrashAliasLookupForDefauledImp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "derived", "result", "result2"]
 rebuilt        : ScopeId(0): ["derived", "result", "result2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/flowAfterFinally1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Base", "Both", "Kind", "foo", "isBoth"]
 rebuilt        : ScopeId(0): ["Kind", "foo", "isBoth"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Kind"]
 rebuilt        : ScopeId(1): ["Kind"]
@@ -8450,9 +7282,6 @@ tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AB", "B", "C", "CD", "D", "x", "y"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("y")
 rebuilt        : ReferenceId(0): None
@@ -8496,9 +7325,6 @@ tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Cls2", "Foo2", "Foo3", "Foo6", "foo4", "obj1", "obj2", "s", "s1", "s2", "s3", "s4", "s5"]
 rebuilt        : ScopeId(0): ["Cls2", "obj2", "s1", "s2", "s3", "s4", "s5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -8524,16 +7350,6 @@ Unresolved references mismatch:
 after transform: ["Cls1", "const"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/functionAssignabilityWithArrayLike01.ts
 semantic error: Unresolved references mismatch:
 after transform: ["ArrayLike"]
@@ -8552,15 +7368,9 @@ tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolution
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arguments", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -8582,25 +7392,16 @@ tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionO
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arguments", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["f", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
 semantic error: Semantic Collector failed after transform
@@ -8634,181 +7435,31 @@ Missing ReferenceId: _foo2
 Missing ReferenceId: foo
 Missing ReferenceId: foo
 
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads12.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads13.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads14.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads15.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads16.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads21.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads23.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads24.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads25.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads26.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads28.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads30.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads31.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads32.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads33.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads35.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads38.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads39.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads43.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Cat", "Dog", "foo1", "foo2", "x1", "x2", "y1", "y2"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "x1", "x2", "y1", "y2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloads45.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Cat", "Dog", "foo1", "foo2", "x1", "x2", "y1", "y2"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "x1", "x2", "y1", "y2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads7.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads8.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/functionOverloads9.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["V"]
 rebuilt        : ScopeId(1): []
 Bindings mismatch:
@@ -8828,9 +7479,6 @@ tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
 semantic error: Semantic Collector failed after transform
@@ -8843,9 +7491,6 @@ tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyUnknown", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Unresolved references mismatch:
 after transform: ["Math", "Record"]
 rebuilt        : ["Math"]
@@ -8853,9 +7498,6 @@ rebuilt        : ["Math"]
 tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Unresolved reference IDs mismatch for "B":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -8867,9 +7509,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Q"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
@@ -8885,9 +7524,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericOverload1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["c2", "callable2"]
 rebuilt        : ScopeId(0): ["c2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty.ts
 semantic error: Bindings mismatch:
@@ -8941,9 +7577,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericCallWithinOwnBodyCastTypeP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Thenable", "toThenable", "toThenableInferred"]
 rebuilt        : ScopeId(0): ["toThenable", "toThenableInferred"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(3): ["Input", "Result", "fn"]
 rebuilt        : ScopeId(1): ["fn"]
@@ -9056,9 +7689,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): ["A", "B"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T1"]
 rebuilt        : ScopeId(1): []
@@ -9078,9 +7708,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 tasks/coverage/typescript/tests/cases/compiler/genericConstraint3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
@@ -9139,9 +7766,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterf
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "r", "v"]
 rebuilt        : ScopeId(0): ["r", "v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctionHasFreshTypeArgs.ts
 semantic error: Bindings mismatch:
@@ -9152,9 +7776,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HandleCreatorsFactory", "MyState", "Props", "Reducer", "enhancer4", "foo", "myReducer1", "myReducer2"]
 rebuilt        : ScopeId(0): ["enhancer4", "myReducer1", "myReducer2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("foo")
 rebuilt        : ReferenceId(2): None
@@ -9166,10 +7787,7 @@ after transform: ["combineReducers", "withH"]
 rebuilt        : ["combineReducers", "foo", "withH"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctionSpecializations1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "test"]
 rebuilt        : ScopeId(1): ["test"]
 Bindings mismatch:
@@ -9183,9 +7801,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Query", "from"]
 rebuilt        : ScopeId(0): ["from"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
@@ -9194,9 +7809,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInf
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Boxified", "LR", "Ops", "Result", "Target", "Targets", "foo", "left", "leftOk", "leftOrphaned", "ok", "orphaned", "qq", "right", "rightOk", "rightOrphaned"]
 rebuilt        : ScopeId(0): ["foo", "left", "leftOk", "leftOrphaned", "ok", "orphaned", "qq", "right", "rightOk", "rightOrphaned"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(4): ["U", "V", "obj"]
 rebuilt        : ScopeId(1): ["obj"]
@@ -9219,9 +7831,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Utils", "utils"]
 rebuilt        : ScopeId(0): ["utils"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -9230,9 +7839,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Collection", "Utils", "c", "f1", "f2", "r3", "r4", "r5", "utils"]
 rebuilt        : ScopeId(0): ["Collection", "c", "f1", "f2", "r3", "r4", "r5", "utils"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -9244,9 +7850,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodInterse
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExtendedService", "Service", "createService"]
 rebuilt        : ScopeId(0): ["createService"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(5): ["ServiceCtr", "T"]
 rebuilt        : ScopeId(1): ["ServiceCtr"]
@@ -9255,25 +7858,16 @@ tasks/coverage/typescript/tests/cases/compiler/genericInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["age_v", "ko", "name_v", "o", "rr_v", "x_v", "yy_v", "zz_v"]
 rebuilt        : ScopeId(0): ["age_v", "name_v", "o", "rr_v", "x_v", "yy_v", "zz_v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Type"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ButtonBaseProps", "Component", "ComponentPropsWithRef", "ElementType", "React", "ReactNode", "_jsxFileName", "v1"]
 rebuilt        : ScopeId(0): ["Component", "React", "_jsxFileName", "v1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "props"]
 rebuilt        : ScopeId(1): ["props"]
@@ -9285,9 +7879,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericInheritedDefaultConstructo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Constructor", "c"]
 rebuilt        : ScopeId(0): ["A", "B", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["U"]
 rebuilt        : ScopeId(1): []
@@ -9302,9 +7893,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericInstanceOf.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "F"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(1): []
@@ -9313,9 +7901,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericInterfaceFunctionTypeParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IFoo", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "fn"]
 rebuilt        : ScopeId(1): ["fn"]
@@ -9324,9 +7909,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericInterfaceImplementation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IOption", "None"]
 rebuilt        : ScopeId(0): ["None"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(1): []
@@ -9338,9 +7920,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericInterfaceTypeCall.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "bar", "foo", "test"]
 rebuilt        : ScopeId(0): ["foo", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
 semantic error: Bindings mismatch:
@@ -9351,9 +7930,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericMethodOverspecialization.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Document", "HTMLElement", "document", "elements", "names", "widths", "xxx"]
 rebuilt        : ScopeId(0): ["elements", "names", "widths", "xxx"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("document")
 rebuilt        : ReferenceId(1): None
@@ -9364,9 +7940,6 @@ rebuilt        : ["document"]
 tasks/coverage/typescript/tests/cases/compiler/genericNumberIndex.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericObjectCreationWithoutTypeArgs.ts
@@ -9386,9 +7959,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Params", "getType", "params"]
 rebuilt        : ScopeId(0): ["getType"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["P", "foo", "params", "rest"]
 rebuilt        : ScopeId(1): ["foo", "params", "rest"]
@@ -9445,9 +8015,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "C2", "D", "I2", "I3", "b", "f"]
 rebuilt        : ScopeId(0): ["C2", "b", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(11): ["T"]
 rebuilt        : ScopeId(2): []
@@ -9472,9 +8039,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseEvent", "BaseEventWrapper", "EventTarget", "MyEvent", "MyEventWrapper"]
 rebuilt        : ScopeId(0): ["BaseEvent", "BaseEventWrapper", "MyEvent", "MyEventWrapper"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(2): []
@@ -9529,24 +8093,15 @@ tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericSpecializationToTypeLiteral1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IDictionary", "IEnumerable"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(17)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericStaticAnyTypeFunction.ts
@@ -9561,9 +8116,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericTemplateOverloadResolution
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IFooFn", "fooFn"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("fooFn")
 rebuilt        : ReferenceId(1): None
@@ -9575,15 +8127,9 @@ tasks/coverage/typescript/tests/cases/compiler/genericTupleWithSimplifiableEleme
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "SS1", "SS2", "y", "z"]
 rebuilt        : ScopeId(0): ["I", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(5): ["SS"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
 semantic error: Bindings mismatch:
@@ -9617,9 +8163,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallableMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Constructable"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
@@ -9631,48 +8174,30 @@ rebuilt        : ScopeId(1): ["f"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "f"]
 rebuilt        : ScopeId(2): ["f"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3)]
-rebuilt        : ScopeId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IA", "IB", "IC", "c", "x", "y"]
 rebuilt        : ScopeId(0): ["c", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatureReturningSpecialization.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Callable", "CallableExtention"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType1.ts
@@ -9741,9 +8266,6 @@ tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mock", "Tester"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Function", "cases", "fn"]
 rebuilt        : ["cases", "fn"]
@@ -9751,9 +8273,6 @@ rebuilt        : ["cases", "fn"]
 tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Thing"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
@@ -9765,9 +8284,6 @@ tasks/coverage/typescript/tests/cases/compiler/getterSetterSubtypeAssignment.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "NumberOrObject", "NumberOrString", "NumberOrUndefined", "numberOrObject", "numberOrString", "numberOrUndefined"]
 rebuilt        : ScopeId(0): ["NumberOrObject", "NumberOrString", "NumberOrUndefined", "numberOrObject", "numberOrString", "numberOrUndefined"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(16)]
 
 tasks/coverage/typescript/tests/cases/compiler/global.ts
 semantic error: Semantic Collector failed after transform
@@ -9782,49 +8298,31 @@ tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverloa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["global"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "foo", "global", "obj"]
 rebuilt        : ScopeId(0): ["a", "b", "foo", "obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/hidingCallSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "F", "d", "e", "f"]
 rebuilt        : ScopeId(0): ["d", "e", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/hidingConstructSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "F", "d", "e", "f"]
 rebuilt        : ScopeId(0): ["d", "e", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/hidingIndexSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/higherOrderMappedIndexLookupInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IdMapped", "T", "U", "f", "f1", "f2", "f3", "g", "h"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "h"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
@@ -9834,9 +8332,6 @@ rebuilt        : ScopeId(2): ["a", "b"]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "U", "a", "b"]
 rebuilt        : ScopeId(3): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(3): []
 Reference symbol mismatch:
 after transform: ReferenceId(35): Some("f")
 rebuilt        : ReferenceId(12): None
@@ -9856,9 +8351,6 @@ tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Identity", "Test", "UnboxArray"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -9867,9 +8359,6 @@ tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomom
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HandleOptions", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["PropertyKey", "Record", "func1"]
 rebuilt        : ["func1"]
@@ -9878,29 +8367,17 @@ tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IComparable", "StringComparable", "sc", "x"]
 rebuilt        : ScopeId(0): ["sc", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/identicalGenericConditionalsWithInferRelated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Constructor", "MappedResult", "X", "Y", "f"]
 rebuilt        : ScopeId(0): ["Y", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(7), ScopeId(11), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Cond1", "Cond2", "X", "arg", "x", "y"]
 rebuilt        : ScopeId(1): ["arg", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(15): ["C", "ctor"]
 rebuilt        : ScopeId(3): ["ctor"]
-Scope children mismatch:
-after transform: ScopeId(15): [ScopeId(16)]
-rebuilt        : ScopeId(3): []
 Unresolved references mismatch:
 after transform: ["Boolean", "Error", "Number", "String"]
 rebuilt        : ["Error"]
@@ -9909,9 +8386,6 @@ tasks/coverage/typescript/tests/cases/compiler/identicalTypesNoDifferByCheckOrde
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FunctionComponent1", "FunctionComponent2", "SomeProps", "SomePropsClone", "SomePropsCloneX", "SomePropsX", "Validator", "WeakValidationMap", "comp2", "comp3", "needsComponentOfSomeProps2", "needsComponentOfSomeProps3"]
 rebuilt        : ScopeId(0): ["comp2", "comp3", "needsComponentOfSomeProps2", "needsComponentOfSomeProps3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Omit", "Pick", "Required"]
 rebuilt        : []
@@ -9920,9 +8394,6 @@ tasks/coverage/typescript/tests/cases/compiler/identityAndDivergentNormalizedTyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ApiPost", "PostBody", "PostPath", "fx1", "post", "tmp"]
 rebuilt        : ScopeId(0): ["fx1", "post", "tmp"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(4): ["PATH", "body", "options", "path"]
 rebuilt        : ScopeId(1): ["body", "options", "path"]
@@ -9940,33 +8411,21 @@ tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Sequence"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/implementInterfaceAnyMemberWithVoid.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bug", "I"]
 rebuilt        : ScopeId(0): ["Bug"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/implementsInClassExpression.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "cls"]
 rebuilt        : ScopeId(0): ["cls"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Comparer", "c", "r"]
 rebuilt        : ScopeId(0): ["c", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenerics.ts
 semantic error: Bindings mismatch:
@@ -9989,9 +8448,6 @@ tasks/coverage/typescript/tests/cases/compiler/implicitIndexSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["StringMap", "empty1", "empty2", "f1", "f2", "f3", "f4", "f5", "map", "names1", "names2"]
 rebuilt        : ScopeId(0): ["empty1", "empty2", "f1", "f2", "f3", "f4", "f5", "map", "names1", "names2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(9): ["A", "B", "E1"]
 rebuilt        : ScopeId(6): ["E1"]
@@ -10040,9 +8496,6 @@ tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmb
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
@@ -10059,10 +8512,7 @@ after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | ArrowFunction)
 Symbol span mismatch:
@@ -10106,9 +8556,6 @@ rebuilt        : ["dec"]
 tasks/coverage/typescript/tests/cases/compiler/importHelpersInAmbientContext.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importHelpersInIsolatedModules.ts
@@ -10206,9 +8653,6 @@ tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-refe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ITest"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/import_var-referencing-an-imported-module-alias.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -10217,9 +8661,6 @@ Please consider using `import lib from '...';` alongside Typescript's --allowSyn
 tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Actual", "Expected", "Handler", "lambdaTester"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
@@ -10257,33 +8698,21 @@ tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inKeywordAndIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "ClassOne", "InstanceOne", "InstanceTwo", "f10", "instance"]
 rebuilt        : ScopeId(0): ["A", "B", "ClassOne", "f10", "instance"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -10295,10 +8724,7 @@ after transform: ["Object", "true"]
 rebuilt        : ["Object"]
 
 tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(7)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Record", "invariant"]
 rebuilt        : ["invariant"]
 
@@ -10306,9 +8732,6 @@ tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AOrB", "AWithMethod", "AWithOptionalProp", "B", "BWithMethod", "BWithOptionalProp", "C", "ClassWithUnionProp", "D", "NegativeClassTest", "UnreachableCodeDetection", "checkIsTouchDevice", "error", "f", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "foo", "isHTMLTable", "narrowsToNever", "negativeClassesTest", "negativeIntersectionTest", "negativeMultipleClassesTest", "negativePropTest", "negativeTestClassesWithMemberMissingInBothClasses", "negativeTestClassesWithMembers", "positiveClassesTest", "positiveIntersectionTest", "positiveTestClassesWithOptionalProperties", "sym", "test1", "test2", "test3", "x"]
 rebuilt        : ScopeId(0): ["A", "AWithMethod", "AWithOptionalProp", "B", "BWithMethod", "BWithOptionalProp", "C", "ClassWithUnionProp", "D", "NegativeClassTest", "UnreachableCodeDetection", "checkIsTouchDevice", "f", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "foo", "isHTMLTable", "narrowsToNever", "negativeClassesTest", "negativeIntersectionTest", "negativeMultipleClassesTest", "negativePropTest", "negativeTestClassesWithMemberMissingInBothClasses", "negativeTestClassesWithMembers", "positiveClassesTest", "positiveIntersectionTest", "positiveTestClassesWithOptionalProperties", "sym", "test1", "test2", "test3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(21), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(33), ScopeId(37), ScopeId(41), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(56), ScopeId(59), ScopeId(64), ScopeId(67), ScopeId(72), ScopeId(75), ScopeId(79), ScopeId(83), ScopeId(88), ScopeId(90), ScopeId(92), ScopeId(95), ScopeId(98), ScopeId(101), ScopeId(104), ScopeId(107), ScopeId(110), ScopeId(111), ScopeId(113), ScopeId(114), ScopeId(115), ScopeId(116), ScopeId(119), ScopeId(122)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(21), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(33), ScopeId(37), ScopeId(41), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(50), ScopeId(54), ScopeId(57), ScopeId(62), ScopeId(65), ScopeId(70), ScopeId(73), ScopeId(77), ScopeId(81), ScopeId(86), ScopeId(88), ScopeId(90), ScopeId(93), ScopeId(96), ScopeId(99), ScopeId(102), ScopeId(105), ScopeId(108), ScopeId(109), ScopeId(111), ScopeId(112), ScopeId(113), ScopeId(114), ScopeId(117), ScopeId(120)]
 Bindings mismatch:
 after transform: ScopeId(67): ["T", "x"]
 rebuilt        : ScopeId(65): ["x"]
@@ -10400,9 +8823,6 @@ tasks/coverage/typescript/tests/cases/compiler/incrementOnNullAssertion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Dictionary", "foo", "x"]
 rebuilt        : ScopeId(0): ["foo", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
 semantic error: Semantic Collector failed after transform
@@ -10423,9 +8843,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexTypeNoSubstitutionTemplateLi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Test"]
 rebuilt        : ScopeId(0): ["Foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -10434,9 +8851,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyObject", "State", "Store", "f1", "f2", "f3", "syncStoreProp"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "syncStoreProp"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["K", "T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -10454,10 +8868,7 @@ after transform: ["Partial", "PropertyKey", "Record", "hasOwnProperty", "undefin
 rebuilt        : ["hasOwnProperty", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "a", "b", "item"]
 rebuilt        : ScopeId(1): ["a", "b", "item"]
 
@@ -10465,9 +8876,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexedAccessKeyofNestedSimplifie
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AWrapped", "AnyFunction", "B", "BWrapped", "Params", "Wrapper"]
 rebuilt        : ScopeId(0): ["A", "B"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference flags mismatch:
 after transform: ReferenceId(12): ReferenceFlags(Type)
 rebuilt        : ReferenceId(0): ReferenceFlags(Read)
@@ -10479,9 +8887,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexedAccessNormalization.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyMap", "f1", "f2"]
 rebuilt        : ScopeId(0): ["f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(4): ["M", "elemofM", "k", "mymap"]
 rebuilt        : ScopeId(1): ["elemofM", "k", "mymap"]
@@ -10493,9 +8898,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignatur
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Diff", "O", "Omit", "Omit1", "Omit2", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Pick"]
 rebuilt        : []
@@ -10504,17 +8906,11 @@ tasks/coverage/typescript/tests/cases/compiler/indexedAccessToThisTypeOnIntersec
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "T"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/indexedAccessTypeConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Data", "Foo", "IData", "Parent", "foo"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "Parent", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(3): ["M"]
 rebuilt        : ScopeId(1): []
@@ -10532,17 +8928,11 @@ tasks/coverage/typescript/tests/cases/compiler/indexer.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JQuery", "JQueryElement", "jq"]
 rebuilt        : ScopeId(0): ["jq"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/indexer2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IDirectChildrenMap", "IHeapObjectProperty", "directChildrenMap"]
 rebuilt        : ScopeId(0): ["directChildrenMap"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/indexer3.ts
 semantic error: Unresolved references mismatch:
@@ -10561,9 +8951,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexerReturningTypeParameter1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "a2", "c", "f", "r", "r2"]
 rebuilt        : ScopeId(0): ["a", "a2", "c", "r", "r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(2): []
@@ -10575,9 +8962,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexingTypesWithNever.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["EmptyObj", "Example", "ExpectType", "Match", "O0", "O0Names", "O0Props", "O1", "O1Names", "O1Props", "O2", "O2Names", "O2Props", "O3", "O3Names", "O3Props", "OptionalPropNames", "OptionalProps", "P0", "P0Names", "P0Props", "P1", "P1Names", "P1Props", "P2", "P2Names", "P2Props", "P3", "P3Names", "P3Props", "RequiredPropNames", "RequiredProps", "Res1", "Res2", "Res3", "Result1", "Result2", "TestObj", "key", "o0NameTest", "o0Test", "o1NameTest", "o1Test", "o2NameTest", "o2Test", "o3NameTest", "o3Test", "obj", "p0NameTest", "p0Test", "p1NameTest", "p1Test", "p2NameTest", "p2Test", "p3NameTest", "p3Test", "result3", "result4", "result5", "result6"]
 rebuilt        : ScopeId(0): ["result3", "result4", "result5", "result6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(22), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("obj")
 rebuilt        : ReferenceId(3): None
@@ -10597,22 +8981,13 @@ tasks/coverage/typescript/tests/cases/compiler/indirectTypeParameterReferences.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "combined", "flowtypes", "literal", "n"]
 rebuilt        : ScopeId(0): ["combined", "flowtypes", "literal", "n"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "Combined", "b", "combined", "literal"]
 rebuilt        : ScopeId(1): ["b", "combined", "literal"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["KeysWithoutStringIndex", "RemoveIdxSgn", "test"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Pick", "U"]
@@ -10622,9 +8997,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mapper", "SetOf", "a1", "a2", "a3", "a4", "a5", "a6", "compose", "f1", "f2", "f3", "f4", "filter", "map", "t1", "t2", "testSet"]
 rebuilt        : ScopeId(0): ["SetOf", "a1", "a2", "a3", "a4", "a5", "a6", "compose", "f1", "f2", "f3", "f4", "filter", "map", "t1", "t2", "testSet"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(24), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(19), ScopeId(22), ScopeId(25), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34)]
 Bindings mismatch:
 after transform: ScopeId(19): ["A"]
 rebuilt        : ScopeId(14): []
@@ -10648,9 +9020,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferObjectTypeFromStringLiteralT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["two", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("two")
 rebuilt        : ReferenceId(1): None
@@ -10669,50 +9038,26 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 
-tasks/coverage/typescript/tests/cases/compiler/inferPropertyWithContextSensitiveReturnStatement.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyMappedTupleNew", "MyMappedTupleOld", "MyMappedType", "TupleMapperNew", "TupleMapperOld", "myPrimitiveTupleNew", "myPrimitiveTupleOld"]
 rebuilt        : ScopeId(0): ["myPrimitiveTupleNew", "myPrimitiveTupleOld"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ib", "b"]
 rebuilt        : ScopeId(0): ["b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Function"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/inferStringLiteralUnionForBindingElement.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/inferTInParentheses.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F1", "IsNumber", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/inferTupleFromBindingPattern.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/inferTypeArgumentsInSignatureWithRestParameters.ts
 semantic error: Bindings mismatch:
@@ -10729,9 +9074,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationC
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AMappedType", "Cell", "F1", "F2", "HasM", "InferIOItemToJSType", "Items", "MyObject", "Simplify", "X1", "X2", "ZodObject", "ZodRawShape", "ZodType", "addQuestionMarks", "optionalKeys", "requiredKeys"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(12), ScopeId(14), ScopeId(17), ScopeId(18), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude"]
 rebuilt        : []
@@ -10740,9 +9082,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClass", "Constrain", "Constructor", "E0", "E1", "Foo", "IsSub", "Klass", "SubGuard", "T0", "U", "inferTest", "m"]
 rebuilt        : ScopeId(0): ["BaseClass", "Klass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(11): ["V"]
 rebuilt        : ScopeId(1): []
@@ -10766,17 +9105,11 @@ tasks/coverage/typescript/tests/cases/compiler/inferTypesWithFixedTupleExtendsAt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SubTup2FixedLength", "SubTup2FixedLengthTest", "SubTup2RestAndTrailingVariadic2", "SubTup2RestAndTrailingVariadic2Test", "SubTup2TrailingVariadic", "SubTup2TrailingVariadicTest", "SubTup2TrailingVariadicTest2", "SubTup2TrailingVariadicWithTrailingFixedElements", "SubTup2TrailingVariadicWithTrailingFixedElementsTest", "SubTup2TrailingVariadicWithTrailingFixedElementsTest2", "SubTup2Variadic", "SubTup2VariadicAndRest", "SubTup2VariadicAndRestTest", "SubTup2VariadicTest", "SubTup2VariadicTest2", "SubTup2VariadicWithLeadingFixedElements", "SubTup2VariadicWithLeadingFixedElementsTest", "SubTup2VariadicWithLeadingFixedElementsTest2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(25)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceAndHKTs.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Apply", "B", "F", "T", "TTypeLambda", "TypeClass", "TypeLambda", "a", "map", "typeClass", "x1", "x2"]
 rebuilt        : ScopeId(0): ["x1", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(25): Some("map")
 rebuilt        : ReferenceId(0): None
@@ -10800,9 +9133,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceAndSelfReferentialConstr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test", "res1", "res2", "res3", "test"]
 rebuilt        : ScopeId(0): ["res1", "res2", "res3", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
@@ -10814,9 +9144,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceDoesNotAddUndefinedOrNul
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Node", "NodeArray", "flatMapChildren", "flatMapChildren2"]
 rebuilt        : ScopeId(0): ["flatMapChildren", "flatMapChildren2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "cb", "node", "result"]
 rebuilt        : ScopeId(1): ["cb", "node", "result"]
@@ -10831,9 +9158,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceDoesntCompareAgainstUnin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassA", "ConcreteClass", "SettingsInterface", "ValueInterface", "thisGetsTheFalseError", "thisIsOk"]
 rebuilt        : ScopeId(0): ["ClassA", "ConcreteClass", "thisGetsTheFalseError", "thisIsOk"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(1): ["TEntityClass"]
 rebuilt        : ScopeId(1): []
@@ -10845,14 +9169,8 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseType", "CType", "GetT1", "InheritedType", "MType", "RType", "SomeAbstractClass", "SomeClass", "SomeClassC", "SomeClassM", "SomeClassR", "StructuralVersion", "T1", "T2"]
 rebuilt        : ScopeId(0): ["SomeAbstractClass", "SomeClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(21), ScopeId(23), ScopeId(28), ScopeId(30), ScopeId(31)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["C", "M", "R"]
-rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
 rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(8), ReferenceId(12), ReferenceId(15), ReferenceId(18)]
@@ -10868,17 +9186,11 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties1
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceFromParameterlessLambda.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Make", "Take", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "i", "o"]
 rebuilt        : ScopeId(1): ["i", "o"]
@@ -10895,9 +9207,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceOfNullableObjectTypesWit
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "D", "equal", "v"]
 rebuilt        : ScopeId(0): ["equal", "v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
@@ -10906,9 +9215,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToInde
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a1", "a2", "a3", "a4", "obj", "param2", "query", "x1", "x2", "x3", "x4"]
 rebuilt        : ScopeId(0): ["a1", "a2", "a3", "a4", "obj", "param2", "query"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("x1")
 rebuilt        : ReferenceId(1): None
@@ -10929,9 +9235,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Assign", "Base", "Foo", "Supervisor", "Test", "Zip"]
 rebuilt        : ScopeId(0): ["Base", "Foo", "Test", "Zip"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B"]
 rebuilt        : ScopeId(1): []
@@ -10964,9 +9267,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedCont
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Entity", "RowRenderer", "RowRendererMeta", "test"]
 rebuilt        : ScopeId(0): ["test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
@@ -10975,17 +9275,11 @@ tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMet
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Int"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Int"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType1.ts
 semantic error: Bindings mismatch:
@@ -10996,43 +9290,24 @@ tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentTyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CharField", "Field", "NumberField", "ObjectField", "person"]
 rebuilt        : ScopeId(0): ["CharField", "NumberField", "ObjectField", "person"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(7): ["A", "T"]
 rebuilt        : ScopeId(5): []
-
-tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "a"]
 rebuilt        : ScopeId(1): ["a"]
 
-tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeNested.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeSyntacticScenarios.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IdentityConstructor", "dottedIdentity", "ic", "s", "t"]
 rebuilt        : ScopeId(0): ["dottedIdentity", "ic", "s", "t"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "identity":
 after transform: [ReferenceId(6), ReferenceId(15), ReferenceId(16), ReferenceId(24), ReferenceId(27), ReferenceId(28), ReferenceId(31), ReferenceId(34)]
 rebuilt        : [ReferenceId(0), ReferenceId(9), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(25)]
@@ -11041,11 +9316,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "T", "U", "i", "pair", "result", "zipWith"]
 rebuilt        : ScopeId(0): ["i", "pair", "result", "zipWith"]
-
-tasks/coverage/typescript/tests/cases/compiler/inferentiallyTypingAnEmptyArray.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
 semantic error: Bindings mismatch:
@@ -11098,33 +9368,21 @@ tasks/coverage/typescript/tests/cases/compiler/infiniteExpandingTypeThroughInher
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["KnockoutObservableBase2", "KnockoutSubscription2", "Validatable2", "ValidationPlacement2", "Validator2", "ViewModel", "Widget"]
 rebuilt        : ScopeId(0): ["Validator2", "ViewModel", "Widget"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(7): ["TValue"]
 rebuilt        : ScopeId(1): []
@@ -11134,9 +9392,6 @@ rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(9): ["TValue"]
 rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(8)]
 rebuilt        : SymbolId(0): []
@@ -11151,49 +9406,31 @@ tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypeAssignabil
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "f", "v"]
 rebuilt        : ScopeId(0): ["f", "v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["List", "OwnerList", "OwnerList2", "o1", "o2"]
 rebuilt        : ScopeId(0): ["o1", "o2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Grouping", "Query", "QueryEnumerator", "q1", "q2", "q3"]
 rebuilt        : ScopeId(0): ["q1", "q2", "q3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Enumerator", "Query", "from"]
 rebuilt        : ScopeId(0): ["from"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypesNonGenericBase.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Base", "Functionality", "Options", "OptionsBase", "o"]
 rebuilt        : ScopeId(0): ["A", "Base", "Functionality", "o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["V"]
 rebuilt        : ScopeId(1): []
@@ -11211,17 +9448,11 @@ tasks/coverage/typescript/tests/cases/compiler/infinitelyGenerativeInheritance1.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyStack", "Stack"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromSameOrigin.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "C2"]
 rebuilt        : ScopeId(0): ["B", "C", "C2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(2)]
 rebuilt        : SymbolId(1): []
@@ -11274,17 +9505,11 @@ tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyConte
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Assignment", "State"]
 rebuilt        : ScopeId(0): ["Assignment"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/inheritedFunctionAssignmentCompatibility.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IResultCallback", "fn"]
 rebuilt        : ScopeId(0): ["fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Unresolved references mismatch:
 after transform: ["Function"]
 rebuilt        : []
@@ -11293,9 +9518,6 @@ tasks/coverage/typescript/tests/cases/compiler/inheritedGenericCallSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "Object", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date", "undefined"]
 rebuilt        : ["undefined"]
@@ -11304,39 +9526,24 @@ tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignature
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inheritedOverloadedSpecializedSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "C1", "C2", "b", "c", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
 rebuilt        : ScopeId(0): ["b", "c", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEnums.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyExtract", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["CustomType", "T", "a", "b", "c", "d", "e"]
 rebuilt        : ScopeId(1): ["a", "b", "c", "d", "e"]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
 after transform: ["Extract"]
 rebuilt        : []
@@ -11345,14 +9552,8 @@ tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstrain
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Name", "RelationFields", "ShouldA"]
 rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(6): ["A1", "A2", "N", "RF"]
-rebuilt        : ScopeId(2): []
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
 rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(8), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(21), ReferenceId(24)]
@@ -11404,18 +9605,10 @@ Missing ReferenceId: tungsten
 Missing ReferenceId: M
 Missing ReferenceId: M
 
-tasks/coverage/typescript/tests/cases/compiler/innerOverloads.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/compiler/innerTypeArgumentInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Generate", "Generator"]
 rebuilt        : ScopeId(0): ["Generate"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["U", "func"]
 rebuilt        : ScopeId(1): ["func"]
@@ -11429,9 +9622,6 @@ tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ABC", "Alpha", "Animal", "Base", "Beta", "Derived1", "Derived2", "Gamma", "Giraffe", "Mammal", "fn1", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8"]
 rebuilt        : ScopeId(0): ["ABC", "Animal", "Derived1", "Derived2", "Giraffe", "Mammal", "fn1", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(11), ReferenceId(14), ReferenceId(21), ReferenceId(23)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(12)]
@@ -11456,17 +9646,11 @@ tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Table", "fn", "fn2", "o"]
 rebuilt        : ScopeId(0): ["fn", "fn2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "o"]
 rebuilt        : ScopeId(1): ["o"]
@@ -11487,9 +9671,6 @@ tasks/coverage/typescript/tests/cases/compiler/instantiateConstraintsToTypeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
 semantic error: Semantic Collector failed after transform
@@ -11502,22 +9683,16 @@ tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGener
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["$", "JQuery", "lines"]
 rebuilt        : ScopeId(0): ["$", "lines"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateCrossFileMerge.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["P"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo"]
 rebuilt        : ScopeId(0): ["Bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(5)]
 rebuilt        : SymbolId(0): []
@@ -11526,17 +9701,11 @@ tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints2.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/instantiatedReturnTypeContravariance.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "c", "d"]
 rebuilt        : ScopeId(0): ["c", "d"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
 semantic error: Semantic Collector failed after transform
@@ -11628,15 +9797,9 @@ tasks/coverage/typescript/tests/cases/compiler/interface0.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Generic", "y"]
 rebuilt        : ScopeId(0): ["y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch:
@@ -11647,10 +9810,7 @@ after transform: SymbolId(0): [Span { start: 149, end: 152 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch:
@@ -11673,17 +9833,11 @@ tasks/coverage/typescript/tests/cases/compiler/interfaceContextualType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bug", "IMap", "IOptions"]
 rebuilt        : ScopeId(0): ["Bug"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "I4"]
 rebuilt        : ScopeId(0): ["I2", "I3", "I4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -11716,17 +9870,11 @@ tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "I1"]
 rebuilt        : ScopeId(0): ["C1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceExtendsClass1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Button", "Control", "Image", "Location", "SelectableControl", "TextBox"]
 rebuilt        : ScopeId(0): ["Button", "Control", "Image", "Location", "TextBox"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -11744,9 +9892,6 @@ tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "C6", "I1"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "C6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(11), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(10), ScopeId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
 semantic error: Semantic Collector failed after transform
@@ -11761,16 +9906,10 @@ tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I6", "I7", "v1"]
 rebuilt        : ScopeId(0): ["v1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ns"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["ReturnType"]
@@ -11780,25 +9919,16 @@ tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mover", "MoverShaker", "Shaker"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceSubtyping.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Camera", "iface"]
 rebuilt        : ScopeId(0): ["Camera"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceWithCommaSeparators.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "v"]
 rebuilt        : ScopeId(0): ["v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -11807,9 +9937,6 @@ tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModul
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -11831,16 +9958,10 @@ tasks/coverage/typescript/tests/cases/compiler/intersectionApparentTypeCaching.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T0", "T1", "TX"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyKey", "KeyIfSignatureOfObject", "MustBeKey", "Reduced1", "Reduced2", "ReturnTypeKeyof", "Test1", "Test2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(9), ScopeId(12), ScopeId(16)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Extract"]
@@ -11849,9 +9970,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["x"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("x")
@@ -11864,9 +9982,6 @@ tasks/coverage/typescript/tests/cases/compiler/intersectionOfTypeVariableHasAppa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "Props"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Readonly", "f"]
 rebuilt        : ["f"]
@@ -11875,17 +9990,11 @@ tasks/coverage/typescript/tests/cases/compiler/intersectionReductionGenericStrin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_1", "_2", "keyContaining1", "keyContaining2", "obj"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6), ScopeId(9)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionSatisfiesConstraint.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FirstInterface", "SecondInterface", "myFirstFunction", "mySecondFunction"]
 rebuilt        : ScopeId(0): ["myFirstFunction", "mySecondFunction"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "newParam", "param1"]
 rebuilt        : ScopeId(1): ["newParam", "param1"]
@@ -11915,30 +10024,18 @@ tasks/coverage/typescript/tests/cases/compiler/intersectionTypeWithLeadingOperat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Baz", "Foo", "bar"]
 rebuilt        : ScopeId(0): ["Baz", "bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "_p"]
 rebuilt        : ScopeId(1): ["_p"]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PersonPrototype", "PersonType"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["EmberObject", "Readonly"]
@@ -11948,17 +10045,11 @@ tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObject
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IDef", "TestController"]
 rebuilt        : ScopeId(0): ["TestController"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Windows", "p", "p2", "x"]
 rebuilt        : ScopeId(0): ["p", "p2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Windows"]
 rebuilt        : []
@@ -11967,17 +10058,11 @@ tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IPromise3", "p1", "p2"]
 rebuilt        : ScopeId(0): ["p1", "p2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Windows", "p"]
 rebuilt        : ScopeId(0): ["p"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Unresolved references mismatch:
 after transform: ["Windows"]
 rebuilt        : []
@@ -11986,9 +10071,6 @@ tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["EventName"]
 rebuilt        : []
@@ -11996,9 +10078,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnum.ts
@@ -12034,31 +10113,6 @@ Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
-tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-AMD.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-CommonJS.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-ES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-System.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-UMD.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportAlias.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
@@ -12069,16 +10123,10 @@ tasks/coverage/typescript/tests/cases/compiler/isolatedModulesShadowGlobalTypeNo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Date", "Event"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSketchyAliasLocalMerge.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FC"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule.ts
@@ -12094,9 +10142,6 @@ tasks/coverage/typescript/tests/cases/compiler/jqueryInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DoNothingAlias", "MyPromise", "p1", "p2"]
 rebuilt        : ScopeId(0): ["p2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("p1")
 rebuilt        : ReferenceId(1): None
@@ -12131,17 +10176,11 @@ tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectly
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "data", "fn"]
 rebuilt        : ScopeId(0): ["data", "fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "MyComponent", "RouteProps", "_jsxFileName", "_reactJsxRuntime", "global"]
 rebuilt        : ScopeId(0): ["MyComponent", "_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(15): ["T"]
 rebuilt        : ScopeId(1): []
@@ -12156,9 +10195,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["App", "Props", "React", "Tab", "TabLayout", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["App", "React", "TabLayout", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(10), ReferenceId(12), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(8)]
@@ -12170,9 +10206,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabili
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ArrowRendererHandler", "ArrowRendererProps", "AutocompleteResult", "ClearRendererHandler", "ExtractValueType", "FilterOptionHandler", "FilterOptionsHandler", "FocusOptionHandler", "HandlerRendererResult", "InputRendererHandler", "IsOptionUniqueHandler", "IsValidNewOptionHandler", "LoadOptionsAsyncHandler", "LoadOptionsHandler", "LoadOptionsLegacyHandler", "MenuRendererHandler", "MenuRendererProps", "NewOptionCreatorHandler", "Omit", "OnBlurHandler", "OnChangeHandler", "OnChangeMultipleHandler", "OnChangeSingleHandler", "OnCloseHandler", "OnFocusHandler", "OnInputChangeHandler", "OnInputKeyDownHandler", "OnMenuScrollToBottomHandler", "OnNewOptionClickHandler", "OnOpenHandler", "OnValueClickHandler", "Option", "OptionComponentProps", "OptionComponentType", "OptionRendererHandler", "OptionValues", "Options", "Overwrite", "PromptTextCreatorHandler", "Props", "React", "ReactSelectProps", "ReactSingleSelectProps", "SelectValueHandler", "ShouldKeyDownEventCreateNewOptionHandler", "ValueComponentProps", "ValueComponentType", "ValueRendererHandler", "_jsxFileName", "createReactSingleSelect"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "createReactSingleSelect"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(6): ["WrappedComponent", "WrappedProps"]
 rebuilt        : ScopeId(1): ["WrappedComponent"]
@@ -12190,9 +10223,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesN
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "NoticeList", "Props", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["NoticeList", "_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
@@ -12201,9 +10231,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyParams.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ElemClass", "JSX", "_jsxFileName", "_reactJsxRuntime", "elem"]
 rebuilt        : ScopeId(0): ["ElemClass", "_jsxFileName", "_reactJsxRuntime", "elem"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(9): ["T"]
 rebuilt        : ScopeId(1): []
@@ -12218,9 +10245,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "JSX", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["A", "B", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -12251,9 +10275,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "React", "Wrapper", "_jsxFileName", "_reactJsxRuntime", "element"]
 rebuilt        : ScopeId(0): ["Wrapper", "_jsxFileName", "_reactJsxRuntime", "element"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(9)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
@@ -12283,9 +10304,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AppComponent", "JSX", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["AppComponent", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedName.ts
 semantic error: Semantic Collector failed after transform
@@ -12302,17 +10320,11 @@ tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Counter", "CounterProps", "Fragment", "_jsxFileName", "createElement"]
 rebuilt        : ScopeId(0): ["Counter", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "otherProps"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(13): Some("otherProps")
 rebuilt        : ReferenceId(4): None
@@ -12327,9 +10339,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyComponent", "Props", "React", "_jsxFileName", "m"]
 rebuilt        : ScopeId(0): ["MyComponent", "React", "_jsxFileName", "m"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["P"]
 rebuilt        : ScopeId(1): []
@@ -12341,9 +10350,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxInExtendsClause.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["Foo", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("React")
 rebuilt        : ReferenceId(2): None
@@ -12373,9 +10379,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record", "require"]
 rebuilt        : ["require"]
@@ -12389,9 +10392,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnused
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Comp", "React", "_jsxFileName", "jsx"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(1): [ReferenceId(0)]
@@ -12403,10 +10403,7 @@ after transform: []
 rebuilt        : ["Comp"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule)
 rebuilt        : SymbolId(1): SymbolFlags(Export | Class)
 Symbol redeclarations mismatch:
@@ -12437,9 +10434,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "createElement"]
 rebuilt        : ScopeId(0): ["createElement"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["JSX", "Record"]
 rebuilt        : []
@@ -12448,9 +10442,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNon
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "react", "tag"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "tag"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "require"]
 rebuilt        : ["require"]
@@ -12470,17 +10461,11 @@ tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxSpreadFirstUnionNoErrors.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Info", "InfoProps", "React", "_jsxFileName", "a", "b", "c", "infoProps"]
 rebuilt        : ScopeId(0): ["Info", "React", "_jsxFileName", "a", "b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(13), ReferenceId(16), ReferenceId(19)]
 rebuilt        : SymbolId(2): [ReferenceId(7), ReferenceId(10), ReferenceId(13)]
@@ -12500,21 +10485,12 @@ tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Okay", "Oops", "Orig", "Remapped", "f", "g", "sym", "x"]
 rebuilt        : ScopeId(0): ["f", "g", "sym"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(7): ["Okay", "Oops", "Orig", "Remapped", "T", "a", "x"]
 rebuilt        : ScopeId(1): ["a", "x"]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(13)]
-rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(14): ["DistributiveNonIndex", "NonIndex", "Okay", "Oops", "Orig", "Remapped", "T", "a", "x"]
 rebuilt        : ScopeId(2): ["a", "x"]
-Scope children mismatch:
-after transform: ScopeId(14): [ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23)]
-rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(12), ReferenceId(14), ReferenceId(20), ReferenceId(29), ReferenceId(31), ReferenceId(37), ReferenceId(53)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(6), ReferenceId(9), ReferenceId(13), ReferenceId(16)]
@@ -12532,9 +10508,6 @@ tasks/coverage/typescript/tests/cases/compiler/keyofGenericExtendingClassDoubleL
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AutoModel", "Model", "ModelAttributes", "PersonModel"]
 rebuilt        : ScopeId(0): ["AutoModel", "Model", "PersonModel"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Attributes"]
 rebuilt        : ScopeId(1): []
@@ -12551,18 +10524,10 @@ Unresolved references mismatch:
 after transform: ["Date", "Omit"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/keyofModuleObjectHasCorrectKeys.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Q", "obj"]
 rebuilt        : ScopeId(0): ["obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2)]
 rebuilt        : SymbolId(0): []
@@ -12591,9 +10556,6 @@ tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["GenericClass", "GenericFunction", "MyTuple", "MyTupleItem", "consumeClass", "createClass"]
 rebuilt        : ScopeId(0): ["GenericClass", "consumeClass", "createClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(1): []
@@ -12608,17 +10570,9 @@ tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExpandSmallerTuples", "GrowExp", "GrowExpRev", "Shift", "Tuple", "UnshiftTuple"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(12), ScopeId(16)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array", "ArrayValidator", "Exclude"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/letConstMatchingParameterNames.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
 semantic error: Semantic Collector failed after transform
@@ -12630,9 +10584,6 @@ Missing ReferenceId: A
 tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HTMLElement"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/library_RegExpExecArraySlice.ts
@@ -12699,16 +10650,6 @@ tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop_ES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
 semantic error: Semantic Collector failed after transform
 Missing SymbolId: Keyboard
@@ -12728,9 +10669,6 @@ tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriori
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ColumnSelectView1", "ColumnSelectView2", "ColumnSelectViewImp", "S", "Schema", "Table", "UnrollOnHover"]
 rebuilt        : ScopeId(0): ["ColumnSelectView1", "ColumnSelectView2", "ColumnSelectViewImp", "Table"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(5): ["S"]
 rebuilt        : ScopeId(1): []
@@ -12751,9 +10689,6 @@ tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C1", "C2", "ISomething", "s", "x", "y1", "y2", "y3"]
 rebuilt        : ScopeId(0): ["C1", "C2", "s", "x", "y1", "y2", "y3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
@@ -12772,9 +10707,6 @@ tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Employee", "basic", "byNonKey", "byRole", "chars", "employees"]
 rebuilt        : ScopeId(0): ["basic", "byNonKey", "byRole", "chars", "employees"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(4), ReferenceId(6)]
 rebuilt        : [ReferenceId(4)]
@@ -12783,17 +10715,11 @@ tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Boxify", "Hmm", "MustBeArray", "T1", "T2", "T3", "T4", "T5", "X"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(13)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "K", "V", "a", "fn", "x"]
 rebuilt        : ScopeId(0): ["E", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -12820,9 +10746,6 @@ tasks/coverage/typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelati
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Bar2", "Bar3", "Foo", "Identity", "Merge2", "Merge3", "Same", "T1", "T2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(15)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["PropertyKey", "Record"]
 rebuilt        : []
@@ -12831,31 +10754,19 @@ tasks/coverage/typescript/tests/cases/compiler/mappedTypeCircularReferenceInAcce
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FilteredKeys", "SerializablePartial", "User"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(9)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeContextualTypesApplied.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TakeString"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Field", "f", "g", "r1", "r2", "v"]
 rebuilt        : ScopeId(0): ["f", "g", "r1", "r2", "v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "R", "x"]
 rebuilt        : ScopeId(1): ["x"]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "R", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -12863,9 +10774,6 @@ rebuilt        : ScopeId(2): ["x"]
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceCircularity.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Block", "HTML", "h"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("h")
@@ -12878,10 +10786,7 @@ after transform: []
 rebuilt        : ["h"]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceToMappedType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Base"]
 rebuilt        : []
 
@@ -12889,33 +10794,21 @@ tasks/coverage/typescript/tests/cases/compiler/mappedTypeMultiInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Style", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeNestedGenericInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Chainable", "square", "v"]
 rebuilt        : ScopeId(0): ["square", "v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeOverArrayWithBareAnyRestCanBeUsedAsRestParam1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Replace", "ReplaceParams1"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeParameterConstraint.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyMap", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["U", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
@@ -12924,9 +10817,6 @@ tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyClass", "MyInterface", "MySubClass", "fn"]
 rebuilt        : ScopeId(0): ["MyClass", "MySubClass", "fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(1): []
@@ -12941,9 +10831,6 @@ tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialNonHomomorphicBa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Errors", "Model"]
 rebuilt        : ScopeId(0): ["Model"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["D"]
 rebuilt        : ScopeId(1): []
@@ -12952,23 +10839,14 @@ tasks/coverage/typescript/tests/cases/compiler/mappedTypeRecursiveInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MorphTuple", "nestedTuple", "objectLiteral", "shallow", "validateDefinition", "validateMorph"]
 rebuilt        : ScopeId(0): ["nestedTuple", "objectLiteral", "shallow"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeTupleConstraintAssignability.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyObject", "AnyTuple", "EnumValues", "Flags", "ISchema", "Maybe", "Values", "Writeable", "create"]
 rebuilt        : ScopeId(0): ["create"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(16): ["T", "schemas"]
 rebuilt        : ScopeId(1): ["schemas"]
-Scope children mismatch:
-after transform: ScopeId(16): [ScopeId(17)]
-rebuilt        : ScopeId(1): []
 Unresolved references mismatch:
 after transform: ["Readonly", "TupleSchema", "ZodEnum"]
 rebuilt        : ["TupleSchema"]
@@ -12976,9 +10854,6 @@ rebuilt        : ["TupleSchema"]
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mappy", "NotArray", "x"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("x")
@@ -13026,17 +10901,11 @@ tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): ["B"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["./a", "A", "B"]
 rebuilt        : ScopeId(0): ["A", "B"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
 semantic error: Bindings mismatch:
@@ -13081,9 +10950,6 @@ rebuilt        : SymbolId(5): [ReferenceId(4)]
 tasks/coverage/typescript/tests/cases/compiler/mergedInterfaceFromMultipleFiles1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
@@ -13264,9 +11130,6 @@ tasks/coverage/typescript/tests/cases/compiler/metadataOfEventAlias.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Event"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfStringLiteral.ts
 semantic error: Unresolved references mismatch:
@@ -13328,16 +11191,10 @@ tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["linq"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mixedExports.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "M", "M1"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(8)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComparison.ts
@@ -13348,9 +11205,6 @@ tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AMixin", "Constructor", "Initable", "Serializable"]
 rebuilt        : ScopeId(0): ["AMixin", "Serializable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(4): ["K", "LocalMixin", "ResultClass", "SuperClass"]
 rebuilt        : ScopeId(1): ["LocalMixin", "ResultClass", "SuperClass"]
@@ -13362,9 +11216,6 @@ tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassInterface", "Constructor", "InstanceInterface", "cloneClass"]
 rebuilt        : ScopeId(0): ["cloneClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(6): ["AnotherOriginalClass", "OriginalClass", "T"]
 rebuilt        : ScopeId(1): ["AnotherOriginalClass", "OriginalClass"]
@@ -13376,9 +11227,6 @@ tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "Constructor", "Tagged"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "Tagged"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(2): ["Base", "T"]
 rebuilt        : ScopeId(1): ["Base"]
@@ -13395,9 +11243,6 @@ tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Q"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions1.ts
 semantic error: Bindings mismatch:
@@ -13474,9 +11319,6 @@ tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "z", "z2"]
 rebuilt        : ScopeId(0): ["z", "z2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["X"]
 rebuilt        : []
@@ -13485,9 +11327,6 @@ tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "z", "z2"]
 rebuilt        : ScopeId(0): ["z", "z2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["X"]
 rebuilt        : []
@@ -13495,9 +11334,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D3"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["D3"]
@@ -13507,57 +11343,36 @@ tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceEnumMergeOfReexport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Root"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceMergeOfReexport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Root"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDuringSyntheticDefaultCheck.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_moment", "moment", "moment-timezone"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Observable", "observable"]
 rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["./observable", "Observable"]
 rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendFileModule2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["./observable", "Observable"]
 rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports4.ts
 semantic error: Semantic Collector failed after transform
@@ -13584,16 +11399,10 @@ semantic error: Missing initializer in destructuring declaration
 Bindings mismatch:
 after transform: ScopeId(0): ["./observable", "Observable"]
 rebuilt        : ScopeId(0): ["Observable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationOfAlias.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest3.ts
@@ -13628,9 +11437,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 tasks/coverage/typescript/tests/cases/compiler/moduleImportedForTypeArgumentPosition.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M2C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleLocalImportNotIncorrectlyRedirected.ts
@@ -13716,10 +11522,7 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/moduleRedifinitionErrors.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch:
@@ -14093,16 +11896,10 @@ tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModul
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ng"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["ng"]
@@ -14112,17 +11909,11 @@ tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ICallback", "f1", "f2", "load"]
 rebuilt        : ScopeId(0): ["f1", "f2", "load"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "I", "a", "b", "i", "i1", "i2"]
 rebuilt        : ScopeId(0): ["a", "b", "i", "i1", "i2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -14134,9 +11925,6 @@ tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AllParams", "AllReturns", "Expected", "InferTwoOverloads", "JustOneSignature", "JustTheOtherSignature", "Overloads", "Params1", "Params2", "Params3", "Returns1", "Returns2", "Returns3", "ok1", "ok2", "ok3", "ok4", "ok5", "ok6"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "f1", "f2", "f3"]
 rebuilt        : []
@@ -14145,9 +11933,6 @@ tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ComponentOptionsProperties", "ConstructorOptions", "Data", "Instance", "Moon", "r2"]
 rebuilt        : ScopeId(0): ["r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("Moon")
 rebuilt        : ReferenceId(0): None
@@ -14159,17 +11944,11 @@ tasks/coverage/typescript/tests/cases/compiler/mutrec.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "I1", "I2", "I3", "I4", "I5", "b", "f", "g", "i2", "i3", "i4"]
 rebuilt        : ScopeId(0): ["b", "f", "g", "i2", "i3", "i4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "b"]
 rebuilt        : ScopeId(0): ["b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes2.ts
 semantic error: Bindings mismatch:
@@ -14216,9 +11995,6 @@ tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "x", "x2"]
 rebuilt        : ScopeId(0): ["x", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["X"]
 rebuilt        : []
@@ -14242,9 +12018,6 @@ tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExport
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Q", "Q2", "Q3", "Q4", "try1", "try2", "try3", "try4"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Q", "Q2", "Q3", "Q4"]
 rebuilt        : []
@@ -14253,9 +12026,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "ACTOR_TYPE", "Actor", "B", "C", "Entity", "MyUnion", "WebError", "isA", "isActor", "isFunction", "test1", "test2", "test3", "test4", "test5", "test6", "test7"]
 rebuilt        : ScopeId(0): ["ACTOR_TYPE", "WebError", "isA", "isActor", "isFunction", "test1", "test2", "test3", "test4", "test5", "test6", "test7"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(35)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(21), ScopeId(22), ScopeId(25), ScopeId(28), ScopeId(29)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(16): [ReferenceId(46), ReferenceId(50)]
 rebuilt        : SymbolId(11): [ReferenceId(40)]
@@ -14267,9 +12037,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AorB", "B", "SomeType", "isA", "isB", "processInput", "test1", "test2", "x"]
 rebuilt        : ScopeId(0): ["isA", "isB", "processInput", "test1", "test2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
 Unresolved reference IDs mismatch for "RegExp":
 after transform: [ReferenceId(25), ReferenceId(30)]
 rebuilt        : [ReferenceId(19)]
@@ -14339,25 +12106,16 @@ tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "All", "B", "C", "D", "E", "fn1ifelse", "fn1switch", "fn2ifelse", "fn2switch", "fn3switch"]
 rebuilt        : ScopeId(0): ["fn1ifelse", "fn1switch", "fn2ifelse", "fn2switch", "fn3switch"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(10), ScopeId(15), ScopeId(18), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(9), ScopeId(12), ScopeId(17)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "IProps"]
 rebuilt        : ScopeId(0): ["Foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AA", "B", "BB", "C", "Car", "Person", "PersonMixin", "bar", "cls", "foo", "test"]
 rebuilt        : ScopeId(0): ["Car", "Person", "PersonMixin", "bar", "cls", "foo", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(21), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(15), ScopeId(17)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(16): [ReferenceId(28), ReferenceId(33), ReferenceId(39)]
 rebuilt        : SymbolId(11): [ReferenceId(19)]
@@ -14369,17 +12127,11 @@ tasks/coverage/typescript/tests/cases/compiler/narrowByParenthesizedSwitchExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Base", "Foo", "getV", "v"]
 rebuilt        : ScopeId(0): ["getV", "v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowBySwitchDiscriminantUndefinedCase1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "assertUnreachable", "func", "func2"]
 rebuilt        : ScopeId(0): ["assertUnreachable", "func", "func2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 Unresolved references mismatch:
 after transform: ["Error", "Math", "const", "undefined"]
 rebuilt        : ["Error", "Math", "undefined"]
@@ -14388,9 +12140,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowTypeByInstanceof.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FileMatch", "FileMatchOrMatch", "Match", "elementA", "elementB"]
 rebuilt        : ScopeId(0): ["FileMatch", "Match", "elementA", "elementB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(13), ReferenceId(15)]
 rebuilt        : SymbolId(0): [ReferenceId(9), ReferenceId(11)]
@@ -14410,9 +12159,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespec
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiCaseFixture", "TestCase", "dataFunc", "subDataFunc", "testFunc"]
 rebuilt        : ScopeId(0): ["dataFunc", "subDataFunc", "testFunc"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "subFunc"]
 rebuilt        : ScopeId(2): ["subFunc"]
@@ -14424,9 +12170,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingByDiscriminantInLoop.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "ConstantMemberType", "IDLMemberTypes", "IDLTypeDescription", "InterfaceType", "OperationMemberType", "f1", "f2", "foo", "insertInterface", "insertInterface2"]
 rebuilt        : ScopeId(0): ["f1", "f2", "foo", "insertInterface", "insertInterface2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(11), ScopeId(15), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(10), ScopeId(13), ScopeId(17)]
 Unresolved references mismatch:
 after transform: ["true"]
 rebuilt        : []
@@ -14435,9 +12178,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Basic", "L", "R", "a1", "assertAll", "assertBoolean", "assertBooleanOrObject", "assertFunction", "assertNever", "assertNumber", "assertObject", "assertObjectOrNull", "assertString", "assertStringOrNumber", "assertSymbol", "assertUndefined", "exhaustiveChecks", "exhaustiveChecksGenerics", "fallThroughTest", "fallThroughTestWithTempalte", "keyofNarrowing", "keyofNarrowingWithTemplate", "multipleGeneric", "multipleGenericExhaustive", "multipleGenericFuse", "multipleGenericFuseWithBoth", "narrowingNarrows", "narrowingNarrows2", "switchOrdering", "switchOrderingWithDefault", "testAny", "testExtendsExplicitDefault", "testExtendsImplicitDefault", "testExtendsUnion", "testUnion", "testUnionExplicitDefault", "testUnionImplicitDefault", "testUnionWithTempalte", "unknownNarrowing"]
 rebuilt        : ScopeId(0): ["a1", "assertAll", "assertBoolean", "assertBooleanOrObject", "assertFunction", "assertNever", "assertNumber", "assertObject", "assertObjectOrNull", "assertString", "assertStringOrNumber", "assertSymbol", "assertUndefined", "exhaustiveChecks", "exhaustiveChecksGenerics", "fallThroughTest", "fallThroughTestWithTempalte", "keyofNarrowing", "keyofNarrowingWithTemplate", "multipleGeneric", "multipleGenericExhaustive", "multipleGenericFuse", "multipleGenericFuseWithBoth", "narrowingNarrows", "narrowingNarrows2", "switchOrdering", "switchOrderingWithDefault", "testAny", "testExtendsExplicitDefault", "testExtendsImplicitDefault", "testExtendsUnion", "testUnion", "testUnionExplicitDefault", "testUnionImplicitDefault", "testUnionWithTempalte", "unknownNarrowing"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(54), ScopeId(56), ScopeId(58), ScopeId(60), ScopeId(62), ScopeId(66)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(50), ScopeId(52), ScopeId(54), ScopeId(56), ScopeId(58), ScopeId(61)]
 Bindings mismatch:
 after transform: ScopeId(16): ["T", "x"]
 rebuilt        : ScopeId(15): ["x"]
@@ -14462,15 +12202,9 @@ rebuilt        : ScopeId(36): ["xy"]
 Bindings mismatch:
 after transform: ScopeId(50): ["S", "assertKeyofS", "k"]
 rebuilt        : ScopeId(47): ["assertKeyofS", "k"]
-Scope children mismatch:
-after transform: ScopeId(50): [ScopeId(51), ScopeId(52), ScopeId(53)]
-rebuilt        : ScopeId(47): [ScopeId(48), ScopeId(49)]
 Bindings mismatch:
 after transform: ScopeId(62): ["S", "assertKeyofS", "k"]
 rebuilt        : ScopeId(58): ["assertKeyofS", "k"]
-Scope children mismatch:
-after transform: ScopeId(62): [ScopeId(63), ScopeId(64), ScopeId(65)]
-rebuilt        : ScopeId(58): [ScopeId(59), ScopeId(60)]
 Bindings mismatch:
 after transform: ScopeId(66): ["X", "Y", "xy"]
 rebuilt        : ScopeId(61): ["xy"]
@@ -14482,9 +12216,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingConstrainedTypeParameter
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Pet", "isPet", "speak"]
 rebuilt        : ScopeId(0): ["isPet", "speak"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["TPet", "pet", "voice"]
 rebuilt        : ScopeId(2): ["pet", "voice"]
@@ -14493,9 +12224,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingDestructuring.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Z", "farr", "func", "func2", "func3"]
 rebuilt        : ScopeId(0): ["farr", "func", "func2", "func3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "value"]
 rebuilt        : ScopeId(1): ["value"]
@@ -14513,17 +12241,11 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Disjoint", "FooAndBaz", "TrivialIntersection", "test1", "test2", "want0"]
 rebuilt        : ScopeId(0): ["test1", "test2", "want0"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingNoInfer1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TaggedA", "TaggedB", "TaggedUnion", "m", "map", "something"]
 rebuilt        : ScopeId(0): ["m", "map", "something"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "f", "items"]
 rebuilt        : ScopeId(1): ["f", "items"]
@@ -14540,9 +12262,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Slugs", "call", "obj"]
 rebuilt        : ScopeId(0): ["call"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "cb", "obj"]
 rebuilt        : ScopeId(1): ["cb", "obj"]
@@ -14557,17 +12276,11 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofDiscriminant.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["WrappedStringOr", "booleanBad", "booleanFixed", "f1", "f2", "numberOk"]
 rebuilt        : ScopeId(0): ["booleanBad", "booleanFixed", "f1", "f2", "numberOk"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(11)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "Meta", "f1", "f2", "f3"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "x"]
 rebuilt        : ScopeId(4): ["x"]
@@ -14576,9 +12289,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofObject.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "f1", "test"]
 rebuilt        : ScopeId(0): ["f1", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined1.ts
 semantic error: Bindings mismatch:
@@ -14607,10 +12317,7 @@ after transform: []
 rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
 Unresolved references mismatch:
@@ -14621,17 +12328,11 @@ tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BorkedType", "FixedType", "WorkingType", "borked", "fixed", "working"]
 rebuilt        : ScopeId(0): ["borked", "fixed", "working"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "TA", "TB", "TC", "TL", "fA", "fB", "fC"]
 rebuilt        : ScopeId(0): ["fB", "fC"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -14664,15 +12365,9 @@ tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithG
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Name"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedGenericSpreadInference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
 
@@ -14680,16 +12375,10 @@ tasks/coverage/typescript/tests/cases/compiler/nestedGenerics.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MatchArguments", "SinonSpyCallApi"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial"]
@@ -14699,9 +12388,6 @@ tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursive
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "G", "f", "g"]
 rebuilt        : ScopeId(0): ["f", "g"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedLoopWithOnlyInnerLetCaptured.ts
 semantic error: Bindings mismatch:
@@ -14748,15 +12434,9 @@ tasks/coverage/typescript/tests/cases/compiler/nestedThisContainer.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Record", "direct", "hasZField", "nested", "nestedUnion"]
 rebuilt        : ["direct", "hasZField", "nested", "nestedUnion"]
 
@@ -14764,9 +12444,6 @@ tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo1", "Foo2", "GatewayEvents", "GatewayOpcode", "GatewayParams", "GatewayPayload", "GatewayPayloadStructure", "adaptSession", "assertMessage", "f1", "f2"]
 rebuilt        : ScopeId(0): ["GatewayOpcode", "adaptSession", "assertMessage", "f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
 Bindings mismatch:
 after transform: ScopeId(14): ["DISPATCH", "GatewayOpcode", "HEARTBEAT", "HEARTBEAT_ACK", "HELLO", "IDENTIFY", "INVALID_SESSION", "PRESENCE_UPDATE", "RECONNECT", "REQUEST_GUILD_MEMBERS", "RESUME", "VOICE_STATE_UPDATE"]
 rebuilt        : ScopeId(5): ["GatewayOpcode"]
@@ -14791,16 +12468,10 @@ tasks/coverage/typescript/tests/cases/compiler/newExpressionWithTypeParameterCon
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i", "y"]
 rebuilt        : ScopeId(0): ["i", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/newLineInTypeofInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["a"]
@@ -14810,9 +12481,6 @@ tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Cleaner", "FeatureRunner", "Store"]
 rebuilt        : ScopeId(0): ["C", "FeatureRunner"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(3): ["W"]
 rebuilt        : ScopeId(1): []
@@ -14832,10 +12500,7 @@ after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | Ambient)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol reference IDs mismatch:
@@ -14848,28 +12513,10 @@ Unresolved references mismatch:
 after transform: ["cat"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInLambda.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionInFunctionAndVarInGlobal.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IListenable", "ObservableValue", "notifyListeners"]
 rebuilt        : ScopeId(0): ["ObservableValue", "notifyListeners"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "change", "listenable"]
 rebuilt        : ScopeId(1): ["change", "listenable"]
@@ -14883,9 +12530,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SomeInterface", "value"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers2.ts
@@ -14910,26 +12554,15 @@ Bindings mismatch:
 after transform: ScopeId(2): ["T", "f", "x"]
 rebuilt        : ScopeId(2): ["f", "x"]
 
-tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/noIterationTypeErrorsInCFA.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "doRemove"]
 rebuilt        : ScopeId(0): ["doRemove"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/noSubtypeReduction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "IA", "IAB"]
 rebuilt        : ScopeId(0): ["F"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexAccess.ts
 semantic error: Bindings mismatch:
@@ -14967,9 +12600,6 @@ tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInTypeCon
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IThing", "bar", "baz", "foo", "qwe"]
 rebuilt        : ScopeId(0): ["bar", "baz", "foo", "qwe"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2)]
 rebuilt        : SymbolId(0): []
@@ -15016,17 +12646,11 @@ tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nonContextuallyTypedLogicalOr.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Contextual", "Ellement", "c", "e"]
 rebuilt        : ScopeId(0): ["c", "e"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nonGenericClassExtendingGenericClassWithAny.ts
 semantic error: Bindings mismatch:
@@ -15037,9 +12661,6 @@ tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Op", "Thing", "result1", "result2", "thing"]
 rebuilt        : ScopeId(0): ["result1", "result2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(34): Some("thing")
 rebuilt        : ReferenceId(1): None
@@ -15054,9 +12675,6 @@ tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Either", "Left", "Predicate", "Refinement", "Right", "es", "filter", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(42): Some("es")
 rebuilt        : ReferenceId(1): None
@@ -15071,23 +12689,14 @@ tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Callback", "make", "usersOverAge"]
 rebuilt        : ScopeId(0): ["make", "usersOverAge"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/nonNullMappedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "p0", "p1", "v"]
 rebuilt        : ScopeId(1): ["p0", "p1", "v"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/nonNullParameterExtendingStringAssignableToString.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "one", "three", "two"]
 rebuilt        : ScopeId(1): ["one", "three", "two"]
 
@@ -15095,9 +12704,6 @@ tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatching.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "ComponentProps", "ElementRef", "ThumbProps"]
 rebuilt        : ScopeId(0): ["Component"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["HTMLElement"]
 rebuilt        : []
@@ -15105,9 +12711,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/nonNullableAndObjectIntersections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["NonNullableNew", "NonNullableOld", "T0", "T1", "T2", "T3", "T4", "T6", "TestNew", "TestOld"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["NonNullable"]
@@ -15117,18 +12720,12 @@ tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Transform1", "Transform2", "f1", "f2", "test"]
 rebuilt        : ScopeId(0): ["f1", "f2", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "f1", "f2"]
 rebuilt        : ScopeId(1): ["f1", "f2"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "x", "z"]
 rebuilt        : ScopeId(2): ["x", "z"]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(8): ["T", "U", "x", "z"]
 rebuilt        : ScopeId(3): ["x", "z"]
@@ -15137,18 +12734,12 @@ tasks/coverage/typescript/tests/cases/compiler/nonNullableReductionNonStrict.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Transform1", "Transform2", "f1", "f2", "test"]
 rebuilt        : ScopeId(0): ["f1", "f2", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "f1", "f2"]
 rebuilt        : ScopeId(1): ["f1", "f2"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "x", "z"]
 rebuilt        : ScopeId(2): ["x", "z"]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(8): ["T", "U", "x", "z"]
 rebuilt        : ScopeId(3): ["x", "z"]
@@ -15156,9 +12747,6 @@ rebuilt        : ScopeId(3): ["x", "z"]
 tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ordering", "Query", "QueryHandler", "StateNodesConfig", "StateSchema"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["NonNullable", "StateNode"]
@@ -15168,16 +12756,10 @@ tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInf
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "E", "R", "Sync", "_A", "_E", "_R"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
@@ -15186,9 +12768,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "ObjectContaining", "cafoo", "cfoo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("cfoo")
@@ -15214,9 +12793,6 @@ rebuilt        : ["document"]
 tasks/coverage/typescript/tests/cases/compiler/nounusedTypeParameterConstraint.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IEventSourcedEntity"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
@@ -15250,17 +12826,9 @@ tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Explode", "ExtractRawComponent", "Interface", "data1", "defaultValue", "e1", "t1"]
 rebuilt        : ScopeId(0): ["data1", "defaultValue"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(13), ReferenceId(17)]
 rebuilt        : SymbolId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/objectBindingPatternContextuallyTypesArgument.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/objectCreate.ts
 semantic error: Bindings mismatch:
@@ -15294,17 +12862,11 @@ tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Callback", "Emitter", "IMap"]
 rebuilt        : ScopeId(0): ["Emitter"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/objectInstantiationFromUnionSpread.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Fail", "Item", "Success", "f1", "f2"]
 rebuilt        : ScopeId(0): ["f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "a"]
 rebuilt        : ScopeId(4): ["a"]
@@ -15321,17 +12883,11 @@ tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyArrayWrapper", "thing"]
 rebuilt        : ScopeId(0): ["thing"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Nums", "Strs", "TestNums", "TestStrs", "a", "an", "b", "bn", "m", "n", "um", "un", "ux", "uz", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["Nums", "Strs", "a", "an", "b", "bn", "m", "n", "um", "un", "ux", "uz", "x", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Strs"]
 rebuilt        : ScopeId(1): ["Strs"]
@@ -15358,25 +12914,16 @@ tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerNoImplicitAny
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b", "c", "o1"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "o1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/objectMembersOnTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AAA", "I", "c", "i", "x"]
 rebuilt        : ScopeId(0): ["AAA", "c", "i", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
@@ -15385,9 +12932,6 @@ tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInfere
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ImageHolder", "SetupImageRefs", "SetupImages", "TestInterface", "prepare", "rest", "test"]
 rebuilt        : ScopeId(0): ["prepare", "rest"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("test")
 rebuilt        : ReferenceId(1): None
@@ -15399,9 +12943,6 @@ tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ObservableInput", "ObservedValueOf", "Subscribable", "asObservable"]
 rebuilt        : ScopeId(0): ["asObservable"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Observable", "from", "of"]
 rebuilt        : ["from", "of"]
@@ -15410,16 +12951,10 @@ tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyPropertyDescriptor", "MyPropertyDescriptor2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a", "b"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("a")
@@ -15440,9 +12975,6 @@ tasks/coverage/typescript/tests/cases/compiler/optionalParameterRetainsNull.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "a"]
 rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["K", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
@@ -15451,18 +12983,12 @@ tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Test", "UnNullify", "v"]
 rebuilt        : ScopeId(0): ["v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["NonNullable", "true"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overload2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope flags mismatch:
@@ -15488,38 +13014,21 @@ tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationB
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Opt1", "Opt2", "Opt3", "Opt4", "a", "a1"]
 rebuilt        : ScopeId(0): ["a", "a1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(10)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Opt1", "Opt2", "Opt3", "Opt4"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/overloadCallTest.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/overloadCrash.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "i3"]
 rebuilt        : ScopeId(0): ["i3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadEquivalenceWithStatics.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(4): ["S", "v"]
 rebuilt        : ScopeId(2): ["v"]
@@ -15528,10 +13037,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), R
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadGenericFunctionWithRestArgs.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["V"]
 rebuilt        : ScopeId(1): []
 Bindings mismatch:
@@ -15551,12 +13057,6 @@ tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks1.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "D", "Derived1", "Derived2", "Derived3", "MyDoc"]
 rebuilt        : ScopeId(0): ["Base", "D", "Derived1", "Derived2", "Derived3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9)]
-Scope children mismatch:
-after transform: ScopeId(14): [ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
-rebuilt        : ScopeId(9): [ScopeId(10)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
@@ -15571,10 +13071,7 @@ after transform: SymbolId(3): [ReferenceId(6), ReferenceId(11)]
 rebuilt        : SymbolId(3): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 Symbol reference IDs mismatch:
@@ -15585,10 +13082,7 @@ after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 Symbol reference IDs mismatch:
@@ -15599,10 +13093,7 @@ after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -15615,85 +13106,41 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(4)]
 rebuilt        : SymbolId(3): []
 
-tasks/coverage/typescript/tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInBaseWithBadImplementationInDerived.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInCallback1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInObjectLiteralImplementingAnInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i2"]
 rebuilt        : ScopeId(0): ["i2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Deriver"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Deriver"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoNonSpecializedSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(4): []
 Symbol reference IDs mismatch:
@@ -15732,39 +13179,22 @@ tasks/coverage/typescript/tests/cases/compiler/overloadRet.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Accessor", "IFace", "attr"]
 rebuilt        : ScopeId(0): ["Accessor", "attr"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-
-tasks/coverage/typescript/tests/cases/compiler/overloadWithCallbacksWithDifferingOptionalityOnArgs.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AsyncLoader", "AsyncLoaderProps", "Box", "ErrorResult", "load"]
 rebuilt        : ScopeId(0): ["AsyncLoader", "load"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(4): ["TResult"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Exclude", "true"]
 rebuilt        : []
@@ -15773,9 +13203,6 @@ tasks/coverage/typescript/tests/cases/compiler/overloadedStaticMethodSpecializat
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(4): ["S", "v"]
 rebuilt        : ScopeId(2): ["v"]
@@ -15783,21 +13210,8 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstantsInImplementation.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArity.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Number", "String", "f"]
 rebuilt        : ["f"]
 
@@ -15805,9 +13219,6 @@ tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Constructor", "Foo", "Point", "WithLocation"]
 rebuilt        : ScopeId(0): ["Foo", "Point", "WithLocation"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
 Bindings mismatch:
 after transform: ScopeId(2): ["Base", "T"]
 rebuilt        : ScopeId(1): ["Base"]
@@ -15819,9 +13230,6 @@ tasks/coverage/typescript/tests/cases/compiler/parameterReferenceInInitializer1.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Y", "fn"]
 rebuilt        : ScopeId(0): ["C", "fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["a", "set", "y"]
 rebuilt        : ScopeId(1): ["set", "y"]
@@ -15859,9 +13267,6 @@ tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftSh
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "T", "a", "b", "foo"]
 rebuilt        : ScopeId(0): ["b", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "_x"]
 rebuilt        : ScopeId(1): ["_x"]
@@ -15884,17 +13289,11 @@ tasks/coverage/typescript/tests/cases/compiler/parseShortform.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyAPI", "PartialNull", "keys", "obj", "obj2"]
 rebuilt        : ScopeId(0): ["obj", "obj2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("keys")
 rebuilt        : ReferenceId(0): None
@@ -15909,18 +13308,12 @@ tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Obj", "PartialUser", "User", "getUserName", "isUser"]
 rebuilt        : ScopeId(0): ["getUserName", "isUser"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Partial"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientClodule.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch:
@@ -15931,10 +13324,7 @@ after transform: SymbolId(0): [Span { start: 59, end: 62 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientFundule.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -15948,9 +13338,6 @@ tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "AB", "B", "Circle", "Shape", "Shapes", "Square", "ab", "fail", "isShape"]
 rebuilt        : ScopeId(0): ["Circle", "Square", "ab", "fail", "isShape"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(9)]
 rebuilt        : SymbolId(1): []
@@ -15960,56 +13347,6 @@ rebuilt        : SymbolId(2): []
 Unresolved reference IDs mismatch for "Array":
 after transform: [ReferenceId(11), ReferenceId(15)]
 rebuilt        : [ReferenceId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_classic.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_node.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_classic.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_node.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_classic.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_node.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_classic.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_node.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
 semantic error: Bindings mismatch:
@@ -16085,9 +13422,6 @@ tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructural
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "InterfaceA", "InterfaceB", "ThenArg"]
 rebuilt        : ScopeId(0): ["A", "B"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(18), ScopeId(31), ScopeId(45)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(15)]
 Bindings mismatch:
 after transform: ScopeId(31): ["T"]
 rebuilt        : ScopeId(1): []
@@ -16152,9 +13486,6 @@ tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Cat", "CatBag", "IKitty", "cat", "catBag", "catThing"]
 rebuilt        : ScopeId(0): ["Cat", "CatBag", "cat", "catBag", "catThing"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(2): ["CatType"]
 rebuilt        : ScopeId(1): []
@@ -16165,9 +13496,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsmoduleName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["string"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
@@ -16374,9 +13702,6 @@ tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["privateClass", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
 rebuilt        : ScopeId(0): ["privateClass", "privateClassWithWithPrivateTypeParameters", "privateClassWithWithPublicTypeParameters", "privateClassWithWithPublicTypeParametersWithoutExtends", "privateFunctionWithPrivateTypeParameters", "privateFunctionWithPublicTypeParameters", "privateFunctionWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassWithWithPrivateTypeParameters", "publicClassWithWithPublicTypeParameters", "publicClassWithWithPublicTypeParametersWithoutExtends", "publicFunctionWithPrivateTypeParameters", "publicFunctionWithPublicTypeParameters", "publicFunctionWithPublicTypeParametersWithoutExtends"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(20), ScopeId(25), ScopeId(30), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(45), ScopeId(50), ScopeId(55), ScopeId(56)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(8), ScopeId(13), ScopeId(18), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(32), ScopeId(37), ScopeId(38)]
 Bindings mismatch:
 after transform: ScopeId(16): ["T"]
 rebuilt        : ScopeId(4): []
@@ -16504,9 +13829,6 @@ tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterface.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["privateClass", "privateClassT", "privateInterfaceWithPrivateTypeParameters", "privateInterfaceWithPublicTypeParameters", "privateInterfaceWithPublicTypeParametersWithoutExtends", "publicClass", "publicClassT", "publicInterfaceWithPrivateTypeParameters", "publicInterfaceWithPublicTypeParameters", "publicInterfaceWithPublicTypeParametersWithoutExtends"]
 rebuilt        : ScopeId(0): ["privateClass", "privateClassT", "publicClass", "publicClassT"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(12), ScopeId(19), ScopeId(26), ScopeId(33), ScopeId(36)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -16553,9 +13875,6 @@ tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ISyncableObject", "SyncableObject", "SyncableRef", "Type", "__ValueDescriptorType"]
 rebuilt        : ScopeId(0): ["SyncableObject"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
@@ -16564,9 +13883,6 @@ tasks/coverage/typescript/tests/cases/compiler/privatePropertyUsingObjectType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FilterManager", "IFilterProvider"]
 rebuilt        : ScopeId(0): ["FilterManager"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
 semantic error: Bindings mismatch:
@@ -16588,9 +13904,6 @@ tasks/coverage/typescript/tests/cases/compiler/promiseTest.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Promise", "p", "p2", "x"]
 rebuilt        : ScopeId(0): ["p", "p2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 semantic error: Bindings mismatch:
@@ -17066,9 +14379,6 @@ tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["$$x", "IPromise"]
 rebuilt        : ScopeId(0): ["$$x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["CPromise", "convert", "load"]
 rebuilt        : ["convert", "load"]
@@ -17555,9 +14865,6 @@ tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T1", "T2", "T3", "f1", "f2", "x3"]
 rebuilt        : ScopeId(0): ["f1", "f2", "x3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
 after transform: ["Error", "Promise"]
 rebuilt        : ["Promise"]
@@ -17569,25 +14876,16 @@ tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "promise", "reject", "resolve"]
 rebuilt        : ScopeId(0): ["promise", "reject", "resolve"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/promises.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Promise"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExtractPropsMatch", "ExtractedProps", "ExtractedPropsWithoutAnnotation", "PropTypes", "PropTypesMap", "Props", "arrayOfTypes", "innerProps", "propTypes", "propTypesWithoutAnnotation", "x"]
 rebuilt        : ScopeId(0): ["PropTypes", "arrayOfTypes", "innerProps", "propTypes", "propTypesWithoutAnnotation", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(20)]
@@ -17601,18 +14899,10 @@ Unresolved references mismatch:
 after transform: ["true"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/propagateNonInferrableType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IPromise", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/propertyAccessOnObjectLiteral.ts
 semantic error: Symbol reference IDs mismatch:
@@ -17631,9 +14921,6 @@ tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "i"]
 rebuilt        : ScopeId(0): ["i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/qualifiedName_ImportDeclarations-entity-names-referencing-a-var.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -17641,9 +14928,6 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Curry", "R", "Tools"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(29), ScopeId(31)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["NonNullable", "Parameters", "R", "Record", "ReturnType", "Tools", "true"]
@@ -17653,22 +14937,9 @@ tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Any/Cast", "Any/Compute", "Any/Extends", "Any/Implements", "Any/Key", "Any/Kind", "Any/Type", "Any/_Internal", "Any/x", "Boolean/Boolean", "Boolean/Not", "Function/Curry", "Function/Function", "Function/Parameters", "Function/Return", "Iteration/Format", "Iteration/Iteration", "Iteration/IterationOf", "Iteration/Key", "Iteration/Next", "Iteration/Pos", "Iteration/Prev", "Iteration/_Internal", "List/Append", "List/Concat", "List/Drop", "List/Keys", "List/Length", "List/List", "List/NonNullable", "List/ObjectOf", "List/Prepend", "List/Reverse", "List/Tail", "List/_Internal", "Number/Number", "Number/NumberOf", "Number/_Internal", "Object/At", "Object/Keys", "Object/ListOf", "Object/Merge", "Object/NonNullable", "Object/Omit", "Object/Overwrite", "Object/Pick", "Object/_Internal", "Union/Exclude", "Union/Has", "Union/Keys", "Union/NonNullable", "Union/Union"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(13), ScopeId(19), ScopeId(21), ScopeId(25), ScopeId(31), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(44), ScopeId(48), ScopeId(51), ScopeId(53), ScopeId(56), ScopeId(62), ScopeId(64), ScopeId(71), ScopeId(73), ScopeId(81), ScopeId(88), ScopeId(92), ScopeId(98), ScopeId(100), ScopeId(103), ScopeId(106), ScopeId(108), ScopeId(111), ScopeId(113), ScopeId(115), ScopeId(120), ScopeId(127), ScopeId(132), ScopeId(141), ScopeId(143), ScopeId(145), ScopeId(148), ScopeId(151), ScopeId(154), ScopeId(156), ScopeId(162), ScopeId(167), ScopeId(171), ScopeId(173), ScopeId(175), ScopeId(177), ScopeId(180), ScopeId(182), ScopeId(184), ScopeId(186), ScopeId(190)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "Function", "ReadonlyArray", "Required"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/reExportUndefined2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/reachabilityCheckWithEmptyDefault.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -17821,9 +15092,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action", "ActionType", "ReducerAction", "assertNever", "reducer"]
 rebuilt        : ScopeId(0): ["ActionType", "assertNever", "reducer"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["ActionType", "Bar", "Batch", "Baz", "Foo"]
 rebuilt        : ScopeId(1): ["ActionType"]
@@ -17843,10 +15111,7 @@ after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["abc", "base", "xyz"]
 rebuilt        : ["xyz"]
 Unresolved reference IDs mismatch for "xyz":
@@ -17882,25 +15147,16 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CanBeExpanded", "Expand__", "UseQueryOptions"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AllKeys", "Base", "CanBeExpanded", "Expand", "ExpandResult", "Expand_", "Expand__", "Join", "KeysCanBeExpanded", "KeysCanBeExpanded_", "PrefixWith", "Role", "SplitAC", "SplitWithAllPossibleCombinations", "UseQueryOptions", "UseQueryOptions2", "UseQueryOptions3", "UseQueryOptions4", "User", "X", "t", "y1", "y2"]
 rebuilt        : ScopeId(0): ["t", "y1", "y2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(10), ScopeId(12), ScopeId(16), ScopeId(24), ScopeId(25), ScopeId(33), ScopeId(36), ScopeId(37), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(44), ScopeId(46)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -17909,9 +15165,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalEvaluationNon
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test", "a", "b", "x", "y"]
 rebuilt        : ScopeId(0): ["b", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("x")
 rebuilt        : ReferenceId(0): None
@@ -17926,9 +15179,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassSpec", "Converted", "DefaultsDeep", "MaybeMergePrivateSpecs", "MaybeMergePrivateSuperSpec", "MergePrivateSpecs", "MergePrivateSuperSpec", "SimplifyPrivateSpec", "UnionToIntersection", "_Array", "z"]
 rebuilt        : ScopeId(0): ["z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(20), ScopeId(22)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["NonNullable", "Record"]
 rebuilt        : []
@@ -17937,9 +15187,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveExcessPropertyChecks.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ITreeItem", "NodeWithId", "getMaxId", "nodes"]
 rebuilt        : ScopeId(0): ["getMaxId", "nodes"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType7.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -17967,9 +15214,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveGenericMethodCall.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Generate", "Generator"]
 rebuilt        : ScopeId(0): ["Generate"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "func"]
 rebuilt        : ScopeId(1): ["func"]
@@ -17983,17 +15227,11 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveGenericTypeHierarchy.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1", "Test2", "s1", "s2", "x"]
 rebuilt        : ScopeId(0): ["s1", "s2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Test1", "Test2"]
 rebuilt        : []
@@ -18002,9 +15240,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1", "Test2", "s1", "s2", "x"]
 rebuilt        : ScopeId(0): ["s1", "s2", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Test1", "Test2"]
 rebuilt        : []
@@ -18013,9 +15248,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalOverloadResolution.ts
 semantic error: Semantic Collector failed after transform
@@ -18028,9 +15260,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "a", "b", "c", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["x", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("a")
 rebuilt        : ReferenceId(0): None
@@ -18060,9 +15289,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D", "F"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["E"]
 rebuilt        : []
@@ -18071,9 +15297,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveReverseMappedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Recur", "a", "join"]
 rebuilt        : ScopeId(0): ["a", "join"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "l"]
 rebuilt        : ScopeId(1): ["l"]
@@ -18084,9 +15307,6 @@ rebuilt        : ScopeId(2): ["l", "x"]
 tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfExtendedTypeWithError.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HTMLSelectElement"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
@@ -18101,25 +15321,16 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Tree1", "Tree2", "tree1", "tree2"]
 rebuilt        : ScopeId(0): ["tree1", "tree2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Tree1", "Tree2", "tree1", "tree2"]
 rebuilt        : ScopeId(0): ["tree1", "tree2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Option", "UnzipOption", "UnzipOptionArray1", "UnzipOptionArray2", "UnzipOptionArray3", "opt1", "opt2", "opt3", "zipped1", "zipped2", "zipped3"]
 rebuilt        : ScopeId(0): ["zipped1", "zipped2", "zipped3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(43): Some("opt1")
 rebuilt        : ReferenceId(0): None
@@ -18155,25 +15366,16 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Observable", "Property", "p", "stuck"]
 rebuilt        : ScopeId(0): ["p", "stuck"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveTypeIdentity.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C2", "Foo", "Foo2", "X", "f", "f2", "r", "r2"]
 rebuilt        : ScopeId(0): ["C2", "X", "f", "f2", "r", "r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -18191,25 +15393,16 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceEr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["List", "List2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Customer", "Entity", "Person"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveUnionTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "bar"]
 rebuilt        : ScopeId(0): ["bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -18243,18 +15436,10 @@ Missing ReferenceId: _MsPortal
 Missing ReferenceId: MsPortal
 Missing ReferenceId: MsPortal
 
-tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithGenericType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyOneof", "AnyOneofKind", "GetPayload", "MappedPayload2", "Payload", "PayloadA", "PayloadB", "PayloadC", "PayloadStructure", "Type", "payloads2"]
 rebuilt        : ScopeId(0): ["Type", "payloads2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Type"]
 rebuilt        : ScopeId(1): ["Type"]
@@ -18273,10 +15458,7 @@ semantic error: `export = <value>;` is only supported when compiling modules to 
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 Symbol span mismatch:
@@ -18295,9 +15477,6 @@ tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoErro
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "DiscriminatedUnion", "Model"]
 rebuilt        : ScopeId(0): ["A", "B", "Model"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(3): []
@@ -18311,9 +15490,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AObjOrBObj", "AOrBObj", "Generic", "T", "x", "y"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("x")
@@ -18335,9 +15511,6 @@ tasks/coverage/typescript/tests/cases/compiler/reorderProperties.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "c", "d"]
 rebuilt        : ScopeId(0): ["c", "d"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
 semantic error: Semantic Collector failed after transform
@@ -18450,9 +15623,6 @@ tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["test"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["mstring"]
 rebuilt        : []
@@ -18463,10 +15633,7 @@ after transform: ScopeId(0): ["a", "b"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch:
@@ -18480,10 +15647,7 @@ after transform: SymbolId(0): [Span { start: 22, end: 30 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch:
@@ -18509,10 +15673,7 @@ after transform: SymbolId(0): [Span { start: 60, end: 74 }]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | NameSpaceModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch:
@@ -18529,15 +15690,9 @@ tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDecla
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["punycode"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveNameWithNamspace.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -18548,10 +15703,7 @@ after transform: SymbolId(0): [Span { start: 91, end: 99 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveTypeAliasWithSameLetDeclarationName1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch:
@@ -18571,9 +15723,6 @@ tasks/coverage/typescript/tests/cases/compiler/restParamUsingMappedTypeOverUnion
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HomomorphicMappedType"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/restParameterAssignmentCompatibility.ts
 semantic error: Symbol reference IDs mismatch:
@@ -18590,9 +15739,6 @@ tasks/coverage/typescript/tests/cases/compiler/restParameterTypeInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TestGeneric", "removeF", "result"]
 rebuilt        : ScopeId(0): ["removeF", "result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["TX", "f", "rest"]
 rebuilt        : ScopeId(1): ["f", "rest"]
@@ -18601,9 +15747,6 @@ tasks/coverage/typescript/tests/cases/compiler/restTypeRetainsMappyness.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "test"]
 rebuilt        : ScopeId(0): ["test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "arr", "fn"]
 rebuilt        : ScopeId(1): ["arr", "fn"]
@@ -18634,9 +15777,6 @@ tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Opts", "Signs", "Wrapper", "y", "yone", "yun"]
 rebuilt        : ScopeId(0): ["y", "yone", "yun"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
 semantic error: Semantic Collector failed after transform
@@ -18670,27 +15810,16 @@ tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/reverseInferenceInContextualInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
 
-tasks/coverage/typescript/tests/cases/compiler/reverseMappedContravariantInference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTupleContext.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CompilerOptions", "Definition", "KeepLiteralStrings", "Schema", "created1", "created2", "result1", "result2", "result4"]
 rebuilt        : ScopeId(0): ["created1", "created2", "result1", "result2", "result4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
 after transform: ["Record", "create", "test1", "test2", "test4"]
 rebuilt        : ["create", "test1", "test2", "test4"]
@@ -18698,9 +15827,6 @@ rebuilt        : ["create", "test1", "test2", "test4"]
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["InferFromMapped", "Inferred", "LiteralType", "Mapped", "MappedLiteralType", "Test1"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record", "true"]
@@ -18710,25 +15836,14 @@ tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypesP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Tuple"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["EventTarget", "Extract", "HTMLButtonElement", "Parameters", "bindAll"]
 rebuilt        : ["bindAll"]
-
-tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "bar", "test"]
 rebuilt        : ScopeId(0): ["bar", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(6): ["V", "value"]
 rebuilt        : ScopeId(1): ["value"]
@@ -18737,9 +15852,6 @@ tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyExtractor", "Extractor", "Identifier", "StringLiteral", "identifierExtractor", "myUnion", "stringExtractor"]
 rebuilt        : ScopeId(0): ["identifierExtractor", "myUnion", "stringExtractor"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["const", "createExtractor", "isIdentifier", "isStringLiteral", "unionType"]
 rebuilt        : ["createExtractor", "isIdentifier", "isStringLiteral", "unionType"]
@@ -18748,17 +15860,11 @@ tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a"]
 rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MouseEvent", "Window", "X", "o", "window"]
 rebuilt        : ScopeId(0): ["X", "o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("window")
 rebuilt        : ReferenceId(0): None
@@ -18766,17 +15872,9 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["window"]
 
-tasks/coverage/typescript/tests/cases/compiler/selfReference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "InferRecursive", "Recursive", "t1", "t2", "t3"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
@@ -18788,18 +15886,10 @@ Missing ReferenceId: f
 Missing ReferenceId: X
 Missing ReferenceId: X
 
-tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/sigantureIsSubTypeIfTheyAreIdentical.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CacheService", "ICache"]
 rebuilt        : ScopeId(0): ["CacheService"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "key"]
 rebuilt        : ScopeId(2): ["key"]
@@ -18836,9 +15926,6 @@ tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalWithInterio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ConditionalOrUndefined", "ConditionalType", "JustConditional", "JustGeneric", "f", "genericOrUndefined"]
 rebuilt        : ScopeId(0): ["ConditionalOrUndefined", "JustConditional", "JustGeneric", "f", "genericOrUndefined"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
@@ -18854,16 +15941,10 @@ rebuilt        : ScopeId(4): []
 Bindings mismatch:
 after transform: ScopeId(7): ["A", "One", "T", "x"]
 rebuilt        : ScopeId(5): ["x"]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(10)]
-rebuilt        : ScopeId(5): []
 
 tasks/coverage/typescript/tests/cases/compiler/singletonLabeledTuple.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Alias", "AliasOptional", "AliasRest", "AliasedRest", "Labeled", "Literal", "LiteralRest", "Normal", "NormalRest"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(15)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["true"]
@@ -18910,9 +15991,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMap-InterfacePrecedingVaria
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts
 semantic error: Semantic Collector failed after transform
@@ -18948,9 +16026,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobot", "getRobot", "multiRobotA", "multiRobotB", "robotA"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "multiRobotA", "multiRobotB", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(5): None
@@ -19031,9 +16106,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19114,9 +16186,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobot", "getRobot", "multiRobotA", "multiRobotB", "robotA"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "multiRobotA", "multiRobotB", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(5): None
@@ -19188,9 +16257,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "secondarySkillA", "skillA2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43)]
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19262,9 +16328,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobot", "getRobot", "multiRobot", "robot"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "multiRobot", "robot"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("console")
 rebuilt        : ReferenceId(5): None
@@ -19309,9 +16372,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19392,9 +16452,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobot", "getRobot", "multiRobot", "robot"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "multiRobot", "robot"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("console")
 rebuilt        : ReferenceId(5): None
@@ -19439,9 +16496,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobot", "getRobot", "i", "multiRobot", "name", "nameA", "primary", "primaryA", "robot", "secondary", "secondaryA", "skill", "skillA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19522,9 +16576,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobotA", "multiRobotB", "multiRobots", "robotA", "robotB", "robots"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobotA", "multiRobotB", "multiRobots", "robotA", "robotB", "robots"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19605,9 +16656,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("console")
 rebuilt        : ReferenceId(8): None
@@ -19688,9 +16736,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobotA", "multiRobotB", "multiRobots", "robotA", "robotB", "robots"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobotA", "multiRobotB", "multiRobots", "robotA", "robotB", "robots"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43)]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("console")
 rebuilt        : ReferenceId(7): None
@@ -19762,9 +16807,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiRobots", "nameA", "nameA2", "nameB", "nameMA", "numberA2", "numberA3", "numberB", "primarySkillA", "robotA", "robotAInfo", "robotB", "robots", "secondarySkillA", "skillA2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43)]
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("console")
 rebuilt        : ReferenceId(8): None
@@ -19836,9 +16878,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobots", "robots"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobots", "robots"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("console")
 rebuilt        : ReferenceId(3): None
@@ -19883,9 +16922,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -19966,9 +17002,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobots", "getRobots", "multiRobots", "robots"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "multiRobots", "robots"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("console")
 rebuilt        : ReferenceId(3): None
@@ -20013,9 +17046,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringF
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiRobot", "Robot", "console", "getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
 rebuilt        : ScopeId(0): ["getMultiRobots", "getRobots", "i", "multiRobots", "name", "nameA", "primary", "primaryA", "robots", "secondary", "secondaryA", "skill", "skillA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -20096,9 +17126,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20116,9 +17143,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("console")
 rebuilt        : ReferenceId(1): None
@@ -20136,9 +17160,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "hello", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "hello", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20156,9 +17177,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "hello", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "hello", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20176,9 +17194,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "foo4", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "foo4", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20199,9 +17214,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "foo4", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "foo4", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20222,9 +17234,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "foo4", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "foo4", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20245,9 +17254,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringP
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "foo1", "foo2", "foo3", "robotA"]
 rebuilt        : ScopeId(0): ["foo1", "foo2", "foo3", "robotA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
@@ -20265,9 +17271,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "hello", "nameA", "nameB", "nameC", "robotA", "robotB", "skillB", "skillC"]
 rebuilt        : ScopeId(0): ["hello", "nameA", "nameB", "nameC", "robotA", "robotB", "skillB", "skillC"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -20282,9 +17285,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "a", "a1", "b", "b1", "c", "c1", "console", "hello", "nameA", "nameB", "nameC", "robotA", "robotB", "skillB", "skillC"]
 rebuilt        : ScopeId(0): ["a", "a1", "b", "b1", "c", "c1", "hello", "nameA", "nameB", "nameC", "robotA", "robotB", "skillB", "skillC"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("console")
 rebuilt        : ReferenceId(14): None
@@ -20299,9 +17299,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "nameA", "nameA2", "nameC", "numberA2", "numberA3", "numberB", "numberC", "numberC2", "robotA", "robotAInfo", "robotB", "skillA2", "skillC"]
 rebuilt        : ScopeId(0): ["nameA", "nameA2", "nameC", "numberA2", "numberA3", "numberB", "numberC", "numberC2", "robotA", "robotAInfo", "robotB", "skillA2", "skillC"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
@@ -20313,9 +17310,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "console", "multiRobotA", "multiRobotAInfo", "multiRobotB", "nameMA", "nameMB", "nameMC", "nameMC2", "primarySkillA", "primarySkillC", "secondarySkillA", "secondarySkillC", "skillA"]
 rebuilt        : ScopeId(0): ["multiRobotA", "multiRobotAInfo", "multiRobotB", "nameMA", "nameMB", "nameMC", "nameMC2", "primarySkillA", "primarySkillC", "secondarySkillA", "secondarySkillC", "skillA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
@@ -20327,9 +17321,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobotB", "getRobotB", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiSkillB", "nameA", "nameB", "nameMB", "numberB", "primarySkillB", "robotA", "robotAInfo", "robotB", "secondarySkillB", "skillB"]
 rebuilt        : ScopeId(0): ["getMultiRobotB", "getRobotB", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiSkillB", "nameA", "nameB", "nameMB", "numberB", "primarySkillB", "robotA", "robotAInfo", "robotB", "secondarySkillB", "skillB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(62): Some("console")
 rebuilt        : ReferenceId(57): None
@@ -20341,9 +17332,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "nameA", "nameA2", "nameC", "numberA2", "numberA3", "numberB", "numberC", "numberC2", "robotA", "robotAInfo", "robotB", "skillA2", "skillC"]
 rebuilt        : ScopeId(0): ["nameA", "nameA2", "nameC", "numberA2", "numberA3", "numberB", "numberC", "numberC2", "robotA", "robotAInfo", "robotB", "skillA2", "skillC"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
@@ -20355,9 +17343,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "console", "multiRobotA", "multiRobotB", "nameMA", "nameMB", "nameMC", "nameMC2", "primarySkillA", "primarySkillC", "secondarySkillA", "secondarySkillC", "skillA"]
 rebuilt        : ScopeId(0): ["multiRobotA", "multiRobotB", "nameMA", "nameMB", "nameMC", "nameMC2", "primarySkillA", "primarySkillC", "secondarySkillA", "secondarySkillC", "skillA"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("console")
 rebuilt        : ReferenceId(5): None
@@ -20369,9 +17354,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MultiSkilledRobot", "Robot", "console", "getMultiRobotB", "getRobotB", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiSkillB", "nameA", "nameB", "nameMB", "numberB", "primarySkillB", "robotA", "robotAInfo", "robotB", "secondarySkillB", "skillB"]
 rebuilt        : ScopeId(0): ["getMultiRobotB", "getRobotB", "multiRobotA", "multiRobotAInfo", "multiRobotB", "multiSkillB", "nameA", "nameB", "nameMB", "numberB", "primarySkillB", "robotA", "robotAInfo", "robotB", "secondarySkillB", "skillB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(57): Some("console")
 rebuilt        : ReferenceId(52): None
@@ -20383,9 +17365,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "hello", "nameA", "nameB", "nameC", "robotA", "robotB", "skillB", "skillC"]
 rebuilt        : ScopeId(0): ["hello", "nameA", "nameB", "nameC", "robotA", "robotB", "skillB", "skillC"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -20400,9 +17379,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "nameB", "nameC", "primaryA", "primaryB", "robotA", "robotB", "secondaryA", "secondaryB"]
 rebuilt        : ScopeId(0): ["nameB", "nameC", "primaryA", "primaryB", "robotA", "robotB", "secondaryA", "secondaryB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -20417,9 +17393,6 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringV
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Robot", "console", "nameB", "nameC", "primaryA", "primaryB", "robotA", "robotB", "secondaryA", "secondaryB"]
 rebuilt        : ScopeId(0): ["nameB", "nameC", "primaryA", "primaryB", "robotA", "robotB", "secondaryA", "secondaryB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("console")
 rebuilt        : ReferenceId(4): None
@@ -20473,9 +17446,6 @@ tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ErrorMsg", "Predicate", "Result", "Spec", "SpecArray", "SpecFunction", "SpecObject", "SpecValue"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(11), ScopeId(14)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array", "Partial", "ReadonlyArray", "spected", "true"]
 rebuilt        : ["spected"]
@@ -20483,9 +17453,6 @@ rebuilt        : ["spected"]
 tasks/coverage/typescript/tests/cases/compiler/specializationError.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Promise"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
@@ -20501,17 +17468,11 @@ tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEac
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Series", "foo", "keyExtent2", "series"]
 rebuilt        : ScopeId(0): ["foo", "keyExtent2", "series"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/specializeVarArgs1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Observable", "ObservableArray", "a", "observableArray"]
 rebuilt        : ScopeId(0): ["a", "observableArray"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(1): []
@@ -20520,9 +17481,6 @@ tasks/coverage/typescript/tests/cases/compiler/specializedInheritedConstructors1
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Model", "MyView", "View", "ViewOptions", "aView", "aView2", "m", "myView"]
 rebuilt        : ScopeId(0): ["Model", "MyView", "View", "aView", "aView2", "m", "myView"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(2): ["TModel"]
 rebuilt        : ScopeId(1): []
@@ -20539,10 +17497,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -20553,24 +17508,15 @@ tasks/coverage/typescript/tests/cases/compiler/specializedSignatureInInterface.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/specializedSignatureOverloadReturnTypeWithIndexers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/spreadBooleanRespectsFreshness.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "FooArray", "FooBase", "foo1", "foo2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("foo1")
@@ -20597,9 +17543,6 @@ tasks/coverage/typescript/tests/cases/compiler/spreadIdenticalTypesRemoved.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Animal2", "billOwner", "clonePet"]
 rebuilt        : ScopeId(0): ["billOwner", "clonePet"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadIntersectionJsx.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -20613,9 +17556,6 @@ tasks/coverage/typescript/tests/cases/compiler/spreadObjectNoCircular1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Foo", "b"]
 rebuilt        : ScopeId(0): ["Foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(0): []
@@ -20748,9 +17688,6 @@ tasks/coverage/typescript/tests/cases/compiler/spreadOfObjectLiteralAssignableTo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["RecordOfRecords", "RecordOfRecordsOrEmpty", "foo", "recordOfRecords", "recordsOfRecordsOrEmpty"]
 rebuilt        : ScopeId(0): ["foo", "recordOfRecords", "recordsOfRecordsOrEmpty"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record", "undefined"]
 rebuilt        : ["undefined"]
@@ -20764,24 +17701,15 @@ tasks/coverage/typescript/tests/cases/compiler/spreadTypeRemovesReadonly.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ReadonlyData", "clone", "data"]
 rebuilt        : ScopeId(0): ["clone", "data"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTupleTypes.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["const", "foo", "fx1", "fx2"]
 rebuilt        : ["foo", "fx1", "fx2"]
 
 tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SelectorMap"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record"]
@@ -20808,9 +17736,6 @@ tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "c", "c10", "c11", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "ex", "f"]
 rebuilt        : ScopeId(0): ["c", "c10", "c11", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "ex", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
 
 tasks/coverage/typescript/tests/cases/compiler/staticInitializersAndLegacyClassDecorators.ts
 semantic error: Bindings mismatch:
@@ -20840,9 +17765,6 @@ tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Shape", "ShapeFactory", "x"]
 rebuilt        : ScopeId(0): ["Shape", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -20851,9 +17773,6 @@ tasks/coverage/typescript/tests/cases/compiler/staticPrototypePropertyOnClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
 semantic error: Bindings mismatch:
@@ -20873,9 +17792,6 @@ tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeShouldW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Foo", "FooClass", "Test", "Test2"]
 rebuilt        : ScopeId(0): ["FooClass", "Test", "Test2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(1): []
@@ -20889,20 +17805,9 @@ Unresolved references mismatch:
 after transform: ["Readonly"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6)]
-rebuilt        : ScopeId(4): []
-
 tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["someVal", "someVal2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("someVal")
@@ -20927,9 +17832,6 @@ tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimit
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyStyledComponent", "Defaultize", "FORWARD_REF_STATICS", "ForwardRefExoticBase", "IntrinsicElementsKeys", "KNOWN_STATICS", "MEMO_STATICS", "NonReactStatics", "REACT_STATICS", "React", "ReactDefaultizedProps", "StyledComponent", "StyledComponentBase", "StyledComponentInnerAttrs", "StyledComponentInnerComponent", "StyledComponentInnerOtherProps", "StyledComponentProps", "StyledComponentPropsWithAs", "StyledComponentPropsWithRef", "WithChildrenIfReactComponentClass", "WithOptionalTheme"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(16), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(30), ScopeId(32), ScopeId(35), ScopeId(38)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "Extract", "JSX", "Omit", "Partial", "Pick", "true"]
 rebuilt        : []
@@ -20938,9 +17840,6 @@ tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "ClassComponent", "Component", "Lifecycle", "MyAttrs", "Vnode", "test8"]
 rebuilt        : ScopeId(0): ["C", "test8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(31), ReferenceId(33)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -20949,9 +17848,6 @@ tasks/coverage/typescript/tests/cases/compiler/subclassWithPolymorphicThisIsAssi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CustomDocument", "Document", "Example"]
 rebuilt        : ScopeId(0): ["Example"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["Z"]
 rebuilt        : ScopeId(1): []
@@ -20963,9 +17859,6 @@ tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesCons
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FFG", "M", "O", "X"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["ReturnType"]
 rebuilt        : []
@@ -20974,24 +17867,15 @@ tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AddPropToObject"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Str"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericIndexedAccessType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Record"]
@@ -21001,9 +17885,6 @@ tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignab
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Entity", "Entry", "Fields", "Nodes", "makeEntityStore", "myTest"]
 rebuilt        : ScopeId(0): ["makeEntityStore", "myTest"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(8): ["T", "config"]
 rebuilt        : ScopeId(1): ["config"]
@@ -21015,9 +17896,6 @@ tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar1", "Bar2", "Foo1", "Foo2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Set"]
 rebuilt        : []
@@ -21025,9 +17903,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bug", "BugHelper", "Q", "R", "UnionKeys"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude"]
@@ -21037,17 +17912,11 @@ tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Subset", "UserArgs", "boundaryResult", "withoutBoundaryResult"]
 rebuilt        : ScopeId(0): ["boundaryResult", "withoutBoundaryResult"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/subtypeReductionUnionConstraints.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "BarNode", "Document", "FooNode", "Node", "f1", "visitNodes"]
 rebuilt        : ScopeId(0): ["f1", "visitNodes"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "node", "predicate"]
 rebuilt        : ScopeId(1): ["node", "predicate"]
@@ -21094,26 +17963,17 @@ Missing ReferenceId: test
 Missing ReferenceId: test
 
 tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved reference IDs mismatch for "B":
+semantic error: Unresolved reference IDs mismatch for "B":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved reference IDs mismatch for "B":
+semantic error: Unresolved reference IDs mismatch for "B":
 after transform: [ReferenceId(0), ReferenceId(2)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch:
@@ -21132,10 +17992,7 @@ after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved reference IDs mismatch for "B":
+semantic error: Unresolved reference IDs mismatch for "B":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(0)]
 
@@ -21147,9 +18004,6 @@ rebuilt        : SymbolId(0): []
 tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Constructor", "ControllerClass"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/symbolMergeValueAndImportedType.ts
@@ -21174,17 +18028,14 @@ after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule15.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["moduleC", "moduleCStar", "value", "value2"]
+rebuilt        : ScopeId(0): ["moduleC", "moduleCStar", "value"]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule17.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "I"]
 rebuilt        : ScopeId(0): ["A"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule18.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -21201,9 +18052,6 @@ tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "c", "e", "foo", "promise"]
 rebuilt        : ScopeId(0): ["c", "e", "foo", "promise"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("E")
 rebuilt        : ReferenceId(3): None
@@ -21271,11 +18119,6 @@ Missing SymbolId: _ns
 Missing ReferenceId: ns
 Missing ReferenceId: ns
 
-tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
 semantic error: Unresolved references mismatch:
 after transform: ["TemplateStringsArray"]
@@ -21297,17 +18140,11 @@ tasks/coverage/typescript/tests/cases/compiler/templateExpressionAsPossiblyDiscr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BiomeButtonProps", "BiomePlainLinkProps", "ClickableDiscriminatedUnion", "p3"]
 rebuilt        : ScopeId(0): ["p3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/templateExpressionNoInlininingOfConstantBindingWithInitializer.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Params", "example", "example2"]
 rebuilt        : ScopeId(0): ["example", "example2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/templateLiteralConstantEvaluation.ts
 semantic error: Bindings mismatch:
@@ -21321,9 +18158,6 @@ tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "E", "MixA", "MixB", "MixC", "MixD", "MixE", "OriginA1", "OriginA2", "OriginB1", "OriginB2", "OriginC", "OriginD", "OriginE", "OriginF", "a"]
 rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
 rebuilt        : SymbolId(0): []
@@ -21331,9 +18165,6 @@ rebuilt        : SymbolId(0): []
 tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Path", "lowercasePath", "options1", "path"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("options1")
@@ -21358,9 +18189,6 @@ tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Provider", "StateHook", "StoreUtils", "useAge", "useStore", "useUsername"]
 rebuilt        : ScopeId(0): ["Provider", "useAge", "useStore", "useUsername"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Capitalize", "Omit", "createStore"]
 rebuilt        : ["createStore"]
@@ -21387,23 +18215,14 @@ tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IComparable"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(2): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(3): []
 Bindings mismatch:
 after transform: ScopeId(6): ["T"]
 rebuilt        : ScopeId(4): []
@@ -21454,22 +18273,13 @@ tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParameterConstrain
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "Boolean", "Function", "IArguments", "Number", "Object", "RegExp", "String", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(13)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["Key", "params"]
 rebuilt        : ScopeId(4): ["params"]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(4): []
 Bindings mismatch:
 after transform: ScopeId(8): ["T0"]
-rebuilt        : ScopeId(7): []
-Scope children mismatch:
-after transform: ScopeId(8): [ScopeId(9)]
 rebuilt        : ScopeId(7): []
 Unresolved references mismatch:
 after transform: ["Error", "this"]
@@ -21479,9 +18289,6 @@ tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldI
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnchorType", "CoachMarkAnchorDecorator", "CoachMarkAnchorProps"]
 rebuilt        : ScopeId(0): ["CoachMarkAnchorDecorator"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(5): ["P", "anchor"]
 rebuilt        : ScopeId(2): ["anchor"]
@@ -21508,9 +18315,6 @@ tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Collection", "Combinators", "_", "c2", "r1a", "r1b", "rf1"]
 rebuilt        : ScopeId(0): ["_", "c2", "r1a", "r1b", "rf1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -21519,27 +18323,16 @@ tasks/coverage/typescript/tests/cases/compiler/topLevelBlockExpando.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Person"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
-tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(35)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32)]
-
 tasks/coverage/typescript/tests/cases/compiler/transitiveTypeArgumentInference1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I1", "c", "i"]
 rebuilt        : ScopeId(0): ["C", "c", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
@@ -21548,9 +18341,6 @@ tasks/coverage/typescript/tests/cases/compiler/trivialSubtypeReductionNoStructur
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Wizard", "WizardStepProps", "props"]
 rebuilt        : ScopeId(0): ["Wizard"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
 rebuilt        : SymbolId(0): []
@@ -21565,9 +18355,6 @@ tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f", "g"]
 rebuilt        : ScopeId(0): ["f", "g"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelpers.ts
 semantic error: Bindings mismatch:
@@ -21584,9 +18371,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsO
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["Foo", "_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(2): [ReferenceId(4), ReferenceId(6)]
@@ -21595,9 +18379,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxAttributesHasInferrableIndex.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AttributeValue", "Attributes", "Button", "_jsxFileName", "b", "createElement"]
 rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "b", "createElement"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol flags mismatch:
 after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
@@ -21626,9 +18407,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "JSX", "Props", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Unresolved references mismatch:
 after transform: ["Comp", "JSX", "parseInt", "require", "true", "undefined"]
 rebuilt        : ["Comp", "parseInt", "require", "undefined"]
@@ -21651,9 +18429,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "Props", "PropsBase", "PropsWithConvert", "ShouldInferFromData", "_jsxFileName", "_reactJsxRuntime", "f1", "f2", "f3"]
 rebuilt        : ScopeId(0): ["ShouldInferFromData", "_jsxFileName", "_reactJsxRuntime", "f1", "f2", "f3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "props"]
 rebuilt        : ScopeId(1): ["props"]
@@ -21668,9 +18443,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnI
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ButtonProps", "CustomButton", "CustomButtonProps", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["CustomButton", "React", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(1): [ReferenceId(0)]
@@ -21690,9 +18462,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxStatelessComponentDefaultProps
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BackButton", "Props", "React", "_jsxFileName", "a"]
 rebuilt        : ScopeId(0): ["BackButton", "React", "_jsxFileName", "a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(6)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(4)]
@@ -21701,9 +18470,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFilterDataPro
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["React", "ReactElement", "RootHappy", "RootNotHappy", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["React", "RootHappy", "RootNotHappy", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved reference IDs mismatch for "NotHappy":
 after transform: [ReferenceId(2), ReferenceId(5)]
 rebuilt        : [ReferenceId(1)]
@@ -21715,9 +18481,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnimalComponent", "AnimalInfo", "CatInfo", "DogInfo", "JSX", "_jsxFileName", "_reactJsxRuntime", "component", "component2", "getProps", "props", "props2"]
 rebuilt        : ScopeId(0): ["AnimalComponent", "_jsxFileName", "_reactJsxRuntime", "component", "component2", "getProps", "props", "props2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(8), ReferenceId(11), ReferenceId(13), ReferenceId(16)]
 rebuilt        : SymbolId(2): [ReferenceId(4), ReferenceId(8)]
@@ -21729,9 +18492,6 @@ tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["$q", "IPromise", "IQService", "a", "b", "c"]
 rebuilt        : ScopeId(0): ["a", "b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("$q")
 rebuilt        : ReferenceId(0): None
@@ -21767,17 +18527,11 @@ tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "C2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Set1", "Set2", "State", "newState", "state"]
 rebuilt        : ScopeId(0): ["newState", "state"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Exclude", "Pick", "Required", "set"]
 rebuilt        : ["set"]
@@ -21786,28 +18540,16 @@ tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["foo", "i"]
 rebuilt        : ScopeId(2): ["i"]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(8)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(4): ["foo"]
 rebuilt        : ScopeId(4): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(9)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(6): ["foo"]
 rebuilt        : ScopeId(6): []
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(10)]
-rebuilt        : ScopeId(6): [ScopeId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasDoesntMakeModuleInstantiated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "m"]
@@ -21817,9 +18559,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["undefined"]
 rebuilt        : []
@@ -21828,15 +18567,9 @@ tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSharedSymbol
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Crashes", "Mixin", "ReturnTypeOf"]
 rebuilt        : ScopeId(0): ["Mixin"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Base", "TBase"]
 rebuilt        : ScopeId(1): ["Base"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
@@ -21851,25 +18584,16 @@ tasks/coverage/typescript/tests/cases/compiler/typeAnnotationBestCommonTypeInArr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IMenuItem", "menuData"]
 rebuilt        : ScopeId(0): ["menuData"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o", "t1", "t2", "t3", "t4", "x"]
 rebuilt        : ScopeId(0): ["o", "t1", "t2", "t3", "t4", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Item", "z1", "z2", "z3", "z4", "z5", "z6"]
 rebuilt        : ScopeId(0): ["z1", "z2", "z3", "z4", "z5", "z6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
 semantic error: Bindings mismatch:
@@ -21905,9 +18629,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Goo", "I", "foo", "x"]
 rebuilt        : ScopeId(0): ["C", "foo", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "f"]
 rebuilt        : ScopeId(2): ["f"]
@@ -21916,17 +18637,11 @@ tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursiv
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TreeNode", "nodes"]
 rebuilt        : ScopeId(0): ["nodes"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral02.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TreeNode", "TreeNodeMiddleman", "nodes"]
 rebuilt        : ScopeId(0): ["nodes"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgumentsInFunctionExpressions.ts
 semantic error: Bindings mismatch:
@@ -21940,9 +18655,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSigna
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Constructable"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
@@ -21973,9 +18685,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedFi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arrayLikeOrIterable"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("arrayLikeOrIterable")
 rebuilt        : ReferenceId(1): None
@@ -21990,9 +18699,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arrayLikeOrIterable"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("arrayLikeOrIterable")
 rebuilt        : ReferenceId(1): None
@@ -22007,17 +18713,11 @@ tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "Circle", "Rectangle", "Shape", "Square", "Subshape", "X", "Y", "Z", "area", "check", "g", "subarea"]
 rebuilt        : ScopeId(0): ["area", "check", "g", "subarea"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "m"]
 rebuilt        : ScopeId(0): ["E"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -22044,9 +18744,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "m"]
 rebuilt        : ScopeId(0): ["E"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -22078,25 +18775,16 @@ tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "foo", "index"]
 rebuilt        : ScopeId(0): ["foo", "index"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "a", "aIndex", "b", "bIndex", "c", "cIndex"]
 rebuilt        : ScopeId(0): ["a", "aIndex", "b", "bIndex", "c", "cIndex"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "a", "aIndex", "b", "bIndex", "c", "cIndex"]
 rebuilt        : ScopeId(0): ["a", "b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("aIndex")
 rebuilt        : ReferenceId(1): None
@@ -22143,9 +18831,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Callback"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceFBoundedTypeParams.ts
 semantic error: Bindings mismatch:
@@ -22155,18 +18840,10 @@ Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "value", "values"]
 rebuilt        : ScopeId(4): ["value", "values"]
 
-tasks/coverage/typescript/tests/cases/compiler/typeInferenceFixEarly.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceLiteralUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["NumCoercible", "Numeric", "Primitive", "extent", "extentMixed"]
 rebuilt        : ScopeId(0): ["NumCoercible", "extent", "extentMixed"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "array"]
 rebuilt        : ScopeId(4): ["array"]
@@ -22181,9 +18858,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeInferenceReturnTypeCallback.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Cons", "IList", "Nil"]
 rebuilt        : ScopeId(0): ["Cons", "Nil"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["C"]
 rebuilt        : ScopeId(1): []
@@ -22200,18 +18874,10 @@ Bindings mismatch:
 after transform: ScopeId(8): ["E", "f", "z"]
 rebuilt        : ScopeId(6): ["f", "z"]
 
-tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Named", "parrot"]
 rebuilt        : ScopeId(0): ["parrot"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "obj"]
 rebuilt        : ScopeId(1): ["obj"]
@@ -22221,26 +18887,15 @@ semantic error: Semantic Collector failed after transform
 Missing SymbolId: React
 Missing ReferenceId: require
 
-tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithTypeAnnotation.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/typeLiteralCallback.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "bar", "foo", "test"]
 rebuilt        : ScopeId(0): ["foo", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AsyncSequenceFactory", "SequenceFactory", "SyncSequenceFactory", "asyncFactory", "looserAsyncFactory", "looserSyncFactory", "syncFactory"]
 rebuilt        : ScopeId(0): ["asyncFactory", "looserAsyncFactory", "looserSyncFactory", "syncFactory"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
 Unresolved references mismatch:
 after transform: ["AsyncGenerator", "Generator"]
 rebuilt        : []
@@ -22276,9 +18931,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccross
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2", "a", "a2", "i", "i2"]
 rebuilt        : ScopeId(0): ["a", "a2", "i", "i2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "y"]
 rebuilt        : ScopeId(1): ["y"]
@@ -22287,17 +18939,11 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTy
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraintInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mapper", "a", "m"]
 rebuilt        : ScopeId(0): ["a", "m"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond1.ts
 semantic error: Bindings mismatch:
@@ -22309,11 +18955,6 @@ rebuilt        : ScopeId(2): ["diamondBottom"]
 Bindings mismatch:
 after transform: ScopeId(3): ["Bottom", "bottom", "middle", "top"]
 rebuilt        : ScopeId(3): ["bottom", "middle", "top"]
-
-tasks/coverage/typescript/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterEquality.ts
 semantic error: Bindings mismatch:
@@ -22352,9 +18993,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "IdMap", "f", "g", "h"]
 rebuilt        : ScopeId(0): ["f", "g", "h"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "t", "v"]
 rebuilt        : ScopeId(1): ["t", "v"]
@@ -22372,17 +19010,11 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraint
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IBar", "IFoo", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b", "d", "d2", "d3", "f"]
 rebuilt        : ScopeId(0): ["a", "b", "d", "d2", "d3", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "f", "x", "y"]
 rebuilt        : ScopeId(1): ["f", "x", "y"]
@@ -22391,9 +19023,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b", "d", "f"]
 rebuilt        : ScopeId(0): ["a", "b", "d", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "p", "p1", "y", "y1"]
 rebuilt        : ScopeId(1): ["p", "p1", "y", "y1"]
@@ -22402,9 +19031,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b", "d", "f"]
 rebuilt        : ScopeId(0): ["a", "b", "d", "f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "pf1", "pf2", "t1", "u1"]
 rebuilt        : ScopeId(1): ["pf1", "pf2", "t1", "u1"]
@@ -22418,9 +19044,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "BoxFactory", "BoxFactoryFactory", "BoxTypes", "b", "f"]
 rebuilt        : ScopeId(0): ["b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("f")
 rebuilt        : ReferenceId(0): None
@@ -22437,9 +19060,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "tFirst", "uFirst", "z"]
 rebuilt        : ScopeId(0): ["tFirst", "uFirst", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -22451,9 +19071,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantia
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Identity", "Settable", "Test1", "Test2", "Test2Base", "test1", "test2"]
 rebuilt        : ScopeId(0): ["Identity", "test1", "test2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["V"]
 rebuilt        : ScopeId(1): []
@@ -22465,9 +19082,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Options", "Test"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial"]
 rebuilt        : []
@@ -22476,9 +19090,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Item", "Narrow", "Narrowable", "filteredValues1", "filteredValues2", "isNotNull", "item1", "item2", "item3", "satisfies", "values1", "values2"]
 rebuilt        : ScopeId(0): ["filteredValues1", "filteredValues2", "isNotNull", "item1", "item2", "item3", "satisfies", "values1", "values2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(5): ["TWide"]
 rebuilt        : ScopeId(1): []
@@ -22496,9 +19107,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicateStructuralMatch.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Result", "Results", "getResults1", "getResults2", "isPlainResponse", "isResponseInData"]
 rebuilt        : ScopeId(0): ["getResults1", "getResults2", "isPlainResponse", "isResponseInData"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "value"]
 rebuilt        : ScopeId(1): ["value"]
@@ -22515,9 +19123,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "isFoo1", "isFoo2", "test"]
 rebuilt        : ScopeId(0): ["isFoo1", "isFoo2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("test")
 rebuilt        : ReferenceId(3): None
@@ -22538,9 +19143,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscrimi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["fruit", "fruit2", "kind"]
 rebuilt        : ScopeId(0): ["kind"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("fruit")
 rebuilt        : ReferenceId(1): None
@@ -22567,15 +19169,9 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Or", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "isString":
+semantic error: Unresolved reference IDs mismatch for "isString":
 after transform: [ReferenceId(0), ReferenceId(3)]
 rebuilt        : [ReferenceId(1)]
 Unresolved reference IDs mismatch for "isNumber":
@@ -22586,17 +19182,11 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Or", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "isNotNull", "title", "x"]
 rebuilt        : ScopeId(0): ["isNotNull", "title", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -22608,17 +19198,11 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Person", "getName1", "getName2", "isString"]
 rebuilt        : ScopeId(0): ["getName1", "getName2", "isString"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Breed", "getBreedSizeWithFunction", "getBreedSizeWithoutFunction"]
 rebuilt        : ScopeId(0): ["getBreedSizeWithFunction", "getBreedSizeWithoutFunction"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
 semantic error: Semantic Collector failed after transform
@@ -22680,10 +19264,7 @@ Missing ReferenceId: TopLevelModule2
 Missing ReferenceId: TopLevelModule2
 
 tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch:
@@ -22700,9 +19281,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["OptionHandlers", "OptionOne", "OptionTwo", "Options", "T00", "T01", "T02", "T10", "T11", "T12", "T20", "T21", "T22", "T23", "T30", "T31", "T32", "T33", "T40", "T41", "T42", "T43", "T50", "T51", "T52", "T53", "T54", "T55", "T60", "T61", "T62", "T63", "T70", "T71", "T72", "T73", "foo", "handleOption", "optionHandlers"]
 rebuilt        : ScopeId(0): ["foo", "handleOption", "optionHandlers"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(8), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(36): ["K", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -22714,9 +19292,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Banana", "BigBanana", "BigMonkey", "Foo", "Item", "Monkey", "f1", "f2", "f3", "f4", "f5", "f6"]
 rebuilt        : ScopeId(0): ["A", "BigMonkey", "Monkey", "f1", "f2", "f3", "f4", "f5", "f6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(11), ScopeId(12), ScopeId(15), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(8), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21)]
 Bindings mismatch:
 after transform: ScopeId(3): ["P"]
 rebuilt        : ScopeId(1): []
@@ -22782,9 +19357,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Arg", "myFunction"]
 rebuilt        : ScopeId(0): ["myFunction"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
@@ -22793,10 +19365,7 @@ after transform: ["Record", "true"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
@@ -22813,9 +19382,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["First", "a", "b", "c", "d", "decorateA", "decorateB", "decorateC", "decorateD", "val"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "decorateA", "decorateB", "decorateC", "decorateD", "val"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12)]
 Bindings mismatch:
 after transform: ScopeId(1): ["O", "fn"]
 rebuilt        : ScopeId(1): ["fn"]
@@ -22841,9 +19407,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeofStripsFreshness.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ALL", "ANOTHER", "All", "Another", "Both", "Collection", "CollectionStatic", "result", "result2"]
 rebuilt        : ScopeId(0): ["ALL", "ANOTHER", "result", "result2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
@@ -22869,9 +19432,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "T", "W", "o", "o2"]
 rebuilt        : ScopeId(0): ["C", "o", "o2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): []
@@ -23034,9 +19594,6 @@ tasks/coverage/typescript/tests/cases/compiler/undefinedAsDiscriminantWithUnknow
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "s"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("s")
 rebuilt        : ReferenceId(0): None
@@ -23079,9 +19636,6 @@ tasks/coverage/typescript/tests/cases/compiler/underscoreMapFirst.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IData", "ISeries", "MyView", "_"]
 rebuilt        : ScopeId(0): ["MyView"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
 semantic error: Semantic Collector failed after transform
@@ -23097,9 +19651,6 @@ tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Err", "Ok", "e", "e2"]
 rebuilt        : ScopeId(0): ["e2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("e")
 rebuilt        : ReferenceId(0): None
@@ -23111,16 +19662,10 @@ tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["INumberDictionary", "IStringDictionary", "count"]
 rebuilt        : ScopeId(0): ["count"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unionExcessPropsWithPartialMember.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "ab"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("ab")
@@ -23136,17 +19681,11 @@ tasks/coverage/typescript/tests/cases/compiler/unionOfArraysFilterCall.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Buzz", "Fizz"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/unionOfClassCalls.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "arr", "arr1", "arr2", "tmp"]
 rebuilt        : ScopeId(0): ["arr", "arr1", "arr2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(18), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("tmp")
 rebuilt        : ReferenceId(0): None
@@ -23161,9 +19700,6 @@ tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Enum", "Interface", "bar", "foo"]
 rebuilt        : ScopeId(0): ["Enum", "bar", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "Enum"]
 rebuilt        : ScopeId(1): ["Enum"]
@@ -23195,12 +19731,6 @@ tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ReturnVal", "k", "run", "val"]
 rebuilt        : ScopeId(0): ["k", "run"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(2): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("val")
 rebuilt        : ReferenceId(1): None
@@ -23209,10 +19739,7 @@ after transform: []
 rebuilt        : ["val"]
 
 tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Capitalize", "upperFirst"]
 rebuilt        : ["upperFirst"]
 
@@ -23220,17 +19747,11 @@ tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "ctor", "t"]
 rebuilt        : ScopeId(1): ["ctor", "t"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/unionTypeParameterInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "unlift"]
 rebuilt        : ScopeId(0): ["unlift"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["U", "value"]
 rebuilt        : ScopeId(1): ["value"]
@@ -23239,25 +19760,16 @@ tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndMethodSignat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Options"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexedLiteralType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "Idx", "U", "u"]
 rebuilt        : ScopeId(0): ["u"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction1.ts
 semantic error: Symbol reference IDs mismatch:
@@ -23277,9 +19789,6 @@ tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["NumList", "StrList", "TypedArray", "flatten", "foo", "isTypedArray"]
 rebuilt        : ScopeId(0): ["flatten", "foo", "isTypedArray"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "arr", "zz"]
 rebuilt        : ScopeId(1): ["arr", "zz"]
@@ -23297,9 +19806,6 @@ tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAug
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FOO_SYMBOL", "foo", "global"]
 rebuilt        : ScopeId(0): ["FOO_SYMBOL", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "p"]
 rebuilt        : ScopeId(1): ["p"]
@@ -23314,9 +19820,6 @@ tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPro
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "myUnusedFunction", "myVar"]
 rebuilt        : ScopeId(0): ["myUnusedFunction", "myVar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
 semantic error: Unresolved references mismatch:
@@ -23336,11 +19839,6 @@ rebuilt        : ReferenceId(1): None
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["s"]
-
-tasks/coverage/typescript/tests/cases/compiler/untypedArgumentInLambdaExpression.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -23381,9 +19879,6 @@ tasks/coverage/typescript/tests/cases/compiler/unusedLocalProperty.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "console"]
 rebuilt        : ScopeId(0): ["Animal"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(1): None
@@ -23398,21 +19893,10 @@ Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
 
-tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(2): [ScopeId(3), ScopeId(4)]
-
 tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I3", "handler1", "handler2", "handler3", "handler4", "handler5", "handler6", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -23420,9 +19904,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/unusedParameterUsedInTypeOf.ts
@@ -23449,9 +19930,6 @@ tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3"]
 rebuilt        : ScopeId(0): ["C1", "C2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -23475,9 +19953,6 @@ tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersNotCheckedByN
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "T", "f", "l"]
 rebuilt        : ScopeId(0): ["C", "f", "l"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -23495,9 +19970,6 @@ tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "CalcObj", "CalcValue", "a", "b", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["O", "unk", "x"]
 rebuilt        : ScopeId(1): ["unk", "x"]
@@ -23705,9 +20177,6 @@ tasks/coverage/typescript/tests/cases/compiler/varArgsOnConstructorTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "I1", "reg"]
 rebuilt        : ScopeId(0): ["A", "B", "reg"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -23716,9 +20185,6 @@ tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccess
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action1", "MessageEventLike", "PostMessageObject", "Source", "Target", "WindowLike", "f1"]
 rebuilt        : ScopeId(0): ["f1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["AddEventListenerOptions", "EventListenerOrEventListenerObject", "Window", "WindowEventMap"]
 rebuilt        : []
@@ -23726,9 +20192,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "a", "a2", "b", "b2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
@@ -23786,9 +20249,6 @@ tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndex
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Any", "Either", "Left", "MyInfo", "MyServer", "NeededInfo", "Right", "Server", "ToA", "ToB", "Type", "TypeOf", "tmp1", "tmp2"]
 rebuilt        : ScopeId(0): ["Left", "MyServer", "Right", "Server", "Type", "tmp1", "tmp2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(10), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(12), ScopeId(13), ScopeId(14)]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "L"]
 rebuilt        : ScopeId(1): []
@@ -23830,9 +20290,6 @@ tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndex
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Any", "Either", "Left", "MyInfo", "MyServer", "NeededInfo", "Right", "Server", "ToA", "ToB", "Type", "TypeOf", "tmp1", "tmp2"]
 rebuilt        : ScopeId(0): ["Left", "MyServer", "Right", "Server", "Type", "tmp1", "tmp2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(10), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(12), ScopeId(13), ScopeId(14)]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "L"]
 rebuilt        : ScopeId(1): []
@@ -23874,9 +20331,6 @@ tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithU
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "I", "P1", "P2", "X", "_i", "i", "p2"]
 rebuilt        : ScopeId(0): ["_i", "i", "p2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Pick", "Record"]
 rebuilt        : []
@@ -23905,18 +20359,10 @@ Please consider using `import lib from '...';` alongside Typescript's --allowSyn
 `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "bad", "safeInvoke"]
 rebuilt        : ScopeId(0): ["bad", "safeInvoke"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A1", "R", "arg1", "func"]
 rebuilt        : ScopeId(1): ["arg1", "func"]
@@ -23948,9 +20394,6 @@ tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DataDef", "Instance", "Options", "PropsDefinition", "ThisTypedOptions", "WatchHandler"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Readonly", "Record", "ThisType", "test"]
 rebuilt        : ["test"]
@@ -23959,9 +20402,6 @@ tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DataDef", "Instance", "Options", "PropsDefinition", "ThisTypedOptions", "WatchHandler"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved references mismatch:
 after transform: ["Readonly", "Record", "ThisType", "test"]
 rebuilt        : ["test"]
@@ -23970,9 +20410,6 @@ tasks/coverage/typescript/tests/cases/compiler/weakTypeAndPrimitiveNarrowing.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LiteralsAndWeakTypes", "PrimitivesAndWeakTypes", "g", "h"]
 rebuilt        : ScopeId(0): ["g", "h"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Unresolved references mismatch:
 after transform: ["true"]
 rebuilt        : []
@@ -23981,24 +20418,15 @@ tasks/coverage/typescript/tests/cases/compiler/wideningWithTopLevelTypeParameter
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "FormControl", "FormControl2", "FormControl3", "a", "b", "c", "c0", "c1", "c2", "c3", "c4"]
 rebuilt        : ScopeId(0): ["FormControl", "FormControl2", "FormControl3", "a", "b", "c", "c0", "c1", "c2", "c3", "c4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(17), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(14): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(15): [ScopeId(16)]
-rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(17): ["T"]
 rebuilt        : ScopeId(3): []
 Bindings mismatch:
 after transform: ScopeId(19): ["T"]
 rebuilt        : ScopeId(5): []
-Scope children mismatch:
-after transform: ScopeId(20): [ScopeId(21)]
-rebuilt        : ScopeId(6): []
 
 tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 semantic error: 'with' statements are not allowed
@@ -24021,17 +20449,11 @@ tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Symbol", "SymbolConstructor", "obj"]
 rebuilt        : ScopeId(0): ["Symbol", "obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E1", "E2", "E3", "M1", "external1", "m", "n", "p", "q", "x"]
 rebuilt        : ScopeId(0): ["p", "q", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(23)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("E3")
 rebuilt        : ReferenceId(0): None
@@ -24043,24 +20465,15 @@ tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["equ", "equ2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "E1"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleMerging.ts
@@ -24077,9 +20490,6 @@ Missing ReferenceId: M2
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbientExternalModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "M", "x"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand.ts
@@ -24102,10 +20512,7 @@ after transform: ["Promise"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Promise", "someOtherFunction"]
 rebuilt        : ["someOtherFunction"]
 
@@ -24136,9 +20543,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24153,9 +20557,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24170,9 +20571,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24187,9 +20585,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24204,9 +20599,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("p")
 rebuilt        : ReferenceId(2): None
@@ -24218,9 +20610,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
 rebuilt        : ReferenceId(2): None
@@ -24238,9 +20627,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("p")
 rebuilt        : ReferenceId(2): None
@@ -24258,9 +20644,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
 rebuilt        : ReferenceId(2): None
@@ -24278,9 +20661,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("pfn")
 rebuilt        : ReferenceId(1): None
@@ -24301,9 +20681,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -24324,9 +20701,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -24347,9 +20721,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -24370,9 +20741,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpressi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("po")
 rebuilt        : ReferenceId(1): None
@@ -24393,9 +20761,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitClassExpress
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(0): None
@@ -24407,9 +20772,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitInheritedPro
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("a")
 rebuilt        : ReferenceId(0): None
@@ -24438,10 +20800,7 @@ after transform: ["Promise"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Promise", "someOtherFunction"]
 rebuilt        : ["someOtherFunction"]
 
@@ -24491,9 +20850,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24508,9 +20864,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24525,9 +20878,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24542,9 +20892,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24559,9 +20906,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("p")
 rebuilt        : ReferenceId(2): None
@@ -24573,9 +20917,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
 rebuilt        : ReferenceId(2): None
@@ -24593,9 +20934,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("p")
 rebuilt        : ReferenceId(2): None
@@ -24613,9 +20951,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
 rebuilt        : ReferenceId(2): None
@@ -24633,9 +20968,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("pfn")
 rebuilt        : ReferenceId(1): None
@@ -24656,9 +20988,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -24679,9 +21008,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -24702,9 +21028,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -24725,9 +21048,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("po")
 rebuilt        : ReferenceId(1): None
@@ -24748,9 +21068,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitClassExpression
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(0): None
@@ -24800,9 +21117,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PromiseAlias", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Promise"]
 rebuilt        : []
@@ -24813,10 +21127,7 @@ after transform: ["Promise"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Promise", "someOtherFunction"]
 rebuilt        : ["someOtherFunction"]
 
@@ -24850,9 +21161,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24867,9 +21175,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24884,9 +21189,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24901,9 +21203,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(1): None
@@ -24918,9 +21217,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpressio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("p")
 rebuilt        : ReferenceId(2): None
@@ -24932,9 +21228,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
 rebuilt        : ReferenceId(2): None
@@ -24952,9 +21245,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("p")
 rebuilt        : ReferenceId(2): None
@@ -24972,9 +21262,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a")
 rebuilt        : ReferenceId(2): None
@@ -24992,9 +21279,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("pfn")
 rebuilt        : ReferenceId(1): None
@@ -25015,9 +21299,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -25038,9 +21319,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -25061,9 +21339,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("o")
 rebuilt        : ReferenceId(1): None
@@ -25084,9 +21359,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "func", "o", "p", "pfn", "po"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("po")
 rebuilt        : ReferenceId(1): None
@@ -25107,9 +21379,6 @@ tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitClassExpression
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["func", "p"]
 rebuilt        : ScopeId(0): ["func"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(0): None
@@ -25228,17 +21497,11 @@ tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/merg
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C4"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BaseClass", "BaseInterface", "Child", "ChildNoBaseClass", "Grandchild", "child", "grandchild"]
 rebuilt        : ScopeId(0): ["BaseClass", "Child", "ChildNoBaseClass", "Grandchild", "child", "grandchild"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
 Symbol flags mismatch:
 after transform: SymbolId(2): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
@@ -25304,10 +21567,7 @@ after transform: SymbolId(1): [ReferenceId(2)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(7)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(1): [ReferenceId(10)]
 
@@ -25317,35 +21577,20 @@ after transform: SymbolId(2): [ReferenceId(2)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(7): ["T"]
 rebuilt        : ScopeId(5): []
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithOptionalParameters.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithExpressionLessReturn.ts
 semantic error: Bindings mismatch:
@@ -25454,34 +21699,22 @@ after transform: ["Object"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["B", "undefined"]
 rebuilt        : ["B"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["B", "undefined"]
 rebuilt        : ["B"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["B", "undefined"]
 rebuilt        : ["B"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["B", "undefined"]
 rebuilt        : ["B"]
 
@@ -25517,9 +21750,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/p
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -25546,17 +21776,11 @@ tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Foo"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Constructor", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "Timestamped", "f1", "f2"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "Timestamped", "f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16)]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "superClass"]
 rebuilt        : ScopeId(5): ["superClass"]
@@ -25574,9 +21798,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I"]
 rebuilt        : ScopeId(0): ["B", "C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol flags mismatch:
 after transform: SymbolId(1): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -25594,9 +21815,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyCtor", "Base", "MyClass", "Properties", "Types", "mine", "value"]
 rebuilt        : ScopeId(0): ["Base", "MyClass", "mine", "value"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Unresolved references mismatch:
 after transform: ["classWithProperties", "const"]
 rebuilt        : ["classWithProperties"]
@@ -25605,9 +21823,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem", "ApiItemContainerMixin", "Constructor", "IApiItemConstructor", "PropertiesOf"]
 rebuilt        : ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem", "ApiItemContainerMixin"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(9): ["MixedClass", "TBaseClass", "baseClass"]
 rebuilt        : ScopeId(4): ["MixedClass", "baseClass"]
@@ -25633,11 +21848,6 @@ Unresolved references mismatch:
 after transform: ["ReadonlyArray"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializationOrdering1.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
@@ -25647,9 +21857,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["K", "V"]
 rebuilt        : ScopeId(2): []
-Scope children mismatch:
-after transform: ScopeId(3): [ScopeId(4)]
-rebuilt        : ScopeId(3): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorsAreNotContextuallyTyped.ts
 semantic error: Symbol reference IDs mismatch:
@@ -25662,15 +21869,9 @@ after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(4): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicOverloads.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(16): ["T"]
 rebuilt        : ScopeId(6): []
-Scope children mismatch:
-after transform: ScopeId(16): [ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30)]
-rebuilt        : ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/typeOfThisInMemberFunctions.ts
 semantic error: Bindings mismatch:
@@ -25687,9 +21888,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Kasizz", "Mup", "MupConstructor", "Sizz"]
 rebuilt        : ScopeId(0): ["Kasizz", "Sizz"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("Mup")
 rebuilt        : ReferenceId(0): None
@@ -25763,9 +21961,6 @@ tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TestType", "TestTypeStr", "f1", "f2"]
 rebuilt        : ScopeId(0): ["TestType", "f1", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["TestType", "bar", "foo"]
 rebuilt        : ScopeId(1): ["TestType"]
@@ -25783,9 +21978,6 @@ tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
 semantic error: Bindings mismatch:
@@ -25801,27 +21993,16 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates2.ts
 semantic error: Cannot use export statement outside a module
 
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(13)]
-
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D", "o", "obj", "x"]
 rebuilt        : ScopeId(0): ["o", "obj", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["fn", "true"]
 rebuilt        : ["fn"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["const", "f"]
 rebuilt        : ["f"]
 
@@ -25829,29 +22010,17 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryO
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["EventTargetLike", "HTMLCollection", "NodeList", "cond", "sourceObj", "x"]
 rebuilt        : ScopeId(0): ["cond", "sourceObj", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(9): ["Window", "bar", "foo", "window"]
 rebuilt        : ScopeId(9): ["bar", "foo", "window"]
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(9): [ScopeId(10), ScopeId(11)]
 Bindings mismatch:
 after transform: ScopeId(13): ["Window", "bar", "foo", "window"]
 rebuilt        : ScopeId(12): ["bar", "foo", "window"]
-Scope children mismatch:
-after transform: ScopeId(13): [ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(12): [ScopeId(13), ScopeId(14)]
 Bindings mismatch:
 after transform: ScopeId(17): ["Window", "bar", "foo", "window"]
 rebuilt        : ScopeId(15): ["bar", "foo", "window"]
-Scope children mismatch:
-after transform: ScopeId(17): [ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
-rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
 Unresolved references mismatch:
 after transform: ["Error", "console", "const", "undefined"]
 rebuilt        : ["Error", "console", "undefined"]
@@ -25860,9 +22029,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowCompute
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Thing", "f1", "f2", "f3", "f4"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7), ScopeId(8), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7), ScopeId(11)]
 Bindings mismatch:
 after transform: ScopeId(12): ["K", "key", "obj"]
 rebuilt        : ScopeId(11): ["key", "obj"]
@@ -25905,9 +22071,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElement
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TestTscCompile", "TestTscEdit", "VerifyTscEditDiscrepanciesInput", "testTscCompile", "verifyTscEditDiscrepancies"]
 rebuilt        : ScopeId(0): ["testTscCompile", "verifyTscEditDiscrepancies"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement.ts
 semantic error: Unresolved references mismatch:
@@ -25918,9 +22081,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "c", "keywordA", "keywordB", "stringB"]
 rebuilt        : ScopeId(0): ["keywordA", "keywordB", "stringB"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
@@ -25969,9 +22129,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfState
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "b", "c", "cond", "d", "e", "x"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "cond", "d", "e", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15)]
 Bindings mismatch:
 after transform: ScopeId(9): ["T", "data"]
 rebuilt        : ScopeId(9): ["data"]
@@ -25989,9 +22146,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOpera
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b", "c", "d", "uniqueID_54790", "uniqueID_54790_2", "uniqueID_54790_3"]
 rebuilt        : ScopeId(0): ["a", "b", "d", "uniqueID_54790", "uniqueID_54790_2", "uniqueID_54790_3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(13), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(11), ScopeId(15)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9), ReferenceId(13)]
 rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(9)]
@@ -26041,9 +22195,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanc
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "global", "x"]
 rebuilt        : ScopeId(0): ["X", "Y", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(6), ReferenceId(8)]
@@ -26052,17 +22203,11 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptiona
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "N", "U", "X", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "funcThree", "funcTwo"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "funcThree", "funcTwo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(13), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(25), ScopeId(28), ScopeId(31)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(20), ScopeId(23), ScopeId(26)]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "value"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("value")
 rebuilt        : ReferenceId(0): None
@@ -26079,16 +22224,8 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["value"]
 
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
-
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTruthiness.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(20), ScopeId(23), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(13), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(25)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(23): ["T", "x"]
 rebuilt        : ScopeId(22): ["x"]
 Bindings mismatch:
@@ -26119,9 +22256,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructu
 semantic error: Bindings mismatch:
 after transform: ScopeId(5): ["T", "fn", "promises"]
 rebuilt        : ScopeId(5): ["fn", "promises"]
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
 Unresolved references mismatch:
 after transform: ["Awaited", "Error", "Math", "Promise", "String", "const", "undefined"]
 rebuilt        : ["Error", "Math", "Promise", "String", "undefined"]
@@ -26138,9 +22272,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsAsAssert
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["None", "Optional", "Some", "cond", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "fn", "foo1", "foo2", "isSome", "none", "someFrom"]
 rebuilt        : ScopeId(0): ["cond", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "fn", "foo1", "foo2", "isSome", "none", "someFrom"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(25), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(22), ScopeId(23)]
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "value"]
 rebuilt        : ScopeId(1): ["value"]
@@ -26152,10 +22283,7 @@ after transform: ScopeId(6): ["makeSome", "r", "result"]
 rebuilt        : ScopeId(3): ["makeSome", "result"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsNestedAssignments.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(16)]
 rebuilt        : SymbolId(0): [ReferenceId(11)]
 Unresolved references mismatch:
@@ -26172,9 +22300,6 @@ rebuilt        : ScopeId(4): ["x"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "item", "strings"]
 rebuilt        : ScopeId(6): ["item", "strings"]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(6): [ScopeId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
@@ -26183,47 +22308,29 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "Boolean", "Date", "Error", "EvalError", "Function", "IArguments", "Infinity", "JSON", "Math", "NaN", "Number", "Object", "PropertyDescriptor", "PropertyDescriptorMap", "RangeError", "ReferenceError", "RegExp", "RegExpExecArray", "String", "SyntaxError", "T", "TypeError", "URIError"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(13), ScopeId(14), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(76), ScopeId(77), ScopeId(96), ScopeId(140), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146), ScopeId(147), ScopeId(170), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(177), ScopeId(178), ScopeId(179), ScopeId(180), ScopeId(181), ScopeId(182), ScopeId(183), ScopeId(184), ScopeId(185), ScopeId(186), ScopeId(187), ScopeId(188), ScopeId(189), ScopeId(196), ScopeId(222), ScopeId(223), ScopeId(224), ScopeId(225)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(13), ScopeId(15)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
@@ -26250,10 +22357,7 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Function", "dec"]
 rebuilt        : ["dec"]
 
@@ -26261,9 +22365,6 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/p
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BulkEditPreviewProvider", "IFoo"]
 rebuilt        : ScopeId(0): ["BulkEditPreviewProvider"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("IFoo")
 rebuilt        : ReferenceId(1): None
@@ -26293,9 +22394,6 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClas
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123"]
 rebuilt        : ScopeId(0): ["Testing123"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
@@ -26307,9 +22405,6 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClas
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123"]
 rebuilt        : ScopeId(0): ["Testing123"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
@@ -26321,9 +22416,6 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClas
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123"]
 rebuilt        : ScopeId(0): ["Testing123"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
@@ -26335,9 +22427,6 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClas
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Something", "Testing123"]
 rebuilt        : ScopeId(0): ["Testing123"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
@@ -26349,31 +22438,6 @@ tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClas
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Decorated"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass9.ts
 semantic error: Bindings mismatch:
@@ -26387,18 +22451,12 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
@@ -26467,99 +22525,47 @@ after transform: []
 rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Scope children mismatch:
-after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Object", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["Object", "dec"]
 rebuilt        : ["dec"]
 
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty10.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty12.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["PropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata.ts
 semantic error: Bindings mismatch:
@@ -26768,9 +22774,6 @@ tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["defaultModule", "directory", "j", "loadModule", "moduleFile", "p1", "p11", "p2", "p3", "whatToLoad"]
 rebuilt        : ScopeId(0): ["j", "loadModule", "p1", "p11", "p2", "p3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("directory")
 rebuilt        : ReferenceId(0): None
@@ -26961,9 +22964,6 @@ tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntri
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "I", "a", "entries", "entries1", "entries2", "entries3", "entries4", "entries5", "entries6", "i", "o", "values", "values1", "values2", "values3", "values4", "values5", "values6", "x"]
 rebuilt        : ScopeId(0): ["E", "a", "entries", "entries1", "entries2", "entries3", "entries4", "entries5", "entries6", "i", "o", "values", "values1", "values2", "values3", "values4", "values5", "values6", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "B", "E"]
 rebuilt        : ScopeId(3): ["E"]
@@ -26995,24 +22995,6 @@ tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMetaNa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["global"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2019.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingES2020.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissingESNext.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
 semantic error: Unresolved reference IDs mismatch for "Intl":
@@ -27028,9 +23010,6 @@ tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Alias", "ns"]
 rebuilt        : ScopeId(0): ["ns"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -27073,9 +23052,6 @@ rebuilt        : ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
 tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a", "b", "c", "result"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
@@ -27139,9 +23115,6 @@ tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logic
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a", "b", "c", "result"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(0): None
@@ -27190,9 +23163,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "c", "i"]
 rebuilt        : ScopeId(0): ["C", "c", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
@@ -27204,9 +23174,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "i"]
 rebuilt        : ScopeId(0): ["C", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
@@ -27218,9 +23185,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty14.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "i"]
 rebuilt        : ScopeId(0): ["C", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
@@ -27232,9 +23196,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty15.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "i"]
 rebuilt        : ScopeId(0): ["C", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
@@ -27246,9 +23207,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty16.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "i"]
 rebuilt        : ScopeId(0): ["C", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
@@ -27260,9 +23218,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i"]
 rebuilt        : ScopeId(0): ["i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5)]
 rebuilt        : [ReferenceId(0), ReferenceId(2)]
@@ -27271,9 +23226,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(9)]
 rebuilt        : [ReferenceId(1)]
@@ -27282,9 +23234,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(2)]
 rebuilt        : [ReferenceId(0)]
@@ -27298,9 +23247,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
@@ -27309,26 +23255,17 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved reference IDs mismatch for "Symbol":
+semantic error: Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(8)]
 rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved reference IDs mismatch for "Symbol":
+semantic error: Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(8)]
 rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
 
@@ -27374,16 +23311,10 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SymbolConstructor", "obj"]
 rebuilt        : ScopeId(0): ["obj"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "I4", "mySymbol"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
@@ -27393,9 +23324,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
@@ -27404,25 +23332,16 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Symbol", "sym"]
 rebuilt        : ScopeId(0): ["sym"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType17.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType18.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
 semantic error: Scope flags mismatch:
@@ -27435,37 +23354,15 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationOverloadInES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithConstructorInES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
-
 tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionAndTypeArgumentInES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithTypeArgumentAndOverloadInES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithTypeArgumentInES6.ts
 semantic error: Bindings mismatch:
@@ -27570,10 +23467,7 @@ after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["E", "x"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
@@ -27584,10 +23478,7 @@ after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["E", "x"]
 rebuilt        : ScopeId(1): ["E"]
 Scope flags mismatch:
@@ -27623,182 +23514,86 @@ tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/compute
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType1_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType2_ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType2_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType3_ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType3_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType4_ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType4_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType5_ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType5_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "J"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "J"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass1.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass2.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass3.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass4.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass5.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass6.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass7.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass8.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TypedPropertyDescriptor", "dec"]
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Object", "dec"]
 rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/declarationInAmbientContext.ts
 semantic error: Bindings mismatch:
@@ -27820,17 +23615,11 @@ tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructurin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "F1", "a1", "a2", "b1", "b21", "b3", "b4", "b52", "bar", "c0", "c1", "d1", "foo", "foo1"]
 rebuilt        : ScopeId(0): ["a1", "a2", "b1", "b21", "b3", "b4", "b52", "bar", "c0", "c1", "d1", "foo", "foo1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "F1", "a1", "a2", "b1", "b21", "b3", "b4", "b52", "bar", "c0", "c1", "d1", "foo", "foo1"]
 rebuilt        : ScopeId(0): ["a1", "a2", "b1", "b21", "b3", "b4", "b52", "bar", "c0", "c1", "d1", "foo", "foo1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment7.ts
 semantic error: Bindings mismatch:
@@ -27858,17 +23647,11 @@ tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructurin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ISomething", "baz", "foo", "one", "two"]
 rebuilt        : ScopeId(0): ["baz", "foo", "one", "two"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5iterable.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ISomething", "baz", "foo", "one", "two"]
 rebuilt        : ScopeId(0): ["baz", "foo", "one", "two"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
 semantic error: Bindings mismatch:
@@ -27910,9 +23693,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "arr"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("arr")
 rebuilt        : ReferenceId(0): None
@@ -27947,11 +23727,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsUmd/decorated
 semantic error: Unresolved references mismatch:
 after transform: ["ClassDecorator"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultExportWithOverloads01.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1-amd.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -28047,9 +23822,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f", "x"]
 rebuilt        : ScopeId(0): ["f", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["TemplateStringsArray"]
 rebuilt        : []
@@ -28058,26 +23830,17 @@ tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f", "x"]
 rebuilt        : ScopeId(0): ["f", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["TemplateStringsArray"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TemplateStringsArray", "undefined"]
 rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2_ES6.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["TemplateStringsArray", "undefined"]
 rebuilt        : ["undefined"]
 
@@ -28085,9 +23848,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["TemplateStringsArray"]
 rebuilt        : []
@@ -28096,9 +23856,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["TemplateStringsArray"]
 rebuilt        : []
@@ -28112,9 +23869,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplatesW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Stuff", "T", "a", "b", "c", "obj"]
 rebuilt        : ScopeId(0): ["a", "b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Reference symbol mismatch:
 after transform: ReferenceId(27): Some("obj")
 rebuilt        : ReferenceId(8): None
@@ -28126,10 +23880,7 @@ after transform: ["Array", "TemplateStringsArray", "f", "g"]
 rebuilt        : ["f", "g", "obj"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Iterable"]
 rebuilt        : []
 
@@ -28222,18 +23973,12 @@ after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Iterator", "foo", "undefined"]
 rebuilt        : ["foo", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Iterable", "Symbol", "foo", "undefined"]
 rebuilt        : ["Symbol", "foo", "undefined"]
 
@@ -28241,9 +23986,6 @@ tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generator
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Nothing1", "Nothing2", "Nothing3", "State", "StrategicState", "Strategy", "strategy"]
 rebuilt        : ScopeId(0): ["Nothing1", "Nothing2", "Nothing3", "strategy"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "gen", "stratName"]
 rebuilt        : ScopeId(1): ["gen", "stratName"]
@@ -28378,9 +24120,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec", "method"]
 rebuilt        : ScopeId(0): ["C", "method"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28409,9 +24148,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec", "x"]
 rebuilt        : ScopeId(0): ["C", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28423,9 +24159,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec", "method"]
 rebuilt        : ScopeId(0): ["C", "method"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28437,9 +24170,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "dec", "x"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28457,9 +24187,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "dec"]
 rebuilt        : ScopeId(0): ["C"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28847,9 +24574,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["dec", "method"]
 rebuilt        : ScopeId(0): ["method"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28878,9 +24602,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["dec", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28892,9 +24613,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["dec", "method"]
 rebuilt        : ScopeId(0): ["method"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28906,9 +24624,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["dec", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -28926,9 +24641,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["dec"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
@@ -29461,9 +25173,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-pres
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "instance"]
 rebuilt        : ScopeId(0): ["C", "D"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("instance")
 rebuilt        : ReferenceId(0): None
@@ -29492,10 +25201,7 @@ after transform: []
 rebuilt        : ["metadata"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["AdvancedList", "AppType", "Composite", "HeaderDetail", "HeaderMultiDetail", "ListOnly", "ModuleSettings", "Relationship", "Report", "Standard"]
 rebuilt        : ScopeId(1): ["AppType"]
 Scope flags mismatch:
@@ -29530,9 +25236,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arra
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "myArray", "myArray2", "temp", "temp1", "temp2", "temp3", "temp4"]
 rebuilt        : ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "temp", "temp1", "temp2", "temp3", "temp4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Array", "Number", "String", "undefined"]
 rebuilt        : ["undefined"]
@@ -29541,9 +25244,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arra
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "myArray", "myArray2", "temp", "temp1", "temp2"]
 rebuilt        : ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "temp", "temp1", "temp2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Array", "Number", "String", "undefined"]
 rebuilt        : ["undefined"]
@@ -29565,21 +25265,8 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["x"]
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorASI.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["K", "element", "key", "x"]
 rebuilt        : ScopeId(1): ["element", "key", "x"]
 
@@ -29587,9 +25274,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AOrArrA", "a", "arr", "x"]
 rebuilt        : ScopeId(0): ["a", "arr", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["RegExp"]
 rebuilt        : []
@@ -29695,9 +25379,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/co
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "A3", "A4", "A5", "A6", "B1", "B2", "B3", "B4", "B5", "B6", "Base", "a1", "a2", "a3", "a4", "a5", "a6", "b1", "b2", "b3", "b4", "b5", "b6", "base1", "base2", "r1a1", "r1a2", "r1a3", "r1a4", "r1a5", "r1a6", "r1a7", "r1b1", "r1b2", "r1b3", "r1b4", "r1b5", "r1b6", "r1b7", "r2a1", "r2a2", "r2a3", "r2a4", "r2a5", "r2a6", "r2a7", "r2b1", "r2b2", "r2b3", "r2b4", "r2b5", "r2b6", "r2b7", "r3a1", "r3a2", "r3a3", "r3a4", "r3a5", "r3a6", "r3a7", "r3b1", "r3b2", "r3b3", "r3b4", "r3b5", "r3b6", "r3b7", "r4a1", "r4a2", "r4a3", "r4a4", "r4a5", "r4a6", "r4a7", "r4b1", "r4b2", "r4b3", "r4b4", "r4b5", "r4b6", "r4b7", "r5a1", "r5a2", "r5a3", "r5a4", "r5a5", "r5a6", "r5a7", "r5b1", "r5b2", "r5b3", "r5b4", "r5b5", "r5b6", "r5b7", "r6a1", "r6a2", "r6a3", "r6a4", "r6a5", "r6a6", "r6a7", "r6b1", "r6b2", "r6b3", "r6b4", "r6b5", "r6b6", "r6b7", "r7a1", "r7a2", "r7a3", "r7a4", "r7a5", "r7a6", "r7a7", "r7b1", "r7b2", "r7b3", "r7b4", "r7b5", "r7b6", "r7b7", "r8a1", "r8a2", "r8a3", "r8a4", "r8a5", "r8a6", "r8a7", "r8b1", "r8b2", "r8b3", "r8b4", "r8b5", "r8b6", "r8b7"]
 rebuilt        : ScopeId(0): ["A1", "A2", "B1", "B2", "Base", "a1", "a2", "a3", "a4", "a5", "a6", "b1", "b2", "b3", "b4", "b5", "b6", "base1", "base2", "r1a1", "r1a2", "r1a3", "r1a4", "r1a5", "r1a6", "r1a7", "r1b1", "r1b2", "r1b3", "r1b4", "r1b5", "r1b6", "r1b7", "r2a1", "r2a2", "r2a3", "r2a4", "r2a5", "r2a6", "r2a7", "r2b1", "r2b2", "r2b3", "r2b4", "r2b5", "r2b6", "r2b7", "r3a1", "r3a2", "r3a3", "r3a4", "r3a5", "r3a6", "r3a7", "r3b1", "r3b2", "r3b3", "r3b4", "r3b5", "r3b6", "r3b7", "r4a1", "r4a2", "r4a3", "r4a4", "r4a5", "r4a6", "r4a7", "r4b1", "r4b2", "r4b3", "r4b4", "r4b5", "r4b6", "r4b7", "r5a1", "r5a2", "r5a3", "r5a4", "r5a5", "r5a6", "r5a7", "r5b1", "r5b2", "r5b3", "r5b4", "r5b5", "r5b6", "r5b7", "r6a1", "r6a2", "r6a3", "r6a4", "r6a5", "r6a6", "r6a7", "r6b1", "r6b2", "r6b3", "r6b4", "r6b5", "r6b6", "r6b7", "r7a1", "r7a2", "r7a3", "r7a4", "r7a5", "r7a6", "r7a7", "r7b1", "r7b2", "r7b3", "r7b4", "r7b5", "r7b6", "r7b7", "r8a1", "r8a2", "r8a3", "r8a4", "r8a5", "r8a6", "r8a7", "r8b1", "r8b2", "r8b3", "r8b4", "r8b5", "r8b6", "r8b7"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(6)]
 rebuilt        : SymbolId(0): []
@@ -29723,10 +25404,7 @@ after transform: ScopeId(1): ["T", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8
 rebuilt        : ScopeId(1): ["r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "t"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(16), ReferenceId(18)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -29734,10 +25412,7 @@ after transform: SymbolId(2): [ReferenceId(17)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(16), ReferenceId(18)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -29748,9 +25423,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/co
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BrandedNum", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts
 semantic error: Bindings mismatch:
@@ -29804,10 +25476,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(8), R
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(12), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(22), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(42), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(62), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(72), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(82), ReferenceId(85), ReferenceId(86), ReferenceId(87)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(12), ReferenceId(14)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -29815,10 +25484,7 @@ after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(6), R
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(21), ReferenceId(22), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -29834,10 +25500,7 @@ after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15), ReferenceId(17)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -29845,10 +25508,7 @@ after transform: SymbolId(1): [ReferenceId(16)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15), ReferenceId(17)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -29859,9 +25519,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/co
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "J", "a", "b", "ra1", "ra2", "rb1", "rb2", "rc1", "rc2", "rd1", "rd2", "re1", "re2", "rf1", "rf2", "rg1", "rg2", "rh1", "rh2"]
 rebuilt        : ScopeId(0): ["a", "b", "ra1", "ra2", "rb1", "rb2", "rc1", "rc2", "rd1", "rd2", "re1", "re2", "rf1", "rf2", "rg1", "rg2", "rh1", "rh2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
 semantic error: Symbol reference IDs mismatch:
@@ -29884,10 +25541,7 @@ after transform: SymbolId(5): [ReferenceId(9)]
 rebuilt        : SymbolId(5): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Unresolved reference IDs mismatch for "StaticToString":
+semantic error: Unresolved reference IDs mismatch for "StaticToString":
 after transform: [ReferenceId(0), ReferenceId(2)]
 rebuilt        : [ReferenceId(1)]
 Unresolved reference IDs mismatch for "StaticToNumber":
@@ -29914,9 +25568,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/in
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HasInstanceOf", "HasInstanceOf1", "HasInstanceOf2", "Line", "Point", "Point3D", "Point3D2", "Rhs14", "Rhs15", "lhs0", "lhs1", "lhs2", "lhs3", "lhs4", "obj", "rhs0", "rhs1", "rhs14", "rhs15", "rhs2", "rhs3", "rhs4", "rhs5", "rhs6"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(38), ScopeId(39), ScopeId(41), ScopeId(43)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(53): Some("lhs0")
 rebuilt        : ReferenceId(0): None
@@ -30393,9 +26044,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/in
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f1", "f2", "f3", "f4", "r1", "r2", "r3", "r4", "r5", "r6", "x"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "r1", "r2", "r3", "r4", "r5", "r6", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Function", "undefined"]
 rebuilt        : ["undefined"]
@@ -30511,11 +26159,6 @@ Unresolved references mismatch:
 after transform: ["Number"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -30536,10 +26179,7 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T", "g", "tempStrs", "x"]
 rebuilt        : ScopeId(1): ["g", "tempStrs", "x"]
 Unresolved references mismatch:
@@ -30555,9 +26195,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/s
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "CBase", "ContextualType"]
 rebuilt        : ScopeId(0): ["C", "CBase"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
@@ -30566,9 +26203,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncType", "tempTag1"]
 rebuilt        : ScopeId(0): ["tempTag1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "rest"]
 rebuilt        : ScopeId(1): ["rest"]
@@ -30586,9 +26220,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncType1", "FuncType2", "tempTag2"]
 rebuilt        : ScopeId(0): ["tempTag2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Unresolved references mismatch:
 after transform: ["TemplateStringsArray", "undefined", "x"]
 rebuilt        : ["undefined"]
@@ -30597,9 +26228,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/stri
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "Item", "e", "item", "snb"]
 rebuilt        : ScopeId(0): ["E", "snb"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -30626,9 +26254,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/call
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "X", "a", "foo", "obj", "xa", "z"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "foo", "obj", "xa", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 Unresolved references mismatch:
 after transform: ["Function"]
 rebuilt        : []
@@ -30637,9 +26262,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/call
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "X", "a", "foo", "obj", "xa", "z"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "foo", "obj", "xa", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5)]
 Unresolved references mismatch:
 after transform: ["Function"]
 rebuilt        : []
@@ -30648,9 +26270,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "a", "b", "c", "d", "e", "f", "f2", "g", "h", "i"]
 rebuilt        : ScopeId(0): ["B", "a", "b", "c", "d", "e", "f", "f2", "g", "h", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(7): [ReferenceId(0), ReferenceId(1), ReferenceId(45), ReferenceId(46), ReferenceId(48)]
 rebuilt        : SymbolId(6): [ReferenceId(36), ReferenceId(37), ReferenceId(39)]
@@ -30659,9 +26278,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "a", "b", "c", "d", "e", "f", "f2", "g", "h", "i"]
 rebuilt        : ScopeId(0): ["B", "a", "b", "c", "d", "e", "f", "f2", "g", "h", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(7): [ReferenceId(0), ReferenceId(1), ReferenceId(45), ReferenceId(46), ReferenceId(48)]
 rebuilt        : SymbolId(6): [ReferenceId(36), ReferenceId(37), ReferenceId(39)]
@@ -30670,9 +26286,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newW
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "a", "b", "c", "d", "e", "f", "f2", "g", "h", "i"]
 rebuilt        : ScopeId(0): ["B", "a", "b", "c", "d", "e", "f", "f2", "g", "h", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(7): [ReferenceId(0), ReferenceId(1), ReferenceId(45), ReferenceId(46), ReferenceId(48)]
 rebuilt        : SymbolId(6): [ReferenceId(36), ReferenceId(37), ReferenceId(39)]
@@ -30685,11 +26298,6 @@ Unresolved reference IDs mismatch for "Date":
 after transform: [ReferenceId(0), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
 rebuilt        : [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedFunctionExpressionsAndReturnAnnotations.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
 semantic error: Semantic Collector failed after transform
 Missing SymbolId: M
@@ -30701,9 +26309,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functions/voidPara
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Obj", "gg", "o"]
 rebuilt        : ScopeId(0): ["gg"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("o")
 rebuilt        : ReferenceId(2): None
@@ -30712,24 +26317,15 @@ after transform: ["g"]
 rebuilt        : ["g", "o"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(4): []
 Bindings mismatch:
 after transform: ScopeId(10): ["T", "p", "s"]
 rebuilt        : ScopeId(6): ["p", "s"]
-Scope children mismatch:
-after transform: ScopeId(10): [ScopeId(11)]
-rebuilt        : ScopeId(6): []
 Bindings mismatch:
 after transform: ScopeId(12): ["T", "p", "s"]
 rebuilt        : ScopeId(7): ["p", "s"]
-Scope children mismatch:
-after transform: ScopeId(12): [ScopeId(13)]
-rebuilt        : ScopeId(7): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -30753,9 +26349,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingO
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a1", "a2", "a3", "a4", "aa1", "aa2", "aa3", "aa4", "b1", "b2", "b3", "b4", "bb1", "bb2", "bb3", "bb4", "c1", "c2", "c3", "c4", "cc1", "cc2", "cc3", "cc4", "d1", "d2", "d3", "d4", "dd1", "dd2", "dd3", "dd4", "maybeBool"]
 rebuilt        : ScopeId(0): ["aa1", "aa2", "aa3", "aa4", "bb1", "bb2", "bb3", "bb4", "cc1", "cc2", "cc3", "cc4", "dd1", "dd2", "dd3", "dd4", "maybeBool"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a1")
 rebuilt        : ReferenceId(0): None
@@ -30807,11 +26400,6 @@ rebuilt        : ReferenceId(15): None
 Unresolved references mismatch:
 after transform: ["foo"]
 rebuilt        : ["a1", "a2", "a3", "a4", "b1", "b2", "b3", "b4", "c1", "c2", "c3", "c4", "d1", "d2", "d3", "d4", "foo"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator10.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator2.ts
 semantic error: Bindings mismatch:
@@ -30910,9 +26498,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingO
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "n1", "n2", "n3"]
 rebuilt        : ScopeId(0): ["n1", "n2", "n3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("a")
 rebuilt        : ReferenceId(0): None
@@ -31153,9 +26738,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "o1", "o2", "o3", "o4", "o5", "v"]
 rebuilt        : ScopeId(0): ["v"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("o1")
 rebuilt        : ReferenceId(0): None
@@ -31248,9 +26830,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/c
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Y", "value"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("value")
 rebuilt        : ReferenceId(0): None
@@ -31323,9 +26902,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/e
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "o1", "o2", "o3", "o4", "o5", "o6"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("o1")
 rebuilt        : ReferenceId(0): None
@@ -31382,9 +26958,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/o
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "fnu", "ofnu", "osu", "su", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8"]
 rebuilt        : ScopeId(0): ["b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("su")
 rebuilt        : ReferenceId(0): None
@@ -31433,9 +27006,6 @@ rebuilt        : ["o1", "o2", "o3"]
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "o1", "o2", "o3", "o4", "o5", "o6"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("o1")
@@ -31522,9 +27092,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "I1", "a", "b", "f1", "obj", "subType", "union", "union2", "union3"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "D", "a", "b", "f1", "obj", "subType", "union", "union2", "union3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(14), ReferenceId(19), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(34), ReferenceId(39)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -31536,10 +27103,7 @@ after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(10), 
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionGenerics.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -31553,9 +27117,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Beast", "Legged", "Winged", "X", "Y", "Z", "beastFoo", "f1", "hasLegs", "hasWings", "identifyBeast", "isB", "union"]
 rebuilt        : ScopeId(0): ["beastFoo", "f1", "hasLegs", "hasWings", "identifyBeast", "isB", "union"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(32)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(20)]
 Unresolved references mismatch:
 after transform: ["Object", "isX", "isY", "isZ", "log"]
 rebuilt        : ["isX", "isY", "isZ", "log"]
@@ -31564,9 +27125,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Tag", "Tag2", "value"]
 rebuilt        : ScopeId(0): ["Tag2", "value"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -31576,16 +27134,6 @@ rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(8), ReferenceId(9), ReferenceId(17)]
 rebuilt        : SymbolId(1): [ReferenceId(7)]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1AndExpr2.ts
 semantic error: Symbol reference IDs mismatch:
@@ -31598,10 +27146,7 @@ after transform: SymbolId(6): [ReferenceId(0), ReferenceId(1), ReferenceId(2), R
 rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Object", "isString1", "isString2"]
 rebuilt        : ["isString1", "isString2"]
 
@@ -31623,9 +27168,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "D1", "c1", "c1Orc2", "c2", "c2Ord1", "d1", "num", "r2", "str", "strOrNum"]
 rebuilt        : ScopeId(0): ["c1", "c1Orc2", "c2", "c2Ord1", "d1", "num", "r2", "str", "strOrNum"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsType.ts
 semantic error: Symbol reference IDs mismatch:
@@ -31642,9 +27184,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "D1", "c1", "c1Orc2", "c2", "c2Ord1", "d1", "isC1", "isC2", "isD1", "num", "r2", "str", "strOrNum"]
 rebuilt        : ScopeId(0): ["c1", "c1Orc2", "c2", "c2Ord1", "d1", "isC1", "isC2", "isD1", "num", "r2", "str", "strOrNum"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfBoolean.ts
 semantic error: Symbol reference IDs mismatch:
@@ -31670,11 +27209,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfPrimitiveSubtype.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfString.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
@@ -31684,9 +27218,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AWithOptionalProp", "B", "BWithOptionalProp", "C", "ClassWithUnionProp", "D", "InMemberOfClass", "Indexed", "NestedClassWithProp", "SelfAssert", "anonymousClasses", "f", "inParenthesizedExpression", "inProperty", "innestedProperty", "multipleClasses", "namedClasses", "positiveTestClassesWithOptionalProperties"]
 rebuilt        : ScopeId(0): ["A", "AWithOptionalProp", "B", "BWithOptionalProp", "C", "ClassWithUnionProp", "D", "InMemberOfClass", "NestedClassWithProp", "SelfAssert", "anonymousClasses", "f", "inParenthesizedExpression", "inProperty", "innestedProperty", "multipleClasses", "namedClasses", "positiveTestClassesWithOptionalProperties"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(23), ScopeId(26), ScopeId(27), ScopeId(30), ScopeId(34), ScopeId(38), ScopeId(39)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(11), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(23), ScopeId(26), ScopeId(27), ScopeId(30), ScopeId(34), ScopeId(38)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(7), ReferenceId(27), ReferenceId(32), ReferenceId(43)]
 rebuilt        : SymbolId(0): []
@@ -31755,9 +27286,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePre
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_asConstArrays.ts
 semantic error: Unresolved references mismatch:
@@ -31768,17 +27296,11 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Predicates", "p"]
 rebuilt        : ScopeId(0): ["p"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["StringOrNumberFunc", "fn", "obj", "obj2"]
 rebuilt        : ScopeId(0): ["fn", "obj", "obj2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Unresolved references mismatch:
 after transform: ["Function"]
 rebuilt        : []
@@ -31787,9 +27309,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Movable", "car"]
 rebuilt        : ScopeId(0): ["car"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Unresolved references mismatch:
 after transform: ["Record"]
 rebuilt        : []
@@ -31798,9 +27317,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Facts", "M", "m", "x", "x2"]
 rebuilt        : ScopeId(0): ["m", "x", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
@@ -31809,9 +27325,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Facts", "M", "m", "x", "x2"]
 rebuilt        : ScopeId(0): ["m", "x", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
@@ -31889,9 +27402,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportNotAs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "E1", "I1", "M1"]
 rebuilt        : ScopeId(0): ["C1", "E1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "E1"]
 rebuilt        : ScopeId(2): ["E1"]
@@ -31917,9 +27427,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImport
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "E1", "I1", "M1"]
 rebuilt        : ScopeId(0): ["C1", "E1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(5): ["A", "B", "C", "E1"]
 rebuilt        : ScopeId(2): ["E1"]
@@ -31929,16 +27436,6 @@ rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Export)
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target11.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target12.ts
 semantic error: Semantic Collector failed after transform
@@ -31962,11 +27459,6 @@ Missing SymbolId: _F
 Missing ReferenceId: _F
 Missing ReferenceId: F
 Missing ReferenceId: F
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target5.ts
 semantic error: Bindings mismatch:
@@ -31995,16 +27487,6 @@ Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
 
-tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target11.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target12.ts
 semantic error: Semantic Collector failed after transform
 Missing SymbolId: _C
@@ -32027,11 +27509,6 @@ Missing SymbolId: _F
 Missing ReferenceId: _F
 Missing ReferenceId: F
 Missing ReferenceId: F
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target5.ts
 semantic error: Bindings mismatch:
@@ -32059,11 +27536,6 @@ Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAmbientClassNameWithObject.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -32134,9 +27606,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/exportTypeMerg
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "Something", "myValue"]
 rebuilt        : ScopeId(0): ["Something", "myValue"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -32144,9 +27613,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 tasks/coverage/typescript/tests/cases/conformance/externalModules/globalAugmentationModuleResolution.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["global"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/importImportOnlyModule.ts
@@ -32189,17 +27655,11 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAmbien
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C1", "C2", "C3", "_await", "dec", "x", "y"]
 rebuilt        : ScopeId(0): ["C", "C1", "C2", "C3", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("dec")
 rebuilt        : ReferenceId(11): None
@@ -32221,16 +27681,10 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Drink"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/ambient.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "ns"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A"]
@@ -32253,9 +27707,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/expor
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
 semantic error: Symbol flags mismatch:
@@ -32268,9 +27719,6 @@ rebuilt        : []
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/implementsClause.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType.ts
@@ -32292,16 +27740,10 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/merge
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
@@ -32317,16 +27759,10 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/prese
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D", "b", "c"]
 rebuilt        : ScopeId(0): ["b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_errors.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeQuery.ts
@@ -32338,15 +27774,9 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge1
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-Symbol flags mismatch:
+semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function | TypeAlias)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export | Function)
 Symbol span mismatch:
@@ -32426,27 +27856,11 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModule
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Typey"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid03.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Test", "fb", "fn"]
 rebuilt        : ScopeId(0): ["fb", "fn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -32463,9 +27877,6 @@ tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "f1"]
 rebuilt        : ScopeId(0): ["f1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Iterator"]
 rebuilt        : []
@@ -32497,9 +27908,6 @@ tasks/coverage/typescript/tests/cases/conformance/inferFromBindingPattern.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Person", "SelectProps", "SelectResult", "any", "foo", "isAny", "isStringTuple", "john", "nufinspecial", "person", "personAgain", "whatever", "x", "x1", "x2", "x3"]
 rebuilt        : ScopeId(0): ["any", "foo", "isAny", "isStringTuple", "john", "nufinspecial", "person", "personAgain", "whatever", "x", "x1", "x2", "x3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(1): []
@@ -32507,9 +27915,6 @@ rebuilt        : ScopeId(1): []
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "M2", "N"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces.ts
@@ -32595,17 +28000,11 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "M", "M2", "M3"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a", "r", "r2", "r3"]
 rebuilt        : ScopeId(0): ["a", "r", "r2", "r3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases.ts
 semantic error: Semantic Collector failed after transform
@@ -32625,9 +28024,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "C", "C2", "C3", "C4", "D"]
 rebuilt        : ScopeId(0): ["C", "C2", "C3", "C4", "D"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -32657,9 +28053,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "b", "c", "d", "r", "r2", "r3"]
 rebuilt        : ScopeId(0): ["b", "c", "d", "r", "r2", "r3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(17), ScopeId(19)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
@@ -32682,17 +28075,11 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclaratio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C20", "C21", "C22", "C23", "C3", "C4", "C5", "C6", "C7", "Constructor", "EX", "I1", "I10", "I11", "I12", "I13", "I2", "I20", "I21", "I22", "I23", "I3", "I4", "I5", "I6", "I7", "Identifiable", "NX", "T1", "T10", "T11", "T12", "T13", "T2", "T3", "T4", "T5", "T6", "T7"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C20", "C21", "C22", "C23", "C3", "C4", "C5", "C6", "C7"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
 Unresolved references mismatch:
 after transform: ["CX", "Constructor", "NX", "Partial", "Readonly", "fx"]
 rebuilt        : ["Constructor"]
@@ -32701,57 +28088,36 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclaratio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallAndConstructSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f", "r", "r2"]
 rebuilt        : ScopeId(0): ["f", "r", "r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Derived", "Foo", "d", "r"]
 rebuilt        : ScopeId(0): ["d", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Derived", "Foo", "d", "r"]
 rebuilt        : ScopeId(0): ["d", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Derived", "Foo", "d", "r"]
 rebuilt        : ScopeId(0): ["d", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Derived", "Foo", "d", "r"]
 rebuilt        : ScopeId(0): ["d", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithOverloadedCallAndConstructSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f", "r1", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["f", "r1", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
@@ -32763,9 +28129,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclaratio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f", "r", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["f", "r", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
@@ -32774,9 +28137,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtending
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "I", "f", "i", "r1", "r2", "r3"]
 rebuilt        : ScopeId(0): ["Foo", "f", "i", "r1", "r2", "r3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(6)]
 rebuilt        : SymbolId(0): []
@@ -32902,9 +28262,6 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMer
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "X", "l", "p"]
 rebuilt        : ScopeId(0): ["l", "p"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(13), ScopeId(17)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "X"]
 rebuilt        : []
@@ -32916,9 +28273,6 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMer
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "X", "l", "p"]
 rebuilt        : ScopeId(0): ["l", "p"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(14), ScopeId(18)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["A", "X"]
 rebuilt        : []
@@ -33042,9 +28396,6 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInTypeParameterConstraint.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -33130,56 +28481,35 @@ tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/importTag9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/inferThis.ts
@@ -33194,9 +28524,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag2.ts
 semantic error: Bindings mismatch:
@@ -33207,24 +28534,15 @@ tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseMatchingBackticks.ts
@@ -33233,9 +28551,6 @@ semantic error: Cannot use export statement outside a module
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTwoLineTypedef.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LoadCallback"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
@@ -33250,9 +28565,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsdoc/typeParameterExtendsUnio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "f", "f2"]
 rebuilt        : ScopeId(0): ["f", "f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "a"]
 rebuilt        : ScopeId(1): ["a"]
@@ -33269,9 +28581,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Button", "JSX", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
 rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2), ReferenceId(21)]
 rebuilt        : SymbolId(2): [ReferenceId(19)]
@@ -33280,9 +28589,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty11
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Button", "JSX", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
 rebuilt        : ScopeId(0): ["Button", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2), ReferenceId(21)]
 rebuilt        : SymbolId(2): [ReferenceId(19)]
@@ -33321,9 +28627,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElemen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "JSX", "_jsxFileName", "_reactJsxRuntime", "x", "y"]
 rebuilt        : ScopeId(0): ["C", "_jsxFileName", "_reactJsxRuntime", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(1): []
@@ -33338,9 +28641,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextS
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AsyncLoader", "AsyncLoaderProps", "ErrorResult", "React", "_jsxFileName", "load", "loader"]
 rebuilt        : ScopeId(0): ["AsyncLoader", "React", "_jsxFileName", "load", "loader"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(3): ["TResult"]
 rebuilt        : ScopeId(1): []
@@ -33355,9 +28655,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxUnionSFXContextual
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ComponentWithUnion", "HereIsTheError", "PM", "PS", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["ComponentWithUnion", "HereIsTheError", "React", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(6), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(7)]
@@ -33384,9 +28681,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingError4.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName", "a", "b"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -33495,9 +28789,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution13.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -33513,17 +28804,11 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyParseLessThanComparison1.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "ShortDetails", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["ShortDetails", "_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("React")
 rebuilt        : ReferenceId(1): None
@@ -33553,9 +28838,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CustomTag", "JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["CustomTag", "_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
@@ -33569,9 +28851,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "foo", "t"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "foo", "t"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
@@ -33599,65 +28878,41 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "Obj1", "_jsxFileName", "_reactJsxRuntime", "obj1"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution14.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "Obj1", "_jsxFileName", "_reactJsxRuntime", "obj1"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution17.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "elements1", "elements2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution19.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "MyClass"]
 rebuilt        : ScopeId(0): ["MyClass"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution2.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution5.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "SomeClass", "_jsxFileName", "_reactJsxRuntime", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
 rebuilt        : ScopeId(0): ["SomeClass", "_jsxFileName", "_reactJsxRuntime", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmitSpreadAttribute.ts
 semantic error: Bindings mismatch:
@@ -33735,17 +28990,11 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -33865,9 +29114,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName1.tsx
 semantic error: Namespace tags are not supported by default. React's JSX doesn't support namespace tags. You can set `throwIfNamespace: false` to bypass this warning.
@@ -33887,9 +29133,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("A")
 rebuilt        : ReferenceId(2): None
@@ -33901,17 +29144,11 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "x"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit1.tsx
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -33929,9 +29166,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit3.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
 semantic error: Semantic Collector failed after transform
@@ -33947,9 +29181,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "SomeClass", "_jsxFileName", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
 rebuilt        : ScopeId(0): ["SomeClass", "_jsxFileName", "openClosed1", "openClosed2", "openClosed3", "openClosed4", "openClosed5", "p", "selfClosed1", "selfClosed2", "selfClosed3", "selfClosed4", "selfClosed5", "selfClosed6", "selfClosed7", "whitespace1", "whitespace2", "whitespace3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(17): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -34021,9 +29252,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit2.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "p1", "p2", "p3", "spreads1", "spreads2", "spreads3", "spreads4", "spreads5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -34047,9 +29275,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit3.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "JSX", "React", "_jsxFileName", "baz"]
 rebuilt        : ScopeId(0): ["_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -34088,25 +29313,16 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit5.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit6.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -34158,9 +29374,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName", "p"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "p"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -34202,9 +29415,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "React", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["_jsxFileName"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("React")
 rebuilt        : ReferenceId(0): None
@@ -34293,9 +29503,6 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionCompon
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Context", "_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["JSX", "ThreeThing", "ZeroThingOrTwoThing", "require"]
 rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing", "require"]
@@ -34391,9 +29598,6 @@ tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionMod
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Default", "Import", "ImportRelative", "Require", "RequireRelative"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["x"]
 rebuilt        : []
@@ -34443,9 +29647,6 @@ tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFil
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HTML5Element", "blogPost", "doc"]
 rebuilt        : ScopeId(0): ["HTML5Element", "blogPost"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("doc")
 rebuilt        : ReferenceId(0): None
@@ -34457,9 +29658,6 @@ tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFil
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HTML5Element", "blogPost", "doc"]
 rebuilt        : ScopeId(0): ["HTML5Element", "blogPost"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2)]
-rebuilt        : ScopeId(1): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("doc")
 rebuilt        : ReferenceId(0): None
@@ -34479,29 +29677,8 @@ after transform: []
 rebuilt        : ["val"]
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFilesForNodeNativeModules.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration16.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration19.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration20.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
+semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum1.ts
 semantic error: Bindings mismatch:
@@ -34558,9 +29735,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration5.ts
@@ -34625,21 +29799,10 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecove
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass1.ts
@@ -34661,120 +29824,75 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature10.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature11.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature12.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModule1.ts
@@ -34786,9 +29904,6 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDecla
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["string", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved reference IDs mismatch for "string":
 after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(0)]
@@ -34797,56 +29912,35 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDecla
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["number"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["number"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment4.ts
@@ -34858,117 +29952,70 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySig
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature10.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature11.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature12.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature7.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature9.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser643728.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645484.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression6.ts
@@ -34989,17 +30036,11 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/par
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserExportAsFunctionIdentifier.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f", "x"]
 rebuilt        : ScopeId(0): ["f", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex2.ts
 semantic error: Bindings mismatch:
@@ -35022,16 +30063,10 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOptio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PropertyDescriptor2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOverloadOnConstants1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Document"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["HTMLCanvasElement", "HTMLDivElement", "HTMLElement", "HTMLSpanElement"]
@@ -35041,16 +30076,10 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/par
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
@@ -35060,34 +30089,22 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/par
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["Symbol"]
 rebuilt        : []
 
@@ -35103,9 +30120,6 @@ tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "t"]
 rebuilt        : ScopeId(0): ["a", "t"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(22)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Partial"]
 rebuilt        : []
@@ -35121,22 +30135,11 @@ tasks/coverage/typescript/tests/cases/conformance/salsa/propertyAssignmentUsePar
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N", "ignoreJsdoc", "inlined", "interfaced"]
 rebuilt        : ScopeId(0): ["ignoreJsdoc", "inlined", "interfaced"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-
-tasks/coverage/typescript/tests/cases/conformance/salsa/sourceFileMergeWithFunction.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment30.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Combo", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignmentWithExport.ts
 semantic error: Cannot use export statement outside a module
@@ -35468,9 +30471,6 @@ tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Point", "a", "declSpace", "fn", "p", "x"]
 rebuilt        : ScopeId(0): ["a", "declSpace", "fn", "p", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
@@ -35549,9 +30549,6 @@ tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Point", "a", "declSpace", "fn", "p", "x"]
 rebuilt        : ScopeId(0): ["a", "declSpace", "fn", "p", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(27), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(46), ScopeId(48)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
@@ -35633,9 +30630,6 @@ tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/re
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "I", "fn1", "fn10", "fn11", "fn12", "fn13", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8"]
 rebuilt        : ScopeId(0): ["C", "D", "fn1", "fn10", "fn11", "fn12", "fn13", "fn2", "fn3", "fn4", "fn5", "fn6", "fn7", "fn8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(9): [ReferenceId(4), ReferenceId(7), ReferenceId(8), ReferenceId(10)]
 rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(3)]
@@ -35666,9 +30660,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "a", "b", "c", "d", "e", "e2", "f", "g", "h", "i", "j", "x"]
 rebuilt        : ScopeId(0): ["C", "E", "a", "b", "c", "d", "e", "e2", "f", "g", "h", "i", "j", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -35692,10 +30683,7 @@ after transform: [ReferenceId(11), ReferenceId(14)]
 rebuilt        : [ReferenceId(11)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(49): [ScopeId(50)]
-rebuilt        : ScopeId(49): []
-Unresolved references mismatch:
+semantic error: Unresolved references mismatch:
 after transform: ["AsyncIterable", "AsyncIterableIterator", "AsyncIterator", "Promise", "PromiseLike"]
 rebuilt        : ["Promise"]
 
@@ -35703,15 +30691,9 @@ tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "foo", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["Bar", "foo", "x", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5)]
-rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(9), ReferenceId(11)]
 rebuilt        : SymbolId(4): [ReferenceId(3)]
@@ -35723,9 +30705,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFun
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Obj", "fn1"]
 rebuilt        : ScopeId(0): ["fn1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(0), ReferenceId(4)]
 rebuilt        : [ReferenceId(0)]
@@ -35734,9 +30713,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFun
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AsyncFunc", "Done", "Func", "ILocalExtension", "Metadata", "Obj", "ProcessTreeNode", "TestFunction", "copyExtensions", "fn1", "fn2", "fn3", "fn4", "test"]
 rebuilt        : ScopeId(0): ["copyExtensions", "fn1", "fn2", "fn3", "fn4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(12)]
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("test")
 rebuilt        : ReferenceId(4): None
@@ -35751,33 +30727,19 @@ tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Nested", "Show", "StringIdentity", "StringUnion", "Tuples", "f", "f2", "f3", "ff", "g", "h", "id"]
 rebuilt        : ScopeId(0): ["f", "f2", "f3", "ff", "g", "h", "id"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectLiteralMethodDeclaration01.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Foo", "getFoo1", "getFoo2", "getFoo3"]
 rebuilt        : ScopeId(0): ["getFoo1", "getFoo2", "getFoo3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceWithTypeParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(11), ReferenceId(14), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31)]
 rebuilt        : SymbolId(1): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionWitoutTypeParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.1.ts
 semantic error: Bindings mismatch:
@@ -35827,9 +30789,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ex", "U", "x"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("x")
 rebuilt        : ReferenceId(0): None
@@ -35841,9 +30800,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AorB", "X", "q"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("q")
 rebuilt        : ReferenceId(0): None
@@ -35875,17 +30831,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "Label", "Thing1", "Thing2", "Thing3", "Thing4", "Thing5", "f1", "f2", "test"]
 rebuilt        : ScopeId(0): ["f1", "f2", "test"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeEquivalence.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "ab", "bc", "y", "z", "z1"]
 rebuilt        : ScopeId(0): ["ab", "bc", "y", "z", "z1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(17)]
 rebuilt        : SymbolId(2): []
@@ -35896,9 +30846,6 @@ rebuilt        : SymbolId(3): []
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "obj"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
@@ -35920,9 +30867,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Nominal", "a", "b", "c1", "c2"]
 rebuilt        : ScopeId(0): ["c1", "c2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("a")
 rebuilt        : ReferenceId(1): None
@@ -35937,25 +30881,16 @@ tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "E", "F", "F1", "F2", "G", "X", "Y", "Z", "abc", "de", "defg", "f", "n", "s", "xyz"]
 rebuilt        : ScopeId(0): ["abc", "de", "defg", "f", "n", "s", "xyz"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeOverloading.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F", "G", "fg", "gf", "x", "y"]
 rebuilt        : ScopeId(0): ["fg", "gf", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "Dictionary", "E", "Foo1", "Foo2", "IMyChoiceList", "IUnknownChoiceList", "choices", "d1", "d2", "d3", "d4", "d5", "d6", "defaultChoices", "defaultChoicesAndEmpty", "intersectDictionaries", "myChoices", "myChoicesAndEmpty", "testDictionary", "unknownChoices", "unknownChoicesAndEmpty", "x01", "x02", "x03", "x04", "x05", "x06", "x07", "x08", "x09", "x10", "x11", "x12", "x13", "x14"]
 rebuilt        : ScopeId(0): ["d1", "d2", "d3", "d4", "d5", "d6", "defaultChoices", "defaultChoicesAndEmpty", "intersectDictionaries", "myChoices", "myChoicesAndEmpty", "testDictionary", "unknownChoices", "unknownChoicesAndEmpty", "x01", "x02", "x03", "x04", "x05", "x06", "x07", "x08", "x09", "x10", "x11", "x12", "x13", "x14"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(7): ["F1", "F2", "d1", "d2"]
 rebuilt        : ScopeId(1): ["d1", "d2"]
@@ -35970,17 +30905,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/intersection/operatorsAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Guid", "SerialNo", "b1", "b2", "b3", "b4", "createGuid", "createSerialNo", "guid", "map1", "map2", "n1", "n2", "s1", "s2", "s3", "s4", "s5", "serialNo"]
 rebuilt        : ScopeId(0): ["b1", "b2", "b3", "b4", "createGuid", "createSerialNo", "guid", "map1", "map2", "n1", "n2", "s1", "s2", "s3", "s4", "s5", "serialNo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "Item", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(23), ScopeId(25)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(19)]
 Unresolved references mismatch:
 after transform: ["Error", "g", "true"]
 rebuilt        : ["Error", "g"]
@@ -35989,9 +30918,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTy
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "Item", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(23), ScopeId(25)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(19)]
 Unresolved references mismatch:
 after transform: ["Error", "g", "true"]
 rebuilt        : ["Error", "g"]
@@ -36000,9 +30926,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "Item", "NoYes", "UnknownYesNo", "YesNo", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(21), ScopeId(24), ScopeId(25), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(15), ScopeId(18), ScopeId(20)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
@@ -36020,9 +30943,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "Item", "NoYes", "UnknownYesNo", "YesNo", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(21), ScopeId(24), ScopeId(25), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(15), ScopeId(18), ScopeId(20)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
@@ -36040,9 +30960,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypeWiden
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "FAILURE", "LangCode", "Obj", "Result", "Set", "TestEvent", "a", "arr", "b", "doWork", "f1", "f2", "f3", "f4", "f5", "f6", "increment", "isFailure", "isSuccess", "keys", "langCodeSet", "langCodes", "onMouseOver", "result", "test", "x"]
 rebuilt        : ScopeId(0): ["E", "FAILURE", "Set", "a", "arr", "b", "doWork", "f1", "f2", "f3", "f4", "f5", "f6", "increment", "isFailure", "isSuccess", "keys", "langCodeSet", "langCodes", "onMouseOver", "result", "test", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(11): ["T"]
 rebuilt        : ScopeId(7): []
@@ -36096,9 +31013,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Falsy", "f1", "f2", "f3", "f4", "f5", "one", "oneOrTwo", "two", "zero"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5", "one", "oneOrTwo", "two", "zero"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(10)]
 Unresolved references mismatch:
 after transform: ["true", "undefined"]
 rebuilt        : ["undefined"]
@@ -36107,9 +31021,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bit", "C1", "C2", "E", "a", "aa", "append", "cond", "f1", "f10", "f11", "f12", "f2", "f20", "f3", "f4", "f5", "f6", "makeArray", "x1", "x10", "x11", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
 rebuilt        : ScopeId(0): ["C1", "C2", "E", "a", "aa", "append", "cond", "f1", "f10", "f11", "f12", "f2", "f20", "f3", "f4", "f5", "f6", "makeArray", "x1", "x10", "x11", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -36136,9 +31047,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndD
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "a1", "a2", "a3", "a4", "b1", "b2", "b3", "b4", "bar", "x"]
 rebuilt        : ScopeId(0): ["a1", "a2", "a3", "a4", "b1", "b2", "b3", "b4", "bar"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("x")
 rebuilt        : ReferenceId(0): None
@@ -36171,25 +31079,16 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTy
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "A3", "A4", "A5", "B1", "B2", "B3", "Item", "Tag", "assertNever", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f2", "f20", "f21", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(34)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "A3", "A4", "A5", "B1", "B2", "B3", "Item", "Tag", "assertNever", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f2", "f20", "f21", "f3", "f4", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(26), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(34)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "Item", "NoYes", "UnknownYesNo", "YesNo", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(20), ScopeId(23), ScopeId(24), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(19)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
@@ -36207,9 +31106,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLitera
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Choice", "Item", "NoYes", "UnknownYesNo", "YesNo", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5"]
 rebuilt        : ScopeId(0): ["Choice", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(20), ScopeId(23), ScopeId(24), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(14), ScopeId(17), ScopeId(19)]
 Bindings mismatch:
 after transform: ScopeId(1): ["Choice", "No", "Unknown", "Yes"]
 rebuilt        : ScopeId(1): ["Choice"]
@@ -36232,9 +31128,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingDef
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "E", "F", "G", "x1", "x2", "x3", "x4", "x5"]
 rebuilt        : ScopeId(0): ["x1", "x2", "x3", "x4", "x5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Capitalize", "Lowercase"]
 rebuilt        : []
@@ -36243,9 +31136,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingRed
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["EMap", "EPlusFallback", "Keys", "T00", "T01", "T02", "T10", "T11", "T12", "T20", "T21", "T22", "T30", "T31", "T32", "VirtualEvent", "_virtualOn", "virtualOn"]
 rebuilt        : ScopeId(0): ["virtualOn"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(19)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(19): ["T", "eventQrl"]
 rebuilt        : ScopeId(1): ["eventQrl"]
@@ -36260,9 +31150,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Keyof", "Registry", "f2"]
 rebuilt        : ScopeId(0): ["f2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(4): ["Event", "Scope", "event", "scope"]
 rebuilt        : ScopeId(1): ["event", "scope"]
@@ -36271,9 +31158,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "Stringify", "z1", "z2"]
 rebuilt        : ScopeId(0): ["E", "z1", "z2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(1): ["E", "a", "b"]
 rebuilt        : ScopeId(1): ["E"]
@@ -36291,9 +31175,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes1.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "C", "E", "I", "a"]
 rebuilt        : ScopeId(1): ["C", "E", "a"]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(2): ["E"]
@@ -36303,9 +31184,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(7): ["A", "C", "E", "I", "a"]
 rebuilt        : ScopeId(5): ["C", "a"]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7)]
 Bindings mismatch:
 after transform: ScopeId(8): ["A", "B", "C", "E"]
 rebuilt        : ScopeId(6): ["E"]
@@ -36324,15 +31202,9 @@ rebuilt        : ScopeId(10): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(15): ["A", "C", "I", "a"]
 rebuilt        : ScopeId(11): ["C", "a"]
-Scope children mismatch:
-after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
-rebuilt        : ScopeId(11): [ScopeId(12)]
 Bindings mismatch:
 after transform: ScopeId(19): ["A", "C", "J", "c"]
 rebuilt        : ScopeId(13): ["A", "c"]
-Scope children mismatch:
-after transform: ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22)]
-rebuilt        : ScopeId(13): [ScopeId(14)]
 Bindings mismatch:
 after transform: ScopeId(24): ["C", "E"]
 rebuilt        : ScopeId(16): ["C"]
@@ -36474,9 +31346,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstra
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TargetProps", "f0", "f1", "f2", "f3", "f4", "modifier"]
 rebuilt        : ScopeId(0): ["f0", "f1", "f2", "f3", "f4", "modifier"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "obj"]
 rebuilt        : ScopeId(1): ["obj"]
@@ -36503,9 +31372,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Identity", "Obj1", "Obj10", "Obj11", "Obj12", "Obj13", "Obj2", "Obj3", "Obj4", "Obj5", "Obj6", "Obj7", "Obj8", "Obj9", "Res1", "Res10", "Res11", "Res12", "Res13", "Res2", "Res3", "Res4", "Res5", "Res6", "Res7", "Res8", "Res9", "StrippingIdentity", "StrippingPick"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(31), ScopeId(32)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Pick"]
 rebuilt        : []
@@ -36514,12 +31380,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeModifie
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "BP", "BPR", "BR", "Boxified", "Foo", "T", "TP", "TPR", "TR", "b00", "b01", "b02", "b03", "b04", "f1", "f2", "f3", "f4", "v00", "v01", "v02", "v03", "v04"]
 rebuilt        : ScopeId(0): ["b00", "b01", "b02", "b03", "b04", "f1", "f2", "f3", "f4", "v00", "v01", "v02", "v03", "v04"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Scope children mismatch:
-after transform: ScopeId(29): [ScopeId(30)]
-rebuilt        : ScopeId(4): []
 Unresolved references mismatch:
 after transform: ["Partial", "Pick", "Readonly"]
 rebuilt        : []
@@ -36528,9 +31388,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeOverlap
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AlienAnimalTypes", "AlienCat", "AnimalTypes", "CatMap", "Cats", "TerrestrialAnimalTypes", "TerrestrialCat", "catMap"]
 rebuilt        : ScopeId(0): ["AlienAnimalTypes", "TerrestrialAnimalTypes", "catMap"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["CAT", "DOG", "TerrestrialAnimalTypes"]
 rebuilt        : ScopeId(1): ["TerrestrialAnimalTypes"]
@@ -36563,33 +31420,19 @@ tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGeneri
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "K", "K0", "K1", "KA", "KB", "KC", "KD", "Keys", "Keys1", "Keys2", "M", "M0", "M1", "R1", "R2", "T1", "T2", "T3", "T4", "V0", "V1"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(32)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Readonly"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeBracketAccessIndexSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Function", "Object", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObject.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "i", "r1", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "i", "r1", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -36598,9 +31441,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeProper
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "c", "i", "r1", "r10", "r11", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
 rebuilt        : ScopeId(0): ["C", "a", "c", "i", "r1", "r10", "r11", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -36609,17 +31449,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "b", "i", "r2", "r2b", "r4", "rb4"]
 rebuilt        : ScopeId(0): ["b", "i", "r2", "r2b", "r4", "rb4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfExtendedFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Function", "I", "i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
 rebuilt        : ScopeId(0): ["i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
@@ -36628,17 +31462,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i", "r1", "r1b", "r1c", "r2", "r2b", "r2c", "x"]
 rebuilt        : ScopeId(0): ["i", "r1", "r1b", "r1c", "r2", "r2b", "r2c", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfExtendedFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Function", "I", "i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
 rebuilt        : ScopeId(0): ["i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
@@ -36647,17 +31475,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i", "r1", "r1b", "r1c", "r2", "r2b", "r2c", "x"]
 rebuilt        : ScopeId(0): ["i", "r1", "r1b", "r1c", "r2", "r2b", "r2c", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithNumericProperty.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "i", "r1", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "i", "r1", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -36666,9 +31488,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "i", "r", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "i", "r", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -36677,20 +31496,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithOptiona
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "b", "c", "d", "i"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedCallSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "Derived1", "Derived2", "I", "a", "c", "i", "r1", "r2", "r3"]
 rebuilt        : ScopeId(0): ["Base", "C", "Derived1", "Derived2", "a", "c", "i", "r1", "r2", "r3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(9), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(13), ReferenceId(30)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -36705,12 +31515,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecial
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "Derived1", "Derived2", "I", "a", "c", "i", "r1", "r2", "r3"]
 rebuilt        : ScopeId(0): ["Base", "C", "Derived1", "Derived2", "a", "c", "i", "r1", "r2", "r3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(9), ScopeId(13), ScopeId(14), ScopeId(15)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(10), ReferenceId(22)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -36725,9 +31529,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOnly
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "c", "i"]
 rebuilt        : ScopeId(0): ["C", "c", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
@@ -36739,9 +31540,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOnly
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "c", "i"]
 rebuilt        : ScopeId(0): ["C", "c", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
@@ -36758,33 +31556,21 @@ tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/genericInstan
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Pair", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Comparator", "LinkedList", "Node", "a1", "a2", "list", "neverArray"]
 rebuilt        : ScopeId(0): ["a1", "a2", "list", "neverArray"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10", "T11", "T12"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "foo", "i", "r", "r2", "r3", "r4", "r5"]
 rebuilt        : ScopeId(0): ["a", "foo", "i", "r", "r2", "r3", "r4", "r5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutReturnTypeAnnotationInference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -36796,9 +31582,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2", "I3", "T", "a", "a2"]
 rebuilt        : ScopeId(0): ["a", "a2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
@@ -36807,17 +31590,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithOptionalParameters.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "f", "f2", "foo", "i"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "f", "f2", "foo", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(6)]
 rebuilt        : SymbolId(8): []
@@ -36826,12 +31603,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "c", "foo", "foo2", "i"]
 rebuilt        : ScopeId(0): ["C", "a", "c", "foo", "foo2", "i"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(12), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(9): [ReferenceId(4)]
 rebuilt        : SymbolId(5): []
@@ -36840,33 +31611,21 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2", "T", "a"]
 rebuilt        : ScopeId(0): ["a"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "I", "I2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/parametersWithNoAnnotationAreAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "f", "f2", "f3", "foo"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "f", "f2", "f3", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "x"]
 rebuilt        : ScopeId(4): ["x"]
@@ -36875,48 +31634,25 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "C3", "I", "I2", "I3", "T", "a", "a2", "a3", "foo"]
 rebuilt        : ScopeId(0): ["C", "C2", "C3", "a", "a2", "a3", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(8), ScopeId(13), ScopeId(18), ScopeId(22), ScopeId(26), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6)]
-Scope children mismatch:
-after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(2): [ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(8): ["T"]
 rebuilt        : ScopeId(4): []
-Scope children mismatch:
-after transform: ScopeId(8): [ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(4): [ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(13): ["T"]
 rebuilt        : ScopeId(6): []
-Scope children mismatch:
-after transform: ScopeId(13): [ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(6): [ScopeId(7)]
 Unresolved references mismatch:
 after transform: ["String"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureWithOptional.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "f", "f2", "foo"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "f", "f2", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterAsTypeArgument.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "foo"]
 rebuilt        : ScopeId(0): ["C", "foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(1): ["x", "y"]
@@ -37007,26 +31743,14 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithIdenticalOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "a", "b", "i", "i2", "r1", "r2", "r3", "r4", "r5", "r6"]
 rebuilt        : ScopeId(0): ["C", "C2", "a", "b", "i", "i2", "r1", "r2", "r3", "r4", "r5", "r6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(12), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(6), ReferenceId(23), ReferenceId(24)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -37038,18 +31762,9 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "a", "b", "i", "i2", "r1", "r2", "r3", "r4", "r5", "r6"]
 rebuilt        : ScopeId(0): ["C", "C2", "a", "b", "i", "i2", "r1", "r2", "r3", "r4", "r5", "r6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(12), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(6), ReferenceId(23), ReferenceId(24)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
@@ -37061,9 +31776,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/constr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "a", "b"]
 rebuilt        : ScopeId(0): ["C", "C2", "a", "b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -37078,9 +31790,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexS
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "b2", "c", "i", "r1", "r1a", "r1b", "r2", "r2a", "r2b", "r3", "r4", "r5", "r6"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "b2", "c", "i", "r1", "r1a", "r1b", "r2", "r2a", "r2b", "r3", "r4", "r5", "r6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -37089,9 +31798,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexS
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "i", "r1", "r10", "r11", "r12", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "i", "r1", "r10", "r11", "r12", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -37100,33 +31806,21 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/method
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "b", "b2", "c", "c2"]
 rebuilt        : ScopeId(0): ["b", "b2", "c", "c2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "c", "c2"]
 rebuilt        : ScopeId(0): ["c", "c2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNameWithoutTypeAnnotation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "r1", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "r1", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "a", "c", "i", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]
 rebuilt        : ScopeId(0): ["C", "E", "a", "c", "i", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "abstract", "as", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "debugger", "default", "delete", "do", "double", "else", "enum", "export", "extends", "false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", "interface", "is", "long", "namespace", "native", "new", "null", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true", "try", "typeof", "use", "var", "void", "volatile", "while", "with"]
 rebuilt        : ScopeId(2): ["E"]
@@ -37144,9 +31838,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/proper
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "i", "r1", "r1b", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "i", "r1", "r1b", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
@@ -37155,9 +31846,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/exten
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Boolean", "a", "b", "c", "d", "x"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts
 semantic error: Unresolved references mismatch:
@@ -37168,9 +31856,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/extend
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Number", "a", "b", "c", "d", "x"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
 semantic error: Bindings mismatch:
@@ -37193,19 +31878,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extend
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["String", "a", "b", "c", "d", "x"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/validStringAssignments.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Object", "String"]
 rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -37214,9 +31891,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/val
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "a", "b", "c", "d", "e", "f", "g", "h", "i", "x"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "c", "d", "e", "f", "g", "h", "i", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "a"]
 rebuilt        : ScopeId(2): ["a"]
@@ -37236,9 +31910,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Item", "a", "f1", "f2", "f3", "f4", "sa", "sb"]
 rebuilt        : ScopeId(0): ["a", "f1", "f2", "f3", "f4", "sa", "sb"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "a1", "a2", "a3", "a4", "a5", "b2", "obj", "r0", "r1", "r2", "r3", "r4", "r5"]
 rebuilt        : ScopeId(1): ["a1", "a2", "a3", "a4", "a5", "b2", "obj", "r0", "r1", "r2", "r3", "r4", "r5"]
@@ -37258,28 +31929,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(17): [ReferenceId(11), ReferenceId(14)]
 rebuilt        : SymbolId(16): [ReferenceId(10)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRest2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestParameter.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestParameterES5.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7)]
-
 tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestReadonly.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ObjType", "foo", "obj", "rest"]
 rebuilt        : ScopeId(0): ["foo", "obj", "rest"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Readonly"]
 rebuilt        : []
@@ -37301,9 +31954,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLite
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "x", "y", "y2", "z"]
 rebuilt        : ScopeId(0): ["x", "y", "y2", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -37314,18 +31964,9 @@ after transform: ScopeId(0): ["T", "f", "f2", "f3", "f4"]
 rebuilt        : ScopeId(0): ["f", "f2", "f3", "f4"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(3): []
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
@@ -37354,9 +31995,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQuer
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
 Bindings mismatch:
 after transform: ScopeId(18): ["T"]
 rebuilt        : ScopeId(14): []
@@ -37377,18 +32015,12 @@ tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQuer
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Controller", "IScope"]
 rebuilt        : ScopeId(0): ["Controller"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClass2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-Symbol reference IDs mismatch:
+semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
@@ -37414,9 +32046,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpread.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Header", "a", "addAfter", "addBefore", "anything", "c", "changeTypeAfter", "changeTypeBoth", "combined", "combinedAfter", "combinedNestedChangeType", "conditionalSpreadBoolean", "conditionalSpreadNumber", "conditionalSpreadString", "container", "cplus", "exclusive", "f", "from16326", "genericSpread", "getter", "nested", "o", "o2", "op", "overlap", "overlapConflict", "override", "overwriteId", "propertyNested", "shortCutted", "spreadAny", "spreadC", "spreadFunc", "spreadNonPrimitive", "swap"]
 rebuilt        : ScopeId(0): ["C", "a", "addAfter", "addBefore", "anything", "c", "changeTypeAfter", "changeTypeBoth", "combined", "combinedAfter", "combinedNestedChangeType", "conditionalSpreadBoolean", "conditionalSpreadNumber", "conditionalSpreadString", "container", "cplus", "exclusive", "f", "from16326", "genericSpread", "getter", "nested", "o", "o2", "op", "overlap", "overlapConflict", "override", "overwriteId", "propertyNested", "shortCutted", "spreadAny", "spreadC", "spreadFunc", "spreadNonPrimitive", "swap"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 Bindings mismatch:
 after transform: ScopeId(13): ["T", "U", "t", "u"]
 rebuilt        : ScopeId(11): ["t", "u"]
@@ -37436,9 +32065,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepea
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "parseWithSpread"]
 rebuilt        : ScopeId(0): ["parseWithSpread"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Record", "undefined"]
 rebuilt        : ["undefined"]
@@ -37447,9 +32073,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadContextualT
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Person", "age", "alice", "bob", "naam"]
 rebuilt        : ScopeId(0): ["age", "naam"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("bob")
 rebuilt        : ReferenceId(0): None
@@ -37464,9 +32087,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadExcessPrope
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "a1", "extra1"]
 rebuilt        : ScopeId(0): ["a1", "extra1"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonPrimitive.ts
 semantic error: Bindings mismatch:
@@ -37517,41 +32137,26 @@ tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLite
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "T", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf02.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "T", "f", "isS"]
 rebuilt        : ScopeId(0): ["f", "isS"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralMatchedInSwitch01.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "T", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypeAssertion01.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "T", "s", "str", "t"]
 rebuilt        : ScopeId(0): ["s", "str", "t"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentClasses.ts
 semantic error: Symbol reference IDs mismatch:
@@ -37562,16 +32167,10 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentInterface
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "c", "z"]
 rebuilt        : ScopeId(0): ["c", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/inferThisType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Check", "This", "r1", "r2"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(8)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAndConstraints.ts
@@ -37595,31 +32194,17 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClass
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C5", "Foo"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "C5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
 Unresolved references mismatch:
 after transform: ["Date", "undefined"]
 rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions3.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CorrectObject", "WrongObject", "problemFunction"]
 rebuilt        : ScopeId(0): ["problemFunction"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "name"]
 rebuilt        : ScopeId(2): ["name"]
-Scope children mismatch:
-after transform: ScopeId(6): [ScopeId(7)]
-rebuilt        : ScopeId(2): []
 Unresolved references mismatch:
 after transform: ["callsCallback", "isCorrect", "this"]
 rebuilt        : ["callsCallback", "isCorrect"]
@@ -37627,9 +32212,6 @@ rebuilt        : ["callsCallback", "isCorrect"]
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "I1", "I2", "I3"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date"]
@@ -37639,9 +32221,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjec
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i", "impl", "mutuallyRecursive", "o"]
 rebuilt        : ScopeId(0): ["i", "impl", "mutuallyRecursive", "o"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
 semantic error: Bindings mismatch:
@@ -37655,14 +32234,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTuple
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "a", "b", "c", "t"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "t"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptionalCall.ts
 semantic error: Bindings mismatch:
@@ -37673,9 +32244,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AddMixedConditional", "AddMixedConditionalBoolean", "AddMixedConditionalLiteral", "AddMixedConditionalNumberPrimitive", "AnonymousToAnonymous", "AnonymousToMixed", "ConditionalTuple", "MixedSpread", "MixedToAnonymous", "MixedToMixed", "NamedAndAnonymous", "NamedAnonymousMixed", "NamedToAnonymous", "NamedToMixed", "ToAnonymousTuple", "ToMixedTuple", "fa1", "fa2", "fb1", "fb2", "fb3", "input", "output"]
 rebuilt        : ScopeId(0): ["fa1", "fa2", "fb1", "fb2", "fb3", "output"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(37): Some("input")
 rebuilt        : ReferenceId(1): None
@@ -37687,9 +32255,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["GetKeys", "GetResult", "MultiKeyMap", "id1", "matches", "x"]
 rebuilt        : ScopeId(0): ["id1", "matches", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Iterable"]
 rebuilt        : []
@@ -37706,20 +32271,12 @@ after transform: []
 rebuilt        : ["tuple"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(1): ["x", "y"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "array1", "array2", "i", "length", "zipResult"]
 rebuilt        : ScopeId(2): ["array1", "array2", "i", "length", "zipResult"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples1.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias02.ts
 semantic error: Semantic Collector failed after transform
@@ -37732,9 +32289,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I0", "I3", "I4", "T0", "T3", "T4", "v0", "v3", "v4"]
 rebuilt        : ScopeId(0): ["I0", "I3", "I4", "v0", "v3", "v4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(1): []
@@ -37749,17 +32303,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I0", "I1", "I2", "I3", "I4", "T0", "T1", "T2", "T3", "T4", "v0", "v1", "v2", "v3", "v4"]
 rebuilt        : ScopeId(0): ["v0", "v1", "v2", "v3", "v4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/classDoesNotDependOnBaseTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["StringTree", "StringTreeCollection", "StringTreeCollectionBase", "x"]
 rebuilt        : ScopeId(0): ["StringTreeCollection", "StringTreeCollectionBase", "x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(7)]
 rebuilt        : SymbolId(1): [ReferenceId(4)]
@@ -37768,29 +32316,17 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeA
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AB", "Bar", "Foo", "Lazy", "Pair", "Strange", "TaggedPair", "Tree", "a", "b", "f", "g", "ls", "p", "s", "tree", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["a", "b", "f", "g", "ls", "p", "s", "tree", "x", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(10): ["A", "Foo", "x"]
 rebuilt        : ScopeId(2): ["x"]
-Scope children mismatch:
-after transform: ScopeId(10): [ScopeId(11)]
-rebuilt        : ScopeId(2): []
 Bindings mismatch:
 after transform: ScopeId(12): ["B", "Bar", "x"]
 rebuilt        : ScopeId(3): ["x"]
-Scope children mismatch:
-after transform: ScopeId(12): [ScopeId(13)]
-rebuilt        : ScopeId(3): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/interfaceDoesNotDependOnBaseTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["StringTree", "StringTreeArray", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -37799,9 +32335,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C7", "E", "I13", "I6", "Meters", "StringAndBoolean", "T1", "T10", "T11", "T13", "T14", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "x", "x1", "x10", "x11", "x13_1", "x13_2", "x14", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "y"]
 rebuilt        : ScopeId(0): ["C7", "E", "x", "x1", "x10", "x11", "x13_1", "x13_2", "x14", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(24): ["E", "x"]
 rebuilt        : ScopeId(2): ["E"]
@@ -37819,9 +32352,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "T", "f", "f2", "f3", "i", "i2", "r", "r2", "r3", "r4", "r5", "r6", "r7"]
 rebuilt        : ScopeId(0): ["C", "C2", "f", "f2", "f3", "i", "i2", "r", "r2", "r3", "r4", "r5", "r6", "r7"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -37858,18 +32388,10 @@ Unresolved references mismatch:
 after transform: ["String"]
 rebuilt        : []
 
-tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "a", "foo", "foo2", "i", "i2", "r", "r2"]
 rebuilt        : ScopeId(0): ["C", "C2", "a", "foo", "foo2", "i", "i2", "r", "r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -37890,9 +32412,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "F2", "I", "I2", "T", "a", "a2", "b", "b2", "c", "c2", "f2", "foo", "foo2", "i", "i2", "r", "r1", "r10", "r11", "r12", "r13", "r14", "r15", "r16", "r17", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
 rebuilt        : ScopeId(0): ["C", "C2", "a", "a2", "b", "b2", "c", "c2", "f2", "foo", "foo2", "i", "i2", "r", "r1", "r10", "r11", "r12", "r13", "r14", "r15", "r16", "r17", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -37925,9 +32444,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "T", "a", "a2", "b", "b2", "c", "c2", "foo", "i", "i2", "r1", "r10", "r12", "r15", "r2", "r3", "r4", "r5", "r8", "r9"]
 rebuilt        : ScopeId(0): ["C", "C2", "a", "a2", "b", "b2", "c", "c2", "foo", "i", "i2", "r1", "r10", "r12", "r15", "r2", "r3", "r4", "r5", "r8", "r9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -37953,9 +32469,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "a", "b", "foo", "foo2", "r", "r2", "r3"]
 rebuilt        : ScopeId(0): ["a", "b", "foo", "foo2", "r", "r2", "r3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(1): ["x", "y"]
@@ -37967,9 +32480,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "a", "b", "c", "foo", "foo2"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "foo", "foo2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "V", "x", "y", "z"]
 rebuilt        : ScopeId(1): ["x", "y", "z"]
@@ -37981,9 +32491,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "a", "b", "c", "foo", "foo2"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "foo", "foo2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "V", "x", "y", "z"]
 rebuilt        : ScopeId(1): ["x", "y", "z"]
@@ -37995,9 +32502,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgum
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Foo", "c", "r", "y"]
 rebuilt        : ScopeId(0): ["C", "c", "r", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -38065,9 +32569,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "T", "a", "b", "i", "r", "r2", "r2b", "r3", "r3b", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "i", "r", "r2", "r2b", "r3", "r3b", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -38082,9 +32583,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "T", "U", "a", "aB", "b", "i", "r1", "r1b", "r2", "r2b", "r3", "r3b", "r3c", "r3d", "r4"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "aB", "b", "i", "r1", "r1b", "r2", "r2b", "r3", "r3b", "r3c", "r3d", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "U"]
 rebuilt        : ScopeId(5): []
@@ -38102,9 +32600,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "T", "U", "a", "b", "i", "r1a", "r1b", "r2", "r2b", "r3", "r3b", "r3c", "r3d", "r4"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "i", "r1a", "r1b", "r2", "r2b", "r3", "r3b", "r3c", "r3d", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "U"]
 rebuilt        : ScopeId(5): []
@@ -38122,9 +32617,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "T", "a", "b", "i", "r", "r2", "r2b", "r3", "r3b", "r4"]
 rebuilt        : ScopeId(0): ["C", "a", "b", "i", "r", "r2", "r2b", "r3", "r3b", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -38132,26 +32624,15 @@ Bindings mismatch:
 after transform: ScopeId(4): ["T", "a", "x"]
 rebuilt        : ScopeId(3): ["a", "x"]
 
-tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersWithIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Config", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "C3", "C4", "C5", "C6", "I", "I2", "I3", "I4", "I5", "I6", "T", "U", "V", "a", "a2", "a3", "a4", "a5", "a6", "e", "e2", "e3", "e4", "e5", "e6", "f", "f2", "f3", "f4", "f5", "f6"]
 rebuilt        : ScopeId(0): ["C", "C2", "C3", "C4", "C5", "C6", "a", "a2", "a3", "a4", "a5", "a6", "e", "e2", "e3", "e4", "e5", "e6", "f", "f2", "f3", "f4", "f5", "f6"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U"]
 rebuilt        : ScopeId(1): []
@@ -38240,9 +32721,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "T", "a", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
 rebuilt        : ScopeId(0): ["C", "E", "a", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "E"]
 rebuilt        : ScopeId(2): ["E"]
@@ -38278,9 +32756,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "S", "T", "U", "g", "h"]
 rebuilt        : ScopeId(0): ["g", "h"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
 semantic error: Semantic Collector failed after transform
@@ -38297,9 +32772,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "S2", "T", "T2", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
 rebuilt        : ScopeId(0): ["S", "T", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -38311,9 +32783,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "S2", "T", "T2", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
 rebuilt        : ScopeId(0): ["S", "T", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2)]
 rebuilt        : SymbolId(0): []
@@ -38325,9 +32794,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["S", "S2", "T", "T2", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
 rebuilt        : ScopeId(0): ["S", "T", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
@@ -38339,9 +32805,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(41), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(80), ReferenceId(88), ReferenceId(90), ReferenceId(95), ReferenceId(97), ReferenceId(108)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -38359,9 +32822,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(34), ReferenceId(40), ReferenceId(46), ReferenceId(61), ReferenceId(66)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -38376,9 +32836,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(62), ReferenceId(70), ReferenceId(77), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(94)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -38396,9 +32853,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(41), ReferenceId(59), ReferenceId(65), ReferenceId(73), ReferenceId(80), ReferenceId(88), ReferenceId(90), ReferenceId(95), ReferenceId(97), ReferenceId(108)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -38416,9 +32870,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(29), ReferenceId(36), ReferenceId(44), ReferenceId(50), ReferenceId(53), ReferenceId(71), ReferenceId(76), ReferenceId(85), ReferenceId(87), ReferenceId(91), ReferenceId(94)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -38433,9 +32884,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(62), ReferenceId(70), ReferenceId(77), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(94)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -38453,9 +32901,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "T", "a", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
 rebuilt        : ScopeId(0): ["C", "E", "a", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "E"]
 rebuilt        : ScopeId(2): ["E"]
@@ -38482,9 +32927,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1", "Test2", "hasOwn", "source", "target", "toString"]
 rebuilt        : ScopeId(0): ["hasOwn", "target", "toString"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("source")
 rebuilt        : ReferenceId(0): None
@@ -38496,9 +32938,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "T", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
 rebuilt        : ScopeId(0): ["C", "E", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "E"]
 rebuilt        : ScopeId(2): ["E"]
@@ -38539,9 +32978,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assign
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "T", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
 rebuilt        : ScopeId(0): ["C", "E", "ac", "ae", "ai", "b", "c", "d", "e", "f", "foo", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["A", "E"]
 rebuilt        : ScopeId(2): ["E"]
@@ -38636,9 +33072,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/compar
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["x", "y", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
 semantic error: Bindings mismatch:
@@ -38698,17 +33131,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recurs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AA", "BB"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["G", "ff"]
 rebuilt        : ScopeId(0): ["ff"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "g"]
 rebuilt        : ScopeId(1): ["g"]
@@ -38717,16 +33144,10 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recurs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BinaryTuple", "List", "Sequence"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(6)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "A2", "A3", "B", "C"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeInGenericConstraint.ts
@@ -38747,10 +33168,7 @@ after transform: SymbolId(4): [ReferenceId(10)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 Bindings mismatch:
@@ -38765,9 +33183,6 @@ rebuilt        : ScopeId(4): ["x"]
 Bindings mismatch:
 after transform: ScopeId(9): ["T", "U", "foo3", "foo4", "foo5", "list", "myList", "r", "r2"]
 rebuilt        : ScopeId(5): ["foo3", "foo4", "foo5", "list", "myList", "r", "r2"]
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
-rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(11): ["V", "x"]
 rebuilt        : ScopeId(6): ["x"]
@@ -38792,9 +33207,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "I", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"]
 rebuilt        : ScopeId(0): ["C", "E", "f1", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38)]
 Bindings mismatch:
 after transform: ScopeId(58): ["T", "x"]
 rebuilt        : ScopeId(33): ["x"]
@@ -38847,10 +33259,7 @@ Missing ReferenceId: CallSignature
 Missing ReferenceId: CallSignature
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(55), ScopeId(57), ScopeId(59), ScopeId(61), ScopeId(63), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77), ScopeId(78)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(41): ["T", "x"]
 rebuilt        : ScopeId(5): ["x"]
 Bindings mismatch:
@@ -38929,10 +33338,7 @@ Missing ReferenceId: WithGenericSignaturesInBaseType
 Missing ReferenceId: WithGenericSignaturesInBaseType
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(27): ["T", "x"]
 rebuilt        : ScopeId(5): ["x"]
 Bindings mismatch:
@@ -39013,9 +33419,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "T", "U", "r1", "r10", "r10a", "r10arg1", "r10arg2", "r10b", "r11", "r11a", "r11arg1", "r11arg2", "r11b", "r12", "r12a", "r12arg1", "r12arg2", "r12b", "r13", "r13a", "r13arg1", "r13arg2", "r13b", "r14", "r14a", "r14arg1", "r14arg2", "r14b", "r15", "r15arg1", "r16", "r16arg1", "r17", "r17arg1", "r18", "r18arg1", "r1a", "r1arg1", "r1arg2", "r1b", "r2", "r2a", "r2arg1", "r2arg2", "r2b", "r3", "r3a", "r3arg1", "r3arg2", "r3b", "r4", "r4a", "r4arg1", "r4arg2", "r4b", "r5", "r5a", "r5arg1", "r5arg2", "r5b", "r6", "r6a", "r6arg1", "r6arg2", "r6b", "r7", "r7a", "r7arg1", "r7arg2", "r7b", "r8", "r8a", "r8arg1", "r8arg2", "r8b", "r9", "r9a", "r9arg1", "r9arg2", "r9b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "r1", "r10", "r10a", "r10arg1", "r10arg2", "r10b", "r11", "r11a", "r11arg1", "r11arg2", "r11b", "r12", "r12a", "r12arg1", "r12arg2", "r12b", "r13", "r13a", "r13arg1", "r13arg2", "r13b", "r14", "r14a", "r14arg1", "r14arg2", "r14b", "r15", "r15arg1", "r16", "r16arg1", "r17", "r17arg1", "r18", "r18arg1", "r1a", "r1arg1", "r1arg2", "r1b", "r2", "r2a", "r2arg1", "r2arg2", "r2b", "r3", "r3a", "r3arg1", "r3arg2", "r3b", "r4", "r4a", "r4arg1", "r4arg2", "r4b", "r5", "r5a", "r5arg1", "r5arg2", "r5b", "r6", "r6a", "r6arg1", "r6arg2", "r6b", "r7", "r7a", "r7arg1", "r7arg2", "r7b", "r8", "r8a", "r8arg1", "r8arg2", "r8b", "r9", "r9a", "r9arg1", "r9arg2", "r9b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(36), ScopeId(37), ScopeId(40), ScopeId(41), ScopeId(44), ScopeId(45), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(34), ReferenceId(37), ReferenceId(44), ReferenceId(56), ReferenceId(106), ReferenceId(108), ReferenceId(110), ReferenceId(121), ReferenceId(123), ReferenceId(125), ReferenceId(139), ReferenceId(141), ReferenceId(143), ReferenceId(145), ReferenceId(158), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(186), ReferenceId(187), ReferenceId(195), ReferenceId(200), ReferenceId(202), ReferenceId(214), ReferenceId(220), ReferenceId(246)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -39044,9 +33447,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "T", "U", "V", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(26), ScopeId(27), ScopeId(34)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(34), ReferenceId(40), ReferenceId(46), ReferenceId(99), ReferenceId(104), ReferenceId(114), ReferenceId(118), ReferenceId(140), ReferenceId(144)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -39061,9 +33461,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Base", "Derived", "Derived2", "I", "OtherDerived"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(24), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(62), ReferenceId(70), ReferenceId(77), ReferenceId(85), ReferenceId(87), ReferenceId(92), ReferenceId(94)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
@@ -39096,17 +33493,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtyp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "S", "S2", "S3", "T", "T2", "T3", "a", "b", "r"]
 rebuilt        : ScopeId(0): ["a", "b", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "S", "S2", "S3", "T", "T2", "T3", "a", "b", "r"]
 rebuilt        : ScopeId(0): ["a", "b", "r"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithOptionalProperties.ts
 semantic error: Bindings mismatch:
@@ -39121,9 +33512,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -39147,9 +33535,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "E", "I", "a", "b", "foo10", "foo11", "foo12", "foo13", "foo14", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "E", "a", "b", "foo10", "foo11", "foo12", "foo13", "foo14", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -39185,9 +33570,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
@@ -39211,9 +33593,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
@@ -39240,9 +33619,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
@@ -39266,9 +33642,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2", "a", "foo13", "foo14", "foo14b", "foo15", "foo2", "foo3", "foo4", "foo5"]
 rebuilt        : ScopeId(0): ["a", "foo13", "foo14", "foo14b", "foo15", "foo2", "foo3", "foo4", "foo5"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(11), ReferenceId(14)]
 rebuilt        : SymbolId(0): []
@@ -39277,21 +33650,9 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(14), ScopeId(17), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77), ScopeId(78), ScopeId(79), ScopeId(80)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
-Scope children mismatch:
-after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(1): [ScopeId(2)]
-Scope children mismatch:
-after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(3): [ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(9): ["T"]
 rebuilt        : ScopeId(5): []
-Scope children mismatch:
-after transform: ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(5): [ScopeId(6)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22)]
 rebuilt        : SymbolId(0): []
@@ -39312,17 +33673,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "foo1", "foo10", "foo12", "foo12b", "foo13", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "foo1", "foo10", "foo12", "foo12b", "foo13", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
@@ -39343,9 +33698,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -39369,9 +33721,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -39392,9 +33741,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -39427,9 +33773,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(2): ["x", "y"]
@@ -39462,9 +33805,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -39500,9 +33840,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo6", "foo6c", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "D", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo6", "foo6c", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(2): ["x", "y"]
@@ -39544,9 +33881,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "Five", "Four", "I", "I2", "One", "Six", "Three", "Two", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo6", "foo6c", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "D", "One", "Two", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo6", "foo6c", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77), ScopeId(78), ScopeId(79), ScopeId(80), ScopeId(81), ScopeId(82), ScopeId(83)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
 Bindings mismatch:
 after transform: ScopeId(8): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(4): ["x", "y"]
@@ -39591,9 +33925,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -39629,9 +33960,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -39667,9 +33995,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -39705,9 +34030,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "I", "I2", "Z", "a", "foo1", "foo13", "foo14", "foo14b", "foo15", "foo2", "foo3"]
 rebuilt        : ScopeId(0): ["a", "foo1", "foo13", "foo14", "foo14b", "foo15", "foo2", "foo3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(10), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
 rebuilt        : SymbolId(0): []
@@ -39719,9 +34041,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(2): ["x"]
@@ -39754,9 +34073,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "x", "y"]
 rebuilt        : ScopeId(2): ["x", "y"]
@@ -39789,9 +34105,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(2): ["x", "y"]
@@ -39824,9 +34137,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "I2", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(2): ["x", "y"]
@@ -39859,9 +34169,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -39891,9 +34198,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "D", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5c", "foo6c", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "D", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5c", "foo6c", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U"]
 rebuilt        : ScopeId(1): []
@@ -39929,9 +34233,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "D", "Five", "Four", "I", "I2", "One", "Six", "Three", "Two", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5c", "foo6c", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "D", "One", "Two", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5c", "foo6c", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "U"]
 rebuilt        : ScopeId(3): []
@@ -39970,9 +34271,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -40002,9 +34300,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo15", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -40034,9 +34329,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["U", "V"]
 rebuilt        : ScopeId(1): []
@@ -40066,9 +34358,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["U"]
 rebuilt        : ScopeId(1): []
@@ -40095,9 +34384,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
@@ -40124,9 +34410,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U"]
 rebuilt        : ScopeId(1): []
@@ -40153,9 +34436,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "C", "I", "I2", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["B", "C", "a", "b", "foo10", "foo11", "foo12", "foo12b", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "U"]
 rebuilt        : ScopeId(1): []
@@ -40182,9 +34462,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -40214,9 +34491,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Base", "C", "Derived", "I", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "Base", "C", "Derived", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
@@ -40252,9 +34526,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -40284,9 +34555,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "a", "b", "foo10", "foo12", "foo13", "foo14", "foo2", "foo3", "foo6", "foo7", "foo8"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo10", "foo12", "foo13", "foo14", "foo2", "foo3", "foo6", "foo7", "foo8"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -40310,9 +34578,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -40339,10 +34604,7 @@ after transform: SymbolId(8): [ReferenceId(13), ReferenceId(14), ReferenceId(34)
 rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 Bindings mismatch:
@@ -40359,9 +34621,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "a", "b", "foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -40385,9 +34644,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "I", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
@@ -40417,9 +34673,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Base", "C", "Derived", "I", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
 rebuilt        : ScopeId(0): ["A", "B", "Base", "C", "Derived", "PA", "PB", "a", "b", "foo1", "foo10", "foo11", "foo11b", "foo11c", "foo12", "foo13", "foo14", "foo15", "foo16", "foo1b", "foo1c", "foo2", "foo3", "foo4", "foo5", "foo5b", "foo5c", "foo5d", "foo6", "foo7", "foo8", "foo9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30)]
 Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
@@ -40452,10 +34705,7 @@ after transform: SymbolId(10): [ReferenceId(20), ReferenceId(21), ReferenceId(43
 rebuilt        : SymbolId(8): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/primtiveTypesAreIdentical.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(17): ["A", "E"]
 rebuilt        : ScopeId(6): ["E"]
 Scope flags mismatch:
@@ -40472,9 +34722,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C2", "I", "I2", "foo1", "foo2", "foo3"]
 rebuilt        : ScopeId(0): ["C", "C2", "foo1", "foo2", "foo3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(14), ScopeId(27), ScopeId(37), ScopeId(46)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(11)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
@@ -40484,15 +34731,9 @@ rebuilt        : ScopeId(2): ["x"]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "U", "inner", "inner2", "x", "y"]
 rebuilt        : ScopeId(3): ["inner", "inner2", "x", "y"]
-Scope children mismatch:
-after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
-rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(14): ["T"]
 rebuilt        : ScopeId(6): []
-Scope children mismatch:
-after transform: ScopeId(14): [ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26)]
-rebuilt        : ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 Bindings mismatch:
 after transform: ScopeId(20): ["U", "a", "x"]
 rebuilt        : ScopeId(8): ["a", "x"]
@@ -40505,9 +34746,6 @@ rebuilt        : ScopeId(10): ["x"]
 Bindings mismatch:
 after transform: ScopeId(27): ["T"]
 rebuilt        : ScopeId(11): []
-Scope children mismatch:
-after transform: ScopeId(27): [ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
-rebuilt        : ScopeId(11): [ScopeId(12), ScopeId(13), ScopeId(14)]
 Bindings mismatch:
 after transform: ScopeId(33): ["U", "a", "x"]
 rebuilt        : ScopeId(13): ["a", "x"]
@@ -40522,9 +34760,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "a", "b", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(0): None
@@ -40539,17 +34774,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "FooA", "FooBar", "InferA", "Item", "x1", "x2"]
 rebuilt        : ScopeId(0): ["x1", "x2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallTypeArgumentInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I", "c", "foo", "foo2", "foo2b", "i", "r", "r10", "r11", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
 rebuilt        : ScopeId(0): ["C", "c", "foo", "foo2", "foo2b", "i", "r", "r10", "r11", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(14)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["T", "t"]
 rebuilt        : ScopeId(1): ["t"]
@@ -40593,9 +34822,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "C", "Derived", "Derived2", "I", "b", "c", "d1", "d2", "foo", "foo2", "foo2b", "foo2c", "i", "r", "r10", "r11", "r2", "r3", "r3b", "r4", "r5", "r6", "r7", "r8", "r8b", "r9"]
 rebuilt        : ScopeId(0): ["Base", "C", "Derived", "Derived2", "b", "c", "d1", "d2", "foo", "foo2", "foo2b", "foo2c", "i", "r", "r10", "r11", "r2", "r3", "r3b", "r4", "r5", "r6", "r7", "r8", "r8b", "r9"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(18)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "t"]
 rebuilt        : ScopeId(4): ["t"]
@@ -40648,10 +34874,7 @@ after transform: ScopeId(1): ["T", "U", "cb", "u"]
 rebuilt        : ScopeId(1): ["cb", "u"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments4.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(5): ["T", "U", "cb", "u"]
 rebuilt        : ScopeId(3): ["cb", "u"]
 Symbol reference IDs mismatch:
@@ -40699,9 +34922,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "I", "f", "f2", "i", "r", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "f", "f2", "i", "r", "r2", "r3", "r4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "a"]
 rebuilt        : ScopeId(4): ["a"]
@@ -40739,9 +34959,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "I", "f", "f2", "f3", "i", "r", "r2", "r3", "r4", "r5", "r6", "r7"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "f", "f2", "f3", "i", "r", "r2", "r3", "r4", "r5", "r6", "r7"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "r", "x"]
 rebuilt        : ScopeId(3): ["r", "x"]
@@ -40854,25 +35071,16 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AssignAction", "Config", "LowInfer", "Meta", "PartialAssigner", "PropertyAssigner"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AssignAction", "Config", "LowInfer", "Meta", "PartialAssigner", "PropertyAssigner"]
 rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AnimatedViewProps", "Animations", "B", "C", "Component", "Foo", "Props", "StyleParam", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["Component", "Foo", "_jsxFileName", "_reactJsxRuntime"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
 Bindings mismatch:
 after transform: ScopeId(10): ["T", "animations", "style"]
 rebuilt        : ScopeId(1): ["animations", "style"]
@@ -40893,17 +35101,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "a", "b", "c"]
 rebuilt        : ScopeId(0): ["a", "b", "c"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BookDef", "BookReq", "MakeTable", "bookTable", "f", "insertOnConflictDoNothing"]
 rebuilt        : ScopeId(0): ["bookTable", "f", "insertOnConflictDoNothing"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Bindings mismatch:
 after transform: ScopeId(11): ["Def", "Req", "_conflictTarget", "_table"]
 rebuilt        : ScopeId(1): ["_conflictTarget", "_table"]
@@ -40918,9 +35120,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bear", "ITest", "Man", "Maybe", "Pig", "Y", "assign", "baz1", "createTest", "createTestAsync", "destructure", "foo", "foo1", "func", "get", "isNonVoid", "isVoid", "mbp", "res", "result", "value", "x1", "x2", "y"]
 rebuilt        : ScopeId(0): ["assign", "baz1", "createTest", "createTestAsync", "destructure", "foo", "foo1", "func", "get", "isNonVoid", "isVoid", "res", "result", "value", "x1", "x2", "y"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(10), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Bindings mismatch:
 after transform: ScopeId(2): ["a", "haveValue", "haveY", "r", "something"]
 rebuilt        : ScopeId(1): ["haveValue", "haveY", "something"]
@@ -40958,18 +35157,10 @@ Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(54), ReferenceId(56)]
 rebuilt        : [ReferenceId(27)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference2.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AB", "Bar1", "Bar2", "ComponentClass", "ComponentType", "Foo1", "Foo2", "FunctionComponent", "Maybe", "MyComponent", "Props", "R", "RouteComponentProps", "S", "T", "U", "a", "ab", "b", "f1", "f2", "g", "g1", "g2", "sa", "sx", "x1", "x2", "y1", "y2", "z"]
 rebuilt        : ScopeId(0): ["g", "x1", "x2", "y1", "y2", "z"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(3): ["R", "S", "U", "com"]
 rebuilt        : ScopeId(1): ["com"]
@@ -41025,34 +35216,20 @@ Unresolved references mismatch:
 after transform: ["AsyncIterator", "Component", "Iterable", "Iterator", "Omit", "Promise", "PromiseLike", "concatMaybe", "foo", "foo1", "foo2", "true", "withRouter"]
 rebuilt        : ["MyComponent", "a", "ab", "b", "concatMaybe", "f1", "f2", "foo", "foo1", "foo2", "g1", "g2", "sa", "sx", "withRouter"]
 
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/strictNullChecksNoWidening.ts
-semantic error: Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-
 tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeCallSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IWithCallSignatures", "IWithCallSignatures2", "IWithCallSignatures3", "IWithCallSignatures4", "IWithNoCallSignatures", "x", "x2", "x3", "x4"]
 rebuilt        : ScopeId(0): ["x", "x2", "x3", "x4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeIndexSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IWithNoNumberIndexSignature", "IWithNoStringIndexSignature", "IWithNumberIndexSignature1", "IWithNumberIndexSignature2", "IWithStringIndexSignature1", "IWithStringIndexSignature2", "SomeType", "SomeType2", "x", "x2", "x3", "x4"]
 rebuilt        : ScopeId(0): ["x", "x2", "x3", "x4"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I11", "I2", "I21", "arrayI1OrI2", "arrayOrI11OrI21", "i1", "i11", "i11Ori21", "i1Ori2", "i2", "i21"]
 rebuilt        : ScopeId(0): ["arrayI1OrI2", "arrayOrI11OrI21", "i1", "i11", "i11Ori21", "i1Ori2", "i2", "i21"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24)]
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -41061,9 +35238,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnion
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Correct", "Err", "SomeReturnType", "example"]
 rebuilt        : ScopeId(0): ["example"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
 after transform: ["true", "undefined"]
 rebuilt        : ["undefined"]
@@ -41072,9 +35246,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSigna
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "a1", "a2", "a3", "f1", "f2", "f3", "n1", "n2", "n3", "s1", "s2", "s3"]
 rebuilt        : ScopeId(0): ["a1", "a2", "a3", "f1", "f2", "f3", "n1", "n2", "n3", "s1", "s2", "s3"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
@@ -41106,9 +35277,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSigna
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Callable", "f", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("f")
 rebuilt        : ReferenceId(0): None
@@ -41125,20 +35293,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I2", "I3", "e1", "e2", "i2", "i3", "r1", "r2"]
 rebuilt        : ScopeId(0): ["e1", "e2", "i2", "i3", "r1", "r2"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C0", "C1", "Context", "I", "L", "N", "arrayOfConstCall", "asyncFuncReturnConstCall", "asyncFuncReturnLetCall", "asyncFuncReturnVarCall", "asyncGenFuncYieldConstCall", "asyncGenFuncYieldLetCall", "asyncGenFuncYieldVarCall", "c", "ce0", "constCall", "constInitToCReadonlyCall", "constInitToCReadonlyCallWithIndexedAccess", "constInitToCReadonlyCallWithTypeQuery", "constInitToCReadonlyStaticCall", "constInitToCReadonlyStaticCallWithTypeQuery", "constInitToCReadonlyStaticType", "constInitToCReadonlyStaticTypeAndCall", "constInitToCReadonlyStaticTypeAndCallWithTypeQuery", "constInitToCReadonlyStaticTypeWithTypeQuery", "constInitToCReadwriteCall", "constInitToCReadwriteCallWithIndexedAccess", "constInitToCReadwriteCallWithTypeQuery", "constInitToCReadwriteStaticCall", "constInitToCReadwriteStaticCallWithTypeQuery", "constInitToConstCall", "constInitToConstCallWithTypeQuery", "constInitToConstDeclAmbient", "constInitToConstDeclAmbientWithTypeQuery", "constInitToIReadonlyType", "constInitToIReadonlyTypeWithIndexedAccess", "constInitToIReadonlyTypeWithTypeQuery", "constInitToLReadonlyNestedType", "constInitToLReadonlyNestedTypeWithIndexedAccess", "constInitToLReadonlyNestedTypeWithTypeQuery", "constInitToLReadonlyType", "constInitToLReadonlyTypeWithIndexedAccess", "constInitToLReadonlyTypeWithTypeQuery", "constInitToLetCall", "constInitToVarCall", "constType", "constTypeAndCall", "fromAny", "funcInferredReturnType", "funcReturnConstCall", "funcReturnConstCallWithTypeQuery", "funcReturnLetCall", "funcReturnVarCall", "genFuncYieldConstCall", "genFuncYieldConstCallWithTypeQuery", "genFuncYieldLetCall", "genFuncYieldVarCall", "i", "l", "letCall", "letInitToConstCall", "letInitToConstDeclAmbient", "letInitToLetCall", "letInitToVarCall", "o", "o2", "o3", "o4", "promiseForConstCall", "s", "varCall", "varInitToConstCall", "varInitToConstDeclAmbient", "varInitToLetCall", "varInitToVarCall"]
 rebuilt        : ScopeId(0): ["C", "C0", "C1", "arrayOfConstCall", "asyncFuncReturnConstCall", "asyncFuncReturnLetCall", "asyncFuncReturnVarCall", "asyncGenFuncYieldConstCall", "asyncGenFuncYieldLetCall", "asyncGenFuncYieldVarCall", "ce0", "constCall", "constInitToCReadonlyCall", "constInitToCReadonlyCallWithIndexedAccess", "constInitToCReadonlyCallWithTypeQuery", "constInitToCReadonlyStaticCall", "constInitToCReadonlyStaticCallWithTypeQuery", "constInitToCReadonlyStaticType", "constInitToCReadonlyStaticTypeAndCall", "constInitToCReadonlyStaticTypeAndCallWithTypeQuery", "constInitToCReadonlyStaticTypeWithTypeQuery", "constInitToCReadwriteCall", "constInitToCReadwriteCallWithIndexedAccess", "constInitToCReadwriteCallWithTypeQuery", "constInitToCReadwriteStaticCall", "constInitToCReadwriteStaticCallWithTypeQuery", "constInitToConstCall", "constInitToConstCallWithTypeQuery", "constInitToConstDeclAmbient", "constInitToConstDeclAmbientWithTypeQuery", "constInitToIReadonlyType", "constInitToIReadonlyTypeWithIndexedAccess", "constInitToIReadonlyTypeWithTypeQuery", "constInitToLReadonlyNestedType", "constInitToLReadonlyNestedTypeWithIndexedAccess", "constInitToLReadonlyNestedTypeWithTypeQuery", "constInitToLReadonlyType", "constInitToLReadonlyTypeWithIndexedAccess", "constInitToLReadonlyTypeWithTypeQuery", "constInitToLetCall", "constInitToVarCall", "constTypeAndCall", "fromAny", "funcInferredReturnType", "funcReturnConstCall", "funcReturnConstCallWithTypeQuery", "funcReturnLetCall", "funcReturnVarCall", "genFuncYieldConstCall", "genFuncYieldConstCallWithTypeQuery", "genFuncYieldLetCall", "genFuncYieldVarCall", "letCall", "letInitToConstCall", "letInitToConstDeclAmbient", "letInitToLetCall", "letInitToVarCall", "o2", "o3", "o4", "promiseForConstCall", "varCall", "varInitToConstCall", "varInitToConstDeclAmbient", "varInitToLetCall", "varInitToVarCall"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(33), ScopeId(34), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(50)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(38)]
-Scope children mismatch:
-after transform: ScopeId(50): [ScopeId(51)]
-rebuilt        : ScopeId(38): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(34), ReferenceId(83), ReferenceId(84)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(18), ReferenceId(21), ReferenceId(22), ReferenceId(25), ReferenceId(26), ReferenceId(29), ReferenceId(61), ReferenceId(62)]

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 12619ffe
 
-Passed: 282/953
+Passed: 287/953
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -1965,7 +1965,7 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 
-# babel-plugin-transform-typescript (40/151)
+# babel-plugin-transform-typescript (45/151)
 * cast/as-expression/input.ts
   x Unresolved references mismatch:
   | after transform: ["T", "x"]
@@ -2010,26 +2010,9 @@ failed to resolve query: failed to parse the rest of input: ...''
   | rebuilt        : ["D"]
 
 
-* class/methods/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4),
-  | ScopeId(5)]
-  | rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-
-
-* class/private-method-override/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-  | rebuilt        : ScopeId(1): [ScopeId(2)]
-
-
 * declarations/const-enum/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["E"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
   | rebuilt        : ScopeId(0): []
 
 
@@ -2038,29 +2021,16 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["E", "I", "M", "N", "T", "m", "x"]
   | rebuilt        : ScopeId(0): []
 
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-  | rebuilt        : ScopeId(0): []
-
 
 * declarations/export-declare-enum/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["A"]
   | rebuilt        : ScopeId(0): []
 
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
 
 * declarations/nested-namespace/input.mjs
   x Bindings mismatch:
   | after transform: ScopeId(0): ["P"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
   | rebuilt        : ScopeId(0): []
 
 
@@ -2435,10 +2405,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * exports/declare-namespace/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
   x Symbol flags mismatch:
   | after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule
   | | Ambient)
@@ -2454,11 +2420,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * exports/declare-shadowed/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-
   x Unresolved references mismatch:
   | after transform: ["Signal", "Signal2"]
   | rebuilt        : []
@@ -2470,14 +2431,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["AA", "AA2", "BB", "BB2", "Bar", "C2", "E",
   | "I", "II2", "II3", "M", "N", "T", "foo", "m", "x"]
   | rebuilt        : ScopeId(0): ["BB", "BB2", "C2", "foo"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9),
-  | ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14),
-  | ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(4), ScopeId(5)]
 
   x Bindings mismatch:
   | after transform: ScopeId(12): ["BB", "K"]
@@ -2548,12 +2501,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | rebuilt        : ["Bar", "E", "x"]
 
 
-* exports/default-function/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
-
 * exports/export-const-enums/input.ts
   x Scope flags mismatch:
   | after transform: ScopeId(1): ScopeFlags(StrictMode)
@@ -2582,10 +2529,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 * exports/export-type/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["A"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
   | rebuilt        : ScopeId(0): []
 
 
@@ -2617,19 +2560,11 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["A", "I"]
   | rebuilt        : ScopeId(0): []
 
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
 
 * exports/issue-9916-1/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
   | rebuilt        : ScopeId(0): ["a"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
 
   x Unresolved references mismatch:
   | after transform: ["PromiseLike"]
@@ -2639,10 +2574,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 * exports/issue-9916-2/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
   | rebuilt        : ScopeId(0): []
 
   x Unresolved references mismatch:
@@ -2655,10 +2586,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
   | rebuilt        : ScopeId(0): ["a"]
 
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
   x Unresolved references mismatch:
   | after transform: ["PromiseLike"]
   | rebuilt        : []
@@ -2668,18 +2595,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   x Symbol reference IDs mismatch:
   | after transform: SymbolId(0): [ReferenceId(0)]
   | rebuilt        : SymbolId(0): []
-
-
-* function/overloads/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
-
-
-* function/overloads-exports/input.mjs
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
 
 
 * function/parameters/input.ts
@@ -2754,10 +2669,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["A", "B", "C", "Class", "D", "E", "F", "G",
   | "H", "Iface", "x", "y"]
   | rebuilt        : ScopeId(0): ["A", "Class", "x", "y"]
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): [ScopeId(1)]
 
 
 * imports/elision-qualifiedname/input.ts
@@ -4416,10 +4327,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["Platform"]
   | rebuilt        : ScopeId(0): []
 
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
   x Unresolved references mismatch:
   | after transform: ["Platform"]
   | rebuilt        : []
@@ -5579,10 +5486,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   x Output mismatch
   x Bindings mismatch:
   | after transform: ScopeId(0): ["A"]
-  | rebuilt        : ScopeId(0): []
-
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
   | rebuilt        : ScopeId(0): []
 
   x Reference symbol mismatch:

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -45,10 +45,6 @@ Passed: 10/36
   | after transform: ScopeId(0): ["A", "ReactiveMarkerSymbol"]
   | rebuilt        : ScopeId(0): []
 
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): []
-
 
 * enum-member-reference/input.ts
   x Semantic Collector failed after transform
@@ -101,10 +97,6 @@ Passed: 10/36
 
 
 * redeclarations/input.ts
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-  | rebuilt        : ScopeId(0): []
-
   x Symbol flags mismatch:
   | after transform: SymbolId(0): SymbolFlags(BlockScopedVariable |
   | ConstVariable | Export | Import)
@@ -454,10 +446,6 @@ Passed: 10/36
 
 
 * refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-
   x Bindings mismatch:
   | after transform: No scope
   | rebuilt        : ScopeId(3): []
@@ -496,11 +484,6 @@ Passed: 10/36
 
 
 * refresh/includes-custom-hooks-into-the-signatures/input.jsx
-  x Scope children mismatch:
-  | after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
-  | rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3),
-  | ScopeId(5), ScopeId(6)]
-
   x Bindings mismatch:
   | after transform: No scope
   | rebuilt        : ScopeId(2): []


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/5244