### PR TITLE
fix(traverse)!: `TraverseCtx::ancestor` with level 0 = equivalent to `parent`

### DIFF
--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -99,11 +99,11 @@ impl<'a> Traverse<'a> for NullishCoalescingOperator<'a> {
             return;
         }
 
-        // ctx.ancestor(1) is AssignmentPattern
-        // ctx.ancestor(2) is BindingPattern;
-        // ctx.ancestor(3) is FormalParameter
+        // ctx.ancestor(0) is AssignmentPattern
+        // ctx.ancestor(1) is BindingPattern
+        // ctx.ancestor(2) is FormalParameter
         let is_parent_formal_parameter =
-            matches!(ctx.ancestor(3), Ancestor::FormalParameterPattern(_));
+            matches!(ctx.ancestor(2), Ancestor::FormalParameterPattern(_));
 
         let current_scope_id = if is_parent_formal_parameter {
             ctx.create_child_scope_of_current(ScopeFlags::Arrow | ScopeFlags::Function)

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -140,8 +140,8 @@ impl<'a> TraverseCtx<'a> {
 
     /// Get ancestor of current node.
     ///
-    /// `level` is number of levels above.
-    /// `ancestor(1)` is equivalent to `parent()`.
+    /// `level` is number of levels above parent.
+    /// `ancestor(0)` is equivalent to `parent()` (but better to use `parent()` as it's more efficient).
     ///
     /// If `level` is out of bounds (above `Program`), returns `Ancestor::None`.
     ///

--- a/crates/oxc_traverse/src/lib.rs
+++ b/crates/oxc_traverse/src/lib.rs
@@ -134,7 +134,7 @@ mod compile_fail_tests;
 ///         }
 ///
 ///         // Read grandparent
-///         if let Ancestor::ExpressionStatementExpression(stmt_ref) = ctx.ancestor(2) {
+///         if let Ancestor::ExpressionStatementExpression(stmt_ref) = ctx.ancestor(1) {
 ///             // This is legal
 ///             println!("expression stmt's span: {:?}", stmt_ref.span());
 ///


### PR DESCRIPTION
Change meaning of `level` passed to `TraverseCtx` from "levels above current" to "levels above parent". `ctx.parent()`'s equivalent was `ctx.ancestor(1)`, now it's `ctx.ancestor(0)`.

This prevents out of bounds read on `ctx.ancestor(0)` (UB), which was made possible by #5286.