### PR TITLE
refactor(semantic): transform checker continue checks if missing IDs

### DIFF
--- a/tasks/coverage/semantic_babel.snap
+++ b/tasks/coverage/semantic_babel.snap
@@ -649,12 +649,20 @@ after transform: SymbolId(3): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/nested-same-name/input.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N
+semantic error: Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/annotated/input.ts
 semantic error: Bindings mismatch:
@@ -696,12 +704,16 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/dec
 semantic error: A required parameter cannot follow an optional parameter.
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals/input.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals-in-unambiguous/input.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/equals-require/input.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -712,8 +724,10 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import/input.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/export-import-require/input.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -977,11 +991,16 @@ after transform: ScopeId(0): ["Comma", "Newline", "Semi"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body/input.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N
+semantic error: Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-declare/input.ts
 semantic error: Bindings mismatch:
@@ -1262,8 +1281,16 @@ after transform: ScopeId(0): ["Something"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-equals-var/input.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: a
+semantic error: Missing SymbolId: a
+Bindings mismatch:
+after transform: ScopeId(0): ["M", "a"]
+rebuilt        : ScopeId(0): ["a"]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Import)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(1): Span { start: 20, end: 21 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-let/input.ts
 semantic error: Symbol flags mismatch:

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -149,8 +149,13 @@ after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): ["B", "C"]
 
 tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: r
+semantic error: Missing SymbolId: r
+Bindings mismatch:
+after transform: ScopeId(0): ["M", "r"]
+rebuilt        : ScopeId(0): ["r"]
+Unresolved references mismatch:
+after transform: ["M", "N"]
+rebuilt        : ["M"]
 
 tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
 semantic error: Symbol reference IDs mismatch:
@@ -225,11 +230,22 @@ after transform: ScopeId(0): ["x"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: D
+semantic error: Missing SymbolId: D
 Missing SymbolId: _D
 Missing ReferenceId: D
 Missing ReferenceId: D
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("D")
+rebuilt        : ReferenceId(2): Some("D")
+Unresolved references mismatch:
+after transform: ["A", "C"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
 semantic error: Bindings mismatch:
@@ -336,13 +352,30 @@ after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("M")
+rebuilt        : ReferenceId(6): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 semantic error: Bindings mismatch:
@@ -383,13 +416,27 @@ after transform: ["Array", "use"]
 rebuilt        : ["use"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Test
+semantic error: Missing SymbolId: Test
 Missing SymbolId: _Test
 Missing ReferenceId: _Test
 Missing ReferenceId: Bug
 Missing ReferenceId: Test
 Missing ReferenceId: Test
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Bug", "ILineTokens", "IMode", "IState", "IToken", "_Test"]
+rebuilt        : ScopeId(1): ["Bug", "_Test"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
 semantic error: Bindings mismatch:
@@ -397,8 +444,7 @@ after transform: ScopeId(0): ["Array", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: EmptyTypes
+semantic error: Missing SymbolId: EmptyTypes
 Missing SymbolId: _EmptyTypes
 Missing ReferenceId: EmptyTypes
 Missing ReferenceId: EmptyTypes
@@ -406,6 +452,27 @@ Missing SymbolId: NonEmptyTypes
 Missing SymbolId: _NonEmptyTypes
 Missing ReferenceId: NonEmptyTypes
 Missing ReferenceId: NonEmptyTypes
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(28)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(22)]
+Bindings mismatch:
+after transform: ScopeId(1): ["_EmptyTypes", "base", "base2", "derived", "f", "iface"]
+rebuilt        : ScopeId(1): ["_EmptyTypes", "base", "base2", "derived", "f"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(12): ["_NonEmptyTypes", "base", "base2", "derived", "f", "iface"]
+rebuilt        : ScopeId(8): ["_NonEmptyTypes", "base", "base2", "derived", "f"]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(23)]
+rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(17)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(30): [ReferenceId(39), ReferenceId(46), ReferenceId(48), ReferenceId(49), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(60)]
+rebuilt        : SymbolId(24): [ReferenceId(33), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(50)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
 semantic error: Unresolved references mismatch:
@@ -487,11 +554,19 @@ after transform: ScopeId(0): ["IOptions", "parser"]
 rebuilt        : ScopeId(0): ["parser"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInExpressionStatement2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1)]
+rebuilt        : ScopeId(1): [SymbolId(1)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
 semantic error: Bindings mismatch:
@@ -563,11 +638,19 @@ after transform: ["assertEqual", "const", "true"]
 rebuilt        : ["assertEqual"]
 
 tasks/coverage/typescript/tests/cases/compiler/assign1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["I", "_M", "x"]
+rebuilt        : ScopeId(1): ["_M", "x"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
 semantic error: Symbol reference IDs mismatch:
@@ -978,13 +1061,33 @@ after transform: ["Pick", "pick"]
 rebuilt        : ["pick"]
 
 tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Test
+semantic error: Missing SymbolId: Test
 Missing SymbolId: _Test
 Missing ReferenceId: _Test
 Missing ReferenceId: Bug
 Missing ReferenceId: Test
 Missing ReferenceId: Test
+Bindings mismatch:
+after transform: ScopeId(0): ["Test", "console"]
+rebuilt        : ScopeId(0): ["Test"]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("console")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
 semantic error: Unresolved references mismatch:
@@ -992,13 +1095,24 @@ after transform: ["C"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: C
+semantic error: Missing SymbolId: C
 Missing SymbolId: _C
 Missing ReferenceId: _C
 Missing ReferenceId: Name
 Missing ReferenceId: C
 Missing ReferenceId: C
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/bom-utf16be.ts
 semantic error: Invalid Character `￾`
@@ -1183,13 +1297,24 @@ after transform: ["Date", "RegExp"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m
+semantic error: Missing SymbolId: m
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: foo
 Missing ReferenceId: m
 Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/chainedSpecializationToObjectTypeLiteral.ts
 semantic error: Bindings mismatch:
@@ -1263,12 +1388,32 @@ after transform: ["Capitalize", "foo2"]
 rebuilt        : ["foo2"]
 
 tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _maker
+semantic error: Missing SymbolId: _maker
 Missing ReferenceId: _maker
 Missing ReferenceId: Bar
 Missing ReferenceId: maker
 Missing ReferenceId: maker
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 121, end: 126 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
 semantic error: Bindings mismatch:
@@ -1358,13 +1503,30 @@ after transform: []
 rebuilt        : ["Err"]
 
 tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("M")
+rebuilt        : ReferenceId(2): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 semantic error: Bindings mismatch:
@@ -1404,11 +1566,22 @@ after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M2
+semantic error: Missing SymbolId: M2
 Missing SymbolId: _M2
 Missing ReferenceId: M2
 Missing ReferenceId: M2
+Bindings mismatch:
+after transform: ScopeId(0): ["M1", "M2"]
+rebuilt        : ScopeId(0): ["M2"]
+Bindings mismatch:
+after transform: ScopeId(4): ["C", "T", "_M2"]
+rebuilt        : ScopeId(1): ["C", "_M2"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Unresolved references mismatch:
+after transform: ["M1"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
 semantic error: Bindings mismatch:
@@ -1473,45 +1646,178 @@ after transform: SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(4), R
 rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(9)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(8): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 41, end: 42 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol span mismatch:
+after transform: SymbolId(2): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(3): Span { start: 77, end: 78 }
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 77, end: 78 }]
+rebuilt        : SymbolId(3): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol span mismatch:
+after transform: SymbolId(3): Span { start: 96, end: 99 }
+rebuilt        : SymbolId(4): Span { start: 129, end: 132 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0)]
+rebuilt        : SymbolId(4): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(3): [Span { start: 129, end: 132 }]
+rebuilt        : SymbolId(4): []
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol redeclarations mismatch:
+after transform: SymbolId(6): [Span { start: 197, end: 200 }]
+rebuilt        : SymbolId(5): []
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Foo
+semantic error: Missing SymbolId: _Foo
 Missing ReferenceId: _Foo
 Missing ReferenceId: Baz
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["Bar", "Baz", "_Foo"]
+rebuilt        : ScopeId(3): ["Baz", "_Foo"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 63, end: 66 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Service
+semantic error: Missing SymbolId: _Service
 Missing ReferenceId: _Service
 Missing ReferenceId: Service
 Missing ReferenceId: Service
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(3): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 108, end: 115 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _$
+semantic error: Missing SymbolId: _$
 Missing ReferenceId: _$
 Missing ReferenceId: ajax
 Missing ReferenceId: $
 Missing ReferenceId: $
+Bindings mismatch:
+after transform: ScopeId(0): ["$", "it"]
+rebuilt        : ScopeId(0): ["it"]
+Bindings mismatch:
+after transform: ScopeId(4): ["AjaxSettings", "_$", "ajax"]
+rebuilt        : ScopeId(1): ["_$", "ajax"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(1): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("$")
+rebuilt        : ReferenceId(4): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["$"]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Moclodule2
+semantic error: Missing SymbolId: _Moclodule2
 Missing ReferenceId: _Moclodule2
 Missing ReferenceId: Manager
 Missing ReferenceId: Moclodule
 Missing ReferenceId: Moclodule
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 47, end: 56 }
+rebuilt        : SymbolId(0): Span { start: 132, end: 141 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 132, end: 141 }, Span { start: 178, end: 187 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -1666,18 +1972,34 @@ tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithConstru
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithEnumMemberConflict.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["e", "m1", "m2"]
+rebuilt        : ScopeId(2): ["e"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberClassConflict.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: m1
@@ -1691,15 +2013,74 @@ Missing ReferenceId: _m3
 Missing ReferenceId: _m2
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(7): [ReferenceId(8)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("m1")
+rebuilt        : ReferenceId(4): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m2")
+rebuilt        : ReferenceId(11): Some("m2")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("m2")
+rebuilt        : ReferenceId(12): Some("m2")
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: m2
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Bindings mismatch:
+after transform: ScopeId(1): ["_m", "m1", "m2"]
+rebuilt        : ScopeId(1): ["_m", "m2"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m1")
+rebuilt        : ReferenceId(4): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberVariable.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -1714,22 +2095,56 @@ tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleR
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithPrivateMember.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: c1
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m1")
+rebuilt        : ReferenceId(5): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithUnicodeNames.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: 才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd123
+semantic error: Missing SymbolId: 才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd123
 Missing SymbolId: _才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd
 Missing ReferenceId: _才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd
 Missing ReferenceId: 才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd123
 Missing ReferenceId: 才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd123
 Missing ReferenceId: 才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र्क्ड्राüışğİliيونيكودöÄüßAbcd123
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123")
+rebuilt        : ReferenceId(4): Some("才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123")
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
 semantic error: Bindings mismatch:
@@ -1742,36 +2157,64 @@ after transform: ScopeId(0): ["exports", "m1", "m2", "require"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m2
+semantic error: Missing SymbolId: m2
 Missing SymbolId: _m
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Bindings mismatch:
+after transform: ScopeId(0): ["m1", "m2"]
+rebuilt        : ScopeId(0): ["m2"]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunctionInGlobalFile.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m4
+semantic error: Missing SymbolId: m4
 Missing SymbolId: _m
 Missing ReferenceId: m4
 Missing ReferenceId: m4
+Bindings mismatch:
+after transform: ScopeId(0): ["m3", "m4"]
+rebuilt        : ScopeId(0): ["m4"]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m2
+semantic error: Missing SymbolId: m2
 Missing SymbolId: _m
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Bindings mismatch:
+after transform: ScopeId(0): ["exports", "foo", "foo2", "m1", "m2", "require"]
+rebuilt        : ScopeId(0): ["foo", "foo2", "m2"]
+Bindings mismatch:
+after transform: ScopeId(16): ["_m", "a", "exports", "require"]
+rebuilt        : ScopeId(3): ["_m", "a"]
+Unresolved references mismatch:
+after transform: ["exports", "require"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m2
+semantic error: Missing SymbolId: m2
 Missing SymbolId: _m
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Bindings mismatch:
+after transform: ScopeId(0): ["exports", "m1", "m2", "require"]
+rebuilt        : ScopeId(0): ["m2"]
+Bindings mismatch:
+after transform: ScopeId(2): ["_m", "a", "exports", "require"]
+rebuilt        : ScopeId(1): ["_m", "a"]
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunctionInGlobalFile.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m3
+semantic error: Missing SymbolId: m3
 Missing SymbolId: _m
 Missing ReferenceId: m3
 Missing ReferenceId: m3
@@ -1783,10 +2226,36 @@ Missing ReferenceId: _m2
 Missing ReferenceId: require
 Missing ReferenceId: m4
 Missing ReferenceId: m4
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(9)]
+rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(8): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(9): [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAliasInGlobalFile.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: mOfGloalFile
+semantic error: Missing SymbolId: mOfGloalFile
 Missing SymbolId: _mOfGloalFile
 Missing ReferenceId: _mOfGloalFile
 Missing ReferenceId: c
@@ -1802,6 +2271,57 @@ Missing SymbolId: m2
 Missing SymbolId: _m2
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["_m", "exports", "require"]
+rebuilt        : ScopeId(3): ["_m"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["_m2", "exports", "require"]
+rebuilt        : ScopeId(4): ["_m2"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("mOfGloalFile")
+rebuilt        : ReferenceId(4): Some("mOfGloalFile")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("mOfGloalFile")
+rebuilt        : ReferenceId(5): Some("mOfGloalFile")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("exports")
+rebuilt        : ReferenceId(6): Some("exports")
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("require")
+rebuilt        : ReferenceId(7): Some("require")
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("exports")
+rebuilt        : ReferenceId(8): Some("exports")
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("require")
+rebuilt        : ReferenceId(9): Some("require")
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("exports")
+rebuilt        : ReferenceId(12): Some("exports")
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("require")
+rebuilt        : ReferenceId(13): Some("require")
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninstantiatedModule.ts
 semantic error: Bindings mismatch:
@@ -1858,11 +2378,19 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _this
+semantic error: Missing SymbolId: _this
 Missing SymbolId: _this2
 Missing ReferenceId: _this
 Missing ReferenceId: _this
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 semantic error: Bindings mismatch:
@@ -1879,11 +2407,19 @@ after transform: []
 rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: foo
+semantic error: Missing SymbolId: foo
 Missing SymbolId: _foo
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Bindings mismatch:
+after transform: ScopeId(0): ["empty", "f", "foo"]
+rebuilt        : ScopeId(0): ["f", "foo"]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
 semantic error: Unresolved reference IDs mismatch for "Promise":
@@ -1896,8 +2432,7 @@ after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: hello
+semantic error: Missing SymbolId: hello
 Missing SymbolId: _hello
 Missing SymbolId: hi
 Missing SymbolId: _hi
@@ -1913,6 +2448,27 @@ Missing ReferenceId: _hello
 Missing ReferenceId: _hello
 Missing ReferenceId: hello
 Missing ReferenceId: hello
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(6)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientClass1.ts
 semantic error: Unresolved references mismatch:
@@ -2050,29 +2606,79 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString.ts
-semantic error: Semantic Collector failed after transform
-Missing ReferenceId: Foo
+semantic error: Missing ReferenceId: Foo
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "C", "F", "Foo", "G", "H", "I", "J"]
+rebuilt        : ScopeId(1): ["Foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(10), ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21)]
+rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17)]
 
 tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString2.ts
-semantic error: Semantic Collector failed after transform
+semantic error: Missing ReferenceId: Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
-Missing ReferenceId: Foo
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "C", "D", "E1", "E2", "F", "Foo", "G", "H", "I", "J"]
+rebuilt        : ScopeId(1): ["Foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(10)]
+rebuilt        : SymbolId(0): [ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(21), ReferenceId(26)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): [ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31)]
+rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(27), ReferenceId(28)]
 
 tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: NS
+semantic error: Missing SymbolId: NS
 Missing SymbolId: _NS
 Missing ReferenceId: _NS
 Missing ReferenceId: NS
 Missing ReferenceId: NS
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("NS")
+rebuilt        : ReferenceId(2): Some("NS")
 
 tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
 semantic error: Bindings mismatch:
@@ -2230,39 +2836,154 @@ semantic error: `export = <value>;` is only supported when compiling modules to 
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _foo
+semantic error: Missing SymbolId: _foo
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["E", "X"]
+rebuilt        : ScopeId(3): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 25, end: 28 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _foo
+semantic error: Missing SymbolId: _foo
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["E", "X"]
+rebuilt        : ScopeId(3): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 20, end: 23 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues3.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _foo
+semantic error: Missing SymbolId: _foo
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "foo"]
+rebuilt        : ScopeId(1): ["foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["E", "X"]
+rebuilt        : ScopeId(3): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(8)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 22, end: 25 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues4.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: foo
+semantic error: Missing SymbolId: foo
 Missing SymbolId: _foo
 Missing ReferenceId: foo
 Missing ReferenceId: foo
 Missing SymbolId: _foo2
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["E", "X"]
+rebuilt        : ScopeId(2): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues5.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: foo
+semantic error: Missing SymbolId: foo
 Missing SymbolId: _foo
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["E", "X"]
+rebuilt        : ScopeId(2): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport.ts
 semantic error: Bindings mismatch:
@@ -2276,13 +2997,30 @@ after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: ConstEnumOnlyModule
+semantic error: Missing SymbolId: ConstEnumOnlyModule
 Missing SymbolId: _ConstEnumOnlyModule
 Missing ReferenceId: _ConstEnumOnlyModule
 Missing ReferenceId: ConstFooEnum
 Missing ReferenceId: ConstEnumOnlyModule
 Missing ReferenceId: ConstEnumOnlyModule
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(2): ["ConstFooEnum", "Here", "Some", "Values"]
+rebuilt        : ScopeId(2): ["ConstFooEnum"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumNoEmitReexport.ts
 semantic error: Bindings mismatch:
@@ -2371,8 +3109,7 @@ after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnums.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -2451,6 +3188,228 @@ Missing ReferenceId: A2
 Missing SymbolId: I
 Missing SymbolId: I1
 Missing SymbolId: I2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(31), SymbolId(39), SymbolId(50), SymbolId(56), SymbolId(63), SymbolId(64), SymbolId(65), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(74), SymbolId(76)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5), SymbolId(19), SymbolId(26), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(40), SymbolId(42), SymbolId(44), SymbolId(46), SymbolId(48)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A0", "Enum1"]
+rebuilt        : ScopeId(1): ["Enum1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "C", "D", "E", "Enum1", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "PQ", "Q", "R", "S", "T", "U", "V", "W", "W1", "W2", "W3", "W4", "W5"]
+rebuilt        : ScopeId(2): ["Enum1"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["#", "*/", "-->", "/*", "//", "///", "<!--", "Comments"]
+rebuilt        : ScopeId(3): ["Comments"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(40), SymbolId(78)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(41), SymbolId(79)]
+rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(42), SymbolId(80)]
+rebuilt        : ScopeId(6): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["E", "V1", "V2"]
+rebuilt        : ScopeId(7): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(45), SymbolId(81)]
+rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(46), SymbolId(82)]
+rebuilt        : ScopeId(9): [SymbolId(15), SymbolId(16)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(10): ["E", "_C2"]
+rebuilt        : ScopeId(10): ["_C2"]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(11): ["E", "V3", "V4"]
+rebuilt        : ScopeId(11): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(0x0)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(51), SymbolId(84)]
+rebuilt        : ScopeId(12): [SymbolId(20), SymbolId(21)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(52), SymbolId(85)]
+rebuilt        : ScopeId(13): [SymbolId(22), SymbolId(23)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(14): ["E", "_C3"]
+rebuilt        : ScopeId(14): ["_C3"]
+Scope flags mismatch:
+after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(15): ["E", "V1", "V2"]
+rebuilt        : ScopeId(15): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(0x0)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(16): [SymbolId(57), SymbolId(87)]
+rebuilt        : ScopeId(16): [SymbolId(27), SymbolId(28)]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(16): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(17): [SymbolId(58), SymbolId(88)]
+rebuilt        : ScopeId(17): [SymbolId(29), SymbolId(30)]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(18): ["E", "_C4"]
+rebuilt        : ScopeId(18): ["_C4"]
+Scope flags mismatch:
+after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(18): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(19): ["E", "V1", "V2"]
+rebuilt        : ScopeId(19): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(0x0)
+rebuilt        : ScopeId(19): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(20): [SymbolId(62), SymbolId(90)]
+rebuilt        : ScopeId(20): [SymbolId(33), SymbolId(34)]
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(20): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(23), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(50), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(97), ReferenceId(157), ReferenceId(158)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(67), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 46, end: 51 }]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(92): [ReferenceId(98), ReferenceId(99), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156)]
+rebuilt        : SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66)]
+Symbol flags mismatch:
+after transform: SymbolId(31): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(31): [ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(174)]
+rebuilt        : SymbolId(3): [ReferenceId(83), ReferenceId(214), ReferenceId(215), ReferenceId(216), ReferenceId(217), ReferenceId(218), ReferenceId(219), ReferenceId(220)]
+Symbol flags mismatch:
+after transform: SymbolId(42): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(42): []
+rebuilt        : SymbolId(11): [ReferenceId(91)]
+Reference symbol mismatch:
+after transform: ReferenceId(23): Some("Enum1")
+rebuilt        : ReferenceId(53): Some("Enum1")
+Reference symbol mismatch:
+after transform: ReferenceId(27): Some("Enum1")
+rebuilt        : ReferenceId(62): Some("Enum1")
+Reference symbol mismatch:
+after transform: ReferenceId(28): Some("Enum1")
+rebuilt        : ReferenceId(65): Some("Enum1")
+Reference symbol mismatch:
+after transform: ReferenceId(29): Some("A")
+rebuilt        : ReferenceId(88): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(186): Some("E")
+rebuilt        : ReferenceId(102): None
+Reference symbol mismatch:
+after transform: ReferenceId(30): Some("A")
+rebuilt        : ReferenceId(105): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(31): Some("A")
+rebuilt        : ReferenceId(108): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(185): Some("E")
+rebuilt        : ReferenceId(110): None
+Reference symbol mismatch:
+after transform: ReferenceId(193): Some("E")
+rebuilt        : ReferenceId(123): None
+Reference symbol mismatch:
+after transform: ReferenceId(192): Some("E")
+rebuilt        : ReferenceId(129): None
+Reference symbol mismatch:
+after transform: ReferenceId(200): Some("E")
+rebuilt        : ReferenceId(142): None
+Reference symbol mismatch:
+after transform: ReferenceId(199): Some("E")
+rebuilt        : ReferenceId(148): None
+Reference symbol mismatch:
+after transform: ReferenceId(32): Some("A")
+rebuilt        : ReferenceId(165): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(33): Some("A1")
+rebuilt        : ReferenceId(166): Some("A1")
+Reference symbol mismatch:
+after transform: ReferenceId(34): Some("A2")
+rebuilt        : ReferenceId(167): Some("A2")
+Reference symbol mismatch:
+after transform: ReferenceId(37): Some("I")
+rebuilt        : ReferenceId(169): Some("I")
+Reference symbol mismatch:
+after transform: ReferenceId(39): Some("I")
+rebuilt        : ReferenceId(171): Some("I")
+Reference symbol mismatch:
+after transform: ReferenceId(42): Some("I1")
+rebuilt        : ReferenceId(173): Some("I1")
+Reference symbol mismatch:
+after transform: ReferenceId(44): Some("I1")
+rebuilt        : ReferenceId(175): Some("I1")
+Reference symbol mismatch:
+after transform: ReferenceId(47): Some("I2")
+rebuilt        : ReferenceId(177): Some("I2")
+Reference symbol mismatch:
+after transform: ReferenceId(49): Some("I2")
+rebuilt        : ReferenceId(179): Some("I2")
+Reference symbol mismatch:
+after transform: ReferenceId(82): Some("A")
+rebuilt        : ReferenceId(210): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(83): Some("A")
+rebuilt        : ReferenceId(211): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(84): Some("A")
+rebuilt        : ReferenceId(212): Some("A")
+Unresolved references mismatch:
+after transform: ["A", "A0"]
+rebuilt        : ["E"]
 
 tasks/coverage/typescript/tests/cases/compiler/constIndexedAccess.ts
 semantic error: Bindings mismatch:
@@ -2561,8 +3520,7 @@ after transform: ScopeId(1): ["T", "U", "V"]
 rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/constructorArgWithGenericCallSignature.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Test
+semantic error: Missing SymbolId: Test
 Missing SymbolId: _Test
 Missing ReferenceId: _Test
 Missing ReferenceId: MyClass
@@ -2570,6 +3528,36 @@ Missing ReferenceId: _Test
 Missing ReferenceId: F
 Missing ReferenceId: Test
 Missing ReferenceId: Test
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(7), SymbolId(8)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(7)]
+Bindings mismatch:
+after transform: ScopeId(1): ["F", "MyClass", "MyFunc", "_Test"]
+rebuilt        : ScopeId(1): ["F", "MyClass", "_Test"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("Test")
+rebuilt        : ReferenceId(6): Some("Test")
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("Test")
+rebuilt        : ReferenceId(8): Some("Test")
+Unresolved references mismatch:
+after transform: ["Test"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
 semantic error: Bindings mismatch:
@@ -3170,8 +4158,7 @@ after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5)
 rebuilt        : [ReferenceId(0), ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: XX
@@ -3179,6 +4166,27 @@ Missing ReferenceId: _M
 Missing ReferenceId: f
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["X", "XX", "Y", "_M", "a", "b", "f"]
+rebuilt        : ScopeId(1): ["XX", "_M", "a", "b", "f"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(6)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(4), ReferenceId(7)]
+rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyName.ts
 semantic error: Bindings mismatch:
@@ -3302,8 +4310,13 @@ after transform: ScopeId(0): ["./a"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: ab
+semantic error: Missing SymbolId: ab
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "D", "E", "ab"]
+rebuilt        : ScopeId(0): ["D", "E", "ab"]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("ab")
+rebuilt        : ReferenceId(1): Some("ab")
 
 tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
 semantic error: Bindings mismatch:
@@ -4051,8 +5064,7 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -4070,6 +5082,36 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("A")
+rebuilt        : ReferenceId(12): Some("A")
 
 tasks/coverage/typescript/tests/cases/compiler/dottedSymbolResolution1.ts
 semantic error: Bindings mismatch:
@@ -4094,8 +5136,7 @@ after transform: SymbolId(1): [ReferenceId(3), ReferenceId(10)]
 rebuilt        : SymbolId(0): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Foo
+semantic error: Missing SymbolId: _Foo
 Missing ReferenceId: _Foo
 Missing ReferenceId: ___call
 Missing ReferenceId: Foo
@@ -4105,6 +5146,54 @@ Missing ReferenceId: _Bar
 Missing ReferenceId: __call
 Missing ReferenceId: Bar
 Missing ReferenceId: Bar
+Bindings mismatch:
+after transform: ScopeId(1): ["(Anonymous class)", "(Anonymous function)", "Foo", "__a", "__call"]
+rebuilt        : ScopeId(1): ["Foo"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(5), SymbolId(9)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(10)]
+rebuilt        : ScopeId(5): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(9)]
+rebuilt        : SymbolId(0): [ReferenceId(9), ReferenceId(12), ReferenceId(13)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 117, end: 120 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(3): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(4): [ReferenceId(16), ReferenceId(17)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(6): [Span { start: 235, end: 238 }]
+rebuilt        : SymbolId(4): []
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
 semantic error: Bindings mismatch:
@@ -4139,8 +5228,7 @@ tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousModuleClasses.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: F
+semantic error: Missing SymbolId: F
 Missing SymbolId: _F
 Missing ReferenceId: F
 Missing ReferenceId: F
@@ -4165,6 +5253,51 @@ Missing ReferenceId: Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Gar
 Missing ReferenceId: Gar
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(10)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(11)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(12)]
+rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(5), SymbolId(13)]
+rebuilt        : ScopeId(7): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(7), SymbolId(14)]
+rebuilt        : ScopeId(9): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(8), SymbolId(15)]
+rebuilt        : ScopeId(10): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(9), SymbolId(16)]
+rebuilt        : ScopeId(12): [SymbolId(15), SymbolId(16)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature.ts
 semantic error: Bindings mismatch:
@@ -4182,13 +5315,24 @@ after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierShouldNotShortCircuitBaseTypeBinding.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Shapes
+semantic error: Missing SymbolId: Shapes
 Missing SymbolId: _Shapes
 Missing ReferenceId: _Shapes
 Missing ReferenceId: Point
 Missing ReferenceId: Shapes
 Missing ReferenceId: Shapes
+Bindings mismatch:
+after transform: ScopeId(0): ["IPoint", "Shapes"]
+rebuilt        : ScopeId(0): ["Shapes"]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
 semantic error: Bindings mismatch:
@@ -4211,15 +5355,31 @@ after transform: ScopeId(0): ["Foo", "a", "o"]
 rebuilt        : ScopeId(0): ["a", "o"]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: a
+semantic error: Missing SymbolId: a
+Bindings mismatch:
+after transform: ScopeId(0): ["M", "a"]
+rebuilt        : ScopeId(0): ["a"]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Import)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 73, end: 74 }]
+rebuilt        : SymbolId(0): [Span { start: 0, end: 0 }]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 semantic error: 'with' statements are not allowed
@@ -4276,8 +5436,7 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Microsoft
+semantic error: Missing SymbolId: Microsoft
 Missing SymbolId: _Microsoft
 Missing SymbolId: PeopleAtWork
 Missing SymbolId: _PeopleAtWork
@@ -4295,6 +5454,27 @@ Missing ReferenceId: _Microsoft
 Missing ReferenceId: _Microsoft
 Missing ReferenceId: Microsoft
 Missing ReferenceId: Microsoft
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(7)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(6): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("Model")
+rebuilt        : ReferenceId(0): Some("Model")
 
 tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 semantic error: Bindings mismatch:
@@ -6498,11 +7678,19 @@ after transform: ScopeId(0): ["BaseClassWithConstructor", "BasicMonster", "Child
 rebuilt        : ScopeId(0): ["BaseClassWithConstructor", "BasicMonster", "ChildClassWithoutConstructor", "GetSetMonster", "ImplementsInterface", "OverloadedMonster", "PrototypeMonster", "SplatMonster", "Statics", "SuperChild", "SuperParent", "Visibility", "ccwc", "foo", "m1", "m2", "m3", "m4", "m5", "m6", "stat", "x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
 semantic error: Unresolved references mismatch:
@@ -6544,8 +7732,7 @@ semantic error: `export = <value>;` is only supported when compiling modules to 
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: c3
@@ -6557,10 +7744,39 @@ Missing ReferenceId: _m2
 Missing ReferenceId: c3
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(26): [SymbolId(6), SymbolId(7), SymbolId(9)]
+rebuilt        : ScopeId(26): [SymbolId(7), SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(26): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4)]
+rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(8)]
+rebuilt        : SymbolId(8): [ReferenceId(11), ReferenceId(14)]
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m1")
+rebuilt        : ReferenceId(16): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: _m
@@ -6574,10 +7790,42 @@ Missing ReferenceId: _m2
 Missing ReferenceId: _m2
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(13)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(14)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(20)]
+rebuilt        : ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(21)]
+rebuilt        : ScopeId(2): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable | ConstVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(8): Some("m1")
+rebuilt        : ReferenceId(11): Some("m1")
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("m1")
+rebuilt        : ReferenceId(22): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: e3
@@ -6589,10 +7837,87 @@ Missing ReferenceId: _m2
 Missing ReferenceId: e5
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(23)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
+Bindings mismatch:
+after transform: ScopeId(1): ["a", "b", "c", "e1"]
+rebuilt        : ScopeId(1): ["e1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["e2", "x", "y", "z"]
+rebuilt        : ScopeId(2): ["e2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
+rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["a", "b", "c", "e3"]
+rebuilt        : ScopeId(4): ["e3"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["e4", "x", "y", "z"]
+rebuilt        : ScopeId(5): ["e4"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
+rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["a", "b", "c", "e5"]
+rebuilt        : ScopeId(7): ["e5"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["e6", "x", "y", "z"]
+rebuilt        : ScopeId(8): ["e6"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(4)]
+rebuilt        : SymbolId(8): [ReferenceId(25), ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(24): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): [ReferenceId(8)]
+rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(57)]
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m1")
+rebuilt        : ReferenceId(59): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: e3
@@ -6604,10 +7929,87 @@ Missing ReferenceId: _m2
 Missing ReferenceId: e5
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(23)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
+Bindings mismatch:
+after transform: ScopeId(1): ["a", "b", "c", "e1"]
+rebuilt        : ScopeId(1): ["e1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["e2", "x", "y", "z"]
+rebuilt        : ScopeId(2): ["e2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
+rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["a", "b", "c", "e3"]
+rebuilt        : ScopeId(4): ["e3"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["e4", "x", "y", "z"]
+rebuilt        : ScopeId(5): ["e4"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
+rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["a", "b", "c", "e5"]
+rebuilt        : ScopeId(7): ["e5"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["e6", "x", "y", "z"]
+rebuilt        : ScopeId(8): ["e6"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(4)]
+rebuilt        : SymbolId(8): [ReferenceId(25), ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(24): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): [ReferenceId(8)]
+rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(57)]
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m1")
+rebuilt        : ReferenceId(59): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleEnumDeclaration.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: e3
@@ -6619,10 +8021,87 @@ Missing ReferenceId: _m2
 Missing ReferenceId: e5
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(23)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
+Bindings mismatch:
+after transform: ScopeId(1): ["a", "b", "c", "e1"]
+rebuilt        : ScopeId(1): ["e1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["e2", "x", "y", "z"]
+rebuilt        : ScopeId(2): ["e2"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
+rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["a", "b", "c", "e3"]
+rebuilt        : ScopeId(4): ["e3"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["e4", "x", "y", "z"]
+rebuilt        : ScopeId(5): ["e4"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
+rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["a", "b", "c", "e5"]
+rebuilt        : ScopeId(7): ["e5"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["e6", "x", "y", "z"]
+rebuilt        : ScopeId(8): ["e6"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(4)]
+rebuilt        : SymbolId(8): [ReferenceId(25), ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(24): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): [ReferenceId(8)]
+rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(57)]
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m1")
+rebuilt        : ReferenceId(59): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunctionDeclaration.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: foo3
@@ -6634,6 +8113,36 @@ Missing ReferenceId: _m2
 Missing ReferenceId: foo3
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(9)]
+rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4)]
+rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(8)]
+rebuilt        : SymbolId(8): [ReferenceId(11), ReferenceId(14)]
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("m1")
+rebuilt        : ReferenceId(16): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -6827,12 +8336,32 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("A")
+rebuilt        : ReferenceId(3): Some("A")
 
 tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
 semantic error: Bindings mismatch:
@@ -6873,8 +8402,7 @@ after transform: ScopeId(0): ["A", "x"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: B
@@ -6886,6 +8414,30 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(4)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 84, end: 85 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("A")
+rebuilt        : ReferenceId(9): Some("A")
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty2.ts
 semantic error: Symbol flags mismatch:
@@ -7078,8 +8630,7 @@ after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: B
@@ -7098,6 +8649,54 @@ Missing ReferenceId: _N
 Missing ReferenceId: C3
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(8)]
+rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(5): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(8): [ReferenceId(14)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("M")
+rebuilt        : ReferenceId(12): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType.ts
 semantic error: Symbol reference IDs mismatch:
@@ -7172,8 +8771,7 @@ after transform: ScopeId(0): ["M"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Events
+semantic error: Missing SymbolId: Events
 Missing SymbolId: _Events
 Missing ReferenceId: _Events
 Missing ReferenceId: EventEmitter
@@ -7183,6 +8781,30 @@ Missing SymbolId: Consumer
 Missing SymbolId: _Consumer
 Missing ReferenceId: Consumer
 Missing ReferenceId: Consumer
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(1): ["EventEmitter", "ListenerCallback", "_Events"]
+rebuilt        : ScopeId(1): ["EventEmitter", "_Events"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(6), SymbolId(10)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["Events"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
 semantic error: Bindings mismatch:
@@ -7247,11 +8869,19 @@ after transform: ["AsyncIterable", "Iterable"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/forInStatement3.ts
 semantic error: Bindings mismatch:
@@ -7356,13 +8986,33 @@ after transform: ["ArrayLike"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: c1
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m1")
+rebuilt        : ReferenceId(4): Some("m1")
+Unresolved references mismatch:
+after transform: ["m1"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
 semantic error: Bindings mismatch:
@@ -7404,15 +9054,22 @@ after transform: ScopeId(0): ["Foo", "x"]
 rebuilt        : ScopeId(0): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Midori
+semantic error: Missing SymbolId: Midori
 Missing SymbolId: _Midori
 Missing ReferenceId: Midori
 Missing ReferenceId: Midori
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _foo
+semantic error: Missing SymbolId: _foo
 Missing SymbolId: Bar
 Missing SymbolId: _Bar
 Missing ReferenceId: _Bar
@@ -7434,6 +9091,51 @@ Missing ReferenceId: _foo2
 Missing ReferenceId: _foo2
 Missing ReferenceId: foo
 Missing ReferenceId: foo
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(9)]
+rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(10)]
+rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(15), ReferenceId(16)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 56, end: 59 }, Span { start: 108, end: 111 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(10): [ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
 semantic error: Bindings mismatch:
@@ -7481,11 +9183,22 @@ after transform: ScopeId(0): ["foo"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: test
+semantic error: Missing SymbolId: test
 Missing SymbolId: _test
 Missing ReferenceId: test
 Missing ReferenceId: test
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Array", "_test", "map"]
+rebuilt        : ScopeId(1): ["_test", "map"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["U", "ys"]
+rebuilt        : ScopeId(2): ["ys"]
 
 tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
 semantic error: Bindings mismatch:
@@ -7512,13 +9225,36 @@ after transform: ScopeId(0): ["Q"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1)]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(4): [ReferenceId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(5): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericOverload1.ts
 semantic error: Bindings mismatch:
@@ -7588,8 +9324,7 @@ after transform: ScopeId(6): ["Input", "Result", "fn"]
 rebuilt        : ScopeId(4): ["fn"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C1
@@ -7601,6 +9336,51 @@ Missing ReferenceId: _M
 Missing ReferenceId: D
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "C1", "D", "I", "_M"]
+rebuilt        : ScopeId(1): ["A", "B", "C1", "D", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(2): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(3): []
+Bindings mismatch:
+after transform: ScopeId(6): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(5): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(17)]
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(6)]
+rebuilt        : SymbolId(4): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): []
+rebuilt        : SymbolId(5): [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
 semantic error: Bindings mismatch:
@@ -7608,8 +9388,7 @@ after transform: ScopeId(1): ["First", "Second", "SubFirst", "SubFirstMore", "ha
 rebuilt        : ScopeId(1): ["hasAFoo", "thing"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Portal
+semantic error: Missing SymbolId: Portal
 Missing SymbolId: _Portal
 Missing SymbolId: Controls
 Missing SymbolId: _Controls
@@ -7651,6 +9430,78 @@ Missing ReferenceId: _PortalFx
 Missing ReferenceId: _PortalFx
 Missing ReferenceId: PortalFx
 Missing ReferenceId: PortalFx
+Bindings mismatch:
+after transform: ScopeId(0): ["Contract", "KnockoutObservable", "KnockoutObservableArray", "KnockoutObservableArrayStatic", "KnockoutObservableBase", "Portal", "PortalFx", "ViewModel", "ko"]
+rebuilt        : ScopeId(0): ["Portal", "PortalFx", "ViewModel"]
+Binding symbols mismatch:
+after transform: ScopeId(24): [SymbolId(11), SymbolId(28)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(25): [SymbolId(12), SymbolId(29)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(26): [SymbolId(13), SymbolId(30)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(27): ["TValue"]
+rebuilt        : ScopeId(4): []
+Binding symbols mismatch:
+after transform: ScopeId(31): [SymbolId(18), SymbolId(31)]
+rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(31): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(32): [SymbolId(19), SymbolId(32)]
+rebuilt        : ScopeId(9): [SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(32): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(33): [SymbolId(20), SymbolId(33)]
+rebuilt        : ScopeId(10): [SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(33): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(34): [SymbolId(21), SymbolId(34)]
+rebuilt        : ScopeId(11): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(34): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(35): ["TValue"]
+rebuilt        : ScopeId(12): []
+Bindings mismatch:
+after transform: ScopeId(38): ["TValue"]
+rebuilt        : ScopeId(14): []
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(21): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(17): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(21): []
+rebuilt        : SymbolId(17): [ReferenceId(15)]
+Reference symbol mismatch:
+after transform: ReferenceId(38): Some("Portal")
+rebuilt        : ReferenceId(12): Some("Portal")
+Unresolved references mismatch:
+after transform: ["PortalFx", "ko"]
+rebuilt        : ["ko"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
 semantic error: Bindings mismatch:
@@ -7661,8 +9512,7 @@ after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(3): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Editor
+semantic error: Missing SymbolId: Editor
 Missing SymbolId: _Editor
 Missing ReferenceId: _Editor
 Missing ReferenceId: List
@@ -7670,6 +9520,42 @@ Missing ReferenceId: _Editor
 Missing ReferenceId: ListFactory
 Missing ReferenceId: Editor
 Missing ReferenceId: Editor
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(19), SymbolId(28)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(19)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Bindings mismatch:
+after transform: ScopeId(21): ["T"]
+rebuilt        : ScopeId(21): []
+Bindings mismatch:
+after transform: ScopeId(22): ["T", "entry"]
+rebuilt        : ScopeId(22): ["entry"]
+Bindings mismatch:
+after transform: ScopeId(23): ["T", "data", "entry"]
+rebuilt        : ScopeId(23): ["data", "entry"]
+Bindings mismatch:
+after transform: ScopeId(24): ["T", "entry"]
+rebuilt        : ScopeId(24): ["entry"]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(10), ReferenceId(18), ReferenceId(28), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(61), ReferenceId(63), ReferenceId(72), ReferenceId(74), ReferenceId(82), ReferenceId(86), ReferenceId(88), ReferenceId(90), ReferenceId(98), ReferenceId(100), ReferenceId(102), ReferenceId(110), ReferenceId(112)]
+rebuilt        : SymbolId(2): [ReferenceId(52), ReferenceId(53), ReferenceId(59)]
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(19): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): [ReferenceId(4), ReferenceId(7)]
+rebuilt        : SymbolId(19): [ReferenceId(2), ReferenceId(74)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 semantic error: Bindings mismatch:
@@ -7711,8 +9597,7 @@ after transform: ScopeId(0): ["A", "B", "C"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: EndGate
+semantic error: Missing SymbolId: EndGate
 Missing SymbolId: _EndGate
 Missing SymbolId: Tweening
 Missing SymbolId: _Tweening
@@ -7735,10 +9620,54 @@ Missing ReferenceId: _EndGate2
 Missing ReferenceId: _EndGate2
 Missing ReferenceId: EndGate
 Missing ReferenceId: EndGate
+Bindings mismatch:
+after transform: ScopeId(0): ["EndGate", "Number"]
+rebuilt        : ScopeId(0): ["EndGate"]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(3), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(4), SymbolId(11)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(3): []
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(7), SymbolId(12)]
+rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(8), SymbolId(13)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(4): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(9): [ReferenceId(12)]
+Unresolved references mismatch:
+after transform: ["EndGate", "ICloneable", "Tween"]
+rebuilt        : ["Tween"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: EndGate
+semantic error: Missing SymbolId: EndGate
 Missing SymbolId: _EndGate2
 Missing SymbolId: Tweening
 Missing SymbolId: _Tweening
@@ -7761,6 +9690,51 @@ Missing ReferenceId: _EndGate3
 Missing ReferenceId: _EndGate3
 Missing ReferenceId: EndGate
 Missing ReferenceId: EndGate
+Bindings mismatch:
+after transform: ScopeId(0): ["EndGate", "Number"]
+rebuilt        : ScopeId(0): ["EndGate"]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(3), SymbolId(11)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(4), SymbolId(12)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(3): []
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(7), SymbolId(13)]
+rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(8), SymbolId(14)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(4): [ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(9): [ReferenceId(12)]
+Unresolved references mismatch:
+after transform: ["EndGate", "ICloneable", "Tween"]
+rebuilt        : ["Tween"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
 semantic error: Bindings mismatch:
@@ -7976,8 +9950,7 @@ after transform: []
 rebuilt        : ["params"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
@@ -7990,10 +9963,45 @@ Missing ReferenceId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(8)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(6), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(9)]
+rebuilt        : ScopeId(6): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(3)]
+rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(5), ReferenceId(6)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(4): [Span { start: 100, end: 101 }]
+rebuilt        : SymbolId(4): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(4)]
+Unresolved references mismatch:
+after transform: ["M"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
@@ -8010,6 +10018,48 @@ Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(8)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(6), SymbolId(9)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(6): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(8), SymbolId(11)]
+rebuilt        : ScopeId(8): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(3)]
+rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(5), ReferenceId(6)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(4): [Span { start: 100, end: 101 }]
+rebuilt        : SymbolId(4): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(4)]
+Unresolved references mismatch:
+after transform: ["M"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
 semantic error: Bindings mismatch:
@@ -8061,8 +10111,7 @@ after transform: SymbolId(1): [ReferenceId(4)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TypeScript2
+semantic error: Missing SymbolId: TypeScript2
 Missing SymbolId: _TypeScript
 Missing ReferenceId: _TypeScript
 Missing ReferenceId: PullSymbolVisibility
@@ -8072,6 +10121,48 @@ Missing ReferenceId: _TypeScript
 Missing ReferenceId: PullTypeSymbol
 Missing ReferenceId: TypeScript2
 Missing ReferenceId: TypeScript2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["DeclKind", "PullSymbol", "PullSymbolVisibility", "PullTypeSymbol", "PullTypesymbol", "SymbolLinkKind", "_TypeScript"]
+rebuilt        : ScopeId(1): ["PullSymbol", "PullSymbolVisibility", "PullTypeSymbol", "_TypeScript"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["Private", "Public", "PullSymbolVisibility"]
+rebuilt        : ScopeId(2): ["PullSymbolVisibility"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["A", "B", "C", "kind", "linkTo"]
+rebuilt        : ScopeId(5): ["kind", "linkTo"]
+Bindings mismatch:
+after transform: ScopeId(9): ["A", "B", "C"]
+rebuilt        : ScopeId(6): []
+Bindings mismatch:
+after transform: ScopeId(10): ["A", "B", "C"]
+rebuilt        : ScopeId(7): []
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(2): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(1), ReferenceId(8)]
+rebuilt        : SymbolId(4): [ReferenceId(9), ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(18): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(18): [ReferenceId(3)]
+rebuilt        : SymbolId(9): [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters.ts
 semantic error: Bindings mismatch:
@@ -8254,13 +10345,30 @@ after transform: SymbolId(1): [Span { start: 724, end: 731 }]
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/getAccessorWithImpliedReturnTypeAndFunctionClassMerge.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: MyModule
+semantic error: Missing SymbolId: MyModule
 Missing SymbolId: _MyModule
 Missing ReferenceId: _MyModule
 Missing ReferenceId: MyClass
 Missing ReferenceId: MyModule
 Missing ReferenceId: MyModule
+Bindings mismatch:
+after transform: ScopeId(0): ["MyModule", "_"]
+rebuilt        : ScopeId(0): ["MyModule"]
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(14), SymbolId(16)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Unresolved references mismatch:
+after transform: ["Array", "_"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 semantic error: Bindings mismatch:
@@ -8286,13 +10394,30 @@ after transform: ScopeId(0): ["Foo", "NumberOrObject", "NumberOrString", "Number
 rebuilt        : ScopeId(0): ["NumberOrObject", "NumberOrString", "NumberOrUndefined", "numberOrObject", "numberOrString", "numberOrUndefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/global.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("M")
+rebuilt        : ReferenceId(6): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
 semantic error: Bindings mismatch:
@@ -8477,13 +10602,24 @@ after transform: SymbolId(39): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m
+semantic error: Missing SymbolId: m
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: foo
 Missing ReferenceId: m
 Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -8635,8 +10771,7 @@ semantic error: `export = <value>;` is only supported when compiling modules to 
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: App
+semantic error: Missing SymbolId: App
 Missing SymbolId: _App
 Missing SymbolId: Services
 Missing SymbolId: _Services
@@ -8648,6 +10783,21 @@ Missing ReferenceId: _App
 Missing ReferenceId: _App
 Missing ReferenceId: App
 Missing ReferenceId: App
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-referenecing-aliased-type-throug-array.ts
 semantic error: Bindings mismatch:
@@ -8664,8 +10814,7 @@ after transform: ScopeId(0): ["Actual", "Expected", "Handler", "lambdaTester"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: elaborate
+semantic error: Missing SymbolId: elaborate
 Missing SymbolId: _elaborate
 Missing SymbolId: nested
 Missing SymbolId: _nested
@@ -8689,10 +10838,39 @@ Missing ReferenceId: _elaborate
 Missing ReferenceId: _elaborate
 Missing ReferenceId: elaborate
 Missing ReferenceId: elaborate
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(8): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/importedModuleClassNameClash.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: foo
+semantic error: Missing SymbolId: foo
+Bindings mismatch:
+after transform: ScopeId(0): ["foo", "m1"]
+rebuilt        : ScopeId(0): ["foo"]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | Import)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Class)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules1.ts
 semantic error: Bindings mismatch:
@@ -8825,11 +11003,25 @@ after transform: ScopeId(0): ["Dictionary", "foo", "x"]
 rebuilt        : ScopeId(0): ["foo", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/indexSignaturesInferentialTyping.ts
 semantic error: Bindings mismatch:
@@ -9475,8 +11667,7 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C1
@@ -9492,6 +11683,69 @@ Missing ReferenceId: _N
 Missing ReferenceId: D2
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(12)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(3): []
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(13)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["T"]
+rebuilt        : ScopeId(6): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(8)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(7): [ReferenceId(11)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("M")
+rebuilt        : ReferenceId(6): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("M")
+rebuilt        : ReferenceId(9): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("M")
+rebuilt        : ReferenceId(14): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("N")
+rebuilt        : ReferenceId(15): Some("N")
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("N")
+rebuilt        : ReferenceId(16): Some("N")
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("N")
+rebuilt        : ReferenceId(17): Some("N")
 
 tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
 semantic error: Symbol reference IDs mismatch:
@@ -9560,8 +11814,7 @@ after transform: SymbolId(5): [ReferenceId(0), ReferenceId(1), ReferenceId(2), R
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/innerAliases2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _provider
+semantic error: Missing SymbolId: _provider
 Missing SymbolId: _provider2
 Missing ReferenceId: _provider2
 Missing ReferenceId: UsefulClass
@@ -9571,19 +11824,62 @@ Missing SymbolId: consumer
 Missing SymbolId: _consumer
 Missing ReferenceId: consumer
 Missing ReferenceId: consumer
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["_consumer", "g", "provider", "use"]
+rebuilt        : ScopeId(4): ["_consumer", "g", "use"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("provider")
+rebuilt        : ReferenceId(4): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["provider"]
 
 tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: Foo
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["Array", "M"]
+rebuilt        : ScopeId(0): ["M"]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["M"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9595,15 +11891,50 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["B", "BB", "_A"]
+rebuilt        : ScopeId(1): ["B", "_A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: tungsten
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/innerTypeArgumentInference.ts
 semantic error: Bindings mismatch:
@@ -9673,11 +12004,40 @@ after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N1
+semantic error: Missing SymbolId: N1
 Missing SymbolId: _N
 Missing ReferenceId: N1
 Missing ReferenceId: N1
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "ActionHandler", "ActionType", "AppState", "BaseProps", "BoxConsumerFromOuterBox", "DooDad", "Handler", "InnerBox", "Interesting", "N1", "NON_VOID_ACTION", "O", "OuterBox", "R", "VOID_ACTION", "defaultState", "fn", "handlers", "obj", "outerBoxOfString", "x", "xx"]
+rebuilt        : ScopeId(0): ["Interesting", "N1", "NON_VOID_ACTION", "VOID_ACTION", "defaultState", "fn", "obj", "xx"]
+Bindings mismatch:
+after transform: ScopeId(2): ["a", "value", "values"]
+rebuilt        : ScopeId(1): ["value", "values"]
+Bindings mismatch:
+after transform: ScopeId(25): ["ComponentClass", "CreateElementChildren", "InferFunctionTypes", "_N"]
+rebuilt        : ScopeId(8): ["InferFunctionTypes", "_N"]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("handlers")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(62): Some("x")
+rebuilt        : ReferenceId(14): None
+Reference symbol mismatch:
+after transform: ReferenceId(98): Some("outerBoxOfString")
+rebuilt        : ReferenceId(25): None
+Unresolved references mismatch:
+after transform: ["Component", "GenericComponent", "Partial", "Promise", "alert", "assignPartial", "createElement", "createElement2", "createReducer", "handler", "invoke", "passContentsToFunc", "useStringOrNumber"]
+rebuilt        : ["Component", "GenericComponent", "Promise", "alert", "assignPartial", "createElement", "createElement2", "createReducer", "handler", "handlers", "invoke", "outerBoxOfString", "passContentsToFunc", "useStringOrNumber", "x"]
+Unresolved reference IDs mismatch for "Promise":
+after transform: [ReferenceId(100), ReferenceId(102), ReferenceId(103), ReferenceId(105), ReferenceId(106), ReferenceId(108)]
+rebuilt        : [ReferenceId(27), ReferenceId(28), ReferenceId(29)]
+Unresolved reference IDs mismatch for "Component":
+after transform: [ReferenceId(14), ReferenceId(65), ReferenceId(79)]
+rebuilt        : [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
 semantic error: Bindings mismatch:
@@ -9708,8 +12068,7 @@ after transform: ScopeId(0): ["B", "c", "d"]
 rebuilt        : ScopeId(0): ["c", "d"]
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9721,10 +12080,36 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("A")
+rebuilt        : ReferenceId(8): Some("A")
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9736,10 +12121,36 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("A")
+rebuilt        : ReferenceId(8): Some("A")
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9749,10 +12160,33 @@ Missing ReferenceId: B
 Missing ReferenceId: B
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9762,10 +12196,33 @@ Missing ReferenceId: B
 Missing ReferenceId: B
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces4.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9777,10 +12234,33 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("A")
+rebuilt        : ReferenceId(8): Some("A")
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces5.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -9792,6 +12272,30 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("A")
+rebuilt        : ReferenceId(8): Some("A")
 
 tasks/coverage/typescript/tests/cases/compiler/interface0.ts
 semantic error: Bindings mismatch:
@@ -9894,13 +12398,27 @@ after transform: ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "C6", "I1"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "C4", "C5", "C6"]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m
+semantic error: Missing SymbolId: m
 Missing SymbolId: _m2
 Missing ReferenceId: _m2
 Missing ReferenceId: n
 Missing ReferenceId: m
 Missing ReferenceId: m
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(2): ["_m2", "f", "n"]
+rebuilt        : ScopeId(1): ["_m2", "n"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance2.ts
 semantic error: Bindings mismatch:
@@ -9948,11 +12466,22 @@ after transform: SymbolId(0): [Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: B
+semantic error: Missing SymbolId: B
 Missing SymbolId: _B
 Missing ReferenceId: B
 Missing ReferenceId: B
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B"]
+rebuilt        : ScopeId(0): ["B"]
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "Y", "_B"]
+rebuilt        : ScopeId(1): ["A", "_B"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0)]
+rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionApparentTypeCaching.ts
 semantic error: Bindings mismatch:
@@ -10008,8 +12537,7 @@ after transform: ScopeId(3): ["OwnProps", "f"]
 rebuilt        : ScopeId(3): ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: enums
+semantic error: Missing SymbolId: enums
 Missing SymbolId: _enums
 Missing ReferenceId: _enums
 Missing ReferenceId: A
@@ -10019,6 +12547,54 @@ Missing ReferenceId: _enums
 Missing ReferenceId: C
 Missing ReferenceId: enums
 Missing ReferenceId: enums
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "Bar", "BoxedValue", "C", "D", "Foo", "FooBar", "IntersectionFail", "IntersectionInline", "M", "N", "ToString", "X", "X1", "X2", "X3", "Y", "Y1", "Y2", "Y3", "Z1", "Z2", "Z3", "Z4", "enums", "foo", "getValueAsString", "x", "y", "z"]
+rebuilt        : ScopeId(0): ["enums", "foo", "getValueAsString", "x", "y", "z"]
+Bindings mismatch:
+after transform: ScopeId(26): ["A", "B", "C", "Genre", "_enums"]
+rebuilt        : ScopeId(3): ["A", "B", "C", "_enums"]
+Scope flags mismatch:
+after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(27): ["A", "a1", "a2", "a3", "a75", "a76", "a77"]
+rebuilt        : ScopeId(4): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(27): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(28): ["B", "b1", "b2", "b86", "b87"]
+rebuilt        : ScopeId(5): ["B"]
+Scope flags mismatch:
+after transform: ScopeId(28): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(29): ["C", "c1", "c2", "c210", "c211"]
+rebuilt        : ScopeId(6): ["C"]
+Scope flags mismatch:
+after transform: ScopeId(29): ScopeFlags(0x0)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(28): [ReferenceId(100)]
+rebuilt        : SymbolId(7): [ReferenceId(17)]
+Symbol flags mismatch:
+after transform: SymbolId(35): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(35): [ReferenceId(101)]
+rebuilt        : SymbolId(9): [ReferenceId(28)]
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(40): [ReferenceId(102)]
+rebuilt        : SymbolId(11): [ReferenceId(39)]
+Unresolved references mismatch:
+after transform: ["enums"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
 semantic error: Bindings mismatch:
@@ -10261,8 +12837,7 @@ after transform: ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Element
+semantic error: Missing SymbolId: Element
 Missing SymbolId: _Element
 Missing ReferenceId: _Element
 Missing ReferenceId: isElement
@@ -10270,6 +12845,30 @@ Missing ReferenceId: _Element
 Missing ReferenceId: createElement
 Missing ReferenceId: Element
 Missing ReferenceId: Element
+Bindings mismatch:
+after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
+rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(3), SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("Element")
+rebuilt        : ReferenceId(8): Some("Element")
+Unresolved references mismatch:
+after transform: ["JSX", "undefined"]
+rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
@@ -10290,8 +12889,7 @@ after transform: ScopeId(0): ["_jsxFileName", "h"]
 rebuilt        : ScopeId(0): ["_jsxFileName"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Element
+semantic error: Missing SymbolId: Element
 Missing SymbolId: _Element
 Missing ReferenceId: _Element
 Missing ReferenceId: isElement
@@ -10299,6 +12897,30 @@ Missing ReferenceId: _Element
 Missing ReferenceId: createElement
 Missing ReferenceId: Element
 Missing ReferenceId: Element
+Bindings mismatch:
+after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
+rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(3), SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("Element")
+rebuilt        : ReferenceId(8): Some("Element")
+Unresolved references mismatch:
+after transform: ["JSX", "undefined"]
+rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
 semantic error: Bindings mismatch:
@@ -10306,8 +12928,7 @@ after transform: ScopeId(0): ["AppComponent", "JSX", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["AppComponent", "_jsxFileName"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Element
+semantic error: Missing SymbolId: Element
 Missing SymbolId: _Element
 Missing ReferenceId: _Element
 Missing ReferenceId: isElement
@@ -10315,6 +12936,30 @@ Missing ReferenceId: _Element
 Missing ReferenceId: createElement
 Missing ReferenceId: Element
 Missing ReferenceId: Element
+Bindings mismatch:
+after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
+rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(3), SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("Element")
+rebuilt        : ReferenceId(8): Some("Element")
+Unresolved references mismatch:
+after transform: ["JSX", "undefined"]
+rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx
 semantic error: Bindings mismatch:
@@ -10575,11 +13220,19 @@ after transform: ["Array", "ArrayValidator", "Exclude"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
 semantic error: Bindings mismatch:
@@ -10592,8 +13245,7 @@ after transform: ["RegExpExecArray"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/listFailure.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Editor
+semantic error: Missing SymbolId: Editor
 Missing SymbolId: _Editor
 Missing ReferenceId: _Editor
 Missing ReferenceId: Buffer
@@ -10607,6 +13259,60 @@ Missing ReferenceId: _Editor
 Missing ReferenceId: Line
 Missing ReferenceId: Editor
 Missing ReferenceId: Editor
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5), SymbolId(8), SymbolId(10), SymbolId(13), SymbolId(17), SymbolId(18)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(11), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["U", "entry"]
+rebuilt        : ScopeId(4): ["entry"]
+Bindings mismatch:
+after transform: ScopeId(5): ["U"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(6): ["U", "data"]
+rebuilt        : ScopeId(6): ["data"]
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(7): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(31)]
+rebuilt        : SymbolId(6): [ReferenceId(8), ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(0)]
+rebuilt        : SymbolId(8): [ReferenceId(0), ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(25)]
+rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(13)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(20), ReferenceId(23), ReferenceId(27), ReferenceId(29)]
+rebuilt        : SymbolId(11): []
+Symbol flags mismatch:
+after transform: SymbolId(17): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(14): [ReferenceId(1), ReferenceId(17)]
 
 tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
 semantic error: Bindings mismatch:
@@ -10651,8 +13357,7 @@ semantic error: `export = <value>;` is only supported when compiling modules to 
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Keyboard
+semantic error: Missing SymbolId: Keyboard
 Missing SymbolId: _Keyboard
 Missing ReferenceId: _Keyboard
 Missing ReferenceId: Key
@@ -10664,6 +13369,51 @@ Missing ReferenceId: _App
 Missing ReferenceId: foo
 Missing ReferenceId: App
 Missing ReferenceId: App
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["DOWN", "Key", "LEFT", "RIGHT", "UP"]
+rebuilt        : ScopeId(2): ["Key"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["Key", "_App", "foo"]
+rebuilt        : ScopeId(3): ["_App", "foo"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(2), ReferenceId(4), ReferenceId(6)]
+rebuilt        : SymbolId(6): [ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("Key")
+rebuilt        : ReferenceId(16): None
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("Key")
+rebuilt        : ReferenceId(18): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("Key")
+rebuilt        : ReferenceId(20): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Key"]
 
 tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 semantic error: Bindings mismatch:
@@ -10953,8 +13703,7 @@ after transform: ScopeId(0): ["C", "I"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: X
+semantic error: Missing SymbolId: X
 Missing SymbolId: _X
 Missing SymbolId: Y
 Missing SymbolId: _Y
@@ -10975,10 +13724,42 @@ Missing ReferenceId: _X2
 Missing ReferenceId: _X2
 Missing ReferenceId: X
 Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(7)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(8)]
+rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(9)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(9): [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: my
+semantic error: Missing SymbolId: my
 Missing SymbolId: _my
 Missing SymbolId: data
 Missing SymbolId: _data
@@ -11005,10 +13786,48 @@ Missing ReferenceId: _my2
 Missing ReferenceId: _my2
 Missing ReferenceId: my
 Missing ReferenceId: my
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(9)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(10)]
+rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(11)]
+rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen3.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: my
+semantic error: Missing SymbolId: my
 Missing SymbolId: _my
 Missing SymbolId: data
 Missing SymbolId: _data
@@ -11035,10 +13854,48 @@ Missing ReferenceId: _my2
 Missing ReferenceId: _my2
 Missing ReferenceId: my
 Missing ReferenceId: my
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(10)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(4), SymbolId(11)]
+rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(12)]
+rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: superContain
+semantic error: Missing SymbolId: superContain
 Missing SymbolId: _superContain
 Missing SymbolId: contain
 Missing SymbolId: _contain
@@ -11087,6 +13944,69 @@ Missing ReferenceId: _superContain
 Missing ReferenceId: _superContain
 Missing ReferenceId: superContain
 Missing ReferenceId: superContain
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(13)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(14)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(15)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(16)]
+rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(17)]
+rebuilt        : ScopeId(5): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(6), SymbolId(18)]
+rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(7), SymbolId(19)]
+rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(8), SymbolId(20)]
+rebuilt        : ScopeId(9): [SymbolId(15), SymbolId(16)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(10): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(16): [ReferenceId(16)]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -11114,8 +14034,7 @@ after transform: ["PropertyDecorator"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: MyModule
+semantic error: Missing SymbolId: MyModule
 Missing SymbolId: _MyModule
 Missing ReferenceId: _MyModule
 Missing ReferenceId: inject
@@ -11125,6 +14044,33 @@ Missing ReferenceId: _MyModule
 Missing ReferenceId: Person
 Missing ReferenceId: MyModule
 Missing ReferenceId: MyModule
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(5): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(1)]
+rebuilt        : SymbolId(5): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfEventAlias.ts
 semantic error: Bindings mismatch:
@@ -11173,14 +14119,58 @@ after transform: ScopeId(0): ["Class1", "Class2", "decorate"]
 rebuilt        : ScopeId(0): ["Class2", "decorate"]
 
 tasks/coverage/typescript/tests/cases/compiler/methodContainingLocalFunction.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: exhibitBug
 Missing ReferenceId: M
 Missing ReferenceId: M
 Missing ReferenceId: E
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(14), SymbolId(19), SymbolId(23)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6), SymbolId(10), SymbolId(14), SymbolId(19)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(4): []
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(7): []
+Bindings mismatch:
+after transform: ScopeId(9): ["U", "u"]
+rebuilt        : ScopeId(9): ["u"]
+Bindings mismatch:
+after transform: ScopeId(12): ["U", "u"]
+rebuilt        : ScopeId(12): ["u"]
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(20), SymbolId(27)]
+rebuilt        : ScopeId(13): [SymbolId(15), SymbolId(16)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(16): ["A", "E"]
+rebuilt        : ScopeId(16): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(0x0)
+rebuilt        : ScopeId(16): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(16): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): []
+rebuilt        : SymbolId(16): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(23): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(19): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(28): [ReferenceId(14), ReferenceId(15), ReferenceId(16)]
+rebuilt        : SymbolId(20): [ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(18)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(25): [ReferenceId(13)]
+rebuilt        : SymbolId(21): []
 
 tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
 semantic error: Bindings mismatch:
@@ -11198,8 +14188,67 @@ after transform: ScopeId(0): ["A", "M", "M1"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComparison.ts
-semantic error: Semantic Collector failed after transform
-Missing ReferenceId: E2
+semantic error: Missing ReferenceId: E2
+Bindings mismatch:
+after transform: ScopeId(0): ["E", "E2", "someNumber", "someString", "unionOfEnum"]
+rebuilt        : ScopeId(0): ["E", "E2"]
+Bindings mismatch:
+after transform: ScopeId(1): ["E", "N1", "N2", "S1", "S2"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["C1", "E2", "N1", "S1"]
+rebuilt        : ScopeId(5): ["E2"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(28)]
+rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34)]
+rebuilt        : SymbolId(3): [ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("someNumber")
+rebuilt        : ReferenceId(8): None
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("someNumber")
+rebuilt        : ReferenceId(10): None
+Reference symbol mismatch:
+after transform: ReferenceId(6): Some("someNumber")
+rebuilt        : ReferenceId(12): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("unionOfEnum")
+rebuilt        : ReferenceId(13): None
+Reference symbol mismatch:
+after transform: ReferenceId(8): Some("someNumber")
+rebuilt        : ReferenceId(14): None
+Reference symbol mismatch:
+after transform: ReferenceId(10): Some("someString")
+rebuilt        : ReferenceId(16): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("someString")
+rebuilt        : ReferenceId(18): None
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("someString")
+rebuilt        : ReferenceId(28): None
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("someNumber")
+rebuilt        : ReferenceId(30): None
+Reference symbol mismatch:
+after transform: ReferenceId(19): Some("someNumber")
+rebuilt        : ReferenceId(32): None
+Unresolved references mismatch:
+after transform: ["someValue"]
+rebuilt        : ["someNumber", "someString", "unionOfEnum"]
 
 tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.ts
 semantic error: Bindings mismatch:
@@ -11282,8 +14331,7 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _modes
+semantic error: Missing SymbolId: _modes
 Missing SymbolId: _modes2
 Missing ReferenceId: _modes2
 Missing ReferenceId: Mode
@@ -11314,6 +14362,69 @@ Missing SymbolId: B1
 Missing SymbolId: _B
 Missing ReferenceId: B1
 Missing ReferenceId: B1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(10), SymbolId(11), SymbolId(21), SymbolId(24)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(10), SymbolId(11), SymbolId(23), SymbolId(26)]
+Bindings mismatch:
+after transform: ScopeId(1): ["IMode", "Mode", "_modes2"]
+rebuilt        : ScopeId(1): ["Mode", "_modes2"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["Bug", "_editor", "i", "modes"]
+rebuilt        : ScopeId(3): ["Bug", "_editor", "i"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(12), SymbolId(13), SymbolId(16), SymbolId(18), SymbolId(30)]
+rebuilt        : ScopeId(7): [SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(17), SymbolId(20)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(11): [SymbolId(17), SymbolId(31)]
+rebuilt        : ScopeId(10): [SymbolId(18), SymbolId(19)]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(15): ["A1C1", "A1I1", "_A"]
+rebuilt        : ScopeId(14): ["A1C1", "_A"]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(18): ["A1Alias1", "_B", "c", "i"]
+rebuilt        : ScopeId(16): ["_B", "c", "i"]
+Scope flags mismatch:
+after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(16): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(17): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(19): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): []
+rebuilt        : SymbolId(19): [ReferenceId(8)]
+Symbol flags mismatch:
+after transform: SymbolId(23): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(25): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(23): []
+rebuilt        : SymbolId(25): [ReferenceId(14)]
+Reference symbol mismatch:
+after transform: ReferenceId(5): Some("_modes")
+rebuilt        : ReferenceId(6): Some("_modes")
+Unresolved references mismatch:
+after transform: ["Foo"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName.ts
 semantic error: Bindings mismatch:
@@ -11375,9 +14486,11 @@ after transform: ScopeId(0): ["./observable", "Observable"]
 rebuilt        : ScopeId(0): ["Observable"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports4.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: I
+semantic error: Missing SymbolId: I
 Missing SymbolId: C
+Bindings mismatch:
+after transform: ScopeId(0): ["./f1", "A", "B", "C", "I", "N"]
+rebuilt        : ScopeId(0): ["A", "C", "I"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule2.ts
 semantic error: Bindings mismatch:
@@ -11445,8 +14558,7 @@ after transform: ScopeId(0): ["ISpinButton"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TypeScript
+semantic error: Missing SymbolId: TypeScript
 Missing SymbolId: _TypeScript
 Missing SymbolId: Parser
 Missing SymbolId: _Parser
@@ -11481,13 +14593,87 @@ Missing ReferenceId: _TypeScript4
 Missing ReferenceId: _TypeScript4
 Missing ReferenceId: TypeScript
 Missing ReferenceId: TypeScript
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(24)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(25)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["ISyntaxElement", "ISyntaxToken", "PositionedElement", "PositionedToken", "_TypeScript2"]
+rebuilt        : ScopeId(5): ["PositionedElement", "PositionedToken", "_TypeScript2"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(11), SymbolId(27)]
+rebuilt        : ScopeId(10): [SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(16): [SymbolId(18), SymbolId(28)]
+rebuilt        : ScopeId(14): [SymbolId(20), SymbolId(21)]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(17): [SymbolId(19), SymbolId(20), SymbolId(29)]
+rebuilt        : ScopeId(15): [SymbolId(22), SymbolId(23), SymbolId(24)]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(3)]
+rebuilt        : SymbolId(6): [ReferenceId(8)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(8): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(13): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): []
+rebuilt        : SymbolId(13): [ReferenceId(15)]
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(23): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): []
+rebuilt        : SymbolId(23): [ReferenceId(19)]
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(24): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): []
+rebuilt        : SymbolId(24): [ReferenceId(24)]
+Unresolved references mismatch:
+after transform: ["ISyntaxToken", "PositionedElement", "PositionedToken", "Syntax", "SyntaxNode"]
+rebuilt        : ["PositionedToken", "Syntax"]
+Unresolved reference IDs mismatch for "PositionedToken":
+after transform: [ReferenceId(5), ReferenceId(9)]
+rebuilt        : [ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
@@ -11496,6 +14682,27 @@ Missing ReferenceId: _A2
 Missing ReferenceId: B
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(4): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMergeConstructor.ts
 semantic error: Symbol reference IDs mismatch:
@@ -11503,11 +14710,19 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleNoEmit.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1)]
+rebuilt        : ScopeId(1): [SymbolId(1)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -11530,8 +14745,7 @@ after transform: SymbolId(0): [Span { start: 19, end: 20 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C1
@@ -11542,10 +14756,39 @@ Missing ReferenceId: _M2
 Missing ReferenceId: C2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["C1", "I", "_M"]
+rebuilt        : ScopeId(1): ["C1", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
+Unresolved references mismatch:
+after transform: ["I"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C1
@@ -11556,6 +14799,33 @@ Missing ReferenceId: _M2
 Missing ReferenceId: C2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["C2", "I", "_M2"]
+rebuilt        : ScopeId(3): ["C2", "_M2"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirective.ts
 semantic error: Bindings mismatch:
@@ -11755,8 +15025,7 @@ after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing SymbolId: X
 Missing SymbolId: _X
@@ -11764,10 +15033,24 @@ Missing ReferenceId: X
 Missing ReferenceId: X
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(9)]
+rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Z
+semantic error: Missing SymbolId: Z
 Missing SymbolId: _Z
 Missing SymbolId: M
 Missing SymbolId: _M
@@ -11791,10 +15074,51 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["M", "_M2", "bar"]
+rebuilt        : ScopeId(5): ["_M2", "bar"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(9): [ReferenceId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("M")
+rebuilt        : ReferenceId(10): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Z
+semantic error: Missing SymbolId: Z
 Missing SymbolId: _Z
 Missing SymbolId: M
 Missing SymbolId: _M
@@ -11818,10 +15142,51 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["M", "_M2", "bar"]
+rebuilt        : ScopeId(5): ["_M2", "bar"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(9): [ReferenceId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("M")
+rebuilt        : ReferenceId(10): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Z
+semantic error: Missing SymbolId: Z
 Missing SymbolId: _Z
 Missing SymbolId: M
 Missing SymbolId: _M
@@ -11845,10 +15210,51 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["M", "_M2", "bar"]
+rebuilt        : ScopeId(5): ["_M2", "bar"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(9): [ReferenceId(9)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("M")
+rebuilt        : ReferenceId(10): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt6.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Z
+semantic error: Missing SymbolId: Z
 Missing SymbolId: _Z
 Missing SymbolId: M
 Missing SymbolId: _M
@@ -11872,6 +15278,45 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["M", "_M2", "bar"]
+rebuilt        : ScopeId(5): ["_M2", "bar"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(9): [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -11886,11 +15331,25 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/moduleWithTryStatement1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Reference symbol mismatch:
+after transform: ReferenceId(0): None
+rebuilt        : ReferenceId(2): Some("M")
+Unresolved references mismatch:
+after transform: ["M"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule.ts
 semantic error: Bindings mismatch:
@@ -11973,8 +15432,7 @@ after transform: SymbolId(4): [ReferenceId(5)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
@@ -11983,13 +15441,42 @@ Missing ReferenceId: M
 Missing SymbolId: _M2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4)]
+rebuilt        : ScopeId(3): [SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionInModule.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Variables
+semantic error: Missing SymbolId: Variables
 Missing SymbolId: _Variables
 Missing ReferenceId: Variables
 Missing ReferenceId: Variables
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 semantic error: Bindings mismatch:
@@ -12000,8 +15487,7 @@ after transform: ["X"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: B
 Missing SymbolId: _B
@@ -12013,6 +15499,33 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("A")
+rebuilt        : ReferenceId(8): Some("A")
+Unresolved references mismatch:
+after transform: ["A"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
 semantic error: Bindings mismatch:
@@ -12406,8 +15919,7 @@ after transform: ["Array"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: a
+semantic error: Missing SymbolId: a
 Missing SymbolId: _a
 Missing SymbolId: b
 Missing SymbolId: _b
@@ -12415,15 +15927,44 @@ Missing ReferenceId: b
 Missing ReferenceId: b
 Missing ReferenceId: a
 Missing ReferenceId: a
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/nestedSuperCallEmit.ts
 semantic error: Unresolved reference IDs mismatch for "Error":
@@ -12458,11 +15999,22 @@ after transform: SymbolId(14): [ReferenceId(6), ReferenceId(11), ReferenceId(13)
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/newArrays.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/newExpressionWithTypeParameterConstrainedToOuterTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -13157,18 +16709,34 @@ after transform: SymbolId(5): [ReferenceId(1)]
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Bugs
+semantic error: Missing SymbolId: Bugs
 Missing SymbolId: _Bugs
 Missing ReferenceId: Bugs
 Missing ReferenceId: Bugs
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(9), SymbolId(11)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(10), SymbolId(12)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(14)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Bugs
+semantic error: Missing SymbolId: Bugs
 Missing SymbolId: _Bugs
 Missing ReferenceId: Bugs
 Missing ReferenceId: Bugs
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["IState", "IStateToken", "IToken", "_Bugs", "bug3"]
+rebuilt        : ScopeId(1): ["_Bugs", "bug3"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/overloadResolutionWithAny.ts
 semantic error: Unresolved references mismatch:
@@ -13499,8 +17067,7 @@ after transform: ScopeId(0): ["string"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: m1_c_public
@@ -13536,10 +17103,108 @@ Missing ReferenceId: _m2
 Missing ReferenceId: m2_C12_public
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Bindings mismatch:
+after transform: ScopeId(0): ["glo_C10_private", "glo_C11_public", "glo_C12_public", "glo_C1_private", "glo_C2_private", "glo_C3_public", "glo_C4_public", "glo_C5_private", "glo_C6_private", "glo_C7_public", "glo_C8_public", "glo_C9_private", "glo_c_private", "glo_c_public", "glo_i_private", "glo_i_public", "m1", "m2"]
+rebuilt        : ScopeId(0): ["glo_C10_private", "glo_C11_public", "glo_C12_public", "glo_C1_private", "glo_C2_private", "glo_C3_public", "glo_C4_public", "glo_C5_private", "glo_C6_private", "glo_C7_public", "glo_C8_public", "glo_C9_private", "glo_c_private", "glo_c_public", "m1", "m2"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public", "m1_i_private", "m1_i_public"]
+rebuilt        : ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(19): ["_m2", "m2_C10_private", "m2_C11_public", "m2_C12_public", "m2_C1_private", "m2_C2_private", "m2_C3_public", "m2_C4_public", "m2_C5_private", "m2_C6_private", "m2_C7_public", "m2_C8_public", "m2_C9_private", "m2_c_private", "m2_c_public", "m2_i_private", "m2_i_public"]
+rebuilt        : ScopeId(17): ["_m2", "m2_C10_private", "m2_C11_public", "m2_C12_public", "m2_C1_private", "m2_C2_private", "m2_C3_public", "m2_C4_public", "m2_C5_private", "m2_C6_private", "m2_C7_public", "m2_C8_public", "m2_C9_private", "m2_c_private", "m2_c_public"]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(14)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(14), ReferenceId(16)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(10): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): []
+rebuilt        : SymbolId(10): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(11): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): []
+rebuilt        : SymbolId(11): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(14): [ReferenceId(18)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(15): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(15): [ReferenceId(21)]
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(18): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): [ReferenceId(20), ReferenceId(22), ReferenceId(28), ReferenceId(34)]
+rebuilt        : SymbolId(18): [ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(38), ReferenceId(40)]
+Symbol flags mismatch:
+after transform: SymbolId(24): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(22): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): []
+rebuilt        : SymbolId(22): [ReferenceId(30)]
+Symbol flags mismatch:
+after transform: SymbolId(25): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(23): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(25): []
+rebuilt        : SymbolId(23): [ReferenceId(33)]
+Symbol flags mismatch:
+after transform: SymbolId(28): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(26): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(28): []
+rebuilt        : SymbolId(26): [ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(29): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(27): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(29): []
+rebuilt        : SymbolId(27): [ReferenceId(37)]
+Symbol flags mismatch:
+after transform: SymbolId(32): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(30): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(32): []
+rebuilt        : SymbolId(30): [ReferenceId(42)]
+Symbol flags mismatch:
+after transform: SymbolId(33): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(31): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(33): []
+rebuilt        : SymbolId(31): [ReferenceId(45)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: C1_public
@@ -13563,10 +17228,84 @@ Missing ReferenceId: _m
 Missing ReferenceId: f12_public
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(43), SymbolId(44), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(54)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(40), SymbolId(41), SymbolId(45), SymbolId(47), SymbolId(49), SymbolId(50)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(11), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(55)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(16): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): []
+rebuilt        : SymbolId(16): [ReferenceId(21)]
+Symbol flags mismatch:
+after transform: SymbolId(23): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(20): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(23): []
+rebuilt        : SymbolId(20): [ReferenceId(23)]
+Symbol flags mismatch:
+after transform: SymbolId(29): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(29): []
+rebuilt        : SymbolId(26): [ReferenceId(25)]
+Symbol flags mismatch:
+after transform: SymbolId(33): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(33): []
+rebuilt        : SymbolId(30): [ReferenceId(27)]
+Symbol flags mismatch:
+after transform: SymbolId(36): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(36): []
+rebuilt        : SymbolId(33): [ReferenceId(31)]
+Symbol flags mismatch:
+after transform: SymbolId(38): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(38): []
+rebuilt        : SymbolId(35): [ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(40): []
+rebuilt        : SymbolId(37): [ReferenceId(39)]
+Symbol flags mismatch:
+after transform: SymbolId(42): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(39): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(42): []
+rebuilt        : SymbolId(39): [ReferenceId(43)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
+rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: C1_public
@@ -13582,10 +17321,60 @@ Missing ReferenceId: _m2
 Missing ReferenceId: m2_C3_public
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(13), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(33)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(14), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(35)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(8), SymbolId(38)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(23): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(21), SymbolId(39)]
+rebuilt        : ScopeId(23): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(23)]
+Scope flags mismatch:
+after transform: ScopeId(23): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(23): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(10), ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(16): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30)]
+rebuilt        : SymbolId(16): [ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(22), ReferenceId(23)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35)]
+rebuilt        : SymbolId(17): [ReferenceId(18), ReferenceId(19), ReferenceId(24), ReferenceId(25)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(18): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(18): [ReferenceId(21)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(26): [ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53)]
+rebuilt        : SymbolId(28): [ReferenceId(30), ReferenceId(31), ReferenceId(34), ReferenceId(35)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(27): [ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48)]
+rebuilt        : SymbolId(29): [ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(33)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: m1_c_public
@@ -13603,10 +17392,60 @@ Missing ReferenceId: _m
 Missing ReferenceId: m1_C12_public
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Bindings mismatch:
+after transform: ScopeId(0): ["glo_C11_public", "glo_C3_public", "glo_C7_public", "glo_c_public", "glo_i_public", "m1"]
+rebuilt        : ScopeId(0): ["glo_C11_public", "glo_C3_public", "glo_C7_public", "glo_c_public", "m1"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public", "m1_i_private", "m1_i_public"]
+rebuilt        : ScopeId(1): ["_m", "m1_C10_private", "m1_C11_public", "m1_C12_public", "m1_C1_private", "m1_C2_private", "m1_C3_public", "m1_C4_public", "m1_C5_private", "m1_C6_private", "m1_C7_public", "m1_C8_public", "m1_C9_private", "m1_c_private", "m1_c_public"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(14)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(14), ReferenceId(16)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(9)]
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(10): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): []
+rebuilt        : SymbolId(10): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(12): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(11): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): []
+rebuilt        : SymbolId(11): [ReferenceId(13)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(14): [ReferenceId(18)]
+Symbol flags mismatch:
+after transform: SymbolId(16): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(15): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): []
+rebuilt        : SymbolId(15): [ReferenceId(21)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloFunc.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: C1_public
@@ -13654,10 +17493,156 @@ Missing ReferenceId: _m2
 Missing ReferenceId: f12_public
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(43), SymbolId(86), SymbolId(87), SymbolId(88), SymbolId(96), SymbolId(104), SymbolId(106), SymbolId(108), SymbolId(110), SymbolId(112), SymbolId(114), SymbolId(116), SymbolId(118), SymbolId(120), SymbolId(121), SymbolId(122), SymbolId(123), SymbolId(124), SymbolId(125), SymbolId(126), SymbolId(127)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(40), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(88), SymbolId(94), SymbolId(96), SymbolId(98), SymbolId(100), SymbolId(102), SymbolId(104), SymbolId(106), SymbolId(108), SymbolId(110), SymbolId(111), SymbolId(112), SymbolId(113), SymbolId(114), SymbolId(115), SymbolId(116), SymbolId(117)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(11), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(128)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(57): [SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(54), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(74), SymbolId(76), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(83), SymbolId(84), SymbolId(85), SymbolId(129)]
+rebuilt        : ScopeId(53): [SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(50), SymbolId(56), SymbolId(58), SymbolId(60), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(79)]
+Scope flags mismatch:
+after transform: ScopeId(57): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(53): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(19): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(16): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(19): []
+rebuilt        : SymbolId(16): [ReferenceId(21)]
+Symbol flags mismatch:
+after transform: SymbolId(23): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(20): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(23): []
+rebuilt        : SymbolId(20): [ReferenceId(23)]
+Symbol flags mismatch:
+after transform: SymbolId(29): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(29): []
+rebuilt        : SymbolId(26): [ReferenceId(25)]
+Symbol flags mismatch:
+after transform: SymbolId(33): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(33): []
+rebuilt        : SymbolId(30): [ReferenceId(27)]
+Symbol flags mismatch:
+after transform: SymbolId(36): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(36): []
+rebuilt        : SymbolId(33): [ReferenceId(31)]
+Symbol flags mismatch:
+after transform: SymbolId(38): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(38): []
+rebuilt        : SymbolId(35): [ReferenceId(35)]
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(40): []
+rebuilt        : SymbolId(37): [ReferenceId(39)]
+Symbol flags mismatch:
+after transform: SymbolId(42): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(39): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(42): []
+rebuilt        : SymbolId(39): [ReferenceId(43)]
+Symbol flags mismatch:
+after transform: SymbolId(44): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(42): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(44): [ReferenceId(56), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(80), ReferenceId(81), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(92), ReferenceId(93), ReferenceId(96), ReferenceId(97), ReferenceId(100), ReferenceId(101), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107)]
+rebuilt        : SymbolId(42): [ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(52), ReferenceId(53), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(63), ReferenceId(74), ReferenceId(75), ReferenceId(82), ReferenceId(83)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(45): [ReferenceId(57), ReferenceId(60), ReferenceId(61), ReferenceId(64), ReferenceId(65), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(75), ReferenceId(78), ReferenceId(79), ReferenceId(82), ReferenceId(83), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(94), ReferenceId(95), ReferenceId(98), ReferenceId(99), ReferenceId(102), ReferenceId(103), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111)]
+rebuilt        : SymbolId(43): [ReferenceId(50), ReferenceId(51), ReferenceId(54), ReferenceId(55), ReferenceId(60), ReferenceId(61), ReferenceId(64), ReferenceId(65), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87)]
+Symbol flags mismatch:
+after transform: SymbolId(46): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(44): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(46): []
+rebuilt        : SymbolId(44): [ReferenceId(57)]
+Symbol flags mismatch:
+after transform: SymbolId(62): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(56): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(62): []
+rebuilt        : SymbolId(56): [ReferenceId(67)]
+Symbol flags mismatch:
+after transform: SymbolId(66): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(60): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(66): []
+rebuilt        : SymbolId(60): [ReferenceId(69)]
+Symbol flags mismatch:
+after transform: SymbolId(72): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(66): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(72): []
+rebuilt        : SymbolId(66): [ReferenceId(71)]
+Symbol flags mismatch:
+after transform: SymbolId(76): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(70): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(76): []
+rebuilt        : SymbolId(70): [ReferenceId(73)]
+Symbol flags mismatch:
+after transform: SymbolId(79): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(73): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(79): []
+rebuilt        : SymbolId(73): [ReferenceId(77)]
+Symbol flags mismatch:
+after transform: SymbolId(81): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(75): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(81): []
+rebuilt        : SymbolId(75): [ReferenceId(81)]
+Symbol flags mismatch:
+after transform: SymbolId(83): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(77): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(83): []
+rebuilt        : SymbolId(77): [ReferenceId(85)]
+Symbol flags mismatch:
+after transform: SymbolId(85): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(79): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(85): []
+rebuilt        : SymbolId(79): [ReferenceId(89)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(86): [ReferenceId(112), ReferenceId(116), ReferenceId(117), ReferenceId(120), ReferenceId(121), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(134), ReferenceId(135), ReferenceId(138), ReferenceId(139), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167)]
+rebuilt        : SymbolId(80): [ReferenceId(94), ReferenceId(95), ReferenceId(98), ReferenceId(99), ReferenceId(102), ReferenceId(103), ReferenceId(106), ReferenceId(107), ReferenceId(110), ReferenceId(111), ReferenceId(114), ReferenceId(115)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(87): [ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(118), ReferenceId(119), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(136), ReferenceId(137), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(148), ReferenceId(149), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163)]
+rebuilt        : SymbolId(81): [ReferenceId(92), ReferenceId(93), ReferenceId(96), ReferenceId(97), ReferenceId(100), ReferenceId(101), ReferenceId(104), ReferenceId(105), ReferenceId(108), ReferenceId(109), ReferenceId(112), ReferenceId(113)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloGetter.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: C1_public
@@ -13665,15 +17650,62 @@ Missing ReferenceId: _m
 Missing ReferenceId: C3_public
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(13), SymbolId(14)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(14), SymbolId(15)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(8), SymbolId(17)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(10), ReferenceId(11)]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(7)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21)]
+rebuilt        : SymbolId(14): [ReferenceId(14), ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: C1_public
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Bindings mismatch:
+after transform: ScopeId(0): ["C5_public", "C7_public", "glo_C3_public", "glo_i_public", "m1", "m3"]
+rebuilt        : ScopeId(0): ["C5_public", "m1"]
+Bindings mismatch:
+after transform: ScopeId(1): ["C1_public", "C2_private", "C3_public", "C4_private", "_m"]
+rebuilt        : ScopeId(1): ["C1_public", "C2_private", "_m"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34)]
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44)]
+rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloVar.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -13684,8 +17716,7 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: C1_public
@@ -13697,6 +17728,45 @@ Missing ReferenceId: _m2
 Missing ReferenceId: C1_public
 Missing ReferenceId: m2
 Missing ReferenceId: m2
+Bindings mismatch:
+after transform: ScopeId(0): ["C5_public", "C6_private", "C7_public", "C8_private", "glo_C1_private", "glo_C2_private", "glo_C3_public", "glo_C4_public", "glo_C5_private", "glo_C6_public", "glo_i_private", "glo_i_public", "m1", "m2", "m3", "m4"]
+rebuilt        : ScopeId(0): ["C5_public", "C6_private", "m1", "m2"]
+Bindings mismatch:
+after transform: ScopeId(1): ["C1_public", "C2_private", "C3_public", "C4_private", "_m"]
+rebuilt        : ScopeId(1): ["C1_public", "C2_private", "_m"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(23): ["C1_public", "C2_private", "C3_public", "C4_private", "_m2"]
+rebuilt        : ScopeId(5): ["C1_public", "C2_private", "_m2"]
+Scope flags mismatch:
+after transform: ScopeId(23): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34)]
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
+rebuilt        : SymbolId(3): []
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(66), ReferenceId(68), ReferenceId(70)]
+rebuilt        : SymbolId(6): [ReferenceId(5)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(67), ReferenceId(69), ReferenceId(71)]
+rebuilt        : SymbolId(7): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(72), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(86), ReferenceId(88), ReferenceId(90), ReferenceId(92), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(100), ReferenceId(102), ReferenceId(104), ReferenceId(106)]
+rebuilt        : SymbolId(8): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(87), ReferenceId(89), ReferenceId(91), ReferenceId(93), ReferenceId(95), ReferenceId(97), ReferenceId(99), ReferenceId(101), ReferenceId(103), ReferenceId(105), ReferenceId(107)]
+rebuilt        : SymbolId(9): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunction.ts
 semantic error: Bindings mismatch:
@@ -13863,13 +17933,30 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privateInstanceVisibility.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Test
+semantic error: Missing SymbolId: Test
 Missing SymbolId: _Test
 Missing ReferenceId: _Test
 Missing ReferenceId: Example
 Missing ReferenceId: Test
 Missing ReferenceId: Test
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(1)]
+rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
 semantic error: Bindings mismatch:
@@ -15073,20 +19160,42 @@ after transform: [ReferenceId(1), ReferenceId(7), ReferenceId(8), ReferenceId(9)
 rebuilt        : [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "Foo"]
+rebuilt        : ScopeId(0): ["Foo"]
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "_Foo"]
+rebuilt        : ScopeId(1): ["A", "_Foo"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/rectype.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["I", "_M", "f", "i"]
+rebuilt        : ScopeId(1): ["_M", "f", "i"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 semantic error: Bindings mismatch:
@@ -15119,8 +19228,7 @@ after transform: [ReferenceId(1), ReferenceId(3)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TypeScript2
+semantic error: Missing SymbolId: TypeScript2
 Missing SymbolId: _TypeScript
 Missing ReferenceId: _TypeScript
 Missing ReferenceId: MemberName
@@ -15128,6 +19236,30 @@ Missing ReferenceId: _TypeScript
 Missing ReferenceId: MemberNameArray
 Missing ReferenceId: TypeScript2
 Missing ReferenceId: TypeScript2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("TypeScript2")
+rebuilt        : ReferenceId(7): Some("TypeScript2")
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -15250,11 +19382,19 @@ after transform: ScopeId(0): ["A", "B", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalOverloadResolution.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["I", "_M", "f", "i"]
+rebuilt        : ScopeId(1): ["_M", "f", "i"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
 semantic error: Bindings mismatch:
@@ -15274,8 +19414,7 @@ after transform: []
 rebuilt        : ["a", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: _Foo
 Missing ReferenceId: C
@@ -15284,6 +19423,30 @@ Missing ReferenceId: Foo
 Missing SymbolId: _Foo2
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(8)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Unresolved reference IDs mismatch for "C":
+after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
+rebuilt        : [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
 semantic error: Bindings mismatch:
@@ -15408,8 +19571,7 @@ after transform: ScopeId(2): ["T", "x"]
 rebuilt        : ScopeId(1): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: MsPortal
+semantic error: Missing SymbolId: MsPortal
 Missing SymbolId: _MsPortal
 Missing SymbolId: Controls
 Missing SymbolId: _Controls
@@ -15435,6 +19597,51 @@ Missing ReferenceId: _MsPortal
 Missing ReferenceId: _MsPortal
 Missing ReferenceId: MsPortal
 Missing ReferenceId: MsPortal
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(11)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(12)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(13)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["Interface", "ItemValue", "ViewModel", "_ItemList"]
+rebuilt        : ScopeId(4): ["ItemValue", "ViewModel", "_ItemList"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["T"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(8): ["TValue"]
+rebuilt        : ScopeId(7): []
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(8): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(3)]
+rebuilt        : SymbolId(8): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(10): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(0)]
+rebuilt        : SymbolId(10): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 semantic error: Bindings mismatch:
@@ -15513,13 +19720,24 @@ after transform: ScopeId(0): ["A", "B", "C", "D", "c", "d"]
 rebuilt        : ScopeId(0): ["c", "d"]
 
 tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Models
+semantic error: Missing SymbolId: Models
 Missing SymbolId: _Models
 Missing ReferenceId: _Models
 Missing ReferenceId: Person
 Missing ReferenceId: Models
 Missing ReferenceId: Models
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -15779,8 +19997,7 @@ after transform: ScopeId(0): ["Opts", "Signs", "Wrapper", "y", "yone", "yun"]
 rebuilt        : ScopeId(0): ["y", "yone", "yun"]
 
 tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M1
+semantic error: Missing SymbolId: M1
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: reduce
@@ -15794,6 +20011,54 @@ Missing ReferenceId: _M2
 Missing ReferenceId: compose2
 Missing ReferenceId: M2
 Missing ReferenceId: M2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(16)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "ar", "e", "f"]
+rebuilt        : ScopeId(2): ["ar", "e", "f"]
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "_M2", "compose", "compose2"]
+rebuilt        : ScopeId(3): ["_M2", "compose", "compose2"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["B", "C", "D", "f", "g"]
+rebuilt        : ScopeId(5): ["f", "g"]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(7)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(8): [ReferenceId(14)]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(11)]
+rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(19)]
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("A")
+rebuilt        : ReferenceId(10): None
+Unresolved references mismatch:
+after transform: ["Array", "arguments"]
+rebuilt        : ["A", "Array", "arguments"]
+Unresolved reference IDs mismatch for "Array":
+after transform: [ReferenceId(0), ReferenceId(2)]
+rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
 semantic error: Bindings mismatch:
@@ -15878,13 +20143,27 @@ after transform: ScopeId(0): ["Box", "InferRecursive", "Recursive", "t1", "t2", 
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: X
+semantic error: Missing SymbolId: X
 Missing SymbolId: _X
 Missing ReferenceId: _X
 Missing ReferenceId: f
 Missing ReferenceId: X
 Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/sigantureIsSubTypeIfTheyAreIdentical.ts
 semantic error: Bindings mismatch:
@@ -15962,8 +20241,7 @@ after transform: []
 rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: sas
+semantic error: Missing SymbolId: sas
 Missing SymbolId: _sas
 Missing SymbolId: tools
 Missing SymbolId: _tools
@@ -15975,10 +20253,30 @@ Missing ReferenceId: _sas
 Missing ReferenceId: _sas
 Missing ReferenceId: sas
 Missing ReferenceId: sas
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(4): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Shapes
+semantic error: Missing SymbolId: Shapes
 Missing SymbolId: _Shapes
 Missing ReferenceId: _Shapes
 Missing ReferenceId: Point
@@ -15986,6 +20284,30 @@ Missing ReferenceId: _Shapes
 Missing ReferenceId: foo
 Missing ReferenceId: Shapes
 Missing ReferenceId: Shapes
+Bindings mismatch:
+after transform: ScopeId(0): ["IPoint", "Shapes", "dist", "p"]
+rebuilt        : ScopeId(0): ["Shapes", "dist", "p"]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(10)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(5)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): []
+rebuilt        : SymbolId(6): [ReferenceId(7)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("Shapes")
+rebuilt        : ReferenceId(10): Some("Shapes")
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-InterfacePrecedingVariableDeclaration1.ts
 semantic error: Bindings mismatch:
@@ -15993,22 +20315,43 @@ after transform: ScopeId(0): ["I", "x"]
 rebuilt        : ScopeId(0): ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Bindings mismatch:
+after transform: ScopeId(0): ["Document", "Foo", "Window", "window"]
+rebuilt        : ScopeId(0): ["Foo"]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("window")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["window"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Q
+semantic error: Missing SymbolId: Q
 Missing SymbolId: _Q
 Missing ReferenceId: Q
 Missing ReferenceId: Q
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing SymbolId: Bar
 Missing SymbolId: _Bar
@@ -16018,6 +20361,27 @@ Missing ReferenceId: _Foo
 Missing ReferenceId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(15)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(13), SymbolId(14), SymbolId(16)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(15), SymbolId(16)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(13)]
+rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(12)]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDecorators.ts
 semantic error: Unexpected token
@@ -17414,8 +21778,7 @@ after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m
+semantic error: Missing SymbolId: m
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: c
@@ -17423,6 +21786,33 @@ Missing ReferenceId: m
 Missing ReferenceId: m
 Missing SymbolId: a
 Missing SymbolId: b
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("m")
+rebuilt        : ReferenceId(4): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("m")
+rebuilt        : ReferenceId(5): Some("m")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("a")
+rebuilt        : ReferenceId(6): Some("a")
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("b")
+rebuilt        : ReferenceId(7): Some("b")
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -17431,8 +21821,7 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithFil
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/sourcemapValidationDuplicateNames.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m1
+semantic error: Missing SymbolId: m1
 Missing SymbolId: _m
 Missing ReferenceId: _m
 Missing ReferenceId: c
@@ -17441,6 +21830,30 @@ Missing ReferenceId: m1
 Missing SymbolId: _m2
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("m1")
+rebuilt        : ReferenceId(4): Some("m1")
 
 tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 semantic error: Bindings mismatch:
@@ -17456,13 +21869,33 @@ after transform: ScopeId(0): ["Bar", "Promise"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: C
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("M")
+rebuilt        : ReferenceId(4): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEachOther.ts
 semantic error: Bindings mismatch:
@@ -17724,13 +22157,99 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: tessst
+semantic error: Missing SymbolId: tessst
 Missing SymbolId: _tessst
 Missing ReferenceId: _tessst
 Missing ReferenceId: funkyFor
 Missing ReferenceId: tessst
 Missing ReferenceId: tessst
+Bindings mismatch:
+after transform: ScopeId(0): ["Array", "ListWrapper", "ListWrapper2", "Scanner", "cloned", "outer", "tessst", "y"]
+rebuilt        : ScopeId(0): ["ListWrapper", "ListWrapper2", "cloned", "outer", "tessst", "y"]
+Bindings mismatch:
+after transform: ScopeId(1): ["Inner", "T", "x"]
+rebuilt        : ScopeId(1): ["Inner", "x"]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "array", "dit"]
+rebuilt        : ScopeId(4): ["array", "dit"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "a", "array", "dit"]
+rebuilt        : ScopeId(5): ["a", "array", "dit"]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(14), SymbolId(130)]
+rebuilt        : ScopeId(6): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "U", "array", "callback"]
+rebuilt        : ScopeId(7): ["array", "callback"]
+Bindings mismatch:
+after transform: ScopeId(17): ["T", "array", "dit"]
+rebuilt        : ScopeId(15): ["array", "dit"]
+Bindings mismatch:
+after transform: ScopeId(18): ["T", "array", "dit", "fn", "i"]
+rebuilt        : ScopeId(16): ["array", "dit", "fn", "i"]
+Bindings mismatch:
+after transform: ScopeId(21): ["T", "array", "dit"]
+rebuilt        : ScopeId(19): ["array", "dit"]
+Bindings mismatch:
+after transform: ScopeId(22): ["T", "array", "dit"]
+rebuilt        : ScopeId(20): ["array", "dit"]
+Bindings mismatch:
+after transform: ScopeId(23): ["T", "array", "dit", "startIndex", "value"]
+rebuilt        : ScopeId(21): ["array", "dit", "startIndex", "value"]
+Bindings mismatch:
+after transform: ScopeId(24): ["T", "dit", "el", "list"]
+rebuilt        : ScopeId(22): ["dit", "el", "list"]
+Bindings mismatch:
+after transform: ScopeId(25): ["T", "a", "array", "dit", "scanner"]
+rebuilt        : ScopeId(23): ["a", "array", "dit", "scanner"]
+Bindings mismatch:
+after transform: ScopeId(29): ["T", "dit", "index", "list", "value"]
+rebuilt        : ScopeId(27): ["dit", "index", "list", "value"]
+Bindings mismatch:
+after transform: ScopeId(30): ["T", "dit", "index", "list", "res"]
+rebuilt        : ScopeId(28): ["dit", "index", "list", "res"]
+Bindings mismatch:
+after transform: ScopeId(31): ["T", "dit", "i", "index", "items", "list"]
+rebuilt        : ScopeId(29): ["dit", "i", "index", "items", "list"]
+Bindings mismatch:
+after transform: ScopeId(34): ["T", "dit", "el", "index", "list"]
+rebuilt        : ScopeId(32): ["dit", "el", "index", "list"]
+Bindings mismatch:
+after transform: ScopeId(42): ["T", "dit", "from", "l", "to"]
+rebuilt        : ScopeId(40): ["dit", "from", "l", "to"]
+Bindings mismatch:
+after transform: ScopeId(43): ["T", "dit", "from", "l", "length"]
+rebuilt        : ScopeId(41): ["dit", "from", "l", "length"]
+Bindings mismatch:
+after transform: ScopeId(44): ["T", "compareFn", "dit", "l"]
+rebuilt        : ScopeId(42): ["compareFn", "dit", "l"]
+Bindings mismatch:
+after transform: ScopeId(47): ["T", "dit", "l"]
+rebuilt        : ScopeId(45): ["dit", "l"]
+Bindings mismatch:
+after transform: ScopeId(48): ["T", "dit", "l"]
+rebuilt        : ScopeId(46): ["dit", "l"]
+Bindings mismatch:
+after transform: ScopeId(49): ["T", "candidate", "candidateValue", "dit", "index", "list", "maxValue", "predicate", "solution"]
+rebuilt        : ScopeId(47): ["candidate", "candidateValue", "dit", "index", "list", "maxValue", "predicate", "solution"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(9), ReferenceId(12)]
+rebuilt        : SymbolId(4): [ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): []
+rebuilt        : SymbolId(12): [ReferenceId(21)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(24): [ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(44), ReferenceId(54), ReferenceId(59), ReferenceId(66), ReferenceId(72), ReferenceId(77), ReferenceId(80), ReferenceId(90), ReferenceId(93), ReferenceId(99), ReferenceId(107), ReferenceId(118), ReferenceId(126), ReferenceId(128), ReferenceId(130), ReferenceId(137), ReferenceId(147), ReferenceId(155), ReferenceId(161), ReferenceId(170), ReferenceId(173), ReferenceId(177), ReferenceId(200), ReferenceId(201)]
+rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(130), ReferenceId(131)]
+Reference symbol mismatch:
+after transform: ReferenceId(85): Some("tessst")
+rebuilt        : ReferenceId(51): Some("tessst")
 
 tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
 semantic error: Bindings mismatch:
@@ -17820,13 +22339,27 @@ after transform: ["Required"]
 rebuilt        : ["someVal", "someVal2"]
 
 tasks/coverage/typescript/tests/cases/compiler/structural1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["I", "_M", "f"]
+rebuilt        : ScopeId(1): ["_M", "f"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
 semantic error: Bindings mismatch:
@@ -17952,8 +22485,7 @@ after transform: ["Number"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: test
+semantic error: Missing SymbolId: test
 Missing SymbolId: _test
 Missing ReferenceId: _test
 Missing ReferenceId: A
@@ -17961,6 +22493,27 @@ Missing ReferenceId: _test
 Missing ReferenceId: B
 Missing ReferenceId: test
 Missing ReferenceId: test
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
 semantic error: Unresolved reference IDs mismatch for "B":
@@ -18042,11 +22595,19 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule7.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
 semantic error: Bindings mismatch:
@@ -18060,26 +22621,89 @@ after transform: ["C", "Foo", "Promise"]
 rebuilt        : ["C", "E", "Foo", "Promise"]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnums.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: NonTopLevelConstEnum
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(1), SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
+Bindings mismatch:
+after transform: ScopeId(2): ["TopLevelConstEnum", "X"]
+rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
+rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(5): [ReferenceId(12)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("M")
+rebuilt        : ReferenceId(7): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnumsSeparateCompilation.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: NonTopLevelConstEnum
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(1), SymbolId(3), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
+Bindings mismatch:
+after transform: ScopeId(2): ["TopLevelConstEnum", "X"]
+rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
+rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | ConstEnum)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(5): [ReferenceId(12)]
+Reference symbol mismatch:
+after transform: ReferenceId(3): Some("M")
+rebuilt        : ReferenceId(7): Some("M")
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleDeclarationMerging.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _F
+semantic error: Missing SymbolId: _F
 Missing ReferenceId: F
 Missing ReferenceId: F
 Missing SymbolId: _C
@@ -18088,10 +22712,57 @@ Missing ReferenceId: C
 Missing SymbolId: _E
 Missing ReferenceId: E
 Missing ReferenceId: E
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(6)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(8)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 37, end: 38 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(Export | Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 83, end: 84 }]
+rebuilt        : SymbolId(3): []
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(5), ReferenceId(6)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(4): [Span { start: 128, end: 129 }]
+rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TopLevelModule
+semantic error: Missing SymbolId: TopLevelModule
 Missing SymbolId: _TopLevelModule
 Missing ReferenceId: TopLevelModule
 Missing ReferenceId: TopLevelModule
@@ -18111,13 +22782,90 @@ Missing ReferenceId: _TopLevelModule2
 Missing ReferenceId: NonTopLevelEnum
 Missing ReferenceId: TopLevelModule2
 Missing ReferenceId: TopLevelModule2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(13)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["E", "TopLevelEnum"]
+rebuilt        : ScopeId(4): ["TopLevelEnum"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(11), SymbolId(14)]
+rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(9), SymbolId(15)]
+rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(9): ["E", "NonTopLevelEnum"]
+rebuilt        : ScopeId(9): ["NonTopLevelEnum"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(0x0)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable | Export)
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(9): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): []
+rebuilt        : SymbolId(13): [ReferenceId(12)]
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): []
+rebuilt        : SymbolId(14): [ReferenceId(17)]
 
 tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: ns
+semantic error: Missing SymbolId: ns
 Missing SymbolId: _ns
 Missing ReferenceId: ns
 Missing ReferenceId: ns
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["AnEnum", "ONE", "TWO"]
+rebuilt        : ScopeId(2): ["AnEnum"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable | Export)
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("ns")
+rebuilt        : ReferenceId(8): Some("ns")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("ns")
+rebuilt        : ReferenceId(10): Some("ns")
 
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
 semantic error: Unresolved references mismatch:
@@ -18125,11 +22873,25 @@ after transform: ["TemplateStringsArray"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: n
+semantic error: Missing SymbolId: n
 Missing SymbolId: _n
 Missing ReferenceId: n
 Missing ReferenceId: n
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "x"]
+rebuilt        : ScopeId(2): ["x"]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/targetEs6DecoratorMetadataImportNotElided.ts
 semantic error: Bindings mismatch:
@@ -18205,11 +22967,19 @@ after transform: []
 rebuilt        : ["format"]
 
 tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 semantic error: Bindings mismatch:
@@ -18250,13 +23020,30 @@ after transform: SymbolId(6): [ReferenceId(7), ReferenceId(8), ReferenceId(10), 
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/thisInModuleFunction1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: bar
+semantic error: Missing SymbolId: bar
 Missing SymbolId: _bar
 Missing ReferenceId: _bar
 Missing ReferenceId: bar
 Missing ReferenceId: bar
 Missing ReferenceId: bar
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("bar")
+rebuilt        : ReferenceId(4): Some("bar")
 
 tasks/coverage/typescript/tests/cases/compiler/thisInObjectJs.ts
 semantic error: Cannot use export statement outside a module
@@ -18305,11 +23092,19 @@ after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: ObjectLiteral
+semantic error: Missing SymbolId: ObjectLiteral
 Missing SymbolId: _ObjectLiteral
 Missing ReferenceId: ObjectLiteral
 Missing ReferenceId: ObjectLiteral
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionTypedArgument.ts
 semantic error: Bindings mismatch:
@@ -18811,21 +23606,52 @@ after transform: []
 rebuilt        : ["aIndex", "bIndex", "cIndex"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Foo
+semantic error: Missing SymbolId: Foo
 Missing SymbolId: _Foo
 Missing ReferenceId: _Foo
 Missing ReferenceId: Foo
 Missing ReferenceId: Foo
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("Foo")
+rebuilt        : ReferenceId(4): Some("Foo")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("Foo")
+rebuilt        : ReferenceId(5): Some("Foo")
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TypeGuards
+semantic error: Missing SymbolId: TypeGuards
 Missing SymbolId: _TypeGuards
 Missing ReferenceId: _TypeGuards
 Missing ReferenceId: IsObject
 Missing ReferenceId: TypeGuards
 Missing ReferenceId: TypeGuards
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 semantic error: Bindings mismatch:
@@ -18883,9 +23709,20 @@ after transform: ScopeId(2): ["T", "obj"]
 rebuilt        : ScopeId(1): ["obj"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["React", "TProps", "TranslationEntry", "Translations", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
+Unresolved references mismatch:
+after transform: ["JSX", "T", "require"]
+rebuilt        : ["T", "require"]
+Unresolved reference IDs mismatch for "T":
+after transform: [ReferenceId(9), ReferenceId(11)]
+rebuilt        : [ReferenceId(3)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(14)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeLiteralCallback.ts
 semantic error: Bindings mismatch:
@@ -19205,8 +24042,7 @@ after transform: ScopeId(0): ["Animal", "Breed", "getBreedSizeWithFunction", "ge
 rebuilt        : ScopeId(0): ["getBreedSizeWithFunction", "getBreedSizeWithoutFunction"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TopLevelModule1
+semantic error: Missing SymbolId: TopLevelModule1
 Missing SymbolId: _TopLevelModule
 Missing SymbolId: SubModule1
 Missing SymbolId: _SubModule
@@ -19262,6 +24098,102 @@ Missing ReferenceId: _TopLevelModule2
 Missing ReferenceId: _TopLevelModule2
 Missing ReferenceId: TopLevelModule2
 Missing ReferenceId: TopLevelModule2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(49)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(50)]
+Bindings mismatch:
+after transform: ScopeId(1): ["ClassA", "InterfaceY", "NotExportedModule", "SubModule1", "SubModule2", "_TopLevelModule"]
+rebuilt        : ScopeId(1): ["ClassA", "NotExportedModule", "SubModule1", "SubModule2", "_TopLevelModule"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(2), SymbolId(31), SymbolId(53)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(33)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["ClassA", "ClassB", "InterfaceX", "NonExportedClassQ", "_SubSubModule"]
+rebuilt        : ScopeId(3): ["ClassA", "ClassB", "NonExportedClassQ", "_SubSubModule"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(16): ["InterfaceY", "SubSubModule2", "_SubModule2"]
+rebuilt        : ScopeId(14): ["SubSubModule2", "_SubModule2"]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(17): ["ClassA", "ClassB", "ClassC", "InterfaceY", "NonExportedInterfaceQ", "_SubSubModule2"]
+rebuilt        : ScopeId(15): ["ClassA", "ClassB", "ClassC", "_SubSubModule2"]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(33): [SymbolId(48), SymbolId(57)]
+rebuilt        : ScopeId(24): [SymbolId(48), SymbolId(49)]
+Scope flags mismatch:
+after transform: ScopeId(33): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(24): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(35): [SymbolId(50), SymbolId(58)]
+rebuilt        : ScopeId(26): [SymbolId(51), SymbolId(52)]
+Scope flags mismatch:
+after transform: ScopeId(35): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(26): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(36): [SymbolId(51), SymbolId(59)]
+rebuilt        : ScopeId(27): [SymbolId(53), SymbolId(54)]
+Scope flags mismatch:
+after transform: ScopeId(36): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(27): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(18)]
+rebuilt        : SymbolId(6): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(13): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(16): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(8), ReferenceId(26)]
+rebuilt        : SymbolId(16): [ReferenceId(22)]
+Symbol flags mismatch:
+after transform: SymbolId(39): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(43): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(39): []
+rebuilt        : SymbolId(43): [ReferenceId(40)]
+Symbol flags mismatch:
+after transform: SymbolId(40): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(44): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(40): []
+rebuilt        : SymbolId(44): [ReferenceId(42)]
+Symbol flags mismatch:
+after transform: SymbolId(41): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(45): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(41): []
+rebuilt        : SymbolId(45): [ReferenceId(44)]
+Symbol flags mismatch:
+after transform: SymbolId(48): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(49): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(48): []
+rebuilt        : SymbolId(49): [ReferenceId(54)]
+Symbol flags mismatch:
+after transform: SymbolId(51): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(54): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(51): []
+rebuilt        : SymbolId(54): [ReferenceId(60)]
+Unresolved references mismatch:
+after transform: ["SubModule1", "SubSubModule1", "TopLevelModule1", "TopLevelModule2"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
 semantic error: Symbol flags mismatch:
@@ -19638,14 +24570,28 @@ after transform: ScopeId(0): ["IData", "ISeries", "MyView", "_"]
 rebuilt        : ScopeId(0): ["MyView"]
 
 tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
 Missing SymbolId: _M2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(4), SymbolId(6)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
 semantic error: Bindings mismatch:
@@ -19864,13 +24810,27 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace4.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Validation
+semantic error: Missing SymbolId: Validation
 Missing SymbolId: _Validation
 Missing ReferenceId: _Validation
 Missing ReferenceId: c1
 Missing ReferenceId: Validation
 Missing ReferenceId: Validation
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["_Validation", "c1", "i1", "i2", "i3"]
+rebuilt        : ScopeId(1): ["_Validation", "c1"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace5.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -19887,11 +24847,28 @@ after transform: []
 rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersDeferred.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N
+semantic error: Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14), SymbolId(17), SymbolId(23), SymbolId(29)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(12), SymbolId(13), SymbolId(16), SymbolId(22), SymbolId(28)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T", "a"]
+rebuilt        : ScopeId(1): ["a"]
+Binding symbols mismatch:
+after transform: ScopeId(43): [SymbolId(30), SymbolId(31)]
+rebuilt        : ScopeId(43): [SymbolId(29), SymbolId(30)]
+Scope flags mismatch:
+after transform: ScopeId(43): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(43): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(53): Some("N")
+rebuilt        : ReferenceId(53): Some("N")
 
 tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
 semantic error: Bindings mismatch:
@@ -19984,8 +24961,7 @@ after transform: []
 rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: ts
+semantic error: Missing SymbolId: ts
 Missing SymbolId: _ts
 Missing ReferenceId: _ts
 Missing ReferenceId: printVersion
@@ -19993,6 +24969,24 @@ Missing ReferenceId: _ts
 Missing ReferenceId: log
 Missing ReferenceId: ts
 Missing ReferenceId: ts
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0)]
+rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
 semantic error: Bindings mismatch:
@@ -20481,11 +25475,19 @@ semantic error: `import lib = require(...);` is only supported when compiling mo
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbient.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M2
+semantic error: Missing SymbolId: M2
 Missing SymbolId: _M2
 Missing ReferenceId: M2
 Missing ReferenceId: M2
+Bindings mismatch:
+after transform: ScopeId(0): ["M", "M2"]
+rebuilt        : ScopeId(0): ["M2"]
+Bindings mismatch:
+after transform: ScopeId(6): ["E", "M", "_M2", "x"]
+rebuilt        : ScopeId(1): ["_M2"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbientExternalModule.ts
 semantic error: Bindings mismatch:
@@ -20517,13 +25519,42 @@ after transform: ["Promise", "someOtherFunction"]
 rebuilt        : ["someOtherFunction"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f1
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "M", "MyPromise", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
+rebuilt        : ScopeId(0): ["C", "M", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
+Binding symbols mismatch:
+after transform: ScopeId(25): [SymbolId(20), SymbolId(22)]
+rebuilt        : ScopeId(24): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(24): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): []
+rebuilt        : SymbolId(17): [ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("p")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("mp")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("mp")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("p")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["Promise"]
+rebuilt        : ["mp", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncUseStrict_es2017.ts
 semantic error: Bindings mismatch:
@@ -20810,13 +25841,42 @@ after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f1
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "M", "MyPromise", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
+rebuilt        : ScopeId(0): ["C", "M", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
+Binding symbols mismatch:
+after transform: ScopeId(25): [SymbolId(20), SymbolId(22)]
+rebuilt        : ScopeId(24): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(24): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): []
+rebuilt        : SymbolId(17): [ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("p")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("mp")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("mp")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("p")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["Promise"]
+rebuilt        : ["mp", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncImportedPromise_es5.ts
 semantic error: Bindings mismatch:
@@ -20824,13 +25884,33 @@ after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncQualifiedReturnType_es5.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: X
+semantic error: Missing SymbolId: X
 Missing SymbolId: _X
 Missing ReferenceId: _X
 Missing ReferenceId: MyPromise
 Missing ReferenceId: X
 Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(2)]
+Unresolved references mismatch:
+after transform: ["Promise", "X"]
+rebuilt        : ["Promise"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncUseStrict_es5.ts
 semantic error: Bindings mismatch:
@@ -21132,13 +26212,42 @@ after transform: ["Promise", "someOtherFunction"]
 rebuilt        : ["someOtherFunction"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: f1
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "M", "MyPromise", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
+rebuilt        : ScopeId(0): ["C", "M", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
+Binding symbols mismatch:
+after transform: ScopeId(25): [SymbolId(20), SymbolId(22)]
+rebuilt        : ScopeId(24): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(24): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(17): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(20): []
+rebuilt        : SymbolId(17): [ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(11): Some("p")
+rebuilt        : ReferenceId(0): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("mp")
+rebuilt        : ReferenceId(1): None
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("mp")
+rebuilt        : ReferenceId(2): None
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("p")
+rebuilt        : ReferenceId(3): None
+Unresolved references mismatch:
+after transform: ["Promise"]
+rebuilt        : ["mp", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncUseStrict_es6.ts
 semantic error: Bindings mismatch:
@@ -21433,11 +26542,31 @@ after transform: ["AsyncGenerator"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 35, end: 36 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Class | Interface)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 122, end: 123 }]
+rebuilt        : SymbolId(3): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classWithEmptyBody.ts
 semantic error: Symbol reference IDs mismatch:
@@ -21534,11 +26663,19 @@ after transform: ReferenceId(3): ReferenceFlags(Type)
 rebuilt        : ReferenceId(1): ReferenceFlags(Read)
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/extendClassExpressionFromModule.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -21613,11 +26750,25 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Generic
+semantic error: Missing SymbolId: Generic
 Missing SymbolId: _Generic
 Missing ReferenceId: Generic
 Missing ReferenceId: Generic
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["T"]
+rebuilt        : ScopeId(2): []
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
 semantic error: Unresolved references mismatch:
@@ -21630,8 +26781,7 @@ after transform: ScopeId(2): ["T", "U"]
 rebuilt        : ScopeId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/constructorHasPrototypeProperty.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: NonGeneric
+semantic error: Missing SymbolId: NonGeneric
 Missing SymbolId: _NonGeneric
 Missing ReferenceId: NonGeneric
 Missing ReferenceId: NonGeneric
@@ -21639,6 +26789,27 @@ Missing SymbolId: Generic
 Missing SymbolId: _Generic
 Missing ReferenceId: Generic
 Missing ReferenceId: Generic
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(16)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(6), SymbolId(9), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(17)]
+rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "U"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "U"]
+rebuilt        : ScopeId(6): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
 semantic error: Symbol reference IDs mismatch:
@@ -21905,7 +27076,6 @@ Classes may not have a static property named prototype
 Classes may not have a static property named prototype
 Classes may not have a static property named prototype
 Classes may not have a static property named prototype
-Semantic Collector failed after transform
 Missing SymbolId: TestOnDefaultExportedClass_1
 Missing SymbolId: _TestOnDefaultExportedClass_
 Missing ReferenceId: TestOnDefaultExportedClass_1
@@ -21946,6 +27116,72 @@ Missing SymbolId: TestOnDefaultExportedClass_10
 Missing SymbolId: _TestOnDefaultExportedClass_10
 Missing ReferenceId: TestOnDefaultExportedClass_10
 Missing ReferenceId: TestOnDefaultExportedClass_10
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(43), SymbolId(44), SymbolId(46), SymbolId(47), SymbolId(49), SymbolId(50), SymbolId(52), SymbolId(53), SymbolId(55), SymbolId(56), SymbolId(58), SymbolId(59), SymbolId(61), SymbolId(62), SymbolId(64), SymbolId(65), SymbolId(67), SymbolId(68), SymbolId(70)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(44), SymbolId(45), SymbolId(48), SymbolId(49), SymbolId(52), SymbolId(53), SymbolId(56), SymbolId(57), SymbolId(60), SymbolId(61), SymbolId(64), SymbolId(65), SymbolId(68), SymbolId(69), SymbolId(72), SymbolId(73), SymbolId(76), SymbolId(77), SymbolId(80)]
+Binding symbols mismatch:
+after transform: ScopeId(81): [SymbolId(42), SymbolId(71)]
+rebuilt        : ScopeId(81): [SymbolId(42), SymbolId(43)]
+Scope flags mismatch:
+after transform: ScopeId(81): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(81): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(84): [SymbolId(45), SymbolId(72)]
+rebuilt        : ScopeId(84): [SymbolId(46), SymbolId(47)]
+Scope flags mismatch:
+after transform: ScopeId(84): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(84): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(91): [SymbolId(48), SymbolId(73)]
+rebuilt        : ScopeId(91): [SymbolId(50), SymbolId(51)]
+Scope flags mismatch:
+after transform: ScopeId(91): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(91): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(94): [SymbolId(51), SymbolId(74)]
+rebuilt        : ScopeId(94): [SymbolId(54), SymbolId(55)]
+Scope flags mismatch:
+after transform: ScopeId(94): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(94): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(101): [SymbolId(54), SymbolId(75)]
+rebuilt        : ScopeId(101): [SymbolId(58), SymbolId(59)]
+Scope flags mismatch:
+after transform: ScopeId(101): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(101): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(104): [SymbolId(57), SymbolId(76)]
+rebuilt        : ScopeId(104): [SymbolId(62), SymbolId(63)]
+Scope flags mismatch:
+after transform: ScopeId(104): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(104): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(111): [SymbolId(60), SymbolId(77)]
+rebuilt        : ScopeId(111): [SymbolId(66), SymbolId(67)]
+Scope flags mismatch:
+after transform: ScopeId(111): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(111): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(114): [SymbolId(63), SymbolId(78)]
+rebuilt        : ScopeId(114): [SymbolId(70), SymbolId(71)]
+Scope flags mismatch:
+after transform: ScopeId(114): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(114): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(121): [SymbolId(66), SymbolId(79)]
+rebuilt        : ScopeId(121): [SymbolId(74), SymbolId(75)]
+Scope flags mismatch:
+after transform: ScopeId(121): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(121): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(124): [SymbolId(69), SymbolId(80)]
+rebuilt        : ScopeId(124): [SymbolId(78), SymbolId(79)]
+Scope flags mismatch:
+after transform: ScopeId(124): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(124): ScopeFlags(Function)
+Unresolved references mismatch:
+after transform: ["const"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisInInstanceMemberInitializer.ts
 semantic error: Bindings mismatch:
@@ -22596,13 +27832,24 @@ after transform: []
 rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Services
+semantic error: Missing SymbolId: Services
 Missing SymbolId: _Services
 Missing ReferenceId: _Services
 Missing ReferenceId: Service
 Missing ReferenceId: Services
 Missing ReferenceId: Services
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression2ES2020.ts
 semantic error: Unresolved references mismatch:
@@ -22903,8 +28150,7 @@ after transform: ["Cat", "Dog"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M1
+semantic error: Missing SymbolId: M1
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: EConst1
@@ -22959,6 +28205,198 @@ Missing ReferenceId: _M7
 Missing ReferenceId: _M7
 Missing ReferenceId: M6
 Missing ReferenceId: M6
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(16), SymbolId(25), SymbolId(32), SymbolId(37), SymbolId(42)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(9), SymbolId(15), SymbolId(20), SymbolId(24), SymbolId(27)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(8), SymbolId(15), SymbolId(52)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "B", "C", "EImpl1"]
+rebuilt        : ScopeId(2): ["EImpl1"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(0x0)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["D", "E", "EImpl1", "F"]
+rebuilt        : ScopeId(3): ["EImpl1"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["A", "B", "C", "EConst1"]
+rebuilt        : ScopeId(4): ["EConst1"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["D", "E", "EConst1", "F"]
+rebuilt        : ScopeId(5): ["EConst1"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(17), SymbolId(24), SymbolId(53)]
+rebuilt        : ScopeId(6): [SymbolId(10), SymbolId(11), SymbolId(14)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["A", "B", "C", "EComp2"]
+rebuilt        : ScopeId(7): ["EComp2"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(0x0)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["D", "E", "EComp2", "F"]
+rebuilt        : ScopeId(8): ["EComp2"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(0x0)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(26), SymbolId(54)]
+rebuilt        : ScopeId(9): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(10): ["A", "B", "EInit"]
+rebuilt        : ScopeId(10): ["EInit"]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(0x0)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(11): ["C", "D", "E", "EInit"]
+rebuilt        : ScopeId(11): ["EInit"]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(0x0)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(33), SymbolId(55)]
+rebuilt        : ScopeId(12): [SymbolId(21), SymbolId(22)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(13): ["Blue", "Color", "Green", "Red"]
+rebuilt        : ScopeId(13): ["Color"]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(0x0)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(14): ["Color", "_M5"]
+rebuilt        : ScopeId(14): ["_M5"]
+Scope flags mismatch:
+after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(14): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(15): ["Blue", "Color", "Green", "Red"]
+rebuilt        : ScopeId(15): ["Color"]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(0x0)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(16): [SymbolId(43), SymbolId(57)]
+rebuilt        : ScopeId(16): [SymbolId(28), SymbolId(29)]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(16): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(17): ["Color", "_A"]
+rebuilt        : ScopeId(17): ["_A"]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(18): ["Blue", "Color", "Green", "Red"]
+rebuilt        : ScopeId(18): ["Color"]
+Scope flags mismatch:
+after transform: ScopeId(18): ScopeFlags(0x0)
+rebuilt        : ScopeId(18): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(19): [SymbolId(48), SymbolId(51), SymbolId(59)]
+rebuilt        : ScopeId(19): [SymbolId(32), SymbolId(33), SymbolId(36)]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(19): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(20): ["Color", "_A2"]
+rebuilt        : ScopeId(20): ["_A2"]
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(20): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(21): ["Color", "Yellow"]
+rebuilt        : ScopeId(21): ["Color"]
+Scope flags mismatch:
+after transform: ScopeId(21): ScopeFlags(0x0)
+rebuilt        : ScopeId(21): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 238, end: 244 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(45), ReferenceId(46)]
+rebuilt        : SymbolId(5): [ReferenceId(24), ReferenceId(25), ReferenceId(33), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(8): [Span { start: 351, end: 358 }]
+rebuilt        : SymbolId(5): []
+Symbol flags mismatch:
+after transform: SymbolId(17): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(17): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(61), ReferenceId(62)]
+rebuilt        : SymbolId(11): [ReferenceId(52), ReferenceId(53), ReferenceId(61), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(17): [Span { start: 684, end: 690 }]
+rebuilt        : SymbolId(11): []
+Symbol flags mismatch:
+after transform: SymbolId(26): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
+Symbol redeclarations mismatch:
+after transform: SymbolId(26): [Span { start: 1009, end: 1014 }]
+rebuilt        : SymbolId(17): []
+Symbol flags mismatch:
+after transform: SymbolId(33): SymbolFlags(Export | RegularEnum)
+rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(33): []
+rebuilt        : SymbolId(22): [ReferenceId(96)]
+Reference symbol mismatch:
+after transform: ReferenceId(92): Some("Color")
+rebuilt        : ReferenceId(99): None
+Reference symbol mismatch:
+after transform: ReferenceId(91): Some("Color")
+rebuilt        : ReferenceId(107): None
+Reference symbol mismatch:
+after transform: ReferenceId(101): Some("Color")
+rebuilt        : ReferenceId(112): None
+Reference symbol mismatch:
+after transform: ReferenceId(100): Some("Color")
+rebuilt        : ReferenceId(120): None
+Reference symbol mismatch:
+after transform: ReferenceId(106): Some("Color")
+rebuilt        : ReferenceId(129): None
+Reference symbol mismatch:
+after transform: ReferenceId(105): Some("Color")
+rebuilt        : ReferenceId(133): None
+Reference symbol mismatch:
+after transform: ReferenceId(12): Some("A")
+rebuilt        : ReferenceId(140): Some("A")
+Reference symbol mismatch:
+after transform: ReferenceId(14): Some("A")
+rebuilt        : ReferenceId(142): Some("A")
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Color"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
 semantic error: Bindings mismatch:
@@ -23270,42 +28708,85 @@ after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6)
 rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["C", "Symbol", "_M"]
+rebuilt        : ScopeId(1): ["C", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["C", "Symbol", "_M"]
+rebuilt        : ScopeId(1): ["C", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty55.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Unresolved references mismatch:
+after transform: ["Symbol", "SymbolConstructor"]
+rebuilt        : ["Symbol"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
 semantic error: Bindings mismatch:
@@ -23885,11 +29366,25 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Unresolved references mismatch:
+after transform: ["Iterable"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts
 semantic error: Unresolved references mismatch:
@@ -24291,11 +29786,37 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Example
+semantic error: Missing SymbolId: _Example
 Missing ReferenceId: _Example
 Missing ReferenceId: Example
 Missing ReferenceId: Example
+Bindings mismatch:
+after transform: ScopeId(0): ["Example", "deco"]
+rebuilt        : ScopeId(0): ["Example"]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(3): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(1): [Span { start: 93, end: 100 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("deco")
+rebuilt        : ReferenceId(0): None
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["deco"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
 semantic error: Bindings mismatch:
@@ -26299,11 +31820,19 @@ after transform: [ReferenceId(0), ReferenceId(10), ReferenceId(11), ReferenceId(
 rebuilt        : [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(7), SymbolId(11)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(7), SymbolId(11)]
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(19)]
+rebuilt        : ScopeId(7): [SymbolId(12), SymbolId(13), SymbolId(15), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
 semantic error: Bindings mismatch:
@@ -27247,8 +32776,7 @@ after transform: ["Date", "Object"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: m
+semantic error: Missing SymbolId: m
 Missing SymbolId: _m
 Missing SymbolId: m2
 Missing SymbolId: _m2
@@ -27270,6 +32798,39 @@ Missing ReferenceId: m2
 Missing ReferenceId: m2
 Missing ReferenceId: m1
 Missing ReferenceId: m1
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(9), SymbolId(12), SymbolId(16), SymbolId(21), SymbolId(26)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(9), SymbolId(12), SymbolId(16), SymbolId(21), SymbolId(28)]
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(22), SymbolId(23), SymbolId(32)]
+rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23), SymbolId(24)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(13): [SymbolId(24), SymbolId(25), SymbolId(33)]
+rebuilt        : ScopeId(13): [SymbolId(25), SymbolId(26), SymbolId(27)]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(13): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(16): [SymbolId(27), SymbolId(28), SymbolId(34)]
+rebuilt        : ScopeId(16): [SymbolId(29), SymbolId(30), SymbolId(31)]
+Scope flags mismatch:
+after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(16): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(17): [SymbolId(29), SymbolId(35)]
+rebuilt        : ScopeId(17): [SymbolId(32), SymbolId(33)]
+Scope flags mismatch:
+after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(17): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(18): [SymbolId(30), SymbolId(31), SymbolId(36)]
+rebuilt        : ScopeId(18): [SymbolId(34), SymbolId(35), SymbolId(36)]
+Scope flags mismatch:
+after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(18): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -27413,11 +32974,19 @@ after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule02.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: container
+semantic error: Missing SymbolId: container
 Missing SymbolId: _container
 Missing ReferenceId: container
 Missing ReferenceId: container
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -27438,8 +33007,7 @@ after transform: SymbolId(4): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target12.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _C
+semantic error: Missing SymbolId: _C
 Missing ReferenceId: _C
 Missing ReferenceId: C
 Missing ReferenceId: C
@@ -27459,6 +33027,81 @@ Missing SymbolId: _F
 Missing ReferenceId: _F
 Missing ReferenceId: F
 Missing ReferenceId: F
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "E", "F", "N"]
+rebuilt        : ScopeId(0): ["C", "E", "F"]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(11)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(3): ["E", "w"]
+rebuilt        : ScopeId(3): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["E", "x"]
+rebuilt        : ScopeId(4): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(12)]
+rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(13)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(8), SymbolId(15)]
+rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(10), SymbolId(16)]
+rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 37, end: 38 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(15), ReferenceId(16)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
+rebuilt        : SymbolId(3): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Export | Function | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable | Export | Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): []
+rebuilt        : SymbolId(12): [ReferenceId(21), ReferenceId(22)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(9): [Span { start: 336, end: 337 }]
+rebuilt        : SymbolId(12): []
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable | ConstVariable)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["N"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target5.ts
 semantic error: Bindings mismatch:
@@ -27481,15 +33124,19 @@ after transform: SymbolId(2): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target7.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N
+semantic error: Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Bindings mismatch:
+after transform: ScopeId(0): ["N", "N2"]
+rebuilt        : ScopeId(0): ["N"]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target12.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _C
+semantic error: Missing SymbolId: _C
 Missing ReferenceId: _C
 Missing ReferenceId: C
 Missing ReferenceId: C
@@ -27509,6 +33156,81 @@ Missing SymbolId: _F
 Missing ReferenceId: _F
 Missing ReferenceId: F
 Missing ReferenceId: F
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "E", "F", "N"]
+rebuilt        : ScopeId(0): ["C", "E", "F"]
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(1), SymbolId(11)]
+rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(3): ["E", "w"]
+rebuilt        : ScopeId(3): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["E", "x"]
+rebuilt        : ScopeId(4): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(12)]
+rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(13)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(8), SymbolId(15)]
+rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(10), SymbolId(16)]
+rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 37, end: 38 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable | Export)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(15), ReferenceId(16)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(2): [Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
+rebuilt        : SymbolId(3): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Export | Function | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable | Export | Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): []
+rebuilt        : SymbolId(12): [ReferenceId(21), ReferenceId(22)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(9): [Span { start: 336, end: 337 }]
+rebuilt        : SymbolId(12): []
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable | ConstVariable)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["N"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target5.ts
 semantic error: Bindings mismatch:
@@ -27531,11 +33253,16 @@ after transform: SymbolId(2): SymbolFlags(Export | ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target7.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N
+semantic error: Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Bindings mismatch:
+after transform: ScopeId(0): ["N", "N2"]
+rebuilt        : ScopeId(0): ["N"]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -27747,13 +33474,24 @@ after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: types
+semantic error: Missing SymbolId: types
 Missing SymbolId: _types
 Missing ReferenceId: _types
 Missing ReferenceId: A
 Missing ReferenceId: types
 Missing ReferenceId: types
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports.ts
 semantic error: Bindings mismatch:
@@ -27882,8 +33620,7 @@ after transform: ["Iterator"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Directive
+semantic error: Missing SymbolId: _Directive
 Missing ReferenceId: _Directive
 Missing ReferenceId: is
 Missing ReferenceId: Directive
@@ -27893,6 +33630,66 @@ Missing SymbolId: _StepResult
 Missing ReferenceId: _StepResult
 Missing ReferenceId: StepResult
 Missing ReferenceId: StepResult
+Bindings mismatch:
+after transform: ScopeId(0): ["Directive", "PartialStepState", "QuickInputStep", "QuickPickItem", "QuickPickStep", "StepGenerator", "StepItemType", "StepResult", "StepResultGenerator", "StepSelection", "StepState", "canPickStepContinue", "createPickStep", "showStep"]
+rebuilt        : ScopeId(0): ["Directive", "StepResult", "canPickStepContinue", "createPickStep", "showStep"]
+Bindings mismatch:
+after transform: ScopeId(5): ["Back", "Cancel", "Directive", "LoadMore", "Noop"]
+rebuilt        : ScopeId(3): ["Directive"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(0x0)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(15), SymbolId(53)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "value"]
+rebuilt        : ScopeId(5): ["value"]
+Binding symbols mismatch:
+after transform: ScopeId(15): [SymbolId(27), SymbolId(54)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(23): ["T", "_selection", "_state", "_step"]
+rebuilt        : ScopeId(7): ["_selection", "_state", "_step"]
+Bindings mismatch:
+after transform: ScopeId(24): ["T", "step"]
+rebuilt        : ScopeId(8): ["step"]
+Bindings mismatch:
+after transform: ScopeId(25): ["Context", "State", "_context", "selection", "state", "step"]
+rebuilt        : ScopeId(9): ["_context", "selection", "state", "step"]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(64), ReferenceId(100)]
+rebuilt        : SymbolId(2): [ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(18)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(10): [Span { start: 381, end: 390 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(5): [ReferenceId(16)]
+Symbol flags mismatch:
+after transform: SymbolId(27): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(51): [ReferenceId(83), ReferenceId(84), ReferenceId(86)]
+rebuilt        : SymbolId(19): [ReferenceId(25), ReferenceId(27)]
+Reference symbol mismatch:
+after transform: ReferenceId(90): Some("StepResult")
+rebuilt        : ReferenceId(31): Some("StepResult")
+Unresolved references mismatch:
+after transform: ["AsyncGenerator", "Generator", "Partial", "Record", "Symbol", "f1", "f2"]
+rebuilt        : ["Symbol", "f1", "f2"]
 
 tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes7.ts
 semantic error: Bindings mismatch:
@@ -27918,15 +33715,22 @@ after transform: ScopeId(0): ["M", "M2", "N"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "M", "a", "b", "r1", "r2", "r3", "r4", "r5", "r6"]
+rebuilt        : ScopeId(0): ["M", "a", "b", "r1", "r2", "r3", "r4", "r5", "r6"]
+Bindings mismatch:
+after transform: ScopeId(7): ["A", "B", "_M", "a", "b", "r1", "r2", "r3", "r4", "r5", "r6"]
+rebuilt        : ScopeId(1): ["_M", "a", "b", "r1", "r2", "r3", "r4", "r5", "r6"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M2
+semantic error: Missing SymbolId: M2
 Missing SymbolId: _M
 Missing ReferenceId: M2
 Missing ReferenceId: M2
@@ -27960,17 +33764,75 @@ Missing ReferenceId: _M7
 Missing ReferenceId: _M7
 Missing ReferenceId: M2
 Missing ReferenceId: M2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "_M", "a", "r1", "r2"]
+rebuilt        : ScopeId(1): ["_M", "a", "r1", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "_M2", "a", "r1", "r2", "r3"]
+rebuilt        : ScopeId(2): ["_M2", "a", "r1", "r2", "r3"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(10), SymbolId(29)]
+rebuilt        : ScopeId(3): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["A", "_M4", "a", "r1", "r2"]
+rebuilt        : ScopeId(4): ["_M4", "a", "r1", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(15), SymbolId(31)]
+rebuilt        : ScopeId(5): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(10): ["A", "_M6", "a", "r1", "r2", "r3"]
+rebuilt        : ScopeId(6): ["_M6", "a", "r1", "r2", "r3"]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(21), SymbolId(33)]
+rebuilt        : ScopeId(7): [SymbolId(23), SymbolId(24)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(13): ["A", "_M8", "a", "r1", "r2", "r3"]
+rebuilt        : ScopeId(8): ["_M8", "a", "r1", "r2", "r3"]
+Scope flags mismatch:
+after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "M", "a", "b", "r1", "r2", "r3", "r4"]
+rebuilt        : ScopeId(0): ["M", "a", "b", "r1", "r2", "r3", "r4"]
+Bindings mismatch:
+after transform: ScopeId(5): ["A", "B", "_M", "a", "b", "r1", "r2", "r3", "r4"]
+rebuilt        : ScopeId(1): ["_M", "a", "b", "r1", "r2", "r3", "r4"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M2
+semantic error: Missing SymbolId: M2
 Missing SymbolId: _M
 Missing ReferenceId: M2
 Missing ReferenceId: M2
@@ -27995,6 +33857,45 @@ Missing ReferenceId: _M5
 Missing ReferenceId: _M5
 Missing ReferenceId: M2
 Missing ReferenceId: M2
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "_M", "a", "r1", "r2"]
+rebuilt        : ScopeId(1): ["_M", "a", "r1", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "_M2", "a", "r1", "r2"]
+rebuilt        : ScopeId(2): ["_M2", "a", "r1", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(9), SymbolId(21)]
+rebuilt        : ScopeId(3): [SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["A", "_M4", "a", "r1", "r2"]
+rebuilt        : ScopeId(4): ["_M4", "a", "r1", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(14), SymbolId(23)]
+rebuilt        : ScopeId(5): [SymbolId(15), SymbolId(16)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(9): ["A", "_M6", "a", "r1", "r2"]
+rebuilt        : ScopeId(6): ["_M6", "a", "r1", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames2.ts
 semantic error: Bindings mismatch:
@@ -28007,18 +33908,88 @@ after transform: ScopeId(0): ["A", "a", "r", "r2", "r3"]
 rebuilt        : ScopeId(0): ["a", "r", "r2", "r3"]
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "C", "C2", "D", "M", "a", "r"]
+rebuilt        : ScopeId(0): ["C", "C2", "D", "M", "a", "r"]
+Bindings mismatch:
+after transform: ScopeId(6): ["A", "C", "C2", "D", "_M"]
+rebuilt        : ScopeId(4): ["C", "C2", "D", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(8): ["T"]
+rebuilt        : ScopeId(6): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(7)]
+rebuilt        : SymbolId(7): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(10)]
+rebuilt        : SymbolId(8): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "C", "C2", "C3", "C4", "D", "M", "a", "r"]
+rebuilt        : ScopeId(0): ["C", "C2", "C3", "C4", "D", "M", "a", "r"]
+Bindings mismatch:
+after transform: ScopeId(8): ["A", "C", "C2", "C3", "C4", "D", "_M"]
+rebuilt        : ScopeId(6): ["C", "C2", "C3", "C4", "D", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(9): ["T"]
+rebuilt        : ScopeId(7): []
+Bindings mismatch:
+after transform: ScopeId(10): ["T"]
+rebuilt        : ScopeId(8): []
+Bindings mismatch:
+after transform: ScopeId(11): ["T"]
+rebuilt        : ScopeId(9): []
+Bindings mismatch:
+after transform: ScopeId(12): ["T"]
+rebuilt        : ScopeId(10): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(2)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(11)]
+rebuilt        : SymbolId(9): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(16)]
+rebuilt        : SymbolId(10): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(13): [ReferenceId(13)]
+rebuilt        : SymbolId(11): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): [ReferenceId(17)]
+rebuilt        : SymbolId(12): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases3.ts
 semantic error: Bindings mismatch:
@@ -28058,18 +34029,34 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: G
+semantic error: Missing SymbolId: G
 Missing SymbolId: _G
 Missing ReferenceId: G
 Missing ReferenceId: G
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "G", "a", "r", "r2", "r3"]
+rebuilt        : ScopeId(0): ["G", "a", "r", "r2", "r3"]
+Bindings mismatch:
+after transform: ScopeId(3): ["A", "_G", "a", "r", "r2", "r3", "r4"]
+rebuilt        : ScopeId(1): ["_G", "a", "r", "r2", "r3", "r4"]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface03.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: n
+semantic error: Missing SymbolId: n
 Missing SymbolId: _n
 Missing ReferenceId: n
 Missing ReferenceId: n
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceDoesNotHideBaseSignatures.ts
 semantic error: Bindings mismatch:
@@ -28145,17 +34132,27 @@ after transform: ["Object"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Point
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Point
+semantic error: Missing SymbolId: _Point
 Missing ReferenceId: Point
 Missing ReferenceId: Point
 Missing SymbolId: A
@@ -28169,10 +34166,48 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(3), SymbolId(9)]
+rebuilt        : ScopeId(4): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(6): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(8), SymbolId(11)]
+rebuilt        : ScopeId(10): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 135, end: 140 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(1)]
+rebuilt        : SymbolId(7): [ReferenceId(7), ReferenceId(8), ReferenceId(9)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(5): [Span { start: 399, end: 404 }]
+rebuilt        : SymbolId(7): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Point
+semantic error: Missing SymbolId: _Point
 Missing ReferenceId: Point
 Missing ReferenceId: Point
 Missing SymbolId: A
@@ -28186,36 +34221,137 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(9)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(8), SymbolId(11)]
+rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 124, end: 129 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(1)]
+rebuilt        : SymbolId(7): [ReferenceId(7), ReferenceId(8), ReferenceId(9)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(5): [Span { start: 362, end: 367 }]
+rebuilt        : SymbolId(7): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _enumdule
+semantic error: Missing SymbolId: _enumdule
 Missing ReferenceId: _enumdule
 Missing ReferenceId: Point
 Missing ReferenceId: enumdule
 Missing ReferenceId: enumdule
+Bindings mismatch:
+after transform: ScopeId(1): ["Blue", "Red", "enumdule"]
+rebuilt        : ScopeId(1): ["enumdule"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(2): [SymbolId(3), SymbolId(8)]
+rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(8)]
+rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(0): [Span { start: 40, end: 48 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(3): [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Point
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: enumdule
+semantic error: Missing SymbolId: enumdule
 Missing SymbolId: _enumdule
 Missing ReferenceId: _enumdule
 Missing ReferenceId: Point
 Missing ReferenceId: enumdule
 Missing ReferenceId: enumdule
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(4): ["Blue", "Red", "enumdule"]
+rebuilt        : ScopeId(4): ["enumdule"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | BlockScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(0): Span { start: 7, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(10)]
+rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedClassesOfTheSameName.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Point
@@ -28257,6 +34393,72 @@ Missing ReferenceId: _X2
 Missing ReferenceId: _X2
 Missing ReferenceId: X
 Missing ReferenceId: X
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(12)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(7), SymbolId(20)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(13)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(14)]
+rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(6): [SymbolId(6), SymbolId(15)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(7), SymbolId(16)]
+rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(8), SymbolId(17)]
+rebuilt        : ScopeId(8): [SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(9), SymbolId(18)]
+rebuilt        : ScopeId(10): [SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(10): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(11): [SymbolId(10), SymbolId(19)]
+rebuilt        : ScopeId(11): [SymbolId(16), SymbolId(17)]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(11): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(12): [SymbolId(11), SymbolId(20)]
+rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
+Scope flags mismatch:
+after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(13): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(13): [ReferenceId(9)]
+Unresolved references mismatch:
+after transform: ["A", "X"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts
 semantic error: Bindings mismatch:
@@ -28282,8 +34484,7 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Root
+semantic error: Missing SymbolId: Root
 Missing SymbolId: _Root
 Missing SymbolId: A
 Missing SymbolId: _A
@@ -28301,10 +34502,30 @@ Missing ReferenceId: _Root
 Missing ReferenceId: _Root
 Missing ReferenceId: Root
 Missing ReferenceId: Root
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Bindings mismatch:
+after transform: ScopeId(2): ["Point", "Utils", "_A"]
+rebuilt        : ScopeId(2): ["Utils", "_A"]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "p"]
+rebuilt        : ScopeId(4): ["p"]
+Symbol flags mismatch:
+after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): []
+rebuilt        : SymbolId(6): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing SymbolId: Utils
 Missing SymbolId: _Utils
@@ -28316,6 +34537,24 @@ Missing ReferenceId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Point", "Utils", "_A"]
+rebuilt        : ScopeId(1): ["Utils", "_A"]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
+rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "p"]
+rebuilt        : ScopeId(3): ["p"]
+Symbol flags mismatch:
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Export | Function)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): []
+rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/exportCodeGen.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -28328,34 +34567,64 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Point2d
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Point", "Point2d", "_A"]
+rebuilt        : ScopeId(1): ["Point2d", "_A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInIndexerTypeAnnotations.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: points
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): []
+rebuilt        : SymbolId(3): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Point
@@ -28365,10 +34634,36 @@ Missing ReferenceId: _A
 Missing ReferenceId: fromOrigin
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Line
@@ -28376,10 +34671,33 @@ Missing ReferenceId: _A
 Missing ReferenceId: fromOrigin
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(3): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: A
+semantic error: Missing SymbolId: A
 Missing SymbolId: _A
 Missing ReferenceId: _A
 Missing ReferenceId: Point
@@ -28387,6 +34705,30 @@ Missing ReferenceId: _A
 Missing ReferenceId: fromOrigin
 Missing ReferenceId: A
 Missing ReferenceId: A
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -28427,8 +34769,7 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: moduleA
+semantic error: Missing SymbolId: moduleA
 Missing SymbolId: _moduleA
 Missing ReferenceId: _moduleA
 Missing ReferenceId: Point
@@ -28443,6 +34784,81 @@ Missing SymbolId: _fundule
 Missing ReferenceId: fundule
 Missing ReferenceId: fundule
 Missing SymbolId: funlias
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(11)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(10), SymbolId(11), SymbolId(14)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(12)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(13)]
+rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(8): [SymbolId(10), SymbolId(14)]
+rebuilt        : ScopeId(7): [SymbolId(12), SymbolId(13)]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(1): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): []
+rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(6): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(4), ReferenceId(6)]
+rebuilt        : SymbolId(7): [ReferenceId(7), ReferenceId(8), ReferenceId(9)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(6): [Span { start: 257, end: 264 }]
+rebuilt        : SymbolId(7): []
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(FunctionScopedVariable | Export | Interface)
+rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(7): Span { start: 288, end: 293 }
+rebuilt        : SymbolId(9): Span { start: 340, end: 352 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(3)]
+rebuilt        : SymbolId(9): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(7): [Span { start: 340, end: 352 }]
+rebuilt        : SymbolId(9): []
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(11): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(9): [ReferenceId(8)]
+rebuilt        : SymbolId(11): [ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(9): [Span { start: 539, end: 546 }]
+rebuilt        : SymbolId(11): []
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(FunctionScopedVariable | Export | Interface)
+rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch:
+after transform: SymbolId(10): Span { start: 570, end: 575 }
+rebuilt        : SymbolId(13): Span { start: 622, end: 634 }
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): [ReferenceId(7)]
+rebuilt        : SymbolId(13): []
+Symbol redeclarations mismatch:
+after transform: SymbolId(10): [Span { start: 622, end: 634 }]
+rebuilt        : SymbolId(13): []
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("moduleA")
+rebuilt        : ReferenceId(6): Some("moduleA")
+Unresolved references mismatch:
+after transform: ["fundule", "moduleA"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleBody/moduleWithStatementsOfEveryKind.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -28451,11 +34867,19 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: container
+semantic error: Missing SymbolId: container
 Missing SymbolId: _container
 Missing ReferenceId: container
 Missing ReferenceId: container
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -28470,8 +34894,16 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarat
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: test1
+semantic error: Missing SymbolId: test1
+Bindings mismatch:
+after transform: ScopeId(0): ["mod1", "mod2", "pack1", "pack2", "test1", "test2"]
+rebuilt        : ScopeId(0): ["test1", "test2"]
+Symbol flags mismatch:
+after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable)
+Unresolved references mismatch:
+after transform: ["mod1", "mod2", "pack1", "pack2"]
+rebuilt        : ["mod2", "pack2"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
 semantic error: Cannot use export statement outside a module
@@ -28573,9 +35005,20 @@ after transform: ScopeId(4): ["T", "U", "ab"]
 rebuilt        : ScopeId(2): ["ab"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k", "k1", "k2"]
+rebuilt        : ScopeId(0): ["Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k", "k1", "k2"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(18)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
+Unresolved references mismatch:
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(21)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
 semantic error: Bindings mismatch:
@@ -28594,34 +35037,121 @@ after transform: SymbolId(4): [ReferenceId(1), ReferenceId(2), ReferenceId(21)]
 rebuilt        : SymbolId(2): [ReferenceId(19)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Button", "ButtonProp", "InnerButton", "InnerButtonProp", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Button", "InnerButton", "React", "_jsxFileName", "_reactJsxRuntime"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(0)]
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(14)]
+rebuilt        : SymbolId(5): [ReferenceId(5), ReferenceId(8)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("React")
+rebuilt        : ReferenceId(12): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(19)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Props", "React", "Test", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["React", "Test", "_jsxFileName", "_reactJsxRuntime"]
+Unresolved references mismatch:
+after transform: ["Foo", "JSX", "require", "true"]
+rebuilt        : ["Foo", "require"]
+Unresolved reference IDs mismatch for "Foo":
+after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(15), ReferenceId(18)]
+rebuilt        : [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(23)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["FetchUser", "IFetchUserProps", "IUser", "React", "UserName0", "UserName1", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["FetchUser", "React", "UserName0", "UserName1", "_jsxFileName", "_reactJsxRuntime"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(15)]
+rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(20)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(35), ReferenceId(44), ReferenceId(53)]
+rebuilt        : SymbolId(3): [ReferenceId(13), ReferenceId(22), ReferenceId(31), ReferenceId(40)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(29), ReferenceId(38), ReferenceId(47)]
+rebuilt        : SymbolId(4): [ReferenceId(16), ReferenceId(25), ReferenceId(34)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(14), ReferenceId(17), ReferenceId(18), ReferenceId(32), ReferenceId(41), ReferenceId(50), ReferenceId(56)]
+rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29), ReferenceId(38)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(59)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["AnotherButton", "Button", "Comp", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+rebuilt        : ScopeId(0): ["AnotherButton", "Button", "Comp", "React", "_jsxFileName", "_reactJsxRuntime", "k1", "k2", "k3", "k4"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(26), ReferenceId(35), ReferenceId(44), ReferenceId(53)]
+rebuilt        : SymbolId(3): [ReferenceId(13), ReferenceId(22), ReferenceId(31), ReferenceId(40)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(8), ReferenceId(12), ReferenceId(16), ReferenceId(29), ReferenceId(38), ReferenceId(47)]
+rebuilt        : SymbolId(4): [ReferenceId(16), ReferenceId(25), ReferenceId(34)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(13), ReferenceId(14), ReferenceId(17), ReferenceId(18), ReferenceId(32), ReferenceId(41), ReferenceId(50), ReferenceId(56)]
+rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29), ReferenceId(38)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(59)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(15)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 semantic error: Bindings mismatch:
@@ -28663,9 +35193,14 @@ after transform: ["console", "true"]
 rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
 semantic error: Bindings mismatch:
@@ -28796,9 +35331,20 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Address", "AddressComp", "AmericanAddress", "CanadianAddress", "Properties", "React", "_jsxFileName", "_reactJsxRuntime", "a"]
+rebuilt        : ScopeId(0): ["AddressComp", "React", "_jsxFileName", "_reactJsxRuntime", "a"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
 semantic error: Bindings mismatch:
@@ -28820,14 +35366,39 @@ after transform: [ReferenceId(2)]
 rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5)]
+rebuilt        : SymbolId(3): [ReferenceId(6)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Poisoned", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "p"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(6)]
+rebuilt        : SymbolId(3): [ReferenceId(6)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["require", "true"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName1.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -28866,13 +35437,33 @@ after transform: ["this"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Dotted
+semantic error: Missing SymbolId: Dotted
 Missing SymbolId: _Dotted
 Missing ReferenceId: _Dotted
 Missing ReferenceId: Name
 Missing ReferenceId: Dotted
 Missing ReferenceId: Dotted
+Bindings mismatch:
+after transform: ScopeId(0): ["Dotted", "JSX", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
+rebuilt        : ScopeId(0): ["Dotted", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
+rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(6)]
+rebuilt        : SymbolId(3): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(5): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): []
+rebuilt        : SymbolId(6): [ReferenceId(2)]
+Reference symbol mismatch:
+after transform: ReferenceId(9): Some("Dotted")
+rebuilt        : ReferenceId(13): Some("Dotted")
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
 semantic error: Bindings mismatch:
@@ -29066,49 +35657,214 @@ after transform: []
 rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(9), SymbolId(14), SymbolId(15)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(6), SymbolId(9)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Component", "T"]
+rebuilt        : ScopeId(1): ["Component"]
+Bindings mismatch:
+after transform: ScopeId(3): ["Component", "T"]
+rebuilt        : ScopeId(3): ["Component"]
+Bindings mismatch:
+after transform: ScopeId(5): ["Component", "T", "U"]
+rebuilt        : ScopeId(5): ["Component"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(21)]
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): [ReferenceId(11), ReferenceId(13), ReferenceId(24)]
+rebuilt        : SymbolId(7): [ReferenceId(7)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(12): [ReferenceId(18), ReferenceId(20), ReferenceId(27)]
+rebuilt        : SymbolId(10): [ReferenceId(11)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(30)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Component", "T"]
+rebuilt        : ScopeId(1): ["Component"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(4): [ReferenceId(3)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["U"]
+rebuilt        : ScopeId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(4), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(7)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["U"]
+rebuilt        : ScopeId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(4), ReferenceId(7)]
+rebuilt        : SymbolId(3): [ReferenceId(7)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["U"]
+rebuilt        : ScopeId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(8)]
+rebuilt        : SymbolId(3): [ReferenceId(7)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(11)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T"]
+rebuilt        : ScopeId(1): []
+Bindings mismatch:
+after transform: ScopeId(3): ["U"]
+rebuilt        : ScopeId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(8)]
+rebuilt        : SymbolId(3): [ReferenceId(7)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(5): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(11)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6), SymbolId(9), SymbolId(10)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(2): ["U", "props"]
+rebuilt        : ScopeId(1): ["props"]
+Bindings mismatch:
+after transform: ScopeId(3): ["U", "props"]
+rebuilt        : ScopeId(2): ["props"]
+Unresolved references mismatch:
+after transform: ["Component", "JSX", "require"]
+rebuilt        : ["Component", "require"]
+Unresolved reference IDs mismatch for "Component":
+after transform: [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
+rebuilt        : [ReferenceId(3), ReferenceId(7)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(14)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6), SymbolId(9), SymbolId(10)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5)]
+Bindings mismatch:
+after transform: ScopeId(2): ["U", "props"]
+rebuilt        : ScopeId(1): ["props"]
+Bindings mismatch:
+after transform: ScopeId(3): ["U", "props"]
+rebuilt        : ScopeId(2): ["props"]
+Unresolved references mismatch:
+after transform: ["Component", "JSX", "require"]
+rebuilt        : ["Component", "require"]
+Unresolved reference IDs mismatch for "Component":
+after transform: [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
+rebuilt        : [ReferenceId(3), ReferenceId(7)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(14)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Ctor", "P"]
+rebuilt        : ScopeId(1): ["Ctor"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(5), ReferenceId(6)]
+rebuilt        : SymbolId(4): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["JSX", "require"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(9)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 semantic error: Bindings mismatch:
@@ -29168,14 +35924,30 @@ after transform: ScopeId(0): ["JSX"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x"]
+rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x"]
+Unresolved reference IDs mismatch for "MyComp":
+after transform: [ReferenceId(4), ReferenceId(5)]
+rebuilt        : [ReferenceId(3)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
+rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
+Unresolved reference IDs mismatch for "MyComp":
+after transform: [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9)]
+rebuilt        : [ReferenceId(3), ReferenceId(6)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(12)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 semantic error: Bindings mismatch:
@@ -29438,54 +36210,164 @@ after transform: []
 rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
+rebuilt        : SymbolId(5): [ReferenceId(6)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(8)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
+rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
+rebuilt        : SymbolId(5): [ReferenceId(6)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(8)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(9)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(12)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
+rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsxFileName", "_reactJsxRuntime", "anyobj", "obj", "obj1", "obj3", "x", "x1", "x2", "x3", "x4", "x5"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(4), ReferenceId(7), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(22), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(34)]
+rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(11), ReferenceId(16), ReferenceId(20), ReferenceId(24), ReferenceId(27)]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["require", "true"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(37)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["AnotherComponentProps", "ChildComponent", "Component", "ComponentProps", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["ChildComponent", "Component", "React", "_jsxFileName", "_reactJsxRuntime"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(6): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(11)]
+rebuilt        : SymbolId(6): [ReferenceId(4), ReferenceId(8)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(16)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["AnotherComponent", "AnotherComponentProps", "Component", "ComponentProps", "React", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["AnotherComponent", "Component", "React", "_jsxFileName", "_reactJsxRuntime"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5)]
+rebuilt        : SymbolId(5): [ReferenceId(3)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(10)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Poisoned", "PoisonedProp", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "p", "y"]
+rebuilt        : ScopeId(0): ["Poisoned", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "p", "y"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(7), ReferenceId(10)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(13)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["React", "TextComponent", "TextProps", "_jsxFileName", "_reactJsxRuntime", "textPropsFalse", "textPropsTrue", "y1", "y2"]
+rebuilt        : ScopeId(0): ["React", "TextComponent", "_jsxFileName", "_reactJsxRuntime", "textPropsFalse", "textPropsTrue", "y1", "y2"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(7), ReferenceId(11), ReferenceId(14)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10)]
+Reference symbol mismatch:
+after transform: ReferenceId(1): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved references mismatch:
+after transform: ["require", "true"]
+rebuilt        : ["require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(17)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["OverWriteAttr", "Prop", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "obj3", "x", "x1"]
+rebuilt        : ScopeId(0): ["OverWriteAttr", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "obj3", "x", "x1"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(13)]
+rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(11)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(16)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Opt", "OptionProp", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
+rebuilt        : ScopeId(0): ["Opt", "React", "_jsxFileName", "_reactJsxRuntime", "obj", "obj1", "p", "y", "y1", "y2", "y3"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(26)]
+rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(13), ReferenceId(17), ReferenceId(21)]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("React")
+rebuilt        : ReferenceId(2): Some("React")
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(29)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 semantic error: Spread children are not supported in React.
@@ -29495,9 +36377,20 @@ semantic error: Spread children are not supported in React.
 Spread children are not supported in React.
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
+Unresolved references mismatch:
+after transform: ["JSX", "OneThing", "require"]
+rebuilt        : ["OneThing", "require"]
+Unresolved reference IDs mismatch for "OneThing":
+after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47)]
+rebuilt        : [ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(13), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(31), ReferenceId(34), ReferenceId(37)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(50)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
 semantic error: Bindings mismatch:
@@ -29514,39 +36407,143 @@ after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7)
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12), ReferenceId(16)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["ButtonProps", "ClickableProps", "HyphenProps", "LinkProps", "MainButton", "React", "_jsxFileName", "_reactJsxRuntime", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
+rebuilt        : ScopeId(0): ["MainButton", "React", "_jsxFileName", "_reactJsxRuntime", "b0", "b1", "b10", "b11", "b12", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "obj", "obj1", "obj2"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): [ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(55), ReferenceId(58), ReferenceId(61), ReferenceId(64), ReferenceId(67), ReferenceId(70), ReferenceId(73), ReferenceId(76), ReferenceId(79)]
+rebuilt        : SymbolId(6): [ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(17), ReferenceId(21), ReferenceId(25), ReferenceId(29), ReferenceId(33), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49)]
+Unresolved references mismatch:
+after transform: ["JSX", "console", "require"]
+rebuilt        : ["console", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(82)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["MyComponent", "MyComponentProp", "React", "_jsxFileName", "_reactJsxRuntime", "i", "i1"]
+rebuilt        : ScopeId(0): ["MyComponent", "React", "_jsxFileName", "_reactJsxRuntime", "i", "i1"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "attr"]
+rebuilt        : ScopeId(1): ["attr"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(9)]
+rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(8)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(12)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(8)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(6)]
+rebuilt        : SymbolId(3): [ReferenceId(5)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(3), ReferenceId(13)]
+rebuilt        : SymbolId(6): [ReferenceId(13)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(18)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Baz", "InferParamProp", "React", "_jsxFileName", "_react", "_reactJsxRuntime", "createLink", "createLink1", "i"]
+rebuilt        : ScopeId(0): ["Baz", "React", "_jsxFileName", "_react", "_reactJsxRuntime", "createLink", "createLink1", "i"]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "U", "a0", "a1", "key1", "value"]
+rebuilt        : ScopeId(1): ["a0", "a1", "key1", "value"]
+Unresolved references mismatch:
+after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link", "require"]
+rebuilt        : ["ComponentWithTwoAttributes", "InferParamComponent", "Link", "require"]
+Unresolved reference IDs mismatch for "Link":
+after transform: [ReferenceId(13), ReferenceId(15), ReferenceId(30), ReferenceId(33)]
+rebuilt        : [ReferenceId(14), ReferenceId(18)]
+Unresolved reference IDs mismatch for "ComponentWithTwoAttributes":
+after transform: [ReferenceId(5), ReferenceId(8), ReferenceId(24), ReferenceId(28)]
+rebuilt        : [ReferenceId(4), ReferenceId(9)]
+Unresolved reference IDs mismatch for "InferParamComponent":
+after transform: [ReferenceId(23), ReferenceId(36)]
+rebuilt        : [ReferenceId(22)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(39), ReferenceId(40)]
+rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(7), SymbolId(23), SymbolId(29), SymbolId(30)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(13)]
+Bindings mismatch:
+after transform: ScopeId(4): ["T", "U", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
+rebuilt        : ScopeId(1): ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
+Unresolved references mismatch:
+after transform: ["JSX", "Link", "OverloadComponent", "require"]
+rebuilt        : ["Link", "OverloadComponent", "require"]
+Unresolved reference IDs mismatch for "Link":
+after transform: [ReferenceId(27), ReferenceId(29), ReferenceId(51), ReferenceId(54)]
+rebuilt        : [ReferenceId(32), ReferenceId(36)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(57)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved reference IDs mismatch for "OverloadComponent":
+after transform: [ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(30), ReferenceId(33), ReferenceId(36), ReferenceId(39), ReferenceId(42), ReferenceId(45), ReferenceId(48)]
+rebuilt        : [ReferenceId(3), ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22), ReferenceId(27)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(12), SymbolId(19), SymbolId(20)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(7)]
+Bindings mismatch:
+after transform: ScopeId(2): ["T", "a1", "a2", "arg"]
+rebuilt        : ScopeId(1): ["a1", "a2", "arg"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "a1", "a2", "a3", "a4", "arg"]
+rebuilt        : ScopeId(2): ["a1", "a2", "a3", "a4", "arg"]
+Unresolved references mismatch:
+after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX", "require"]
+rebuilt        : ["Component", "ComponentSpecific", "ComponentSpecific1", "require"]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(38)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
+Unresolved reference IDs mismatch for "Component":
+after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(20), ReferenceId(23)]
+rebuilt        : [ReferenceId(3), ReferenceId(7)]
+Unresolved reference IDs mismatch for "ComponentSpecific":
+after transform: [ReferenceId(12), ReferenceId(16), ReferenceId(18), ReferenceId(26), ReferenceId(32), ReferenceId(35)]
+rebuilt        : [ReferenceId(11), ReferenceId(19), ReferenceId(23)]
+Unresolved reference IDs mismatch for "ComponentSpecific1":
+after transform: [ReferenceId(14), ReferenceId(29)]
+rebuilt        : [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: React
+semantic error: Missing SymbolId: React
 Missing ReferenceId: require
+Bindings mismatch:
+after transform: ScopeId(0): ["Foo", "InterfaceProps", "React", "TypeProps", "_jsxFileName", "_reactJsxRuntime"]
+rebuilt        : ScopeId(0): ["Foo", "React", "_jsxFileName", "_reactJsxRuntime"]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(55), ReferenceId(58), ReferenceId(61), ReferenceId(64), ReferenceId(67), ReferenceId(70), ReferenceId(73), ReferenceId(76), ReferenceId(79), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(91)]
+rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47), ReferenceId(50), ReferenceId(53), ReferenceId(56), ReferenceId(59), ReferenceId(62)]
+Unresolved reference IDs mismatch for "require":
+after transform: [ReferenceId(96)]
+rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeErrors.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -29787,13 +36784,30 @@ after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Shapes
+semantic error: Missing SymbolId: Shapes
 Missing SymbolId: _Shapes
 Missing ReferenceId: _Shapes
 Missing ReferenceId: Point
 Missing ReferenceId: Shapes
 Missing ReferenceId: Shapes
+Bindings mismatch:
+after transform: ScopeId(0): ["IPoint", "Shapes", "dist", "p"]
+rebuilt        : ScopeId(0): ["Shapes", "dist", "p"]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(2), SymbolId(7)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch:
+after transform: SymbolId(2): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(2): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(5)]
+Reference symbol mismatch:
+after transform: ReferenceId(4): Some("Shapes")
+rebuilt        : ReferenceId(8): Some("Shapes")
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature2.ts
 semantic error: Bindings mismatch:
@@ -30156,8 +37170,7 @@ after transform: SymbolId(0): SymbolFlags(Export | RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: A
@@ -30165,10 +37178,57 @@ Missing ReferenceId: _M
 Missing ReferenceId: F2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "D", "F", "I", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aSecondAny", "aString", "aVoid", "anAny", "anInterface", "anObject", "anObjectLiteral", "anOtherFunction", "anOtherObjectLiteral"]
+rebuilt        : ScopeId(0): ["C", "D", "F", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aSecondAny", "aString", "aVoid", "anAny", "anInterface", "anObject", "anObjectLiteral", "anOtherFunction", "anOtherObjectLiteral"]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(2): []
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(30)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(21)]
+rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(12), ReferenceId(14)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(18), ReferenceId(19)]
+rebuilt        : SymbolId(1): [ReferenceId(13)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25)]
+rebuilt        : SymbolId(2): [ReferenceId(15), ReferenceId(16)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(27): Some("M")
+rebuilt        : ReferenceId(17): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(29): Some("M")
+rebuilt        : ReferenceId(18): Some("M")
+Unresolved references mismatch:
+after transform: ["Date", "M", "Object", "undefined"]
+rebuilt        : ["Date", "Object", "undefined"]
+Unresolved reference IDs mismatch for "Date":
+after transform: [ReferenceId(8), ReferenceId(9)]
+rebuilt        : [ReferenceId(7)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(11)]
+rebuilt        : [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: A
@@ -30176,13 +37236,54 @@ Missing ReferenceId: _M
 Missing ReferenceId: F2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "D", "F", "I", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aString", "anAny", "anObject", "anObjectLiteral", "anOtherAny", "anUndefined", "x"]
+rebuilt        : ScopeId(0): ["C", "D", "F", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aString", "anAny", "anObject", "anObjectLiteral", "anOtherAny", "anUndefined", "x"]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(2): []
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(27)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(13)]
+rebuilt        : SymbolId(1): [ReferenceId(12)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(15): Some("M")
+rebuilt        : ReferenceId(14): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(16): Some("M")
+rebuilt        : ReferenceId(15): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(17): Some("M")
+rebuilt        : ReferenceId(16): Some("M")
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: N
+semantic error: Missing SymbolId: N
 Missing SymbolId: _N
 Missing ReferenceId: N
 Missing ReferenceId: N
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(41), SymbolId(43)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(42), SymbolId(44)]
+Binding symbols mismatch:
+after transform: ScopeId(37): [SymbolId(27), SymbolId(44)]
+rebuilt        : ScopeId(37): [SymbolId(27), SymbolId(28)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.15.ts
 semantic error: Symbol flags mismatch:
@@ -30475,56 +37576,8 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(7)]
 rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(9)]
 rebuilt        : SymbolId(7): []
@@ -30535,8 +37588,7 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: A
@@ -30544,6 +37596,54 @@ Missing ReferenceId: _M
 Missing ReferenceId: F2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "D", "F", "I", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aSecondAny", "aString", "aVoid", "anAny", "anInterface", "anObject", "anObjectLiteral", "anOtherFunction", "anOtherObjectLiteral"]
+rebuilt        : ScopeId(0): ["C", "D", "F", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aSecondAny", "aString", "aVoid", "anAny", "anInterface", "anObject", "anObjectLiteral", "anOtherFunction", "anOtherObjectLiteral"]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(2): []
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(30)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(21)]
+rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(12), ReferenceId(14)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(18), ReferenceId(19)]
+rebuilt        : SymbolId(1): [ReferenceId(13)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(4): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25)]
+rebuilt        : SymbolId(2): [ReferenceId(15), ReferenceId(16)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(27): Some("M")
+rebuilt        : ReferenceId(17): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(29): Some("M")
+rebuilt        : ReferenceId(18): Some("M")
+Unresolved references mismatch:
+after transform: ["Date", "M", "Object", "undefined"]
+rebuilt        : ["Date", "Object", "undefined"]
+Unresolved reference IDs mismatch for "Date":
+after transform: [ReferenceId(8), ReferenceId(9)]
+rebuilt        : [ReferenceId(7)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(10), ReferenceId(11)]
+rebuilt        : [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
 semantic error: Bindings mismatch:
@@ -30553,63 +37653,14 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6)]
 rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(4): [ReferenceId(6)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(7)]
 rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(5): [ReferenceId(7)]
-rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(8): [ReferenceId(9)]
-rebuilt        : SymbolId(7): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(9)]
 rebuilt        : SymbolId(7): []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: A
@@ -30625,6 +37676,54 @@ Missing ReferenceId: _N
 Missing ReferenceId: F2
 Missing ReferenceId: N
 Missing ReferenceId: N
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "C2", "D", "F", "F2", "I", "M", "N", "a", "b", "c", "d", "e", "f", "fn", "g", "h", "i", "j", "k"]
+rebuilt        : ScopeId(0): ["C", "C2", "D", "F", "F2", "M", "N", "a", "b", "c", "d", "e", "f", "fn", "g", "h", "i", "j", "k"]
+Bindings mismatch:
+after transform: ScopeId(4): ["T"]
+rebuilt        : ScopeId(3): []
+Binding symbols mismatch:
+after transform: ScopeId(7): [SymbolId(10), SymbolId(11), SymbolId(30)]
+rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9), SymbolId(10)]
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(10): [SymbolId(14), SymbolId(15), SymbolId(31)]
+rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14), SymbolId(15)]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(19), ReferenceId(20), ReferenceId(21)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(17), ReferenceId(19), ReferenceId(21)]
+rebuilt        : SymbolId(2): [ReferenceId(22), ReferenceId(23), ReferenceId(24)]
+Symbol flags mismatch:
+after transform: SymbolId(10): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(9): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(10): []
+rebuilt        : SymbolId(9): [ReferenceId(3)]
+Symbol flags mismatch:
+after transform: SymbolId(11): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(11): []
+rebuilt        : SymbolId(10): [ReferenceId(6)]
+Symbol flags mismatch:
+after transform: SymbolId(14): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(14): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): []
+rebuilt        : SymbolId(14): [ReferenceId(10)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): []
+rebuilt        : SymbolId(15): [ReferenceId(13)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatements.ts
 semantic error: Bindings mismatch:
@@ -30646,8 +37745,7 @@ after transform: ScopeId(11): ["T"]
 rebuilt        : ScopeId(11): []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: _M
 Missing ReferenceId: A
@@ -30655,6 +37753,48 @@ Missing ReferenceId: _M
 Missing ReferenceId: F2
 Missing ReferenceId: M
 Missing ReferenceId: M
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "D", "F", "I", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aString", "anAny", "anObject", "anObjectLiteral", "anOtherAny", "anUndefined", "x"]
+rebuilt        : ScopeId(0): ["C", "D", "F", "M", "aClass", "aClassInModule", "aDate", "aFunction", "aFunctionInModule", "aGenericClass", "aLambda", "aModule", "aNumber", "aString", "anAny", "anObject", "anObjectLiteral", "anOtherAny", "anUndefined", "x"]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(2): []
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(29)]
+rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(10): ["T", "x"]
+rebuilt        : ScopeId(9): ["x"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(21), ReferenceId(42)]
+rebuilt        : SymbolId(1): [ReferenceId(20), ReferenceId(40)]
+Symbol flags mismatch:
+after transform: SymbolId(7): SymbolFlags(Export | Class)
+rebuilt        : SymbolId(6): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(7): []
+rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch:
+after transform: SymbolId(8): SymbolFlags(FunctionScopedVariable | Export)
+rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+Symbol reference IDs mismatch:
+after transform: SymbolId(8): []
+rebuilt        : SymbolId(7): [ReferenceId(4)]
+Reference symbol mismatch:
+after transform: ReferenceId(29): Some("M")
+rebuilt        : ReferenceId(28): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(31): Some("M")
+rebuilt        : ReferenceId(30): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(32): Some("M")
+rebuilt        : ReferenceId(31): Some("M")
+Reference symbol mismatch:
+after transform: ReferenceId(34): Some("M")
+rebuilt        : ReferenceId(33): Some("M")
 
 tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny.ts
 semantic error: Bindings mismatch:
@@ -31978,15 +39118,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLite
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch:
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -32031,11 +39162,19 @@ after transform: SymbolId(10): [ReferenceId(4)]
 rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofModuleWithoutExports.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: M
+semantic error: Missing SymbolId: M
 Missing SymbolId: _M
 Missing ReferenceId: M
 Missing ReferenceId: M
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
 semantic error: Unresolved references mismatch:
@@ -32279,11 +39418,19 @@ after transform: ScopeId(2): ["T", "U", "array1", "array2", "i", "length", "zipR
 rebuilt        : ScopeId(2): ["array1", "array2", "i", "length", "zipResult"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias02.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: container
+semantic error: Missing SymbolId: container
 Missing SymbolId: _container
 Missing ReferenceId: container
 Missing ReferenceId: container
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(4)]
+rebuilt        : ScopeId(1): [SymbolId(4)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithClass.ts
 semantic error: Bindings mismatch:
@@ -32758,8 +39905,7 @@ after transform: ScopeId(0): ["I", "S", "T", "U", "g", "h"]
 rebuilt        : ScopeId(0): ["g", "h"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: SimpleTypes
+semantic error: Missing SymbolId: SimpleTypes
 Missing SymbolId: _SimpleTypes
 Missing ReferenceId: SimpleTypes
 Missing ReferenceId: SimpleTypes
@@ -32767,6 +39913,39 @@ Missing SymbolId: ObjectTypes
 Missing SymbolId: _ObjectTypes
 Missing ReferenceId: ObjectTypes
 Missing ReferenceId: ObjectTypes
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(13)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(12)]
+Bindings mismatch:
+after transform: ScopeId(1): ["S", "S2", "T", "T2", "_SimpleTypes", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
+rebuilt        : ScopeId(1): ["S", "T", "_SimpleTypes", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["S", "S2", "T", "T2", "_ObjectTypes", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
+rebuilt        : ScopeId(4): ["S", "T", "_ObjectTypes", "a", "a2", "b", "b2", "s", "s2", "t", "t2"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(2): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1)]
+rebuilt        : SymbolId(3): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): [ReferenceId(42), ReferenceId(44)]
+rebuilt        : SymbolId(14): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): [ReferenceId(43), ReferenceId(45)]
+rebuilt        : SymbolId(15): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(22): [ReferenceId(50), ReferenceId(72), ReferenceId(75), ReferenceId(76), ReferenceId(78), ReferenceId(80)]
+rebuilt        : SymbolId(20): [ReferenceId(60), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(68)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(23): [ReferenceId(51), ReferenceId(69), ReferenceId(73), ReferenceId(74), ReferenceId(87)]
+rebuilt        : SymbolId(21): [ReferenceId(57), ReferenceId(61), ReferenceId(62), ReferenceId(75)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers2.ts
 semantic error: Bindings mismatch:
@@ -33059,14 +40238,55 @@ after transform: [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: _Derived
+semantic error: Missing SymbolId: _Derived
 Missing ReferenceId: Derived
 Missing ReferenceId: Derived
 Missing SymbolId: WithContextualType
 Missing SymbolId: _WithContextualType
 Missing ReferenceId: WithContextualType
 Missing ReferenceId: WithContextualType
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(30), SymbolId(35), SymbolId(46), SymbolId(61), SymbolId(76)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(31), SymbolId(37), SymbolId(46), SymbolId(59), SymbolId(72)]
+Binding symbols mismatch:
+after transform: ScopeId(15): [SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(92)]
+rebuilt        : ScopeId(15): [SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30)]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(15): ScopeFlags(Function)
+Binding symbols mismatch:
+after transform: ScopeId(29): [SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(93)]
+rebuilt        : ScopeId(29): [SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36)]
+Scope flags mismatch:
+after transform: ScopeId(29): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(29): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(32): ["T", "U", "a", "b", "c", "d", "e", "f", "t", "u"]
+rebuilt        : ScopeId(32): ["a", "b", "c", "d", "e", "f", "t", "u"]
+Bindings mismatch:
+after transform: ScopeId(38): ["T", "U", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "t", "u"]
+rebuilt        : ScopeId(38): ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "t", "u"]
+Bindings mismatch:
+after transform: ScopeId(44): ["T", "U", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "t", "u"]
+rebuilt        : ScopeId(44): ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "t", "u"]
+Bindings mismatch:
+after transform: ScopeId(50): ["T", "U", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "t", "u"]
+rebuilt        : ScopeId(50): ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "t", "u"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(14): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(113)]
+rebuilt        : SymbolId(14): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch:
+after transform: SymbolId(15): SymbolFlags(Class | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(15): SymbolFlags(Class)
+Symbol reference IDs mismatch:
+after transform: SymbolId(15): [ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(48), ReferenceId(69), ReferenceId(70)]
+rebuilt        : SymbolId(15): [ReferenceId(24), ReferenceId(25)]
+Symbol redeclarations mismatch:
+after transform: SymbolId(15): [Span { start: 842, end: 849 }]
+rebuilt        : SymbolId(15): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): [ReferenceId(5)]
+rebuilt        : SymbolId(16): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
 semantic error: Bindings mismatch:
@@ -33252,11 +40472,25 @@ after transform: ScopeId(1): ["T", "U", "V", "r", "r2", "r3", "t", "u", "v"]
 rebuilt        : ScopeId(1): ["r", "r2", "r3", "t", "u", "v"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: CallSignature
+semantic error: Missing SymbolId: CallSignature
 Missing SymbolId: _CallSignature
 Missing ReferenceId: CallSignature
 Missing ReferenceId: CallSignature
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(3), SymbolId(5), SymbolId(10), SymbolId(13), SymbolId(16)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(9)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "x"]
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(9): ["T", "x"]
+rebuilt        : ScopeId(5): ["x"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
 semantic error: Bindings mismatch:
@@ -33327,8 +40561,7 @@ after transform: ["Array", "Date", "Object", "foo1", "foo10", "foo11", "foo12", 
 rebuilt        : ["foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Errors
+semantic error: Missing SymbolId: Errors
 Missing SymbolId: _Errors
 Missing ReferenceId: Errors
 Missing ReferenceId: Errors
@@ -33336,6 +40569,75 @@ Missing SymbolId: WithGenericSignaturesInBaseType
 Missing SymbolId: _WithGenericSignaturesInBaseType
 Missing ReferenceId: WithGenericSignaturesInBaseType
 Missing ReferenceId: WithGenericSignaturesInBaseType
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(113)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(77)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(24), SymbolId(28), SymbolId(33), SymbolId(38), SymbolId(44), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(56), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63), SymbolId(66), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(71), SymbolId(75), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(84), SymbolId(88), SymbolId(89), SymbolId(90), SymbolId(91), SymbolId(94), SymbolId(96), SymbolId(97), SymbolId(98), SymbolId(99), SymbolId(102), SymbolId(103), SymbolId(104), SymbolId(105), SymbolId(108), SymbolId(109), SymbolId(112), SymbolId(128)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(27), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(36), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(53), SymbolId(56), SymbolId(57), SymbolId(58), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(64), SymbolId(65), SymbolId(66), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(71), SymbolId(73), SymbolId(74), SymbolId(76)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(24): ["T", "U", "x"]
+rebuilt        : ScopeId(6): ["x"]
+Bindings mismatch:
+after transform: ScopeId(26): ["T", "U", "x"]
+rebuilt        : ScopeId(8): ["x"]
+Bindings mismatch:
+after transform: ScopeId(27): ["T", "U", "x"]
+rebuilt        : ScopeId(9): ["x"]
+Bindings mismatch:
+after transform: ScopeId(29): ["T", "U", "V", "x"]
+rebuilt        : ScopeId(11): ["x"]
+Bindings mismatch:
+after transform: ScopeId(33): ["T", "U", "x", "y"]
+rebuilt        : ScopeId(15): ["x", "y"]
+Bindings mismatch:
+after transform: ScopeId(37): ["T", "x"]
+rebuilt        : ScopeId(19): ["x"]
+Bindings mismatch:
+after transform: ScopeId(39): ["T", "x", "y"]
+rebuilt        : ScopeId(21): ["x", "y"]
+Bindings mismatch:
+after transform: ScopeId(42): ["T", "x", "y"]
+rebuilt        : ScopeId(24): ["x", "y"]
+Bindings mismatch:
+after transform: ScopeId(43): ["T", "x"]
+rebuilt        : ScopeId(25): ["x"]
+Bindings mismatch:
+after transform: ScopeId(45): ["T", "x"]
+rebuilt        : ScopeId(27): ["x"]
+Bindings mismatch:
+after transform: ScopeId(46): ["T", "x"]
+rebuilt        : ScopeId(28): ["x"]
+Bindings mismatch:
+after transform: ScopeId(47): ["T", "x"]
+rebuilt        : ScopeId(29): ["x"]
+Binding symbols mismatch:
+after transform: ScopeId(48): [SymbolId(117), SymbolId(120), SymbolId(124), SymbolId(127), SymbolId(129)]
+rebuilt        : ScopeId(30): [SymbolId(78), SymbolId(79), SymbolId(81), SymbolId(82), SymbolId(84)]
+Scope flags mismatch:
+after transform: ScopeId(48): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(30): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(51): ["T", "x"]
+rebuilt        : ScopeId(31): ["x"]
+Bindings mismatch:
+after transform: ScopeId(54): ["T", "x"]
+rebuilt        : ScopeId(32): ["x"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(35), ReferenceId(41), ReferenceId(50), ReferenceId(57), ReferenceId(59), ReferenceId(67), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(89), ReferenceId(90), ReferenceId(101), ReferenceId(109), ReferenceId(117), ReferenceId(119), ReferenceId(136)]
+rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(26), ReferenceId(32), ReferenceId(51), ReferenceId(58), ReferenceId(68), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(86), ReferenceId(97), ReferenceId(113)]
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(38), ReferenceId(52), ReferenceId(60), ReferenceId(111), ReferenceId(115)]
+rebuilt        : SymbolId(4): []
+Unresolved references mismatch:
+after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
+rebuilt        : ["foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4.ts
 semantic error: Bindings mismatch:
@@ -33409,11 +40711,19 @@ after transform: SymbolId(2): [ReferenceId(43)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: ConstructSignature
+semantic error: Missing SymbolId: ConstructSignature
 Missing SymbolId: _ConstructSignature
 Missing ReferenceId: ConstructSignature
 Missing ReferenceId: ConstructSignature
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0)]
+rebuilt        : ScopeId(0): [SymbolId(0)]
+Bindings mismatch:
+after transform: ScopeId(1): ["T", "_ConstructSignature", "r", "r2", "r3", "r3arg1", "r4", "r4arg1", "rarg1", "rarg2"]
+rebuilt        : ScopeId(1): ["_ConstructSignature", "r", "r2", "r3", "r3arg1", "r4", "r4arg1", "rarg1", "rarg2"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures2.ts
 semantic error: Bindings mismatch:
@@ -33433,8 +40743,7 @@ after transform: ["Array", "Date", "Object", "foo1", "foo10", "foo11", "foo12", 
 rebuilt        : ["foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Errors
+semantic error: Missing SymbolId: Errors
 Missing SymbolId: _Errors
 Missing ReferenceId: Errors
 Missing ReferenceId: Errors
@@ -33442,6 +40751,33 @@ Missing SymbolId: WithGenericSignaturesInBaseType
 Missing SymbolId: _WithGenericSignaturesInBaseType
 Missing ReferenceId: WithGenericSignaturesInBaseType
 Missing ReferenceId: WithGenericSignaturesInBaseType
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(73)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(49)]
+Bindings mismatch:
+after transform: ScopeId(1): ["Base", "Derived", "Derived2", "OtherDerived", "T", "U", "V", "_Errors", "r1", "r1a", "r1arg1", "r1arg2", "r1b", "r2", "r2a", "r2arg1", "r2arg2", "r2b", "r3", "r3a", "r3arg1", "r3arg2", "r3b", "r4", "r4a", "r4arg1", "r4arg2", "r4b", "r5", "r5a", "r5arg1", "r5arg2", "r5b", "r6", "r6a", "r6arg1", "r6arg2", "r6b", "r7", "r7a", "r7arg1", "r7arg2", "r7arg3", "r7b", "r7c", "r7d", "r7e", "r8", "r8arg", "r9", "r9arg"]
+rebuilt        : ScopeId(1): ["Base", "Derived", "Derived2", "OtherDerived", "_Errors", "r1", "r1a", "r1arg1", "r1arg2", "r1b", "r2", "r2a", "r2arg1", "r2arg2", "r2b", "r3", "r3a", "r3arg1", "r3arg2", "r3b", "r4", "r4a", "r4arg1", "r4arg2", "r4b", "r5", "r5a", "r5arg1", "r5arg2", "r5b", "r6", "r6a", "r6arg1", "r6arg2", "r6b", "r7", "r7a", "r7arg1", "r7arg2", "r7arg3", "r7b", "r7c", "r7d", "r7e", "r8", "r8arg", "r9", "r9arg"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(36): ["T", "_WithGenericSignaturesInBaseType", "r2", "r2arg2", "r3", "r3arg2"]
+rebuilt        : ScopeId(6): ["_WithGenericSignaturesInBaseType", "r2", "r2arg2", "r3", "r3arg2"]
+Scope flags mismatch:
+after transform: ScopeId(36): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(35), ReferenceId(41), ReferenceId(55), ReferenceId(58), ReferenceId(60), ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(90), ReferenceId(91), ReferenceId(102), ReferenceId(110), ReferenceId(116), ReferenceId(118), ReferenceId(139)]
+rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(5), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(26), ReferenceId(32), ReferenceId(56), ReferenceId(59), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(80), ReferenceId(89), ReferenceId(101), ReferenceId(114)]
+rebuilt        : SymbolId(3): [ReferenceId(1)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(38), ReferenceId(57), ReferenceId(61), ReferenceId(112), ReferenceId(121)]
+rebuilt        : SymbolId(4): []
+Unresolved references mismatch:
+after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
+rebuilt        : ["foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures4.ts
 semantic error: Bindings mismatch:
@@ -33483,11 +40819,19 @@ after transform: SymbolId(1): [ReferenceId(3), ReferenceId(6), ReferenceId(9)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: TwoLevels
+semantic error: Missing SymbolId: TwoLevels
 Missing SymbolId: _TwoLevels
 Missing ReferenceId: TwoLevels
 Missing ReferenceId: TwoLevels
+Bindings mismatch:
+after transform: ScopeId(0): ["Base", "Derived", "Derived2", "S", "S2", "S3", "T", "T2", "T3", "TwoLevels", "a", "b", "r"]
+rebuilt        : ScopeId(0): ["TwoLevels", "a", "b", "r"]
+Bindings mismatch:
+after transform: ScopeId(10): ["S", "S2", "S3", "T", "T2", "T3", "_TwoLevels", "a", "b", "r"]
+rebuilt        : ScopeId(1): ["_TwoLevels", "a", "b", "r"]
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality3.ts
 semantic error: Bindings mismatch:
@@ -35035,8 +42379,7 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: NonGenericParameter
+semantic error: Missing SymbolId: NonGenericParameter
 Missing SymbolId: _NonGenericParameter
 Missing ReferenceId: NonGenericParameter
 Missing ReferenceId: NonGenericParameter
@@ -35044,10 +42387,36 @@ Missing SymbolId: GenericParameter
 Missing SymbolId: _GenericParameter
 Missing ReferenceId: GenericParameter
 Missing ReferenceId: GenericParameter
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(8)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(8)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(7), SymbolId(36)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "_GenericParameter", "a", "b", "c", "c2", "foo5", "foo6", "foo7", "r13", "r14", "r15", "r5", "r7", "r8", "r9"]
+rebuilt        : ScopeId(3): ["_GenericParameter", "a", "b", "c", "c2", "foo5", "foo6", "foo7", "r13", "r14", "r15", "r5", "r7", "r8", "r9"]
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(7): ["T", "cb"]
+rebuilt        : ScopeId(4): ["cb"]
+Bindings mismatch:
+after transform: ScopeId(14): ["T", "cb"]
+rebuilt        : ScopeId(5): ["cb"]
+Bindings mismatch:
+after transform: ScopeId(17): ["T", "cb", "x"]
+rebuilt        : ScopeId(6): ["cb", "x"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: NonGenericParameter
+semantic error: Missing SymbolId: NonGenericParameter
 Missing SymbolId: _NonGenericParameter
 Missing ReferenceId: NonGenericParameter
 Missing ReferenceId: NonGenericParameter
@@ -35055,10 +42424,48 @@ Missing SymbolId: GenericParameter
 Missing SymbolId: _GenericParameter
 Missing ReferenceId: GenericParameter
 Missing ReferenceId: GenericParameter
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(10)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(10)]
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(8), SymbolId(41)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(8)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(3): ["T", "x"]
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["T", "_GenericParameter", "a", "foo5", "foo6", "foo7", "r11", "r12", "r13", "r14", "r5", "r7", "r8", "r9"]
+rebuilt        : ScopeId(5): ["_GenericParameter", "a", "foo5", "foo6", "foo7", "r11", "r12", "r13", "r14", "r5", "r7", "r8", "r9"]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "cb"]
+rebuilt        : ScopeId(6): ["cb"]
+Bindings mismatch:
+after transform: ScopeId(8): ["T", "cb"]
+rebuilt        : ScopeId(8): ["cb"]
+Bindings mismatch:
+after transform: ScopeId(10): ["T", "x"]
+rebuilt        : ScopeId(10): ["x"]
+Bindings mismatch:
+after transform: ScopeId(11): ["T", "x", "y"]
+rebuilt        : ScopeId(11): ["x", "y"]
+Bindings mismatch:
+after transform: ScopeId(12): ["T", "cb", "x"]
+rebuilt        : ScopeId(12): ["cb", "x"]
+Bindings mismatch:
+after transform: ScopeId(14): ["T", "x"]
+rebuilt        : ScopeId(14): ["x"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithObjectTypeArgsAndConstraints.ts
-semantic error: Semantic Collector failed after transform
-Missing SymbolId: Class
+semantic error: Missing SymbolId: Class
 Missing SymbolId: _Class
 Missing ReferenceId: Class
 Missing ReferenceId: Class
@@ -35066,6 +42473,51 @@ Missing SymbolId: Interface
 Missing SymbolId: _Interface
 Missing ReferenceId: Interface
 Missing ReferenceId: Interface
+Binding symbols mismatch:
+after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(23)]
+rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(19)]
+Bindings mismatch:
+after transform: ScopeId(3): ["T"]
+rebuilt        : ScopeId(3): []
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(5), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(22), SymbolId(36)]
+rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(18)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(5): ["T"]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(6): ["T", "t", "t2", "x"]
+rebuilt        : ScopeId(6): ["t", "t2", "x"]
+Bindings mismatch:
+after transform: ScopeId(7): ["T"]
+rebuilt        : ScopeId(7): []
+Bindings mismatch:
+after transform: ScopeId(8): ["T", "t", "t2", "x"]
+rebuilt        : ScopeId(8): ["t", "t2", "x"]
+Bindings mismatch:
+after transform: ScopeId(9): ["G", "G2", "_Interface", "c1", "d1", "g", "g2", "r", "r2"]
+rebuilt        : ScopeId(9): ["_Interface", "c1", "d1", "g", "g2", "r", "r2"]
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Symbol reference IDs mismatch:
+after transform: SymbolId(0): [ReferenceId(8), ReferenceId(18), ReferenceId(19), ReferenceId(40), ReferenceId(50), ReferenceId(56)]
+rebuilt        : SymbolId(0): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(1): [ReferenceId(10), ReferenceId(27), ReferenceId(42), ReferenceId(58)]
+rebuilt        : SymbolId(1): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(20), ReferenceId(22), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(41), ReferenceId(51), ReferenceId(53)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(18), ReferenceId(19)]
+Symbol reference IDs mismatch:
+after transform: SymbolId(5): [ReferenceId(11)]
+rebuilt        : SymbolId(5): []
+Symbol reference IDs mismatch:
+after transform: SymbolId(16): [ReferenceId(26)]
+rebuilt        : SymbolId(14): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -9,7 +9,7 @@ use oxc::diagnostics::OxcDiagnostic;
 use oxc::minifier::CompressOptions;
 use oxc::parser::{ParseOptions, ParserReturn};
 use oxc::semantic::{
-    post_transform_checker::{check_semantic_after_transform, SemanticIds},
+    post_transform_checker::{check_semantic_after_transform, check_semantic_ids},
     SemanticBuilderReturn,
 };
 use oxc::span::{SourceType, Span};
@@ -77,8 +77,7 @@ impl CompilerInterface for Driver {
         _semantic_return: &mut SemanticBuilderReturn,
     ) -> ControlFlow<()> {
         if self.check_semantic {
-            let mut ids = SemanticIds::default();
-            if let Some(errors) = ids.check(program) {
+            if let Some(errors) = check_semantic_ids(program) {
                 self.errors.extend(errors);
                 return ControlFlow::Break(());
             }

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -2202,8 +2202,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 * enum/mix-references/input.ts
   x Output mismatch
-  x Semantic Collector failed after transform
-
   x Missing ReferenceId: Foo
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/enum/mix-references/input.ts:1:1]
  1 | var x = 10;
@@ -2238,6 +2236,95 @@ failed to resolve query: failed to parse the rest of input: ...''
    : ^
  2 | 
    `----
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Foo", "a", "b", "c"]
+  | rebuilt        : ScopeId(1): ["Foo"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["Bar", "D", "E", "F", "G"]
+  | rebuilt        : ScopeId(2): ["Bar"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(3): ["Baz", "a", "b", "x"]
+  | rebuilt        : ScopeId(3): ["Baz"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(3): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(4): ["A", "a", "b", "c"]
+  | rebuilt        : ScopeId(4): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(4): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(3), ReferenceId(7),
+  | ReferenceId(18)]
+  | rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(20)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(19): [ReferenceId(11), ReferenceId(12),
+  | ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16),
+  | ReferenceId(17)]
+  | rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(8)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(20): [ReferenceId(19), ReferenceId(20),
+  | ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24),
+  | ReferenceId(25), ReferenceId(26), ReferenceId(27)]
+  | rebuilt        : SymbolId(4): [ReferenceId(10), ReferenceId(11),
+  | ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15),
+  | ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(21)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(10): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(21): [ReferenceId(29), ReferenceId(30),
+  | ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34),
+  | ReferenceId(35)]
+  | rebuilt        : SymbolId(6): [ReferenceId(23), ReferenceId(24),
+  | ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28),
+  | ReferenceId(29), ReferenceId(30)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(14): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(22): [ReferenceId(37), ReferenceId(38),
+  | ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42),
+  | ReferenceId(43)]
+  | rebuilt        : SymbolId(8): [ReferenceId(32), ReferenceId(33),
+  | ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37),
+  | ReferenceId(38), ReferenceId(39), ReferenceId(40)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(17): [ReferenceId(9)]
+  | rebuilt        : SymbolId(9): []
 
 
 * enum/non-foldable-constant/input.ts
@@ -2516,14 +2603,16 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * exports/export-import=/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: JGraph
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/exports/export-import=/input.ts:1:1]
  1 | import * as joint from '@joint/core';
    : ^
  2 | 
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
 
 
 * exports/export-type/input.ts
@@ -2628,8 +2717,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * imports/elide-type-referenced-in-imports-equal-no/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: foo
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/imports/elide-type-referenced-in-imports-equal-no/input.ts:1:1]
  1 | import nsa from "./module-a";
@@ -2643,6 +2730,12 @@ failed to resolve query: failed to parse the rest of input: ...''
    : ^
  2 | import foo = nsa.bar;
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2),
+  | SymbolId(3)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2),
+  | SymbolId(3)]
 
 
 * imports/elide-typeof/input.ts
@@ -2856,8 +2949,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * namespace/alias/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: b
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/alias/input.ts:1:1]
  1 | declare module LongNameModule {
@@ -2872,10 +2963,26 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   export type SomeType = number;
    `----
 
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["AliasModule", "LongNameModule", "b",
+  | "babel", "bar", "baz", "node", "some", "str"]
+  | rebuilt        : ScopeId(0): ["AliasModule", "b", "babel", "bar", "baz",
+  | "node", "some", "str"]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(3): Some("AliasModule")
+  | rebuilt        : ReferenceId(2): Some("AliasModule")
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(4): Some("AliasModule")
+  | rebuilt        : ReferenceId(3): Some("AliasModule")
+
+  x Unresolved reference IDs mismatch for "LongNameModule":
+  | after transform: [ReferenceId(1), ReferenceId(5)]
+  | rebuilt        : [ReferenceId(1)]
+
 
 * namespace/clobber-class/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: _A
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/clobber-class/input.ts:1:1]
  1 | class A { }
@@ -2903,11 +3010,32 @@ failed to resolve query: failed to parse the rest of input: ...''
    : ^
  2 | namespace A {
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule |
+  | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): []
+  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 22, end: 23 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
 
 
 * namespace/clobber-enum/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: _A
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/clobber-enum/input.ts:1:1]
  1 | enum A {
@@ -2936,10 +3064,40 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   C = 2,
    `----
 
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "C"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
+  | rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule
+  | | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(3)]
+  | rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5),
+  | ReferenceId(6)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 30, end: 31 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
 
 * namespace/clobber-export/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: _N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/clobber-export/input.ts:1:1]
  1 | export class N {}
@@ -2961,10 +3119,26 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 | export namespace N { var x; }
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Export | Class | NameSpaceModule
+  | | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(Export | Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(0)]
+  | rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 35, end: 36 }]
+  | rebuilt        : SymbolId(0): []
+
 
 * namespace/contentious-names/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/contentious-names/input.ts:1:1]
  1 | namespace N {
@@ -3945,10 +4119,166 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   namespace N { var x }
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5),
+  | SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15),
+  | SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25),
+  | SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35),
+  | SymbolId(37), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45),
+  | SymbolId(47), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(55),
+  | SymbolId(57), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(65),
+  | SymbolId(67), SymbolId(69)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5),
+  | SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20),
+  | SymbolId(23), SymbolId(26), SymbolId(29), SymbolId(32), SymbolId(35),
+  | SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50),
+  | SymbolId(53), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65),
+  | SymbolId(68), SymbolId(71), SymbolId(74), SymbolId(77), SymbolId(80),
+  | SymbolId(83), SymbolId(86), SymbolId(89), SymbolId(92), SymbolId(95),
+  | SymbolId(98), SymbolId(101)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(70)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(71)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(6), SymbolId(72)]
+  | rebuilt        : ScopeId(4): [SymbolId(9), SymbolId(10)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(8), SymbolId(73)]
+  | rebuilt        : ScopeId(5): [SymbolId(12), SymbolId(13)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(6): [SymbolId(10), SymbolId(74)]
+  | rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(7): [SymbolId(12), SymbolId(75)]
+  | rebuilt        : ScopeId(7): [SymbolId(18), SymbolId(19)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(8): [SymbolId(14), SymbolId(76)]
+  | rebuilt        : ScopeId(8): [SymbolId(21), SymbolId(22)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(9): [SymbolId(16), SymbolId(77)]
+  | rebuilt        : ScopeId(9): [SymbolId(24), SymbolId(25)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(10): [SymbolId(18), SymbolId(78)]
+  | rebuilt        : ScopeId(10): [SymbolId(27), SymbolId(28)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(11): [SymbolId(20), SymbolId(79)]
+  | rebuilt        : ScopeId(11): [SymbolId(30), SymbolId(31)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(12): [SymbolId(22), SymbolId(80)]
+  | rebuilt        : ScopeId(12): [SymbolId(33), SymbolId(34)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(13): [SymbolId(24), SymbolId(81)]
+  | rebuilt        : ScopeId(13): [SymbolId(36), SymbolId(37)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(14): [SymbolId(26), SymbolId(82)]
+  | rebuilt        : ScopeId(14): [SymbolId(39), SymbolId(40)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(15): [SymbolId(28), SymbolId(83)]
+  | rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(16): [SymbolId(30), SymbolId(84)]
+  | rebuilt        : ScopeId(16): [SymbolId(45), SymbolId(46)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(17): [SymbolId(32), SymbolId(85)]
+  | rebuilt        : ScopeId(17): [SymbolId(48), SymbolId(49)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(18): [SymbolId(34), SymbolId(86)]
+  | rebuilt        : ScopeId(18): [SymbolId(51), SymbolId(52)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(19): [SymbolId(36), SymbolId(87)]
+  | rebuilt        : ScopeId(19): [SymbolId(54), SymbolId(55)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(20): [SymbolId(38), SymbolId(88)]
+  | rebuilt        : ScopeId(20): [SymbolId(57), SymbolId(58)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(21): [SymbolId(40), SymbolId(89)]
+  | rebuilt        : ScopeId(21): [SymbolId(60), SymbolId(61)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(22): [SymbolId(42), SymbolId(90)]
+  | rebuilt        : ScopeId(22): [SymbolId(63), SymbolId(64)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(23): [SymbolId(44), SymbolId(91)]
+  | rebuilt        : ScopeId(23): [SymbolId(66), SymbolId(67)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(24): [SymbolId(46), SymbolId(92)]
+  | rebuilt        : ScopeId(24): [SymbolId(69), SymbolId(70)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(25): [SymbolId(48), SymbolId(93)]
+  | rebuilt        : ScopeId(25): [SymbolId(72), SymbolId(73)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(26): [SymbolId(50), SymbolId(94)]
+  | rebuilt        : ScopeId(26): [SymbolId(75), SymbolId(76)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(27): [SymbolId(52), SymbolId(95)]
+  | rebuilt        : ScopeId(27): [SymbolId(78), SymbolId(79)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(28): [SymbolId(54), SymbolId(96)]
+  | rebuilt        : ScopeId(28): [SymbolId(81), SymbolId(82)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(29): [SymbolId(56), SymbolId(97)]
+  | rebuilt        : ScopeId(29): [SymbolId(84), SymbolId(85)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(30): [SymbolId(58), SymbolId(98)]
+  | rebuilt        : ScopeId(30): [SymbolId(87), SymbolId(88)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(31): [SymbolId(60), SymbolId(99)]
+  | rebuilt        : ScopeId(31): [SymbolId(90), SymbolId(91)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(32): [SymbolId(62), SymbolId(100)]
+  | rebuilt        : ScopeId(32): [SymbolId(93), SymbolId(94)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(33): [SymbolId(64), SymbolId(101)]
+  | rebuilt        : ScopeId(33): [SymbolId(96), SymbolId(97)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(34): [SymbolId(66), SymbolId(102)]
+  | rebuilt        : ScopeId(34): [SymbolId(99), SymbolId(100)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(35): [SymbolId(68), SymbolId(103)]
+  | rebuilt        : ScopeId(35): [SymbolId(102), SymbolId(103)]
+
 
 * namespace/declare/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/declare/input.ts:1:1]
  1 | export namespace N {
@@ -3977,10 +4307,16 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   export declare class C {
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["B", "_N", "e", "v"]
+  | rebuilt        : ScopeId(1): ["_N"]
+
 
 * namespace/declare-global-nested-namespace/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: X
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/declare-global-nested-namespace/input.ts:1:1]
  1 | declare global { namespace globalThis { var i18n: any; } }
@@ -4009,10 +4345,16 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 | 
    `----
 
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["X", "global", "i18n"]
+  | rebuilt        : ScopeId(0): ["X", "i18n"]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
 
 * namespace/empty-removed/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: a
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/empty-removed/input.ts:1:1]
  1 | namespace a {
@@ -4293,10 +4635,66 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   namespace b {}
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(14)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(9)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["_a", "b", "c", "d"]
+  | rebuilt        : ScopeId(1): ["_a", "c"]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(3), SymbolId(26)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(6): ["_WithTypes", "a", "b", "c", "d"]
+  | rebuilt        : ScopeId(3): ["_WithTypes", "d"]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(12): [SymbolId(33)]
+  | rebuilt        : ScopeId(4): [SymbolId(8)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(14): [SymbolId(15), SymbolId(17), SymbolId(19),
+  | SymbolId(21), SymbolId(23), SymbolId(34)]
+  | rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11), SymbolId(14),
+  | SymbolId(18), SymbolId(21), SymbolId(24)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(15): [SymbolId(16), SymbolId(35)]
+  | rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(17): [SymbolId(18), SymbolId(36)]
+  | rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(18): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(19): [SymbolId(20), SymbolId(37)]
+  | rebuilt        : ScopeId(10): [SymbolId(19), SymbolId(20)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(21): [SymbolId(22), SymbolId(38)]
+  | rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(22): [SymbolId(39)]
+  | rebuilt        : ScopeId(13): [SymbolId(25)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(18): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
+  | rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
+
 
 * namespace/export/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/export/input.ts:1:1]
  1 | export namespace N { var x }
@@ -4321,6 +4719,14 @@ failed to resolve query: failed to parse the rest of input: ...''
    : ^
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
 
 * namespace/export-type-only/input.ts
   x Bindings mismatch:
@@ -4333,8 +4739,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * namespace/module-nested/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: src
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/module-nested/input.ts:1:1]
  1 | module src {
@@ -4474,11 +4878,41 @@ failed to resolve query: failed to parse the rest of input: ...''
    : ^
  2 |   export namespace ns1 {
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
+  | rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(4): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): []
+  | rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(7): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(7): [ReferenceId(7)]
 
 
 * namespace/module-nested-export/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: src
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/module-nested-export/input.ts:1:1]
  1 | export module src {
@@ -4619,10 +5053,40 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   export namespace ns1 {
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
+  | rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(4): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): []
+  | rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(7): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(7): [ReferenceId(7)]
+
 
 * namespace/multiple/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/multiple/input.ts:1:1]
  1 | namespace N { var x; }
@@ -4672,6 +5136,18 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 | namespace N { var y; }
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
 
 * namespace/mutable-fail/input.ts
   ! Namespaces exporting non-const are not supported by Babel. Change to const
@@ -4695,8 +5171,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * namespace/nested/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: _A
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested/input.ts:1:1]
  1 | class A { }
@@ -4921,10 +5395,139 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 | namespace A {
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(1), SymbolId(4), SymbolId(6),
+  | SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18)]
+  | rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2), SymbolId(6),
+  | SymbolId(9), SymbolId(14), SymbolId(17), SymbolId(20)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(19)]
+  | rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(6): [SymbolId(5), SymbolId(20)]
+  | rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(8): [SymbolId(7), SymbolId(8), SymbolId(21)]
+  | rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11), SymbolId(12)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(9): ["H", "I", "J", "K"]
+  | rebuilt        : ScopeId(9): ["H"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(9): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(11): [SymbolId(13), SymbolId(22)]
+  | rebuilt        : ScopeId(11): [SymbolId(15), SymbolId(16)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(12): [SymbolId(15), SymbolId(23)]
+  | rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(13): ["L", "M"]
+  | rebuilt        : ScopeId(13): ["L"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(13): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule |
+  | ValueModule)
+  | rebuilt        : SymbolId(0): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): []
+  | rebuilt        : SymbolId(0): [ReferenceId(33), ReferenceId(34)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(0): [Span { start: 22, end: 23 }]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(4): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): []
+  | rebuilt        : SymbolId(4): [ReferenceId(1)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(3): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function |
+  | NameSpaceModule | ValueModule)
+  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(10)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(4): [Span { start: 129, end: 130 }]
+  | rebuilt        : SymbolId(6): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export |
+  | Function | NameSpaceModule | ValueModule)
+  | rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): []
+  | rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(22),
+  | ReferenceId(23)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(6): [Span { start: 207, end: 208 }]
+  | rebuilt        : SymbolId(9): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): []
+  | rebuilt        : SymbolId(12): [ReferenceId(21)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule |
+  | ValueModule)
+  | rebuilt        : SymbolId(14): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(12): []
+  | rebuilt        : SymbolId(14): [ReferenceId(26), ReferenceId(27)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(12): [Span { start: 325, end: 326 }]
+  | rebuilt        : SymbolId(14): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(16): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(0): Some("C")
+  | rebuilt        : ReferenceId(8): Some("C")
+
 
 * namespace/nested-namespace/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: A
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-namespace/input.ts:1:1]
  1 | export namespace A {
@@ -4967,10 +5570,32 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   export namespace B {
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["B", "G", "_A"]
+  | rebuilt        : ScopeId(1): ["G", "_A"]
+
+  x Bindings mismatch:
+  | after transform: ScopeId(4): ["G", "H"]
+  | rebuilt        : ScopeId(2): ["G"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(4): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(3): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): []
+  | rebuilt        : SymbolId(2): [ReferenceId(4)]
+
 
 * namespace/nested-shorthand/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: X
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/nested-shorthand/input.ts:1:1]
  1 | namespace X.Y {
@@ -5209,10 +5834,48 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   export const Z = 1;
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(10)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(4): [SymbolId(5), SymbolId(11)]
+  | rebuilt        : ScopeId(4): [SymbolId(8), SymbolId(9)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(6), SymbolId(12)]
+  | rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(6): [SymbolId(7), SymbolId(13)]
+  | rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(7): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
 
 * namespace/same-name/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/same-name/input.ts:1:1]
  1 | namespace N {
@@ -5423,10 +6086,61 @@ failed to resolve query: failed to parse the rest of input: ...''
  2 |   namespace _N7 { var x }
    `----
 
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(7)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(3): [SymbolId(4), SymbolId(9)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
+  | rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(7): [SymbolId(6), SymbolId(11)]
+  | rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(8): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Export
+  | | Function)
+  | rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): []
+  | rebuilt        : SymbolId(7): [ReferenceId(3)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(Export | Class)
+  | rebuilt        : SymbolId(9): SymbolFlags(Class)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): []
+  | rebuilt        : SymbolId(9): [ReferenceId(9)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(Export | RegularEnum)
+  | rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): []
+  | rebuilt        : SymbolId(11): [ReferenceId(16)]
+
 
 * namespace/undeclared/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: N
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/namespace/undeclared/input.ts:1:1]
  1 | namespace N { var x }
@@ -5450,6 +6164,14 @@ failed to resolve query: failed to parse the rest of input: ...''
  1 | namespace N { var x }
    : ^
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 
 
 * optimize-const-enums/custom-values/input.ts
@@ -5654,8 +6376,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 * regression/15768/input.ts
   x Output mismatch
-  x Semantic Collector failed after transform
-
   x Missing ReferenceId: Infinity
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/regression/15768/input.ts:1:1]
  1 | const v = 42;
@@ -5704,6 +6424,55 @@ failed to resolve query: failed to parse the rest of input: ...''
    : ^
  2 | const v2 = Infinity;
    `----
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["StateEnum", "ext", "ext2", "ext3", "nan",
+  | "nanReal", "neg", "negReal", "okay", "pos", "posReal"]
+  | rebuilt        : ScopeId(2): ["StateEnum"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(0): [ReferenceId(5)]
+  | rebuilt        : SymbolId(0): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(1): [ReferenceId(6)]
+  | rebuilt        : SymbolId(1): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(2): [ReferenceId(7)]
+  | rebuilt        : SymbolId(2): []
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(3): [ReferenceId(2), ReferenceId(3)]
+  | rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9),
+  | ReferenceId(14), ReferenceId(17)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(4): [ReferenceId(4)]
+  | rebuilt        : SymbolId(4): []
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(16): [ReferenceId(8), ReferenceId(9),
+  | ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13),
+  | ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17),
+  | ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21),
+  | ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25),
+  | ReferenceId(26), ReferenceId(27), ReferenceId(28)]
+  | rebuilt        : SymbolId(6): [ReferenceId(2), ReferenceId(3),
+  | ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(8),
+  | ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13),
+  | ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(19),
+  | ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23),
+  | ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27),
+  | ReferenceId(28), ReferenceId(29)]
 
 
 * type-arguments/call/input.ts
@@ -6094,8 +6863,6 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 * cross-platform/within-ts-module-block/input.ts
   x Output mismatch
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: Namespaced
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/within-ts-module-block/input.ts:1:1]
  1 | export namespace Namespaced {
@@ -6130,6 +6897,20 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
    : ^
  2 |     export const Component = () => (
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
+  | rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
+  | rebuilt        : ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
 
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -9,8 +9,6 @@ Passed: 10/36
 
 # babel-plugin-transform-typescript (2/7)
 * computed-constant-value/input.ts
-  x Semantic Collector failed after transform
-
   x Missing ReferenceId: Infinity
    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/computed-constant-value/input.ts:1:1]
  1 | enum A {
@@ -38,6 +36,64 @@ Passed: 10/36
    : ^
  2 |   a = Infinity,
    `----
+
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["A", "a", "b", "c", "d", "e"]
+  | rebuilt        : ScopeId(1): ["A"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(2): ["B", "a", "b", "c", "d", "e"]
+  | rebuilt        : ScopeId(2): ["B"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(2): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(3): ["C", "a", "b", "c"]
+  | rebuilt        : ScopeId(3): ["C"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(3): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+
+  x Bindings mismatch:
+  | after transform: ScopeId(4): ["D", "a", "b", "c"]
+  | rebuilt        : ScopeId(4): ["D"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(4): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(0): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(12): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(16): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+
+  x Unresolved references mismatch:
+  | after transform: ["Infinity", "NaN"]
+  | rebuilt        : ["Infinity"]
+
+  x Unresolved reference IDs mismatch for "Infinity":
+  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2),
+  | ReferenceId(3)]
+  | rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8),
+  | ReferenceId(12)]
 
 
 * elimination-declare/input.ts
@@ -47,8 +103,6 @@ Passed: 10/36
 
 
 * enum-member-reference/input.ts
-  x Semantic Collector failed after transform
-
   x Missing ReferenceId: Foo
    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/enum-member-reference/input.ts:1:1]
  1 | var x = 10;
@@ -56,10 +110,28 @@ Passed: 10/36
  2 | 
    `----
 
+  x Bindings mismatch:
+  | after transform: ScopeId(1): ["Foo", "a", "b", "c"]
+  | rebuilt        : ScopeId(1): ["Foo"]
+
+  x Scope flags mismatch:
+  | after transform: ScopeId(1): ScopeFlags(StrictMode)
+  | rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(1): SymbolFlags(RegularEnum)
+  | rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4),
+  | ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8),
+  | ReferenceId(9)]
+  | rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5),
+  | ReferenceId(6), ReferenceId(8)]
+
 
 * export-elimination/input.ts
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: Name
    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/input.ts:1:1]
  1 | import Im, {Ok} from 'a';
@@ -94,6 +166,44 @@ Passed: 10/36
    : ^
  2 | class Foo {}
    `----
+
+  x Bindings mismatch:
+  | after transform: ScopeId(0): ["Baq", "Bar", "Baz", "Foo", "Func", "Im",
+  | "Name", "Ok", "T"]
+  | rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok",
+  | "T"]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
+  | rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Export |
+  | Function | TypeAlias)
+  | rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable | Export
+  | | Function)
+
+  x Symbol span mismatch:
+  | after transform: SymbolId(9): Span { start: 205, end: 206 }
+  | rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(8), ReferenceId(9)]
+  | rebuilt        : SymbolId(8): [ReferenceId(9)]
+
+  x Symbol redeclarations mismatch:
+  | after transform: SymbolId(9): [Span { start: 226, end: 227 }]
+  | rebuilt        : SymbolId(8): []
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(7): Some("Name")
+  | rebuilt        : ReferenceId(8): Some("Name")
 
 
 * redeclarations/input.ts
@@ -446,8 +556,6 @@ Passed: 10/36
 
 
 * refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
-  x Semantic Collector failed after transform
-
   x Missing ScopeId
    ,-[tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx:1:1]
  1 | import FancyHook from 'fancy';
@@ -455,10 +563,40 @@ Passed: 10/36
  2 | 
    `----
 
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(10): [ReferenceId(17), ReferenceId(18),
+  | ReferenceId(20)]
+  | rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(16)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(12), ReferenceId(13),
+  | ReferenceId(15)]
+  | rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(7): [ReferenceId(9), ReferenceId(21),
+  | ReferenceId(22)]
+  | rebuilt        : SymbolId(10): [ReferenceId(19), ReferenceId(22)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(17): Some("_s2")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(12): Some("_s")
+  | rebuilt        : ReferenceId(2): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(21): Some("_c")
+  | rebuilt        : ReferenceId(21): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React", "useFancyEffect", "useThePlatform"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React",
+  | "useFancyEffect", "useThePlatform"]
+
 
 * refresh/includes-custom-hooks-into-the-signatures/input.jsx
-  x Semantic Collector failed after transform
-
   x Missing ScopeId
    ,-[tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/includes-custom-hooks-into-the-signatures/input.jsx:1:1]
  1 | function useFancyState() {
@@ -472,6 +610,46 @@ Passed: 10/36
    : ^
  2 |   const [foo, setFoo] = React.useState(0);
    `----
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(8): [ReferenceId(10), ReferenceId(11),
+  | ReferenceId(13)]
+  | rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(7)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(9): [ReferenceId(14), ReferenceId(15),
+  | ReferenceId(17)]
+  | rebuilt        : SymbolId(2): [ReferenceId(10), ReferenceId(12)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(10): [ReferenceId(19), ReferenceId(20),
+  | ReferenceId(22)]
+  | rebuilt        : SymbolId(3): [ReferenceId(14), ReferenceId(18)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): [ReferenceId(6), ReferenceId(23),
+  | ReferenceId(24)]
+  | rebuilt        : SymbolId(10): [ReferenceId(21), ReferenceId(24)]
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(10): Some("_s")
+  | rebuilt        : ReferenceId(0): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(14): Some("_s2")
+  | rebuilt        : ReferenceId(1): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(19): Some("_s3")
+  | rebuilt        : ReferenceId(2): None
+
+  x Reference symbol mismatch:
+  | after transform: ReferenceId(23): Some("_c")
+  | rebuilt        : ReferenceId(23): None
+
+  x Unresolved references mismatch:
+  | after transform: ["React"]
+  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React"]
 
 
 * refresh/registers-capitalized-identifiers-in-hoc-calls/input.jsx
@@ -1043,8 +1221,6 @@ Passed: 10/36
 
 * refresh/supports-typescript-namespace-syntax/input.tsx
   x Output mismatch
-  x Semantic Collector failed after transform
-
   x Missing SymbolId: Foo
    ,-[tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/refresh/supports-typescript-namespace-syntax/input.tsx:1:1]
  1 | namespace Foo {
@@ -1184,6 +1360,63 @@ Passed: 10/36
    : ^
  2 |   export namespace Bar {
    `----
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(0): [SymbolId(0)]
+  | rebuilt        : ScopeId(0): [SymbolId(0)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(1): [SymbolId(1), SymbolId(5), SymbolId(6),
+  | SymbolId(7), SymbolId(9)]
+  | rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(7),
+  | SymbolId(8), SymbolId(9)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4),
+  | SymbolId(10)]
+  | rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(5),
+  | SymbolId(6)]
+
+  x Binding symbols mismatch:
+  | after transform: ScopeId(7): [SymbolId(8), SymbolId(11)]
+  | rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(2): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
+  | rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(4): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export)
+  | rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(5): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Export
+  | | Function)
+  | rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(6): []
+  | rebuilt        : SymbolId(8): [ReferenceId(9)]
+
+  x Symbol flags mismatch:
+  | after transform: SymbolId(8): SymbolFlags(BlockScopedVariable |
+  | ConstVariable | Export | ArrowFunction)
+  | rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable |
+  | ConstVariable)
 
 
 * refresh/uses-custom-identifiers-for-refresh-reg-and-refresh-sig/input.jsx


### PR DESCRIPTION
Transform checker don't bail out if some IDs missing from AST. Continue to check for other problems.

Also simplify iterating over pairs of IDs.