### PR TITLE
refactor(semantic): combine add scope methods

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -209,7 +209,7 @@ impl<'a> SemanticBuilder<'a> {
     /// # Panics
     pub fn build(mut self, program: &Program<'a>) -> SemanticBuilderReturn<'a> {
         if self.source_type.is_typescript_definition() {
-            let scope_id = self.scope.add_root_scope(AstNodeId::DUMMY, ScopeFlags::Top);
+            let scope_id = self.scope.add_scope(None, AstNodeId::DUMMY, ScopeFlags::Top);
             program.scope_id.set(Some(scope_id));
         } else {
             // Count the number of nodes, scopes, symbols, and references.
@@ -548,7 +548,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn enter_scope(&mut self, flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
         let parent_scope_id = self.current_scope_id;
         let flags = self.scope.get_new_scope_flags(flags, parent_scope_id);
-        self.current_scope_id = self.scope.add_scope(parent_scope_id, self.current_node_id, flags);
+        self.current_scope_id =
+            self.scope.add_scope(Some(parent_scope_id), self.current_node_id, flags);
         scope_id.set(Some(self.current_scope_id));
 
         self.unresolved_references.increment_scope_depth();
@@ -617,7 +618,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if program.is_strict() {
             flags |= ScopeFlags::StrictMode;
         }
-        self.current_scope_id = self.scope.add_root_scope(self.current_node_id, flags);
+        self.current_scope_id = self.scope.add_scope(None, self.current_node_id, flags);
         program.scope_id.set(Some(self.current_scope_id));
         // NB: Don't call `self.unresolved_references.increment_scope_depth()`
         // as scope depth is initialized as 1 already (the scope depth for `Program`).

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -209,36 +209,9 @@ impl ScopeTree {
         &mut self.bindings[scope_id]
     }
 
-    /// Create a scope inside another scope.
-    ///
-    /// For the root [`Program`] scope, use [`add_root_scope`].
-    ///
-    /// [`Program`]: oxc_ast::ast::Program
-    /// [`add_root_scope`]: ScopeTree::add_root_scope
-    pub fn add_scope(
-        &mut self,
-        parent_id: ScopeId,
-        node_id: AstNodeId,
-        flags: ScopeFlags,
-    ) -> ScopeId {
-        self.add_scope_impl(Some(parent_id), node_id, flags)
-    }
-
-    /// Create the root [`Program`] scope.
-    ///
-    /// Do not use this method if a root scope already exists. Use [`add_scope`]
-    /// to create a new scope inside the root scope.
-    ///
-    /// [`Program`]: oxc_ast::ast::Program
-    /// [`add_scope`]: ScopeTree::add_scope
-    pub fn add_root_scope(&mut self, node_id: AstNodeId, flags: ScopeFlags) -> ScopeId {
-        self.add_scope_impl(None, node_id, flags)
-    }
-
-    // `#[inline]` because almost always called from `add_scope` and want to avoid
-    // overhead of a function call there.
+    /// Create a scope.
     #[inline]
-    fn add_scope_impl(
+    pub fn add_scope(
         &mut self,
         parent_id: Option<ScopeId>,
         node_id: AstNodeId,

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -78,7 +78,7 @@ impl TraverseScoping {
     /// `flags` provided are amended to inherit from parent scope's flags.
     pub fn create_child_scope(&mut self, parent_id: ScopeId, flags: ScopeFlags) -> ScopeId {
         let flags = self.scopes.get_new_scope_flags(flags, parent_id);
-        self.scopes.add_scope(parent_id, AstNodeId::DUMMY, flags)
+        self.scopes.add_scope(Some(parent_id), AstNodeId::DUMMY, flags)
     }
 
     /// Create new scope as child of current scope.


### PR DESCRIPTION
#5232 removed `ScopeTree::child_ids`, so it's no longer necessary to have separate `add_scope` and `add_root_scope` methods.