### PR TITLE
refactor(syntax): use `generate_derive` for `CloneIn` in types outside of `oxc_ast` crate.

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -16,6 +16,7 @@ src:
   - 'crates/oxc_ast/src/generated/visit.rs'
   - 'crates/oxc_ast/src/generated/visit_mut.rs'
   - 'crates/oxc_ast/src/generated/derive_clone_in.rs'
+  - 'crates/oxc_syntax/src/generated/derive_clone_in.rs'
   - 'crates/oxc_ast/src/generated/derive_get_span.rs'
   - 'crates/oxc_ast/src/generated/derive_get_span_mut.rs'
   - 'tasks/ast_codegen/src/**'

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -11,7 +11,7 @@ use std::hash::Hash;
 
 use bitflags::bitflags;
 use oxc_allocator::CloneIn;
-use oxc_ast_macros::{ast, CloneIn};
+use oxc_ast_macros::ast;
 use oxc_span::{Atom, GetSpan, GetSpanMut, Span};
 use oxc_syntax::number::{BigintBase, NumberBase};
 #[cfg(feature = "serialize")]
@@ -137,7 +137,7 @@ bitflags! {
     /// Regular expression flags.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags>
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, CloneIn)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct RegExpFlags: u8 {
         /// Global flag
         ///

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -10,6 +10,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use oxc_allocator::CloneIn;
 use oxc_span::{Atom, Span};
 use oxc_syntax::number::NumberBase;
 
@@ -220,5 +221,12 @@ impl<'a> fmt::Display for StringLiteral<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for RegExpFlags {
+    type Cloned = Self;
+    fn clone_in(&self, _: &'alloc oxc_allocator::Allocator) -> Self::Cloned {
+        *self
     }
 }

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -167,32 +167,3 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn ast_derive(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }
-
-/// Derive macro generating an impl of the trait `CloneIn`.
-///
-/// NOTE: This is an internal macro!
-/// # Panics
-///
-#[proc_macro_derive(CloneIn)]
-pub fn derive_clone_in(item: TokenStream) -> TokenStream {
-    let item = syn::parse_macro_input!(item as syn::Item);
-    match &item {
-        syn::Item::Struct(syn::ItemStruct { ident, generics, .. })
-        | syn::Item::Enum(syn::ItemEnum { ident, generics, .. })
-            if generics.params.is_empty() =>
-        {
-            quote! {
-                #[automatically_derived]
-                impl<'alloc> ::oxc_allocator::CloneIn<'alloc> for #ident {
-                    type Cloned = #ident;
-
-                    fn clone_in(&self, _: &'alloc ::oxc_allocator::Allocator) -> Self::Cloned {
-                        std::clone::Clone::clone(self)
-                    }
-                }
-            }
-            .into()
-        }
-        _ => panic!("At the moment `CloneIn` derive macro only works for types without lifetimes and/or generic params"),
-    }
-}

--- a/crates/oxc_syntax/src/generated/derive_clone_in.rs
+++ b/crates/oxc_syntax/src/generated/derive_clone_in.rs
@@ -1,0 +1,127 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/derives/clone_in.rs`
+
+#![allow(clippy::default_trait_access)]
+
+use oxc_allocator::{Allocator, CloneIn};
+
+#[allow(clippy::wildcard_imports)]
+use crate::number::*;
+
+#[allow(clippy::wildcard_imports)]
+use crate::operator::*;
+
+impl<'alloc> CloneIn<'alloc> for NumberBase {
+    type Cloned = NumberBase;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Float => NumberBase::Float,
+            Self::Decimal => NumberBase::Decimal,
+            Self::Binary => NumberBase::Binary,
+            Self::Octal => NumberBase::Octal,
+            Self::Hex => NumberBase::Hex,
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for BigintBase {
+    type Cloned = BigintBase;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Decimal => BigintBase::Decimal,
+            Self::Binary => BigintBase::Binary,
+            Self::Octal => BigintBase::Octal,
+            Self::Hex => BigintBase::Hex,
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for AssignmentOperator {
+    type Cloned = AssignmentOperator;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Assign => AssignmentOperator::Assign,
+            Self::Addition => AssignmentOperator::Addition,
+            Self::Subtraction => AssignmentOperator::Subtraction,
+            Self::Multiplication => AssignmentOperator::Multiplication,
+            Self::Division => AssignmentOperator::Division,
+            Self::Remainder => AssignmentOperator::Remainder,
+            Self::ShiftLeft => AssignmentOperator::ShiftLeft,
+            Self::ShiftRight => AssignmentOperator::ShiftRight,
+            Self::ShiftRightZeroFill => AssignmentOperator::ShiftRightZeroFill,
+            Self::BitwiseOR => AssignmentOperator::BitwiseOR,
+            Self::BitwiseXOR => AssignmentOperator::BitwiseXOR,
+            Self::BitwiseAnd => AssignmentOperator::BitwiseAnd,
+            Self::LogicalAnd => AssignmentOperator::LogicalAnd,
+            Self::LogicalOr => AssignmentOperator::LogicalOr,
+            Self::LogicalNullish => AssignmentOperator::LogicalNullish,
+            Self::Exponential => AssignmentOperator::Exponential,
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for BinaryOperator {
+    type Cloned = BinaryOperator;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Equality => BinaryOperator::Equality,
+            Self::Inequality => BinaryOperator::Inequality,
+            Self::StrictEquality => BinaryOperator::StrictEquality,
+            Self::StrictInequality => BinaryOperator::StrictInequality,
+            Self::LessThan => BinaryOperator::LessThan,
+            Self::LessEqualThan => BinaryOperator::LessEqualThan,
+            Self::GreaterThan => BinaryOperator::GreaterThan,
+            Self::GreaterEqualThan => BinaryOperator::GreaterEqualThan,
+            Self::ShiftLeft => BinaryOperator::ShiftLeft,
+            Self::ShiftRight => BinaryOperator::ShiftRight,
+            Self::ShiftRightZeroFill => BinaryOperator::ShiftRightZeroFill,
+            Self::Addition => BinaryOperator::Addition,
+            Self::Subtraction => BinaryOperator::Subtraction,
+            Self::Multiplication => BinaryOperator::Multiplication,
+            Self::Division => BinaryOperator::Division,
+            Self::Remainder => BinaryOperator::Remainder,
+            Self::BitwiseOR => BinaryOperator::BitwiseOR,
+            Self::BitwiseXOR => BinaryOperator::BitwiseXOR,
+            Self::BitwiseAnd => BinaryOperator::BitwiseAnd,
+            Self::In => BinaryOperator::In,
+            Self::Instanceof => BinaryOperator::Instanceof,
+            Self::Exponential => BinaryOperator::Exponential,
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for LogicalOperator {
+    type Cloned = LogicalOperator;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Or => LogicalOperator::Or,
+            Self::And => LogicalOperator::And,
+            Self::Coalesce => LogicalOperator::Coalesce,
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for UnaryOperator {
+    type Cloned = UnaryOperator;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::UnaryNegation => UnaryOperator::UnaryNegation,
+            Self::UnaryPlus => UnaryOperator::UnaryPlus,
+            Self::LogicalNot => UnaryOperator::LogicalNot,
+            Self::BitwiseNot => UnaryOperator::BitwiseNot,
+            Self::Typeof => UnaryOperator::Typeof,
+            Self::Void => UnaryOperator::Void,
+            Self::Delete => UnaryOperator::Delete,
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for UpdateOperator {
+    type Cloned = UpdateOperator;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Increment => UpdateOperator::Increment,
+            Self::Decrement => UpdateOperator::Decrement,
+        }
+    }
+}

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -13,3 +13,6 @@ pub mod reference;
 pub mod scope;
 pub mod symbol;
 pub mod xml_entities;
+mod generated {
+    mod derive_clone_in;
+}

--- a/crates/oxc_syntax/src/number.rs
+++ b/crates/oxc_syntax/src/number.rs
@@ -1,7 +1,9 @@
-use oxc_ast_macros::{ast, CloneIn};
+use oxc_allocator::CloneIn;
+use oxc_ast_macros::ast;
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 pub enum NumberBase {
     Float = 0,
     Decimal = 1,
@@ -17,7 +19,8 @@ impl NumberBase {
 }
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 pub enum BigintBase {
     Decimal = 0,
     Binary = 1,

--- a/crates/oxc_syntax/src/operator.rs
+++ b/crates/oxc_syntax/src/operator.rs
@@ -4,12 +4,14 @@
 #[cfg(feature = "serialize")]
 use ::{serde::Serialize, tsify::Tsify};
 
-use oxc_ast_macros::{ast, CloneIn};
+use oxc_allocator::CloneIn;
+use oxc_ast_macros::ast;
 
 use crate::precedence::{GetPrecedence, Precedence};
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum AssignmentOperator {
     #[serde(rename = "=")]
@@ -88,7 +90,8 @@ impl AssignmentOperator {
 }
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum BinaryOperator {
     #[serde(rename = "==")]
@@ -276,7 +279,8 @@ impl GetPrecedence for BinaryOperator {
 }
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum LogicalOperator {
     #[serde(rename = "||")]
@@ -316,7 +320,8 @@ impl GetPrecedence for LogicalOperator {
 }
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum UnaryOperator {
     #[serde(rename = "-")]
@@ -369,7 +374,8 @@ impl UnaryOperator {
 }
 
 #[ast]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CloneIn)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[generate_derive(CloneIn)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 pub enum UpdateOperator {
     #[serde(rename = "++")]

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 use nonmax::NonMaxU32;
-use oxc_ast_macros::CloneIn;
+use oxc_allocator::CloneIn;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
@@ -76,7 +76,7 @@ bitflags! {
     /// [`Read`]: ReferenceFlags::Read
     /// [`Write`]: ReferenceFlags::Write
     /// [`TSTypeQuery`]: ReferenceFlags::TSTypeQuery
-    #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, CloneIn)]
+    #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
     #[cfg_attr(feature = "serialize", derive(Serialize))]
     pub struct ReferenceFlags: u8 {
         const None = 0;
@@ -164,5 +164,12 @@ impl ReferenceFlags {
     #[inline]
     pub const fn is_value(&self) -> bool {
         self.intersects(Self::Value)
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for ReferenceFlags {
+    type Cloned = Self;
+    fn clone_in(&self, _: &'alloc oxc_allocator::Allocator) -> Self::Cloned {
+        *self
     }
 }


### PR DESCRIPTION
Removes the temporary `CloneIn` derive macro used for "foreign" types - as in types outside of the `oxc_ast` crate - since now we have support for multiple derive outputs - one per each crate - that allows us to use `generate_derive` across multiple crates.