### PR TITLE
refactor(transformer/react): remove `CalculateSignatureKey` implementation from refresh

### DIFF
--- a/crates/oxc_transformer/src/react/mod.rs
+++ b/crates/oxc_transformer/src/react/mod.rs
@@ -131,6 +131,10 @@ impl<'a> React<'a> {
         if self.display_name_plugin {
             self.display_name.transform_call_expression(call_expr, ctx);
         }
+
+        if self.refresh_plugin {
+            self.refresh.transform_call_expression(call_expr, ctx);
+        }
     }
 
     pub fn transform_jsx_opening_element(


### PR DESCRIPTION
follow-up: https://github.com/oxc-project/oxc/pull/4587#issue-2440174935

The `CalculateSignatureKey`is used to collect signature keys, but since it requires a double visit, it doesn't perform very well. Now I use ScopeId to store the signature key that is generated in `CallExpression`. This way we can then determine which ArrowFunction/Function the `CallExpression` belongs to.