### PR TITLE
refactor(traverse): correct code comments

### DIFF
--- a/crates/oxc_traverse/src/context/ancestry.rs
+++ b/crates/oxc_traverse/src/context/ancestry.rs
@@ -58,7 +58,7 @@ impl<'a> TraverseAncestry<'a> {
     /// Get ancestor of current node.
     ///
     /// `level` is number of levels above.
-    /// `ancestor(1).unwrap()` is equivalent to `parent()`.
+    /// `ancestor(1)` is equivalent to `parent()`.
     ///
     /// If `level` is out of bounds (above `Program`), returns `Ancestor::None`.
     #[inline]

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -141,7 +141,7 @@ impl<'a> TraverseCtx<'a> {
     /// Get ancestor of current node.
     ///
     /// `level` is number of levels above.
-    /// `ancestor(1).unwrap()` is equivalent to `parent()`.
+    /// `ancestor(1)` is equivalent to `parent()`.
     ///
     /// If `level` is out of bounds (above `Program`), returns `Ancestor::None`.
     ///


### PR DESCRIPTION
#5286 changed `TraverseCtx::ancestor` to always return an `Ancestor`. Update doc comments to reflect that.