### PR TITLE
chore: fix install hook

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
 
 # Install git pre-commit to format files
 install-hook:
-  echo "#!/bin/sh\njust fmt" > .git/hooks/pre-commit
+  echo -e "#!/bin/sh\njust fmt" > .git/hooks/pre-commit
   chmod +x .git/hooks/pre-commit
 
 # --no-vcs-ignores: cargo-watch has a bug loading all .gitignores, including the ones listed in .gitignore


### PR DESCRIPTION
Add `-e` for enabling interpretation of backslash escapes.

Before:
```
#!/bin/sh\njust fmt
```
