### PR TITLE
feat(linter/unicorn): add fixer to `throw-new-error`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -48,7 +48,7 @@ declare_oxc_lint!(
     /// ```
     ThrowNewError,
     style,
-    pending
+    fix
 );
 
 impl Rule for ThrowNewError {
@@ -85,7 +85,9 @@ impl Rule for ThrowNewError {
             _ => return,
         }
 
-        ctx.diagnostic(throw_new_error_diagnostic(call_expr.span));
+        ctx.diagnostic_with_fix(throw_new_error_diagnostic(call_expr.span), |fixer| {
+            fixer.insert_text_before_range(call_expr.span, "new ")
+        });
     }
 }
 
@@ -143,5 +145,10 @@ fn test() {
         ("throw (( getGlobalThis().Error ))()", None),
     ];
 
-    Tester::new(ThrowNewError::NAME, pass, fail).test_and_snapshot();
+    let fix = vec![
+        ("throw Error()", "throw new Error()"),
+        ("throw (( getGlobalThis().Error ))()", "throw new (( getGlobalThis().Error ))()"),
+    ];
+
+    Tester::new(ThrowNewError::NAME, pass, fail).expect_fix(fix).test_and_snapshot();
 }


### PR DESCRIPTION
got merged into the wrong branch (https://github.com/oxc-project/oxc/pull/5148), hence setting to merge when ready (as was already approved)