### PR TITLE
ci: enable arithmetic overflow checks in conformance tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,3 +221,4 @@ panic         = "abort" # Let it crash and force ourselves to write safe Rust
 inherits         = "release"
 lto              = "thin" # Faster compile time with thin LTO
 debug-assertions = true # Make sure `debug_assert!`s pass
+overflow-checks  = true # Catch arithmetic overflow errors


### PR DESCRIPTION
Enable checks for arithmetic overflow in conformance tests, to catch more bugs.