### PR TITLE
refactor(traverse)!: `TraverseCtx::ancestor` return `Ancestor::None` if out of bounds

### DIFF
--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -102,9 +102,8 @@ impl<'a> Traverse<'a> for NullishCoalescingOperator<'a> {
         // ctx.ancestor(1) is AssignmentPattern
         // ctx.ancestor(2) is BindingPattern;
         // ctx.ancestor(3) is FormalParameter
-        let is_parent_formal_parameter = ctx
-            .ancestor(3)
-            .is_some_and(|ancestor| matches!(ancestor, Ancestor::FormalParameterPattern(_)));
+        let is_parent_formal_parameter =
+            matches!(ctx.ancestor(3), Ancestor::FormalParameterPattern(_));
 
         let current_scope_id = if is_parent_formal_parameter {
             ctx.create_child_scope_of_current(ScopeFlags::Arrow | ScopeFlags::Function)

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -143,9 +143,11 @@ impl<'a> TraverseCtx<'a> {
     /// `level` is number of levels above.
     /// `ancestor(1).unwrap()` is equivalent to `parent()`.
     ///
+    /// If `level` is out of bounds (above `Program`), returns `Ancestor::None`.
+    ///
     /// Shortcut for `ctx.ancestry.ancestor`.
     #[inline]
-    pub fn ancestor<'t>(&'t self, level: usize) -> Option<Ancestor<'a, 't>> {
+    pub fn ancestor<'t>(&'t self, level: usize) -> Ancestor<'a, 't> {
         self.ancestry.ancestor(level)
     }
 

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -134,7 +134,7 @@ mod compile_fail_tests;
 ///         }
 ///
 ///         // Read grandparent
-///         if let Some(Ancestor::ExpressionStatementExpression(stmt_ref)) = ctx.ancestor(2) {
+///         if let Ancestor::ExpressionStatementExpression(stmt_ref) = ctx.ancestor(2) {
 ///             // This is legal
 ///             println!("expression stmt's span: {:?}", stmt_ref.span());
 ///


### PR DESCRIPTION
This aligns it better with `TraverseCtx::parent` which always returns an `Ancestor`.