### PR TITLE
fix(semantic): remove `check_unresolved_references`

### DIFF
--- a/tasks/coverage/semantic_babel.snap
+++ b/tasks/coverage/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 12619ffe
 
 semantic_babel Summary:
 AST Parsed     : 2100/2100 (100.00%)
-Positive Passed: 1768/2100 (84.19%)
+Positive Passed: 1821/2100 (86.71%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/interpreter-directive/interpreter-directive-import/input.js
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["spawn"]
@@ -133,21 +133,6 @@ semantic error: Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["t"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-like-in-conditional-3/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["v"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-like-in-conditional-4/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["v"]
-rebuilt        : []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-await-null/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -168,11 +153,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-false-positive/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "async"]
-rebuilt        : ["async"]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-tokens-true/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "a"]
@@ -182,11 +162,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-functi
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "a"]
 rebuilt        : ScopeId(1): ["a"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/destructuring-with-annotation-newline/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic/input.ts
 semantic error: Bindings mismatch:
@@ -201,25 +176,10 @@ rebuilt        : ScopeId(1): ["a"]
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts
 semantic error: Expected `<` but found `EOF`
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["asserts"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-as-identifier/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["asserts"]
-rebuilt        : []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/asserts-this-with-predicate/input.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/function-declaration/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["asserts"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assign/TSTypeParameterInstantiation/input.ts
 semantic error: Bindings mismatch:
@@ -243,66 +203,11 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/as/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "x", "y"]
-rebuilt        : ["x", "y"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/as-const/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["a7", "const", "d", "o4"]
-rebuilt        : ["a7", "d", "o4"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/destructuring-assignment-in-parens/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "a", "b", "c", "x", "y"]
-rebuilt        : ["a", "b", "c", "x", "y"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/for-of-lhs/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "a"]
-rebuilt        : ["a"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/need-parentheses/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "x"]
-rebuilt        : ["x"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/satisfies/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "a", "b", "x", "y"]
-rebuilt        : ["a", "b", "x", "y"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/catch-clause/unknown/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["A", "Error"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/async-optional-method/input.js
-semantic error: Unresolved references mismatch:
-after transform: ["B", "Promise"]
-rebuilt        : ["B"]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-modifier-names/input.ts
 semantic error: Multiple constructor implementations are not allowed.
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare/input.ts
 semantic error: Identifier `x` has already been declared
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/declare-readonly-field-initializer/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends-implements/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "X", "f"]
-rebuilt        : ["f"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-generic/input.ts
 semantic error: Bindings mismatch:
@@ -320,21 +225,6 @@ Bindings mismatch:
 after transform: ScopeId(2): ["C", "T"]
 rebuilt        : ScopeId(2): ["C"]
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-implements/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "X"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends-implements/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "X", "f"]
-rebuilt        : ["f"]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/generic/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
@@ -344,16 +234,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/generi
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/implements/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "X"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/method-computed/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/method-generic/input.ts
 semantic error: Bindings mismatch:
@@ -688,17 +568,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/ano
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "input"]
 rebuilt        : ScopeId(1): ["input"]
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/anonymous-generator-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "input"]
 rebuilt        : ScopeId(1): ["input"]
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts
 semantic error: A required parameter cannot follow an optional parameter.
@@ -819,9 +693,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/ex
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X", "Z"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/function-like-node-1/input.ts
 semantic error: Bindings mismatch:
@@ -900,17 +771,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/me
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-computed-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/method-generic/input.ts
 semantic error: Bindings mismatch:
@@ -966,9 +831,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/pr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/property-named-public/input.ts
 semantic error: Bindings mismatch:
@@ -1068,11 +930,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnotherType", "MyType"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/elision-arrow-destructuring-13636/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["b", "c"]
-rebuilt        : ["c"]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/is-default-export/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E", "I", "T"]
@@ -1098,17 +955,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/k
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["var"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
 semantic error: Expected `,` but found `extends`
@@ -1120,17 +971,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/n
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "B", "C", "D", "E", "F", "G"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "B", "C", "D", "E", "F", "G"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/enum-block-scoped/input.ts
 semantic error: Scope flags mismatch:
@@ -1139,16 +984,6 @@ rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-declare-function-after/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-declare-function-before/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-after/input.ts
 semantic error: Scope flags mismatch:
@@ -1170,9 +1005,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m2"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X", "Y"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-import-in-declare-module/input.ts
 semantic error: Bindings mismatch:
@@ -1193,9 +1025,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-type-after/input.ts
 semantic error: Bindings mismatch:
@@ -1585,33 +1414,21 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/anonymou
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "input"]
 rebuilt        : ScopeId(1): ["input"]
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/anonymous-function-generator-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "input"]
 rebuilt        : ScopeId(1): ["input"]
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/brace-is-block/input.tsx
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["D", "T"]
-rebuilt        : ["D"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-arguments/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["C", "T", "f"]
-rebuilt        : ["C", "f"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-parameters/input.ts
 semantic error: Bindings mismatch:
@@ -1647,85 +1464,21 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/g
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/generic-complex-tokens-true-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-alias/plain/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "U", "f"]
-rebuilt        : ["f"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Q", "W", "f"]
-rebuilt        : ["f"]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-asi/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "C1", "C2", "C3", "C4", "I", "bar", "x10", "x11", "x12", "x13", "x14", "x5", "x6", "yy"]
 rebuilt        : ScopeId(0): ["C", "C1", "C2", "C3", "C4", "bar", "x10", "x11", "x12", "x13", "x14", "x5", "x6", "yy"]
-Unresolved references mismatch:
-after transform: ["f", "true"]
-rebuilt        : ["f"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["a", "b", "c"]
-rebuilt        : ["a", "c"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["a", "c"]
-rebuilt        : ["a"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["C", "T", "U"]
-rebuilt        : ["C"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-false-positive-3/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["A", "B", "C"]
-rebuilt        : ["A", "C"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["A", "T"]
-rebuilt        : ["A"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-asi/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["A", "T"]
-rebuilt        : ["A"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "f"]
-rebuilt        : ["f"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template-no-asi/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["C", "T"]
-rebuilt        : ["C"]
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tsx/input.ts
-semantic error: Unresolved reference IDs mismatch for "C":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
-rebuilt        : [ReferenceId(1), ReferenceId(4)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/whitespace/input.ts
 semantic error: Bindings mismatch:
@@ -1736,11 +1489,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-argumen
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/after-bit-shift/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "f", "x"]
-rebuilt        : ["f", "x"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/call-expression/input.ts
 semantic error: Bindings mismatch:
@@ -1763,11 +1511,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like-babel-7/after-bit-shift/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "f", "x"]
-rebuilt        : ["f", "x"]
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like-babel-7/call-expression/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
@@ -1788,11 +1531,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-argumen
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/export-type-only-as-as-keyword/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["as"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-basic/input.ts
 semantic error: Bindings mismatch:
@@ -1857,38 +1595,15 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T", "f"]
 rebuilt        : ScopeId(0): ["f"]
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/function-in-generic/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/function-in-generic-babel-7/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-declaration/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "T", "Types"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Y", "foo"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/indexed/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["K", "T"]
-rebuilt        : []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-with-constraints/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X3", "X4", "X5", "X6", "X7", "X8", "X9"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["MustBeNumber"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-with-constraints-and-conditional-types/input.ts
 semantic error: Bindings mismatch:
@@ -1904,9 +1619,6 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/infer-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X3", "X4", "X5", "X6", "X7", "X8", "X9"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["MustBeNumber"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrinsic-identifier/input.ts
 semantic error: Bindings mismatch:
@@ -1920,27 +1632,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["intrinsic"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["intrinsic"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/literal-boolean/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/literal-string-2/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["bar"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/literal-string-4/input.ts
 semantic error: Bindings mismatch:
@@ -1956,17 +1652,11 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MappedTypeWithNewKeys", "PickByValueType", "RemoveKindField"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude", "NewKeyType"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/mapped-as-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MappedTypeWithNewKeys", "PickByValueType", "RemoveKindField"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude", "NewKeyType"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/object-shorthand/input.ts
 semantic error: Bindings mismatch:
@@ -1998,21 +1688,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic-nested/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
-
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-keyword-labeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncWithDescription"]
@@ -2032,64 +1707,31 @@ tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-before-unlabeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-after-labeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-unlabeled-spread-before-labeled/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/type-operator/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["y"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-asi-false-parameters/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-asi-false-parameters-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
-
-tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters/input.ts
-semantic error: Unresolved references mismatch:
-after transform: ["w", "y"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/types-named-abstract/input.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/semantic_misc.snap
+++ b/tasks/coverage/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
 AST Parsed     : 27/27 (100.00%)
-Positive Passed: 14/27 (51.85%)
+Positive Passed: 17/27 (62.96%)
 tasks/coverage/misc/pass/oxc-1288.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["from"]
@@ -10,11 +10,6 @@ tasks/coverage/misc/pass/oxc-1289.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["infer", "target", "type"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/misc/pass/oxc-1740.tsx
-semantic error: Unresolved reference IDs mismatch for "Bar":
-after transform: [ReferenceId(1), ReferenceId(5)]
-rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/misc/pass/oxc-2087.ts
 semantic error: Bindings mismatch:
@@ -38,14 +33,6 @@ rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
-Unresolved references mismatch:
-after transform: ["F"]
-rebuilt        : []
-
-tasks/coverage/misc/pass/oxc-3910.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ServicesAccessor"]
-rebuilt        : []
 
 tasks/coverage/misc/pass/oxc-3948-1.ts
 semantic error: Bindings mismatch:
@@ -93,9 +80,6 @@ rebuilt        : SymbolId(26): [ReferenceId(15)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(39): [ReferenceId(42), ReferenceId(74), ReferenceId(154), ReferenceId(215)]
 rebuilt        : SymbolId(33): [ReferenceId(56), ReferenceId(185)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(36), ReferenceId(39), ReferenceId(82), ReferenceId(114), ReferenceId(153), ReferenceId(282)]
-rebuilt        : [ReferenceId(252)]
 
 tasks/coverage/misc/pass/oxc-4449.ts
 semantic error: Scope flags mismatch:
@@ -168,12 +152,4 @@ tasks/coverage/misc/pass/swc-7187.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["K"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/misc/pass/swc-8243.tsx
-semantic error: Unresolved reference IDs mismatch for "Baz":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
-rebuilt        : [ReferenceId(4)]
-Unresolved reference IDs mismatch for "Bar":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(8)]
-rebuilt        : [ReferenceId(2)]
 

--- a/tasks/coverage/semantic_test262.snap
+++ b/tasks/coverage/semantic_test262.snap
@@ -10,9 +10,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-b-func-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -21,9 +18,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-stmt-func-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -32,9 +26,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-no-else-func-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -43,9 +34,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 
 tasks/coverage/test262/test/annexB/language/function-code/if-stmt-else-decl-func-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -54,9 +42,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(9)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(11)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(11)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-a-global-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -65,9 +50,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-decl-b-global-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -76,9 +58,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-else-stmt-global-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -87,9 +66,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-decl-no-else-global-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -98,9 +74,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 
 tasks/coverage/test262/test/annexB/language/global-code/if-stmt-else-decl-global-block-scoping.js
 semantic error: Symbol reference IDs mismatch:
@@ -109,9 +82,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(9)]
 rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(9)]
-Unresolved reference IDs mismatch for "f":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(11)]
 
 tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-exec.js
 semantic error: Invalid regular expression: Duplicated capturing group names

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: d8086f14
 
 semantic_typescript Summary:
 AST Parsed     : 6456/6456 (100.00%)
-Positive Passed: 3444/6456 (53.35%)
+Positive Passed: 3636/6456 (56.32%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -44,9 +44,6 @@ rebuilt        : ScopeId(0): ["getAllTags", "getAnnotations", "getReturnTypeFrom
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(20), ReferenceId(22), ReferenceId(26), ReferenceId(34), ReferenceId(46), ReferenceId(48), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(65), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(80), ReferenceId(81), ReferenceId(83), ReferenceId(86), ReferenceId(89), ReferenceId(91), ReferenceId(97)]
 rebuilt        : SymbolId(0): [ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(44), ReferenceId(47), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(60), ReferenceId(62), ReferenceId(65), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(79)]
-Unresolved references mismatch:
-after transform: ["Object", "true", "undefined"]
-rebuilt        : ["Object", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
 semantic error: Bindings mismatch:
@@ -64,9 +61,6 @@ rebuilt        : ReferenceId(42): None
 Reference symbol mismatch:
 after transform: ReferenceId(52): Some("readFileSync")
 rebuilt        : ReferenceId(46): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console", "process", "readFileSync"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_parseConfig.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -79,9 +73,6 @@ rebuilt        : ScopeId(0): ["result", "source", "ts"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("console")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["JSON"]
-rebuilt        : ["JSON", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/APISample_watcher.ts
 semantic error: Bindings mismatch:
@@ -129,9 +120,6 @@ rebuilt        : ReferenceId(67): None
 Reference symbol mismatch:
 after transform: ReferenceId(73): Some("process")
 rebuilt        : ReferenceId(68): None
-Unresolved references mismatch:
-after transform: ["Date", "undefined"]
-rebuilt        : ["console", "fs", "process", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
 semantic error: Symbol flags mismatch:
@@ -153,9 +141,6 @@ semantic error: Missing SymbolId: r
 Bindings mismatch:
 after transform: ScopeId(0): ["M", "r"]
 rebuilt        : ScopeId(0): ["r"]
-Unresolved references mismatch:
-after transform: ["M", "N"]
-rebuilt        : ["M"]
 
 tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
 semantic error: Symbol reference IDs mismatch:
@@ -243,9 +228,6 @@ rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("D")
 rebuilt        : ReferenceId(2): Some("D")
-Unresolved references mismatch:
-after transform: ["A", "C"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
 semantic error: Bindings mismatch:
@@ -393,9 +375,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("isTreeHeader1")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["isTreeHeader1", "x1", "x2"]
 
 tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
 semantic error: Bindings mismatch:
@@ -411,9 +390,6 @@ tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "myFunction"]
 rebuilt        : ScopeId(0): ["myFunction"]
-Unresolved references mismatch:
-after transform: ["Array", "use"]
-rebuilt        : ["use"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
 semantic error: Missing SymbolId: Test
@@ -474,11 +450,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(30): [ReferenceId(39), ReferenceId(46), ReferenceId(48), ReferenceId(49), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(60)]
 rebuilt        : SymbolId(24): [ReferenceId(33), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(50)]
 
-tasks/coverage/typescript/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ArrayBuffer", "ArrayBufferView", "Object"]
-rebuilt        : ["ArrayBuffer"]
-
 tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Fn", "doStuff"]
@@ -486,24 +457,11 @@ rebuilt        : ScopeId(0): ["doStuff"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "T1", "a", "b"]
 rebuilt        : ScopeId(1): ["a", "b"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BooleanLogicExpression", "Expression", "evaluate"]
 rebuilt        : ScopeId(0): ["evaluate"]
-
-tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/arrayFlatMap.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInference.ts
 semantic error: Bindings mismatch:
@@ -524,29 +482,10 @@ tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
 Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
-tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "ReadonlyArray", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-rebuilt        : ["Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(15), ReferenceId(16), ReferenceId(26)]
-rebuilt        : [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
-
-tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2020.ts
-semantic error: Unresolved references mismatch:
-after transform: ["BigInt", "BigInt64Array", "BigUint64Array", "Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "ReadonlyArray", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-rebuilt        : ["BigInt", "BigInt64Array", "BigUint64Array", "Date", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(15), ReferenceId(16), ReferenceId(24)]
-rebuilt        : [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
-
 tasks/coverage/typescript/tests/cases/compiler/arrayTypeInSignatureOfInterfaceAndClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Data", "WinJS"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["WinJS"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/arrayconcat.ts
 semantic error: Bindings mismatch:
@@ -578,9 +517,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "value"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
 semantic error: Bindings mismatch:
@@ -607,35 +543,16 @@ rebuilt        : ScopeId(20): ["value"]
 Bindings mismatch:
 after transform: ScopeId(22): ["T", "value"]
 rebuilt        : ScopeId(22): ["value"]
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "obj"]
 rebuilt        : ScopeId(1): ["obj"]
-Unresolved references mismatch:
-after transform: ["Error", "NonNullable", "undefined"]
-rebuilt        : ["Error", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Animal", "Cat", "Dog", "animal", "animalOrUndef"]
 rebuilt        : ScopeId(0): ["animal", "animalOrUndef"]
-Unresolved references mismatch:
-after transform: ["assertEqual", "const", "true"]
-rebuilt        : ["assertEqual"]
 
 tasks/coverage/typescript/tests/cases/compiler/assign1.ts
 semantic error: Missing SymbolId: M
@@ -756,26 +673,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(9): [ReferenceId(6), ReferenceId(9), ReferenceId(14)]
 rebuilt        : SymbolId(6): [ReferenceId(16)]
 
-tasks/coverage/typescript/tests/cases/compiler/asyncAwaitWithCapturedBlockScopeVar.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyCallback", "increment", "increment2"]
 rebuilt        : ScopeId(0): ["increment", "increment2"]
-Unresolved references mismatch:
-after transform: ["Promise", "PromiseLike", "f", "g", "h"]
-rebuilt        : ["Promise", "f", "g", "h"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(13), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(25)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(17)]
-
-tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
 semantic error: Bindings mismatch:
@@ -808,17 +709,11 @@ rebuilt        : ScopeId(16): ["key", "obj"]
 Bindings mismatch:
 after transform: ScopeId(18): ["K", "TObj", "key", "obj"]
 rebuilt        : ScopeId(17): ["key", "obj"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(21), ReferenceId(23), ReferenceId(26), ReferenceId(28), ReferenceId(33), ReferenceId(38), ReferenceId(40), ReferenceId(44), ReferenceId(46), ReferenceId(51), ReferenceId(56), ReferenceId(58), ReferenceId(62), ReferenceId(64), ReferenceId(71), ReferenceId(80), ReferenceId(83), ReferenceId(90), ReferenceId(93)]
-rebuilt        : [ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(22), ReferenceId(25)]
 
 tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Windows", "sample", "sample2"]
 rebuilt        : ScopeId(0): ["sample", "sample2"]
-Unresolved references mismatch:
-after transform: ["Promise", "Windows", "resolve1", "resolve2"]
-rebuilt        : ["resolve1", "resolve2"]
 
 tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
 semantic error: Bindings mismatch:
@@ -842,9 +737,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(24): Some("g")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Promise", "Symbol"]
-rebuilt        : ["authorPromise", "g", "mapper"]
 
 tasks/coverage/typescript/tests/cases/compiler/augmentArray.ts
 semantic error: Bindings mismatch:
@@ -943,9 +835,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("foo")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/awaitUnionPromise.ts
 semantic error: Bindings mismatch:
@@ -954,25 +843,16 @@ rebuilt        : ScopeId(0): ["AsyncEnumeratorDone", "main"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(6)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/awaitedTypeCrash.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Promise3", "PromiseBase", "T", "Thenable"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Awaited", "Element", "Error", "PromiseLike"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGoodInference.ts
 semantic error: Bindings mismatch:
@@ -1055,11 +935,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "Z", "b1", "b2", "b3", "b4", "b5", "b6", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["b1", "b2", "b3", "b4", "b5", "b6", "x", "y", "z"]
 
-tasks/coverage/typescript/tests/cases/compiler/bindingPatternContextualTypeDoesNotCauseWidening.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Pick", "pick"]
-rebuilt        : ["pick"]
-
 tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
 semantic error: Missing SymbolId: Test
 Missing SymbolId: _Test
@@ -1085,14 +960,6 @@ rebuilt        : SymbolId(2): [ReferenceId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("console")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
-semantic error: Unresolved references mismatch:
-after transform: ["C"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
 semantic error: Missing SymbolId: C
@@ -1130,17 +997,11 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(18): Some("realanys")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Array", "Boolean"]
-rebuilt        : ["Boolean", "Bullean", "anys", "realanys"]
 
 tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IMenuWorkbenchToolBarOptions", "MenuWorkbenchToolBar"]
 rebuilt        : ScopeId(0): ["MenuWorkbenchToolBar"]
-Unresolved references mismatch:
-after transform: ["ConstructorParameters", "InstanceType", "createInstance"]
-rebuilt        : ["createInstance"]
 
 tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
 semantic error: Bindings mismatch:
@@ -1182,9 +1043,6 @@ rebuilt        : ScopeId(1): ["arg"]
 Bindings mismatch:
 after transform: ScopeId(11): ["T", "arg", "useT"]
 rebuilt        : ScopeId(4): ["arg", "useT"]
-Unresolved references mismatch:
-after transform: ["Function", "Parameters"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
 semantic error: Bindings mismatch:
@@ -1230,9 +1088,6 @@ rebuilt        : ReferenceId(93): None
 Reference symbol mismatch:
 after transform: ReferenceId(94): Some("iobj")
 rebuilt        : ReferenceId(94): None
-Unresolved references mismatch:
-after transform: ["use"]
-rebuilt        : ["iobj", "sobj", "use"]
 
 tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 semantic error: Bindings mismatch:
@@ -1277,24 +1132,11 @@ rebuilt        : ReferenceId(10): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("A")
 rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["A", "a"]
 
 tasks/coverage/typescript/tests/cases/compiler/castNewObjectBug.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "xx"]
 rebuilt        : ScopeId(0): ["xx"]
-
-tasks/coverage/typescript/tests/cases/compiler/castTest.ts
-semantic error: Unresolved reference IDs mismatch for "Point":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(10)]
-rebuilt        : [ReferenceId(3)]
-
-tasks/coverage/typescript/tests/cases/compiler/chainedAssignment2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
 semantic error: Missing SymbolId: m
@@ -1338,9 +1180,6 @@ tasks/coverage/typescript/tests/cases/compiler/checkInterfaceBases.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SecondEvent", "Third"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["JQueryEventObjectTest"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/checkJsTypeDefNoUnusedLocalMarked.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -1350,11 +1189,6 @@ tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/checkSwitchStatementIfCaseTypeIsString.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array", "use"]
-rebuilt        : ["use"]
 
 tasks/coverage/typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCrash.ts
 semantic error: Bindings mismatch:
@@ -1368,24 +1202,11 @@ rebuilt        : ScopeId(0): ["applyModelsAndClientExtensions", "getPrismaClient
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/circularContextualMappedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Func", "Mapped"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/circularGetAccessor.ts
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Capitalize", "foo2"]
-rebuilt        : ["foo2"]
 
 tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
 semantic error: Missing SymbolId: _maker
@@ -1422,9 +1243,6 @@ rebuilt        : ScopeId(0): ["myStoreConnect"]
 Reference symbol mismatch:
 after transform: ReferenceId(42): Some("connect")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Partial", "Pick"]
-rebuilt        : ["connect"]
 
 tasks/coverage/typescript/tests/cases/compiler/classDeclarationMergedInModuleWithContinuation.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -1460,9 +1278,6 @@ rebuilt        : ScopeId(0): ["arr"]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts
 semantic error: Bindings mismatch:
@@ -1471,9 +1286,6 @@ rebuilt        : ScopeId(0): ["arr"]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/classExpressions.ts
 semantic error: Bindings mismatch:
@@ -1498,9 +1310,6 @@ rebuilt        : ScopeId(0): ["A", "o"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Err")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Err"]
 
 tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
 semantic error: Missing SymbolId: M
@@ -1532,17 +1341,6 @@ tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "a", "b"]
 rebuilt        : ScopeId(0): ["a", "b"]
-Unresolved reference IDs mismatch for "Foo":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["A", "B", "console"]
-rebuilt        : ["B", "console"]
-Unresolved reference IDs mismatch for "B":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
 semantic error: Bindings mismatch:
@@ -1579,22 +1377,11 @@ rebuilt        : ScopeId(1): ["C", "_M2"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Unresolved references mismatch:
-after transform: ["M1"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Settable"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/classInConvertedLoopES5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping5.ts
 semantic error: Bindings mismatch:
@@ -1603,9 +1390,6 @@ rebuilt        : ScopeId(0): ["Greeter"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/classOrderBug.ts
 semantic error: Symbol reference IDs mismatch:
@@ -1784,9 +1568,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("$")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$"]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
 semantic error: Missing SymbolId: _Moclodule2
@@ -1856,9 +1637,6 @@ rebuilt        : ReferenceId(53): None
 Reference symbol mismatch:
 after transform: ReferenceId(118): Some("types")
 rebuilt        : ReferenceId(56): None
-Unresolved references mismatch:
-after transform: ["Array", "assertNode", "canHaveLocals", "cast", "consume", "every", "isC", "isClassLike", "isExpression", "isNodeArray", "tryCast", "useA"]
-rebuilt        : ["assertNode", "canHaveLocals", "cast", "consume", "every", "isC", "isClassLike", "isExpression", "isNodeArray", "statement", "tryCast", "types", "useA"]
 
 tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
 semantic error: Bindings mismatch:
@@ -1891,9 +1669,6 @@ rebuilt        : ReferenceId(67): None
 Reference symbol mismatch:
 after transform: ReferenceId(190): Some("modifiers")
 rebuilt        : ReferenceId(70): None
-Unresolved references mismatch:
-after transform: ["Extract", "Parameters", "buildOverload", "every", "isArray", "isAssertClause", "isDecorator", "isExpression", "isImportClause", "isModifier", "undefined"]
-rebuilt        : ["DISALLOW_DECORATORS", "buildOverload", "every", "isArray", "isAssertClause", "isDecorator", "isExpression", "isImportClause", "isModifier", "modifiers", "undefined", "updateImportDeclaration"]
 
 tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
 semantic error: Bindings mismatch:
@@ -1917,17 +1692,11 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(20): Some("modifiers")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: ["every", "isDecorator", "isModifier"]
-rebuilt        : ["every", "isDecorator", "isModifier", "modifiers"]
 
 tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SelectOptions", "SelectProps", "Thing", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Unresolved references mismatch:
-after transform: ["Array", "select"]
-rebuilt        : ["select"]
 
 tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
 semantic error: Bindings mismatch:
@@ -1945,9 +1714,6 @@ rebuilt        : ScopeId(7): ["message", "messageList"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(21)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts
 semantic error: Bindings mismatch:
@@ -2197,9 +1963,6 @@ rebuilt        : ScopeId(0): ["foo", "foo2", "m2"]
 Bindings mismatch:
 after transform: ScopeId(16): ["_m", "a", "exports", "require"]
 rebuilt        : ScopeId(3): ["_m", "a"]
-Unresolved references mismatch:
-after transform: ["exports", "require"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
 semantic error: Missing SymbolId: m2
@@ -2327,9 +2090,6 @@ tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninsta
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["exports", "foo", "foo2", "require"]
 rebuilt        : ScopeId(0): ["foo", "foo2"]
-Unresolved references mismatch:
-after transform: ["exports", "require"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
 semantic error: Bindings mismatch:
@@ -2343,9 +2103,6 @@ rebuilt        : ScopeId(0): ["Foo", "_i"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter.ts
 semantic error: Symbol reference IDs mismatch:
@@ -2362,9 +2119,6 @@ rebuilt        : ScopeId(0): ["f"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("_this")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["_this"]
 
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
 semantic error: Bindings mismatch:
@@ -2402,9 +2156,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("console")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
 semantic error: Missing SymbolId: foo
@@ -2420,16 +2171,6 @@ rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-
-tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
-semantic error: Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement2.ts
-semantic error: Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
 semantic error: Missing SymbolId: hello
@@ -2470,11 +2211,6 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 
-tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientClass1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["C"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D"]
@@ -2497,14 +2233,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("x")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
-
-tasks/coverage/typescript/tests/cases/compiler/commentOnAmbientfunction.ts
-semantic error: Unresolved references mismatch:
-after transform: ["bar", "foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/commentOnElidedModule1.ts
 semantic error: Bindings mismatch:
@@ -2581,17 +2309,11 @@ tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersections
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FormikConfig"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Func", "Partial", "Pick", "Readonly"]
-rebuilt        : ["Func"]
 
 tasks/coverage/typescript/tests/cases/compiler/compositeContextualSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "v"]
 rebuilt        : ScopeId(1): ["v"]
-Unresolved references mismatch:
-after transform: ["ReadonlyArray", "console", "undefined"]
-rebuilt        : ["console", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/compositeGenericFunction.ts
 semantic error: Bindings mismatch:
@@ -2689,9 +2411,6 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullabi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Equals", "Foo", "ShouldBe0", "a", "b"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAnyUnion.ts
 semantic error: Bindings mismatch:
@@ -2702,9 +2421,6 @@ tasks/coverage/typescript/tests/cases/compiler/conditionalTypeClassMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DS"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["MyRecord", "MySet"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeContextualTypeSimplificationsSuceeds.ts
 semantic error: Bindings mismatch:
@@ -2727,9 +2443,6 @@ rebuilt        : ScopeId(0): ["makeThing"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "children", "name"]
 rebuilt        : ScopeId(1): ["children", "name"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts
 semantic error: Bindings mismatch:
@@ -2743,22 +2456,11 @@ rebuilt        : ScopeId(0): ["Elem", "g"]
 Bindings mismatch:
 after transform: ScopeId(7): ["C"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["Partial", "f", "undefined"]
-rebuilt        : ["f", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AbstractSchema", "AnySchema", "AnySchemaType", "SchemaType"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSubclassExtendsTypeParam.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Field"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
 semantic error: Bindings mismatch:
@@ -2803,9 +2505,6 @@ rebuilt        : ScopeId(12): ["x", "y"]
 Reference symbol mismatch:
 after transform: ReferenceId(95): Some("z")
 rebuilt        : ReferenceId(24): None
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Pick"]
-rebuilt        : ["z"]
 
 tasks/coverage/typescript/tests/cases/compiler/conditionallyDuplicateOverloadsCausedByOverloadResolution.ts
 semantic error: Symbol reference IDs mismatch:
@@ -2820,11 +2519,6 @@ rebuilt        : SymbolId(5): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(6)]
 rebuilt        : SymbolId(6): []
-
-tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration3.ts
-semantic error: Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/constDeclarations-ambient.ts
 semantic error: Bindings mismatch:
@@ -3407,9 +3101,6 @@ rebuilt        : ReferenceId(211): Some("A")
 Reference symbol mismatch:
 after transform: ReferenceId(84): Some("A")
 rebuilt        : ReferenceId(212): Some("A")
-Unresolved references mismatch:
-after transform: ["A", "A0"]
-rebuilt        : ["E"]
 
 tasks/coverage/typescript/tests/cases/compiler/constIndexedAccess.ts
 semantic error: Bindings mismatch:
@@ -3555,9 +3246,6 @@ rebuilt        : ReferenceId(6): Some("Test")
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("Test")
 rebuilt        : ReferenceId(8): Some("Test")
-Unresolved references mismatch:
-after transform: ["Test"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
 semantic error: Bindings mismatch:
@@ -3616,14 +3304,6 @@ rebuilt        : ScopeId(0): ["yThen"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("y")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["y"]
-
-tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE.ts
-semantic error: Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE2.ts
 semantic error: Bindings mismatch:
@@ -3635,18 +3315,10 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["app"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/contextualSigInstantiationRestParams.ts
-semantic error: Unresolved references mismatch:
-after transform: ["contextual", "toInstantiate"]
-rebuilt        : ["toInstantiate"]
-
 tasks/coverage/typescript/tests/cases/compiler/contextualSignatureConditionalTypeInstantiationUsingDefault.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ActionFunction", "TypegenDisabled", "TypegenEnabled"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["createMachine", "true"]
-rebuilt        : ["createMachine"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation1.ts
 semantic error: Bindings mismatch:
@@ -3711,14 +3383,6 @@ rebuilt        : ScopeId(0): ["applyOptimizationDefaults"]
 Reference symbol mismatch:
 after transform: ReferenceId(20): Some("A")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["MyCompiler", "emit"]
-rebuilt        : ["A", "emit"]
-
-tasks/coverage/typescript/tests/cases/compiler/contextualTypeIterableUnions.ts
-semantic error: Unresolved references mismatch:
-after transform: ["DMap", "Iterable", "true"]
-rebuilt        : ["DMap"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeObjectSpreadExpression.ts
 semantic error: Bindings mismatch:
@@ -3737,17 +3401,11 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncOrGeneratorFunc", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Unresolved references mismatch:
-after transform: ["Generator", "console"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeOnYield2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["OrGen", "g"]
 rebuilt        : ScopeId(0): ["g"]
-Unresolved references mismatch:
-after transform: ["Generator", "console"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts
 semantic error: Bindings mismatch:
@@ -3756,9 +3414,6 @@ rebuilt        : ScopeId(0): ["result"]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("parse")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["parse"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypeShouldBeLiteral.ts
 semantic error: Bindings mismatch:
@@ -3795,20 +3450,11 @@ tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ActionsArray", "ActionsObject", "ActionsObjectOr", "Bar", "JSX", "Options", "Options2", "_jsxFileName", "_reactJsxRuntime", "a", "y"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "a", "y"]
-Unresolved references mismatch:
-after transform: ["App4", "JSX", "app", "app2", "app3", "foo", "require", "undefined"]
-rebuilt        : ["App4", "app", "app2", "app3", "foo", "require", "undefined"]
-Unresolved reference IDs mismatch for "App4":
-after transform: [ReferenceId(50), ReferenceId(52)]
-rebuilt        : [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ErrorRequestHandler", "IRouterHandler", "IRouterMatcher", "MyApp", "NextFunction", "Overload", "PathParams", "Request", "RequestHandler", "RequestHandlerParams", "Response", "app", "use"]
 rebuilt        : ScopeId(0): ["app", "use"]
-Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
 semantic error: Bindings mismatch:
@@ -3834,20 +3480,11 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeAsyncFunctionRetu
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LoadCallback", "cb1", "cb2", "cb3", "fn1"]
 rebuilt        : ScopeId(0): ["cb1", "cb2", "cb3", "fn1"]
-Unresolved references mismatch:
-after transform: ["Promise", "Record", "StateMachine", "createMachine", "load"]
-rebuilt        : ["Promise", "createMachine", "load"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(2), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeGeneratorReturnTypeFromUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action", "Action2", "test1", "test2"]
 rebuilt        : ScopeId(0): ["test1", "test2"]
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Promise"]
-rebuilt        : ["Promise"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
 semantic error: Bindings mismatch:
@@ -3863,9 +3500,6 @@ tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Elements", "Props", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Unresolved reference IDs mismatch for "Test":
-after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(13)]
-rebuilt        : [ReferenceId(2), ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren.tsx
 semantic error: Bindings mismatch:
@@ -3880,12 +3514,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("DropdownMenu")
 rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: ["DropdownMenu", "JSX"]
-rebuilt        : ["DropdownMenu"]
-Unresolved reference IDs mismatch for "DropdownMenu":
-after transform: [ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers2.ts
 semantic error: Bindings mismatch:
@@ -3894,19 +3522,11 @@ rebuilt        : ScopeId(0): ["test2", "test3"]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("num")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Record", "test1"]
-rebuilt        : ["num", "test1"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CanvasDirection", "GraphActions"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Record", "test"]
-rebuilt        : ["test"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator3.ts
 semantic error: Bindings mismatch:
@@ -3917,17 +3537,11 @@ tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceAndTypeGuar
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FilterFn", "IteratorFn", "ListItem", "Test", "filter1", "list2", "x"]
 rebuilt        : ScopeId(0): ["filter1", "list2", "x"]
-Unresolved reference IDs mismatch for "List":
-after transform: [ReferenceId(5), ReferenceId(11), ReferenceId(15), ReferenceId(21), ReferenceId(30), ReferenceId(36), ReferenceId(42), ReferenceId(46), ReferenceId(48), ReferenceId(56)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Funcs", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Unresolved references mismatch:
-after transform: ["Record", "foo"]
-rebuilt        : ["foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/contravariantTypeAliasInference.ts
 semantic error: Bindings mismatch:
@@ -3951,14 +3565,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(22): Some("g2")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: ["bar", "foo"]
-rebuilt        : ["bar", "f1", "f2", "foo", "g1", "g2"]
-
-tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
-semantic error: Unresolved references mismatch:
-after transform: ["isBig", "true"]
-rebuilt        : ["isBig"]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
 semantic error: Bindings mismatch:
@@ -4036,20 +3642,11 @@ rebuilt        : ReferenceId(18): None
 Reference symbol mismatch:
 after transform: ReferenceId(22): Some("obj4")
 rebuilt        : ReferenceId(19): None
-Unresolved references mismatch:
-after transform: ["Record", "isObject1", "isObject2"]
-rebuilt        : ["isObject1", "isObject2", "obj1", "obj2", "obj3", "obj4"]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowForCatchAndFinally.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Browser", "Foo", "Page", "test"]
 rebuilt        : ScopeId(0): ["Foo", "test"]
-Unresolved references mismatch:
-after transform: ["Aborter", "Promise", "test1", "test2", "undefined"]
-rebuilt        : ["Aborter", "test1", "test2", "undefined"]
-Unresolved reference IDs mismatch for "Aborter":
-after transform: [ReferenceId(24), ReferenceId(27)]
-rebuilt        : [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowInitializedDestructuringVariables.ts
 semantic error: Bindings mismatch:
@@ -4058,9 +3655,6 @@ rebuilt        : ScopeId(0): ["a", "b"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("obj")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["obj"]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceof.ts
 semantic error: Bindings mismatch:
@@ -4078,12 +3672,6 @@ rebuilt        : ReferenceId(61): None
 Reference symbol mismatch:
 after transform: ReferenceId(73): Some("x")
 rebuilt        : ReferenceId(62): None
-Unresolved references mismatch:
-after transform: ["Function", "Promise", "Set"]
-rebuilt        : ["Promise", "Set", "ctor", "x"]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(33)]
-rebuilt        : [ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(18), ReferenceId(22), ReferenceId(25)]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 semantic error: Bindings mismatch:
@@ -4095,15 +3683,6 @@ rebuilt        : ScopeId(12): ["value"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(8): [ReferenceId(32), ReferenceId(33)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(1), ReferenceId(20)]
-rebuilt        : [ReferenceId(12)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
-rebuilt        : [ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(18), ReferenceId(22), ReferenceId(25)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
-rebuilt        : [ReferenceId(28), ReferenceId(30)]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 semantic error: Bindings mismatch:
@@ -4131,9 +3710,6 @@ rebuilt        : ScopeId(0): ["HTMLDOMPropertyConfig", "HTMLtoJSX", "StyleParser
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("require")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Error", "JSON"]
-rebuilt        : ["Error", "JSON", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/controlFlowWithIncompleteTypes.ts
 semantic error: Bindings mismatch:
@@ -4145,17 +3721,11 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("cond")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["cond"]
 
 tasks/coverage/typescript/tests/cases/compiler/correctOrderOfPromiseMethod.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "countEverything", "expected"]
 rebuilt        : ScopeId(0): ["countEverything", "expected"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(0), ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
 semantic error: Missing SymbolId: M
@@ -4207,22 +3777,11 @@ tasks/coverage/typescript/tests/cases/compiler/curiousNestedConditionalEvaluatio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Hmm"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["AsyncIterator", "Error", "IteratorResult", "Promise"]
-rebuilt        : ["Error"]
-
-tasks/coverage/typescript/tests/cases/compiler/customEventDetail.ts
-semantic error: Unresolved references mismatch:
-after transform: ["CustomEvent"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiation.ts
 semantic error: Bindings mismatch:
@@ -4322,9 +3881,6 @@ tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["express"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "RegExp", "express"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
 semantic error: Bindings mismatch:
@@ -4345,9 +3901,6 @@ tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataConditionalType.
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["PropertyDecorator", "d", "true"]
-rebuilt        : ["d"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImport.ts
 semantic error: Bindings mismatch:
@@ -4361,9 +3914,6 @@ rebuilt        : ScopeId(0): ["MyClass"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("decorator")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataOnInferredType.ts
 semantic error: Bindings mismatch:
@@ -4372,9 +3922,6 @@ rebuilt        : ScopeId(0): ["A", "B", "decorator"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataPromise.ts
 semantic error: Bindings mismatch:
@@ -4389,17 +3936,11 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("decorator")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["MethodDecorator", "Promise"]
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataRestParameterWithImportedType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassA", "SomeClass", "SomeClass1", "annotation", "annotation1"]
 rebuilt        : ScopeId(0): ["ClassA", "annotation", "annotation1"]
-Unresolved references mismatch:
-after transform: ["ClassDecorator", "MethodDecorator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
 semantic error: Symbol flags mismatch:
@@ -4419,9 +3960,6 @@ rebuilt        : SymbolId(0): [ReferenceId(2)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision.ts
 semantic error: Bindings mismatch:
@@ -4471,17 +4009,11 @@ rebuilt        : ScopeId(0): ["A", "dec"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("console")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Function", "PropertyDescriptor"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLiteralIntersection.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "R", "S", "T", "X", "_S", "a1", "a2", "b"]
 rebuilt        : ScopeId(0): ["a1", "a2", "b"]
-Unresolved references mismatch:
-after transform: ["Partial", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
 semantic error: Symbol flags mismatch:
@@ -4531,17 +4063,11 @@ tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "And", "AndBit", "Bit", "Equals", "Extends", "FilterByStringValue", "FilteredRes1", "FilteredValuesMatchNever", "IsLiteral", "IsNumberLiteral", "Not", "Or", "T0", "T1", "T2", "T3", "T4", "T5", "T6", "TestBit", "TestBitRes", "Values"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Add", "AddTest0", "AddTest1", "AddWithoutParentheses", "IsEqual", "NegativeInfinity", "PositiveInfinity"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/deferredTypeReferenceWithinArrayWithinTuple.ts
 semantic error: Bindings mismatch:
@@ -4602,9 +4128,6 @@ rebuilt        : ReferenceId(12): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("b")
 rebuilt        : ReferenceId(13): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "f"]
 
 tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts
 semantic error: Bindings mismatch:
@@ -4682,9 +4205,6 @@ rebuilt        : ReferenceId(22): None
 Reference symbol mismatch:
 after transform: ReferenceId(28): Some("b")
 rebuilt        : ReferenceId(23): None
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : ["a", "b", "f", "g"]
 
 tasks/coverage/typescript/tests/cases/compiler/dependencyViaImportAlias.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -4696,9 +4216,6 @@ tasks/coverage/typescript/tests/cases/compiler/destructureOfVariableSameAsShorth
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AxiosResponse", "main"]
 rebuilt        : ScopeId(0): ["main"]
-Unresolved references mismatch:
-after transform: ["Promise", "get"]
-rebuilt        : ["get"]
 
 tasks/coverage/typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts
 semantic error: Bindings mismatch:
@@ -4722,9 +4239,6 @@ rebuilt        : ScopeId(0): ["foo"]
 Bindings mismatch:
 after transform: ScopeId(2): ["P", "foo", "props"]
 rebuilt        : ScopeId(1): ["foo", "props"]
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/destructuringWithGenericParameter.ts
 semantic error: Bindings mismatch:
@@ -4760,9 +4274,6 @@ rebuilt        : ReferenceId(19): None
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("myObj2")
 rebuilt        : ReferenceId(20): None
-Unresolved references mismatch:
-after transform: ["Object", "PropertyKey", "Record", "is", "isPlainObject2", "parentElementOrShadowHost"]
-rebuilt        : ["Object", "is", "isPlainObject2", "kPresentationInheritanceParents", "myObj2", "parentElementOrShadowHost"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyCheck.ts
 semantic error: Bindings mismatch:
@@ -4792,17 +4303,11 @@ rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(45): [ReferenceId(79), ReferenceId(80), ReferenceId(86), ReferenceId(87), ReferenceId(126)]
 rebuilt        : SymbolId(28): [ReferenceId(62), ReferenceId(66), ReferenceId(67)]
-Unresolved references mismatch:
-after transform: ["Partial", "Record", "console", "isType", "never", "true", "undefined"]
-rebuilt        : ["console", "isType", "never", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantPropertyInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "Props"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["f", "parseInt", "true", "undefined"]
-rebuilt        : ["f", "parseInt", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantUsingEvaluatableTemplateExpression.ts
 semantic error: Bindings mismatch:
@@ -4828,9 +4333,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("c")
 rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: ["Error", "undefined"]
-rebuilt        : ["Error", "c", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminantsAndPrimitives.ts
 semantic error: Bindings mismatch:
@@ -4875,9 +4377,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("weirdoBox2")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["weirdoBox", "weirdoBox2"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty1.ts
 semantic error: Bindings mismatch:
@@ -4889,9 +4388,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("box")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["box"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty2.ts
 semantic error: Bindings mismatch:
@@ -4900,28 +4396,16 @@ rebuilt        : ScopeId(0): ["doubles", "items", "iterable", "mapAsyncIterable"
 Bindings mismatch:
 after transform: ScopeId(2): ["R", "T", "U", "callback", "iterable", "iterator", "mapResult"]
 rebuilt        : ScopeId(1): ["callback", "iterable", "iterator", "mapResult"]
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "AsyncIterable", "IteratorResult", "Promise", "Symbol", "undefined"]
-rebuilt        : ["Promise", "Symbol", "undefined"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(19), ReferenceId(32), ReferenceId(49)]
-rebuilt        : [ReferenceId(24)]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CoercedVariableValues", "ExecutionArgs", "ExecutionContext", "Maybe", "buildExecutionContext"]
 rebuilt        : ScopeId(0): ["buildExecutionContext"]
-Unresolved references mismatch:
-after transform: ["Error", "GraphQLError", "ReadonlyArray", "getVariableValues"]
-rebuilt        : ["getVariableValues"]
 
 tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MapOrSingleton", "UnionAltA", "UnionAltB", "ValueUnion", "withAsConst", "withoutAsConst"]
 rebuilt        : ScopeId(0): ["withAsConst", "withoutAsConst"]
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
 semantic error: Bindings mismatch:
@@ -4933,17 +4417,11 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("opts")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["opts"]
 
 tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeNeverIntersection1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Conflicted", "Ex1", "Ex2", "Ex3", "IsNumber"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/divergentAccessors1.ts
 semantic error: Bindings mismatch:
@@ -4998,9 +4476,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("u1")
 rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["u1"]
 
 tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes7.ts
 semantic error: Bindings mismatch:
@@ -5023,9 +4498,6 @@ rebuilt        : ScopeId(5): ["filter", "middleware"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(30): [ReferenceId(80), ReferenceId(92), ReferenceId(99)]
 rebuilt        : SymbolId(3): [ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["Array", "Exclude", "Omit", "Partial", "Promise", "Record", "console"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedCommentOnNotEmittedNode.ts
 semantic error: Bindings mismatch:
@@ -5049,9 +4521,6 @@ rebuilt        : ScopeId(0): ["foo"]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("alt")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "dearray"]
-rebuilt        : ["alt", "dearray"]
 
 tasks/coverage/typescript/tests/cases/compiler/doNotWidenAtObjectLiteralPropertyAssignment.ts
 semantic error: Bindings mismatch:
@@ -5199,9 +4668,6 @@ tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Keys", "Properties", "Property2Type", "k", "ok", "partial"]
 rebuilt        : ScopeId(0): ["k", "ok", "partial"]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
 semantic error: Bindings mismatch:
@@ -5210,19 +4676,11 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "thing"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("__foot")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["React"]
-rebuilt        : ["React", "__foot"]
 
 tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst13.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
-semantic error: Unresolved references mismatch:
-after transform: ["NodeJS", "Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -5400,9 +4858,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("MyMethodDecorator")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["ClassDecorator", "MethodDecorator"]
-rebuilt        : ["MyClassDecorator", "MyMethodDecorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_restArgs.ts
 semantic error: Bindings mismatch:
@@ -5420,9 +4875,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("MyMethodDecorator")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["ClassDecorator", "MethodDecorator"]
-rebuilt        : ["MyClassDecorator", "MyMethodDecorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitHelpersWithLocalCollisions.ts
 semantic error: Bindings mismatch:
@@ -5431,9 +4883,6 @@ rebuilt        : ScopeId(0): ["A", "o", "y"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
 semantic error: Missing SymbolId: Microsoft
@@ -5569,9 +5018,6 @@ rebuilt        : ReferenceId(28): None
 Reference symbol mismatch:
 after transform: ReferenceId(31): Some("nonNull")
 rebuilt        : ReferenceId(29): None
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : ["nonNull", "obj", "undefined", "union"]
 
 tasks/coverage/typescript/tests/cases/compiler/emptyArgumentsListComment.ts
 semantic error: Bindings mismatch:
@@ -5583,9 +5029,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
 semantic error: Scope flags mismatch:
@@ -5891,14 +5334,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("x")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: ["Error", "Function", "Object", "RangeError"]
-rebuilt        : ["Error", "RangeError", "x"]
-
-tasks/coverage/typescript/tests/cases/compiler/es2017basicAsync.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/es2018ObjectAssign.ts
 semantic error: Bindings mismatch:
@@ -5907,9 +5342,6 @@ rebuilt        : ScopeId(0): ["test"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("p")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Object", "Promise"]
-rebuilt        : ["Object", "p"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunction.ts
 semantic error: Bindings mismatch:
@@ -5918,9 +5350,6 @@ rebuilt        : ScopeId(0): ["empty", "singleAwait"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("x")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionArrayLiterals.ts
 semantic error: Bindings mismatch:
@@ -6004,9 +5433,6 @@ rebuilt        : ReferenceId(24): None
 Reference symbol mismatch:
 after transform: ReferenceId(25): Some("a")
 rebuilt        : ReferenceId(25): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionBinaryExpressions.ts
 semantic error: Bindings mismatch:
@@ -6240,9 +5666,6 @@ rebuilt        : ReferenceId(74): None
 Reference symbol mismatch:
 after transform: ReferenceId(76): Some("y")
 rebuilt        : ReferenceId(75): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionCallExpressions.ts
 semantic error: Bindings mismatch:
@@ -6455,9 +5878,6 @@ rebuilt        : ReferenceId(67): None
 Reference symbol mismatch:
 after transform: ReferenceId(68): Some("z")
 rebuilt        : ReferenceId(68): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionConditionals.ts
 semantic error: Bindings mismatch:
@@ -6499,9 +5919,6 @@ rebuilt        : ReferenceId(10): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("z")
 rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionDoStatements.ts
 semantic error: Bindings mismatch:
@@ -6597,9 +6014,6 @@ rebuilt        : ReferenceId(28): None
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("y")
 rebuilt        : ReferenceId(29): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionElementAccess.ts
 semantic error: Bindings mismatch:
@@ -6632,9 +6046,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("y")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForInStatements.ts
 semantic error: Bindings mismatch:
@@ -6712,9 +6123,6 @@ rebuilt        : ReferenceId(22): None
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("z")
 rebuilt        : ReferenceId(23): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForOfStatements.ts
 semantic error: Bindings mismatch:
@@ -6900,9 +6308,6 @@ rebuilt        : ReferenceId(58): None
 Reference symbol mismatch:
 after transform: ReferenceId(59): Some("z")
 rebuilt        : ReferenceId(59): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForStatements.ts
 semantic error: Bindings mismatch:
@@ -6989,9 +6394,6 @@ rebuilt        : ReferenceId(25): None
 Reference symbol mismatch:
 after transform: ReferenceId(26): Some("a")
 rebuilt        : ReferenceId(26): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionHoisting.ts
 semantic error: Bindings mismatch:
@@ -7015,9 +6417,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("y")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["y"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionIfStatements.ts
 semantic error: Bindings mismatch:
@@ -7050,9 +6449,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("z")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNestedLoops.ts
 semantic error: Bindings mismatch:
@@ -7070,9 +6466,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNewExpressions.ts
 semantic error: Bindings mismatch:
@@ -7285,9 +6678,6 @@ rebuilt        : ReferenceId(67): None
 Reference symbol mismatch:
 after transform: ReferenceId(68): Some("z")
 rebuilt        : ReferenceId(68): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionObjectLiterals.ts
 semantic error: Bindings mismatch:
@@ -7371,9 +6761,6 @@ rebuilt        : ReferenceId(24): None
 Reference symbol mismatch:
 after transform: ReferenceId(25): Some("z")
 rebuilt        : ReferenceId(25): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionPropertyAccess.ts
 semantic error: Bindings mismatch:
@@ -7400,9 +6787,6 @@ rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("z")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionReturnStatements.ts
 semantic error: Bindings mismatch:
@@ -7420,9 +6804,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("x")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionSwitchStatements.ts
 semantic error: Bindings mismatch:
@@ -7557,17 +6938,11 @@ rebuilt        : ReferenceId(41): None
 Reference symbol mismatch:
 after transform: ReferenceId(42): Some("b")
 rebuilt        : ReferenceId(42): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c", "x", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionTryStatements.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "c", "tryCatch0", "tryCatch1", "tryCatch2", "tryCatch3", "tryCatchFinally0", "tryCatchFinally1", "tryCatchFinally2", "tryCatchFinally3", "tryFinally0", "tryFinally1", "tryFinally2", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["tryCatch0", "tryCatch1", "tryCatch2", "tryCatch3", "tryCatchFinally0", "tryCatchFinally1", "tryCatchFinally2", "tryCatchFinally3", "tryFinally0", "tryFinally1", "tryFinally2"]
-Unresolved references mismatch:
-after transform: ["Function", "Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionWhileStatements.ts
 semantic error: Bindings mismatch:
@@ -7663,9 +7038,6 @@ rebuilt        : ReferenceId(28): None
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("y")
 rebuilt        : ReferenceId(29): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/es5-umd4.ts
 semantic error: Symbol reference IDs mismatch:
@@ -7691,11 +7063,6 @@ rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-
-tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Point"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest5.ts
 semantic error: Bindings mismatch:
@@ -8171,30 +7538,10 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
-tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
-semantic error: Unresolved references mismatch:
-after transform: ["DecoratorContext"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["K", "V"]
 rebuilt        : ScopeId(2): []
-Unresolved references mismatch:
-after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
-rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
-Unresolved reference IDs mismatch for "WeakRef":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
-rebuilt        : [ReferenceId(15)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(1), ReferenceId(14)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
-rebuilt        : [ReferenceId(43), ReferenceId(46)]
-Unresolved reference IDs mismatch for "WeakMap":
-after transform: [ReferenceId(5), ReferenceId(9)]
-rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/escapedIdentifiers.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -8204,9 +7551,6 @@ tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFu
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Args", "B", "EventMap"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/evolvingArrayTypeInAssert.ts
 semantic error: Bindings mismatch:
@@ -8217,9 +7561,6 @@ tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithNestedArra
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BugRepro", "ValueAndKeyFields", "ValueOnlyFields", "repro"]
 rebuilt        : ScopeId(0): ["repro"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckingIntersectionWithConditional.ts
 semantic error: Bindings mismatch:
@@ -8241,9 +7582,6 @@ tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyComponent", "MyComponentProps", "StatelessComponent"]
 rebuilt        : ScopeId(0): ["MyComponent"]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
 semantic error: Bindings mismatch:
@@ -8252,9 +7590,6 @@ rebuilt        : ScopeId(0): ["bar", "foo", "mySymbol", "t"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Symbol", "const", "true"]
-rebuilt        : ["Symbol"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndModule.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -8276,12 +7611,6 @@ rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch:
 after transform: SymbolId(2): [Span { start: 152, end: 158 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Date", "http"]
-rebuilt        : ["Date"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTypeAnnotation.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -8367,14 +7696,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamesp
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Q"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "Q", "_try"]
-rebuilt        : ["Q"]
-
-tasks/coverage/typescript/tests/cases/compiler/exportDefaultAsyncFunction.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultForNonInstantiatedModule.ts
 semantic error: Bindings mismatch:
@@ -8469,12 +7790,6 @@ rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 77, end: 83 }, Span { start: 149, end: 155 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : ["Date"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts
 semantic error: Symbol reference IDs mismatch:
@@ -8489,9 +7804,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportEqualsOfModule.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["popsicle", "popsicle-proxy-agent", "~popsicle/dist/common", "~popsicle/dist/request"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["proxy"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -8512,9 +7824,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Unresolved references mismatch:
-after transform: ["A", "B"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -8537,9 +7846,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportSpecifierAndExportedMemberD
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m2"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X", "Y"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportStarForValues.ts
 semantic error: Bindings mismatch:
@@ -8610,9 +7916,6 @@ tasks/coverage/typescript/tests/cases/compiler/exportedInterfaceInaccessibleInCa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ProgressCallback"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["TPromise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportingContainingVisibleType.ts
 semantic error: Symbol reference IDs mismatch:
@@ -8727,9 +8030,6 @@ tasks/coverage/typescript/tests/cases/compiler/externModuleClobber.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["EM", "ec", "x"]
 rebuilt        : ScopeId(0): ["ec", "x"]
-Unresolved reference IDs mismatch for "EM":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleAssignToVar.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -8802,9 +8102,6 @@ rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["Events"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
 semantic error: Bindings mismatch:
@@ -8816,17 +8113,11 @@ rebuilt        : ScopeId(1): ["x"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("b")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["b"]
 
 tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOnConstructCalls.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/fixCrashAliasLookupForDefauledImport.ts
 semantic error: Bindings mismatch:
@@ -8864,9 +8155,6 @@ tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "source"]
 rebuilt        : ScopeId(1): ["source"]
-Unresolved references mismatch:
-after transform: ["AsyncIterable", "Iterable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
 semantic error: Missing SymbolId: Foo
@@ -8904,9 +8192,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
 semantic error: Bindings mismatch:
@@ -8918,9 +8203,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("x")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/forStatementInnerComments.ts
 semantic error: Bindings mismatch:
@@ -8947,9 +8229,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
 semantic error: Bindings mismatch:
@@ -8976,14 +8255,6 @@ rebuilt        : SymbolId(5): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(8)]
 rebuilt        : SymbolId(6): []
-Unresolved references mismatch:
-after transform: ["Cls1", "const"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/functionAssignabilityWithArrayLike01.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ArrayLike"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
 semantic error: Missing SymbolId: m1
@@ -9010,9 +8281,6 @@ rebuilt        : SymbolId(2): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("m1")
 rebuilt        : ReferenceId(4): Some("m1")
-Unresolved references mismatch:
-after transform: ["m1"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
 semantic error: Bindings mismatch:
@@ -9032,11 +8300,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 26, end: 27 }]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/functionExpressionAndLambdaMatchesFunction.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
 semantic error: Bindings mismatch:
@@ -9156,9 +8419,6 @@ tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
 semantic error: Bindings mismatch:
@@ -9204,17 +8464,11 @@ tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAs
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyUnknown", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8"]
-Unresolved references mismatch:
-after transform: ["Math", "Record"]
-rebuilt        : ["Math"]
 
 tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "B":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -9499,9 +8753,6 @@ rebuilt        : SymbolId(17): [ReferenceId(15)]
 Reference symbol mismatch:
 after transform: ReferenceId(38): Some("Portal")
 rebuilt        : ReferenceId(12): Some("Portal")
-Unresolved references mismatch:
-after transform: ["PortalFx", "ko"]
-rebuilt        : ["ko"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
 semantic error: Bindings mismatch:
@@ -9662,9 +8913,6 @@ rebuilt        : SymbolId(9): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): []
 rebuilt        : SymbolId(9): [ReferenceId(12)]
-Unresolved references mismatch:
-after transform: ["EndGate", "ICloneable", "Tween"]
-rebuilt        : ["Tween"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
 semantic error: Missing SymbolId: EndGate
@@ -9732,9 +8980,6 @@ rebuilt        : SymbolId(9): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): []
 rebuilt        : SymbolId(9): [ReferenceId(12)]
-Unresolved references mismatch:
-after transform: ["EndGate", "ICloneable", "Tween"]
-rebuilt        : ["Tween"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
 semantic error: Bindings mismatch:
@@ -9756,9 +9001,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(17): Some("foo")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: ["combineReducers", "withH"]
-rebuilt        : ["combineReducers", "foo", "withH"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctionSpecializations1.ts
 semantic error: Bindings mismatch:
@@ -9767,9 +9009,6 @@ rebuilt        : ScopeId(1): ["test"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "test"]
 rebuilt        : ScopeId(2): ["test"]
-Unresolved references mismatch:
-after transform: ["String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
 semantic error: Bindings mismatch:
@@ -9805,9 +9044,6 @@ tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParam
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Utils", "utils"]
 rebuilt        : ScopeId(0): ["utils"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters3.ts
 semantic error: Bindings mismatch:
@@ -9907,9 +9143,6 @@ rebuilt        : ScopeId(0): ["elements", "names", "widths", "xxx"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("document")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["document"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericNumberIndex.ts
 semantic error: Bindings mismatch:
@@ -9945,9 +9178,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("params")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["params"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType1.ts
 semantic error: Missing SymbolId: M
@@ -9996,9 +9226,6 @@ rebuilt        : SymbolId(6): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): []
 rebuilt        : SymbolId(6): [ReferenceId(4)]
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType2.ts
 semantic error: Missing SymbolId: M
@@ -10057,9 +9284,6 @@ rebuilt        : SymbolId(6): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): []
 rebuilt        : SymbolId(6): [ReferenceId(4)]
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
 semantic error: Bindings mismatch:
@@ -10210,9 +9434,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("fooFn")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Promise", "TemplateStringsArray", "expect"]
-rebuilt        : ["expect", "fooFn"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts
 semantic error: Bindings mismatch:
@@ -10366,27 +9587,16 @@ rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(14): []
 rebuilt        : SymbolId(2): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Array", "_"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Mock", "Tester"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "cases", "fn"]
-rebuilt        : ["cases", "fn"]
 
 tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Thing"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor"]
-rebuilt        : ["Object"]
 
 tasks/coverage/typescript/tests/cases/compiler/getterSetterSubtypeAssignment.ts
 semantic error: Bindings mismatch:
@@ -10460,33 +9670,21 @@ rebuilt        : ScopeId(3): ["a", "b"]
 Reference symbol mismatch:
 after transform: ReferenceId(35): Some("f")
 rebuilt        : ReferenceId(12): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeIntersectionAssignability.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["TType", "a", "b", "c"]
 rebuilt        : ScopeId(1): ["a", "b", "c"]
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Box", "Identity", "Test", "UnboxArray"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomomorphicInstantiationSpreadable1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HandleOptions", "result"]
 rebuilt        : ScopeId(0): ["result"]
-Unresolved references mismatch:
-after transform: ["PropertyKey", "Record", "func1"]
-rebuilt        : ["func1"]
 
 tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
 semantic error: Bindings mismatch:
@@ -10503,17 +9701,11 @@ rebuilt        : ScopeId(1): ["arg", "x", "y"]
 Bindings mismatch:
 after transform: ScopeId(15): ["C", "ctor"]
 rebuilt        : ScopeId(3): ["ctor"]
-Unresolved references mismatch:
-after transform: ["Boolean", "Error", "Number", "String"]
-rebuilt        : ["Error"]
 
 tasks/coverage/typescript/tests/cases/compiler/identicalTypesNoDifferByCheckOrder.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FunctionComponent1", "FunctionComponent2", "SomeProps", "SomePropsClone", "SomePropsCloneX", "SomePropsX", "Validator", "WeakValidationMap", "comp2", "comp3", "needsComponentOfSomeProps2", "needsComponentOfSomeProps3"]
 rebuilt        : ScopeId(0): ["comp2", "comp3", "needsComponentOfSomeProps2", "needsComponentOfSomeProps3"]
-Unresolved references mismatch:
-after transform: ["Omit", "Pick", "Required"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/identityAndDivergentNormalizedTypes.ts
 semantic error: Bindings mismatch:
@@ -10528,9 +9720,6 @@ rebuilt        : ScopeId(2): ["body", "path"]
 Bindings mismatch:
 after transform: ScopeId(6): ["P", "x", "y"]
 rebuilt        : ScopeId(3): ["x", "y"]
-Unresolved references mismatch:
-after transform: ["Extract", "Omit", "RequestInit"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
 semantic error: Bindings mismatch:
@@ -10632,9 +9821,6 @@ tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmb
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["x"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
 semantic error: Bindings mismatch:
@@ -10674,9 +9860,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/importHelpersES6.ts
 semantic error: Bindings mismatch:
@@ -10685,9 +9868,6 @@ rebuilt        : ScopeId(0): ["A", "o", "y"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/importHelpersInAmbientContext.ts
 semantic error: Bindings mismatch:
@@ -10704,9 +9884,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/importHelpersInTsx.tsx
 semantic error: Bindings mismatch:
@@ -10718,9 +9895,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("o")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React", "o"]
 
 tasks/coverage/typescript/tests/cases/compiler/importHelpersVerbatimModuleSyntax.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -10733,9 +9907,6 @@ rebuilt        : ScopeId(0): ["A", "o", "y"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/importInTypePosition.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -10760,11 +9931,6 @@ Please consider using `export default <value>;`, or add @babel/plugin-transform-
 tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList1.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
 Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
-
-tasks/coverage/typescript/tests/cases/compiler/importUsedInGenericImportResolves.ts
-semantic error: Unresolved references mismatch:
-after transform: ["T", "theme"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -10897,14 +10063,6 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(1)]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Object", "true"]
-rebuilt        : ["Object"]
-
-tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Record", "invariant"]
-rebuilt        : ["invariant"]
 
 tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
 semantic error: Bindings mismatch:
@@ -10988,9 +10146,6 @@ rebuilt        : ReferenceId(44): None
 Reference symbol mismatch:
 after transform: ReferenceId(66): Some("x")
 rebuilt        : ReferenceId(45): None
-Unresolved references mismatch:
-after transform: ["Array", "Error", "Record", "Symbol", "Window", "globalThis", "isAOrB", "window"]
-rebuilt        : ["Array", "Symbol", "error", "isAOrB", "window", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/inOperatorWithGeneric.ts
 semantic error: Bindings mismatch:
@@ -11055,9 +10210,6 @@ rebuilt        : ScopeId(3): ["p1", "p2", "t"]
 Bindings mismatch:
 after transform: ScopeId(9): ["K", "P", "S", "key", "props", "store", "value"]
 rebuilt        : ScopeId(4): ["key", "props", "store", "value"]
-Unresolved references mismatch:
-after transform: ["Partial", "PropertyKey", "Record", "hasOwnProperty", "undefined"]
-rebuilt        : ["hasOwnProperty", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
 semantic error: Bindings mismatch:
@@ -11071,9 +10223,6 @@ rebuilt        : ScopeId(0): ["A", "B"]
 Reference flags mismatch:
 after transform: ReferenceId(12): ReferenceFlags(Type)
 rebuilt        : ReferenceId(0): ReferenceFlags(Read)
-Unresolved references mismatch:
-after transform: ["Extract", "Parameters"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/indexedAccessNormalization.ts
 semantic error: Bindings mismatch:
@@ -11090,9 +10239,6 @@ tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignatur
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Diff", "O", "Omit", "Omit1", "Omit2", "o"]
 rebuilt        : ScopeId(0): ["o"]
-Unresolved references mismatch:
-after transform: ["Pick"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/indexedAccessToThisTypeOnIntersection01.ts
 semantic error: Bindings mismatch:
@@ -11126,11 +10272,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IDirectChildrenMap", "IHeapObjectProperty", "directChildrenMap"]
 rebuilt        : ScopeId(0): ["directChildrenMap"]
 
-tasks/coverage/typescript/tests/cases/compiler/indexer3.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/indexerA.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
@@ -11160,9 +10301,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(22): Some("key")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Record", "Required", "genericFn1", "genericFn2", "genericFn3"]
-rebuilt        : ["genericFn1", "genericFn2", "genericFn3", "key", "obj"]
 
 tasks/coverage/typescript/tests/cases/compiler/indirectGlobalSymbolPartOfObjectType.ts
 semantic error: Symbol flags mismatch:
@@ -11181,9 +10319,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedM
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["KeysWithoutStringIndex", "RemoveIdxSgn", "test"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Pick", "U"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes2.ts
 semantic error: Bindings mismatch:
@@ -11218,9 +10353,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("two")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["inference1", "inference2"]
-rebuilt        : ["inference1", "inference2", "two"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
 semantic error: Symbol reference IDs mismatch:
@@ -11239,17 +10371,11 @@ tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ib", "b"]
 rebuilt        : ScopeId(0): ["b"]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inferTInParentheses.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["F1", "IsNumber", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inferTypeArgumentsInSignatureWithRestParameters.ts
 semantic error: Bindings mismatch:
@@ -11266,9 +10392,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationC
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AMappedType", "Cell", "F1", "F2", "HasM", "InferIOItemToJSType", "Items", "MyObject", "Simplify", "X1", "X2", "ZodObject", "ZodRawShape", "ZodType", "addQuestionMarks", "optionalKeys", "requiredKeys"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
 semantic error: Bindings mismatch:
@@ -11289,9 +10412,6 @@ rebuilt        : SymbolId(1): []
 Reference symbol mismatch:
 after transform: ReferenceId(30): Some("m")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Error"]
-rebuilt        : ["Error", "m"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferTypesWithFixedTupleExtendsAtVariadicPosition.ts
 semantic error: Bindings mismatch:
@@ -11317,9 +10437,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "map", "typeClass"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts
 semantic error: Bindings mismatch:
@@ -11328,9 +10445,6 @@ rebuilt        : ScopeId(0): ["res1", "res2", "res3", "test"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceDoesNotAddUndefinedOrNull.ts
 semantic error: Bindings mismatch:
@@ -11342,9 +10456,6 @@ rebuilt        : ScopeId(1): ["cb", "node", "result"]
 Bindings mismatch:
 after transform: ScopeId(9): ["T", "cb", "node", "result"]
 rebuilt        : ScopeId(4): ["cb", "node", "result"]
-Unresolved references mismatch:
-after transform: ["ReadonlyArray", "toArray", "undefined"]
-rebuilt        : ["toArray", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceDoesntCompareAgainstUninstantiatedTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -11370,9 +10481,6 @@ rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(21), ReferenceId(23), ReferenceId(25)]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Promise", "SomeBaseClass"]
-rebuilt        : ["SomeBaseClass"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties1.ts
 semantic error: Bindings mismatch:
@@ -11391,9 +10499,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["BrokenClass", "MyModule"]
 rebuilt        : ScopeId(0): ["BrokenClass"]
-Unresolved references mismatch:
-after transform: ["Array", "Promise"]
-rebuilt        : ["Promise"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceOfNullableObjectTypesWithCommonBase.ts
 semantic error: Bindings mismatch:
@@ -11419,9 +10524,6 @@ rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("x4")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: ["Math", "Object", "encodeURIComponent", "foo"]
-rebuilt        : ["Math", "Object", "encodeURIComponent", "foo", "x1", "x2", "x3", "x4"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult.ts
 semantic error: Bindings mismatch:
@@ -11451,17 +10553,11 @@ rebuilt        : SymbolId(0): [ReferenceId(2)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(23): [ReferenceId(35), ReferenceId(41)]
 rebuilt        : SymbolId(10): [ReferenceId(11)]
-Unresolved references mismatch:
-after transform: ["Object", "Omit"]
-rebuilt        : ["Object"]
 
 tasks/coverage/typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Entity", "RowRenderer", "RowRendererMeta", "test"]
 rebuilt        : ScopeId(0): ["test"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod1.ts
 semantic error: Bindings mismatch:
@@ -11500,9 +10596,6 @@ tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IdentityConstructor", "dottedIdentity", "ic", "s", "t"]
 rebuilt        : ScopeId(0): ["dottedIdentity", "ic", "s", "t"]
-Unresolved reference IDs mismatch for "identity":
-after transform: [ReferenceId(6), ReferenceId(15), ReferenceId(16), ReferenceId(24), ReferenceId(27), ReferenceId(28), ReferenceId(31), ReferenceId(34)]
-rebuilt        : [ReferenceId(0), ReferenceId(9), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(25)]
 
 tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
 semantic error: Bindings mismatch:
@@ -11590,9 +10683,6 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(18), ReferenceId(20), ReferenceId(22)]
 rebuilt        : SymbolId(1): []
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(12), ReferenceId(15)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypeAssignability.ts
 semantic error: Bindings mismatch:
@@ -11662,9 +10752,6 @@ rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
 semantic error: Missing SymbolId: M
@@ -11764,17 +10851,11 @@ tasks/coverage/typescript/tests/cases/compiler/inheritedFunctionAssignmentCompat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["IResultCallback", "fn"]
 rebuilt        : ScopeId(0): ["fn"]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inheritedGenericCallSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "Object", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Unresolved references mismatch:
-after transform: ["Date", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases2.ts
 semantic error: Bindings mismatch:
@@ -11798,9 +10879,6 @@ rebuilt        : ScopeId(0): ["foo"]
 Bindings mismatch:
 after transform: ScopeId(3): ["CustomType", "T", "a", "b", "c", "d", "e"]
 rebuilt        : ScopeId(1): ["a", "b", "c", "d", "e"]
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
 semantic error: Bindings mismatch:
@@ -11848,9 +10926,6 @@ rebuilt        : SymbolId(2): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("provider")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["provider"]
 
 tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
 semantic error: Missing SymbolId: M
@@ -11874,9 +10949,6 @@ rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 semantic error: Missing SymbolId: A
@@ -11965,9 +11037,6 @@ rebuilt        : SymbolId(2): [ReferenceId(0)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(28)]
 rebuilt        : SymbolId(3): [ReferenceId(1)]
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(32), ReferenceId(33), ReferenceId(35)]
-rebuilt        : [ReferenceId(3), ReferenceId(21)]
 
 tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -11991,12 +11060,6 @@ rebuilt        : ScopeId(2): ["o"]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("o")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["TableClass"]
-rebuilt        : ["TableClass", "o"]
-Unresolved reference IDs mismatch for "TableClass":
-after transform: [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(12)]
-rebuilt        : [ReferenceId(1), ReferenceId(3), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateConstraintsToTypeArguments2.ts
 semantic error: Bindings mismatch:
@@ -12029,15 +11092,6 @@ rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
 after transform: ReferenceId(98): Some("outerBoxOfString")
 rebuilt        : ReferenceId(25): None
-Unresolved references mismatch:
-after transform: ["Component", "GenericComponent", "Partial", "Promise", "alert", "assignPartial", "createElement", "createElement2", "createReducer", "handler", "invoke", "passContentsToFunc", "useStringOrNumber"]
-rebuilt        : ["Component", "GenericComponent", "Promise", "alert", "assignPartial", "createElement", "createElement2", "createReducer", "handler", "handlers", "invoke", "outerBoxOfString", "passContentsToFunc", "useStringOrNumber", "x"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(100), ReferenceId(102), ReferenceId(103), ReferenceId(105), ReferenceId(106), ReferenceId(108)]
-rebuilt        : [ReferenceId(27), ReferenceId(28), ReferenceId(29)]
-Unresolved reference IDs mismatch for "Component":
-after transform: [ReferenceId(14), ReferenceId(65), ReferenceId(79)]
-rebuilt        : [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
 semantic error: Bindings mismatch:
@@ -12104,9 +11158,6 @@ rebuilt        : SymbolId(4): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("A")
 rebuilt        : ReferenceId(8): Some("A")
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
 semantic error: Missing SymbolId: A
@@ -12145,9 +11196,6 @@ rebuilt        : SymbolId(4): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("A")
 rebuilt        : ReferenceId(8): Some("A")
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
 semantic error: Missing SymbolId: A
@@ -12181,9 +11229,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): []
 rebuilt        : SymbolId(4): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
 semantic error: Missing SymbolId: A
@@ -12217,9 +11262,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): []
 rebuilt        : SymbolId(4): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces4.ts
 semantic error: Missing SymbolId: A
@@ -12429,9 +11471,6 @@ tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErr
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ns"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
 semantic error: Bindings mismatch:
@@ -12492,9 +11531,6 @@ tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyKey", "KeyIfSignatureOfObject", "MustBeKey", "Reduced1", "Reduced2", "ReturnTypeKeyof", "Test1", "Test2"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
 semantic error: Bindings mismatch:
@@ -12503,17 +11539,11 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("x")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionOfTypeVariableHasApparentSignatures.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "Props"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Readonly", "f"]
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionReductionGenericStringLikeType.ts
 semantic error: Bindings mismatch:
@@ -12592,9 +11622,6 @@ rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(40): [ReferenceId(102)]
 rebuilt        : SymbolId(11): [ReferenceId(39)]
-Unresolved references mismatch:
-after transform: ["enums"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
 semantic error: Bindings mismatch:
@@ -12613,9 +11640,6 @@ tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignatur
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PersonPrototype", "PersonType"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["EmberObject", "Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
 semantic error: Bindings mismatch:
@@ -12626,9 +11650,6 @@ tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Windows", "p", "p2", "x"]
 rebuilt        : ScopeId(0): ["p", "p2", "x"]
-Unresolved references mismatch:
-after transform: ["Windows"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
 semantic error: Bindings mismatch:
@@ -12639,17 +11660,11 @@ tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Windows", "p"]
 rebuilt        : ScopeId(0): ["p"]
-Unresolved references mismatch:
-after transform: ["Windows"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E2"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["EventName"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
 semantic error: Bindings mismatch:
@@ -12721,9 +11736,6 @@ rebuilt        : ScopeId(0): ["p2"]
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("p1")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["shouldBeIdentity"]
-rebuilt        : ["p1", "shouldBeIdentity"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsFileClassSelfReferencedProperty.ts
 semantic error: Cannot use export statement outside a module
@@ -12763,9 +11775,6 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(17): [ReferenceId(8), ReferenceId(9)]
 rebuilt        : SymbolId(2): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Component", "Readonly", "require"]
-rebuilt        : ["Component", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
 semantic error: Bindings mismatch:
@@ -12788,12 +11797,6 @@ rebuilt        : ScopeId(1): ["WrappedComponent"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(17), ReferenceId(19), ReferenceId(44), ReferenceId(50), ReferenceId(54), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(102), ReferenceId(180), ReferenceId(195), ReferenceId(206), ReferenceId(209), ReferenceId(233), ReferenceId(236), ReferenceId(241)]
 rebuilt        : SymbolId(1): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["Array", "Exclude", "HTMLAnchorElement", "HTMLDivElement", "HTMLInputElement", "JSX", "Pick", "Promise", "ReactSelectClass", "undefined"]
-rebuilt        : ["ReactSelectClass", "undefined"]
-Unresolved reference IDs mismatch for "ReactSelectClass":
-after transform: [ReferenceId(22), ReferenceId(196), ReferenceId(240)]
-rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
@@ -12813,9 +11816,6 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(2): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
@@ -12827,9 +11827,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("React")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitAttributeWithPreserve.tsx
 semantic error: Bindings mismatch:
@@ -12866,9 +11863,6 @@ rebuilt        : SymbolId(4): [ReferenceId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("Element")
 rebuilt        : ReferenceId(8): Some("Element")
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 semantic error: Bindings mismatch:
@@ -12918,9 +11912,6 @@ rebuilt        : SymbolId(4): [ReferenceId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("Element")
 rebuilt        : ReferenceId(8): Some("Element")
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
 semantic error: Bindings mismatch:
@@ -12957,9 +11948,6 @@ rebuilt        : SymbolId(4): [ReferenceId(5)]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("Element")
 rebuilt        : ReferenceId(8): Some("Element")
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx
 semantic error: Bindings mismatch:
@@ -12973,12 +11961,6 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Reference symbol mismatch:
 after transform: ReferenceId(13): Some("otherProps")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["GenericComponent", "Omit", "omit", "require"]
-rebuilt        : ["GenericComponent", "omit", "otherProps", "require"]
-Unresolved reference IDs mismatch for "GenericComponent":
-after transform: [ReferenceId(11), ReferenceId(14)]
-rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
 semantic error: Bindings mismatch:
@@ -12998,9 +11980,6 @@ rebuilt        : ScopeId(0): ["Foo", "_jsxFileName"]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("React")
 rebuilt        : ReferenceId(2): None
-Unresolved reference IDs mismatch for "React":
-after transform: [ReferenceId(2), ReferenceId(4), ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -13016,17 +11995,11 @@ rebuilt        : ScopeId(2): ["el"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(5), ReferenceId(10)]
 rebuilt        : SymbolId(2): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["JSX"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Unresolved references mismatch:
-after transform: ["Record", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -13043,9 +12016,6 @@ rebuilt        : SymbolId(1): [ReferenceId(0)]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("Comp")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Comp"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
 semantic error: Symbol flags mismatch:
@@ -13068,9 +12038,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("React")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx
 semantic error: importSource cannot be set when runtime is classic.
@@ -13079,17 +12046,11 @@ tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "createElement"]
 rebuilt        : ScopeId(0): ["createElement"]
-Unresolved references mismatch:
-after transform: ["JSX", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "react", "tag"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "tag"]
-Unresolved references mismatch:
-after transform: ["Function", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
 semantic error: Bindings mismatch:
@@ -13098,9 +12059,6 @@ rebuilt        : ScopeId(0): ["Repro", "Select", "_jsxFileName", "_reactJsxRunti
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(4)]
-Unresolved references mismatch:
-after transform: ["Parameters", "Partial", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
@@ -13117,9 +12075,6 @@ rebuilt        : SymbolId(2): [ReferenceId(7), ReferenceId(10), ReferenceId(13)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("infoProps")
 rebuilt        : ReferenceId(14): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["infoProps"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.2.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -13145,9 +12100,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(13): Some("x")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Exclude", "PropertyKey", "Record", "Symbol"]
-rebuilt        : ["Symbol", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/keyofGenericExtendingClassDoubleLayer.ts
 semantic error: Bindings mismatch:
@@ -13165,9 +12117,6 @@ rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(8)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Date", "Omit"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
 semantic error: Bindings mismatch:
@@ -13193,9 +12142,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("React")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
 semantic error: Bindings mismatch:
@@ -13215,9 +12161,6 @@ tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ExpandSmallerTuples", "GrowExp", "GrowExpRev", "Shift", "Tuple", "UnshiftTuple"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array", "ArrayValidator", "Exclude"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
 semantic error: Missing SymbolId: A
@@ -13238,11 +12181,6 @@ tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["HTMLElement"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/library_RegExpExecArraySlice.ts
-semantic error: Unresolved references mismatch:
-after transform: ["RegExpExecArray"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/listFailure.ts
 semantic error: Missing SymbolId: Editor
@@ -13348,9 +12286,6 @@ rebuilt        : ReferenceId(36): None
 Reference symbol mismatch:
 after transform: ReferenceId(40): Some("literalUnion")
 rebuilt        : ReferenceId(40): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["literalUnion", "numLiteral"]
 
 tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -13411,9 +12346,6 @@ rebuilt        : ReferenceId(18): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("Key")
 rebuilt        : ReferenceId(20): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Key"]
 
 tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 semantic error: Bindings mismatch:
@@ -13431,9 +12363,6 @@ rebuilt        : ScopeId(3): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(14), ReferenceId(16), ReferenceId(21), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Array", "Pick", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 semantic error: Bindings mismatch:
@@ -13443,23 +12372,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 
-tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable", "Map"]
-rebuilt        : ["Map"]
-
-tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Map", "WeakMap", "const"]
-rebuilt        : ["Map", "WeakMap"]
-
 tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Employee", "basic", "byNonKey", "byRole", "chars", "employees"]
 rebuilt        : ScopeId(0): ["basic", "byNonKey", "byRole", "chars", "employees"]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(4), ReferenceId(6)]
-rebuilt        : [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
 semantic error: Bindings mismatch:
@@ -13488,17 +12404,11 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Record", "enumValues"]
-rebuilt        : ["a", "enumValues", "fn"]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Bar2", "Bar3", "Foo", "Identity", "Merge2", "Merge3", "Same", "T1", "T2"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["PropertyKey", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeCircularReferenceInAccessor.ts
 semantic error: Bindings mismatch:
@@ -13531,14 +12441,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("h")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["h"]
-
-tasks/coverage/typescript/tests/cases/compiler/mappedTypeInferenceToMappedType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeMultiInference.ts
 semantic error: Bindings mismatch:
@@ -13573,9 +12475,6 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(3), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts
 semantic error: Bindings mismatch:
@@ -13597,9 +12496,6 @@ rebuilt        : ScopeId(0): ["create"]
 Bindings mismatch:
 after transform: ScopeId(16): ["T", "schemas"]
 rebuilt        : ScopeId(1): ["schemas"]
-Unresolved references mismatch:
-after transform: ["Readonly", "TupleSchema", "ZodEnum"]
-rebuilt        : ["TupleSchema"]
 
 tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
 semantic error: Bindings mismatch:
@@ -13608,9 +12504,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("x")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["doArrayStuff"]
-rebuilt        : ["doArrayStuff", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/matchingOfObjectLiteralConstraints.ts
 semantic error: Bindings mismatch:
@@ -13637,9 +12530,6 @@ rebuilt        : ScopeId(0): ["t"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("p012")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["p012"]
 
 tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -13676,9 +12566,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 33, end: 34 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mergedInstantiationAssignment.ts
 semantic error: Bindings mismatch:
@@ -14021,17 +12908,11 @@ tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromAlias.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassA", "SomeClass", "annotation"]
 rebuilt        : ScopeId(0): ["ClassA", "annotation"]
-Unresolved references mismatch:
-after transform: ["PropertyDecorator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromAlias2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassA", "SomeClass", "annotation"]
 rebuilt        : ScopeId(0): ["ClassA", "annotation"]
-Unresolved references mismatch:
-after transform: ["PropertyDecorator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromModule.ts
 semantic error: Missing SymbolId: MyModule
@@ -14077,11 +12958,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Event"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/metadataOfStringLiteral.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "C", "D", "E"]
@@ -14098,9 +12974,6 @@ rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(24)]
 rebuilt        : SymbolId(5): [ReferenceId(12)]
-Unresolved references mismatch:
-after transform: ["Object", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
 semantic error: Symbol reference IDs mismatch:
@@ -14109,9 +12982,6 @@ rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(15)]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["Object", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataReferencedWithinFilteredUnion.ts
 semantic error: Bindings mismatch:
@@ -14246,9 +13116,6 @@ rebuilt        : ReferenceId(30): None
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("someNumber")
 rebuilt        : ReferenceId(32): None
-Unresolved references mismatch:
-after transform: ["someValue"]
-rebuilt        : ["someNumber", "someString", "unionOfEnum"]
 
 tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.ts
 semantic error: Bindings mismatch:
@@ -14268,9 +13135,6 @@ rebuilt        : ScopeId(0): ["cloneClass"]
 Bindings mismatch:
 after transform: ScopeId(6): ["AnotherOriginalClass", "OriginalClass", "T"]
 rebuilt        : ScopeId(1): ["AnotherOriginalClass", "OriginalClass"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
 semantic error: Bindings mismatch:
@@ -14300,9 +13164,6 @@ rebuilt        : ScopeId(0): ["Baz", "f", "gen", "gen2", "m", "o", "o1", "out", 
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("console")
 rebuilt        : ReferenceId(19): None
-Unresolved references mismatch:
-after transform: ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments"]
-rebuilt        : ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions2.ts
 semantic error: Bindings mismatch:
@@ -14311,9 +13172,6 @@ rebuilt        : ScopeId(0): ["Baz", "f", "gen", "gen2", "m", "o", "o1", "out", 
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("console")
 rebuilt        : ReferenceId(19): None
-Unresolved references mismatch:
-after transform: ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments"]
-rebuilt        : ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_TargetES5UsingES6Lib.ts
 semantic error: Bindings mismatch:
@@ -14322,9 +13180,6 @@ rebuilt        : ScopeId(0): ["Baz", "f", "gen", "gen2", "m", "o", "o1", "out", 
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("console")
 rebuilt        : ReferenceId(19): None
-Unresolved references mismatch:
-after transform: ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments"]
-rebuilt        : ["Array", "Map", "Math", "Promise", "Proxy", "Reflect", "RegExp", "Symbol", "arguments", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -14422,33 +13277,21 @@ rebuilt        : SymbolId(25): [ReferenceId(14)]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("_modes")
 rebuilt        : ReferenceId(6): Some("_modes")
-Unresolved references mismatch:
-after transform: ["Foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "z", "z2"]
 rebuilt        : ScopeId(0): ["z", "z2"]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "z", "z2"]
 rebuilt        : ScopeId(0): ["z", "z2"]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D3"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["D3"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
 semantic error: Bindings mismatch:
@@ -14662,12 +13505,6 @@ rebuilt        : SymbolId(24): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(20): []
 rebuilt        : SymbolId(24): [ReferenceId(24)]
-Unresolved references mismatch:
-after transform: ["ISyntaxToken", "PositionedElement", "PositionedToken", "Syntax", "SyntaxNode"]
-rebuilt        : ["PositionedToken", "Syntax"]
-Unresolved reference IDs mismatch for "PositionedToken":
-after transform: [ReferenceId(5), ReferenceId(9)]
-rebuilt        : [ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -14783,9 +13620,6 @@ rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): []
 rebuilt        : SymbolId(4): [ReferenceId(5)]
-Unresolved references mismatch:
-after transform: ["I"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
 semantic error: Missing SymbolId: M
@@ -14874,9 +13708,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("require")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequireAndImport.ts
 semantic error: Bindings mismatch:
@@ -14888,9 +13719,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("require")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_empty.ts
 semantic error: Bindings mismatch:
@@ -15347,9 +14175,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Reference symbol mismatch:
 after transform: ReferenceId(0): None
 rebuilt        : ReferenceId(2): Some("M")
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule.ts
 semantic error: Bindings mismatch:
@@ -15360,9 +14185,6 @@ tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModul
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ng"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ng"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
 semantic error: Bindings mismatch:
@@ -15384,9 +14206,6 @@ tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AllParams", "AllReturns", "Expected", "InferTwoOverloads", "JustOneSignature", "JustTheOtherSignature", "Overloads", "Params1", "Params2", "Params3", "Returns1", "Returns2", "Returns3", "ok1", "ok2", "ok3", "ok4", "ok5", "ok6"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "f1", "f2", "f3"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
 semantic error: Bindings mismatch:
@@ -15395,9 +14214,6 @@ rebuilt        : ScopeId(0): ["r2"]
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("Moon")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["ThisType"]
-rebuilt        : ["Moon"]
 
 tasks/coverage/typescript/tests/cases/compiler/mutrec.ts
 semantic error: Bindings mismatch:
@@ -15482,9 +14298,6 @@ tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "x", "x2"]
 rebuilt        : ScopeId(0): ["x", "x2"]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
 semantic error: Missing SymbolId: A
@@ -15523,17 +14336,11 @@ rebuilt        : SymbolId(4): [ReferenceId(1)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("A")
 rebuilt        : ReferenceId(8): Some("A")
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "Q", "Q2", "Q3", "Q4", "try1", "try2", "try3", "try4"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Q", "Q2", "Q3", "Q4"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
 semantic error: Bindings mismatch:
@@ -15542,17 +14349,11 @@ rebuilt        : ScopeId(0): ["ACTOR_TYPE", "WebError", "isA", "isActor", "isFun
 Symbol reference IDs mismatch:
 after transform: SymbolId(16): [ReferenceId(46), ReferenceId(50)]
 rebuilt        : SymbolId(11): [ReferenceId(40)]
-Unresolved references mismatch:
-after transform: ["Array", "Error", "Function", "URIError", "console"]
-rebuilt        : ["Array", "Error", "URIError", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "AorB", "B", "SomeType", "isA", "isB", "processInput", "test1", "test2", "x"]
 rebuilt        : ScopeId(0): ["isA", "isB", "processInput", "test1", "test2", "x"]
-Unresolved reference IDs mismatch for "RegExp":
-after transform: [ReferenceId(25), ReferenceId(30)]
-rebuilt        : [ReferenceId(19)]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue2.ts
 semantic error: Bindings mismatch:
@@ -15591,9 +14392,6 @@ rebuilt        : ReferenceId(9): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("f")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue4.ts
 semantic error: Bindings mismatch:
@@ -15611,9 +14409,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("f")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue5.ts
 semantic error: Bindings mismatch:
@@ -15645,9 +14440,6 @@ tasks/coverage/typescript/tests/cases/compiler/narrowBySwitchDiscriminantUndefin
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "assertUnreachable", "func", "func2"]
 rebuilt        : ScopeId(0): ["assertUnreachable", "func", "func2"]
-Unresolved references mismatch:
-after transform: ["Error", "Math", "const", "undefined"]
-rebuilt        : ["Error", "Math", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowTypeByInstanceof.ts
 semantic error: Bindings mismatch:
@@ -15675,17 +14467,11 @@ rebuilt        : ScopeId(0): ["dataFunc", "subDataFunc", "testFunc"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "subFunc"]
 rebuilt        : ScopeId(2): ["subFunc"]
-Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "console"]
-rebuilt        : ["Array", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingByDiscriminantInLoop.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "ConstantMemberType", "IDLMemberTypes", "IDLTypeDescription", "InterfaceType", "OperationMemberType", "f1", "f2", "foo", "insertInterface", "insertInterface2"]
 rebuilt        : ScopeId(0): ["f1", "f2", "foo", "insertInterface", "insertInterface2"]
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
 semantic error: Bindings mismatch:
@@ -15721,9 +14507,6 @@ rebuilt        : ScopeId(58): ["assertKeyofS", "k"]
 Bindings mismatch:
 after transform: ScopeId(66): ["X", "Y", "xy"]
 rebuilt        : ScopeId(61): ["xy"]
-Unresolved references mismatch:
-after transform: ["Function", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingConstrainedTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -15762,14 +14545,6 @@ rebuilt        : ScopeId(0): ["m", "map", "something"]
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "f", "items"]
 rebuilt        : ScopeId(1): ["f", "items"]
-Unresolved references mismatch:
-after transform: ["NoInfer", "const", "test2"]
-rebuilt        : ["test2"]
-
-tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
 semantic error: Bindings mismatch:
@@ -15781,9 +14556,6 @@ rebuilt        : ScopeId(1): ["cb", "obj"]
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("obj")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["console"]
-rebuilt        : ["console", "obj"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofDiscriminant.ts
 semantic error: Bindings mismatch:
@@ -15825,17 +14597,11 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("a")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
-Unresolved references mismatch:
-after transform: ["Array", "takeArray"]
-rebuilt        : ["takeArray"]
 
 tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
 semantic error: Bindings mismatch:
@@ -15870,9 +14636,6 @@ rebuilt        : ReferenceId(13): None
 Reference symbol mismatch:
 after transform: ReferenceId(30): Some("fA")
 rebuilt        : ReferenceId(19): None
-Unresolved references mismatch:
-after transform: ["accA", "accB", "accC", "accL"]
-rebuilt        : ["accA", "accB", "accC", "accL", "fA"]
 
 tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
 semantic error: Bindings mismatch:
@@ -15893,9 +14656,6 @@ tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithA
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MatchArguments", "SinonSpyCallApi"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
 semantic error: Bindings mismatch:
@@ -15909,14 +14669,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("doSomething")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["doSomething"]
-
-tasks/coverage/typescript/tests/cases/compiler/nestedLoops.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
 semantic error: Missing SymbolId: a
@@ -15966,20 +14718,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(2)]
 
-tasks/coverage/typescript/tests/cases/compiler/nestedSuperCallEmit.ts
-semantic error: Unresolved reference IDs mismatch for "Error":
-after transform: [ReferenceId(1), ReferenceId(6)]
-rebuilt        : [ReferenceId(1)]
-
 tasks/coverage/typescript/tests/cases/compiler/nestedThisContainer.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
-
-tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Record", "direct", "hasZField", "nested", "nestedUnion"]
-rebuilt        : ["direct", "hasZField", "nested", "nestedUnion"]
 
 tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
 semantic error: Bindings mismatch:
@@ -16025,9 +14767,6 @@ tasks/coverage/typescript/tests/cases/compiler/newLineInTypeofInstantiation.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
 semantic error: Bindings mismatch:
@@ -16042,9 +14781,6 @@ rebuilt        : ScopeId(5): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Promise", "const"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/noBundledEmitFromNodeModules.ts
 semantic error: Bindings mismatch:
@@ -16061,9 +14797,6 @@ rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch:
 after transform: SymbolId(1): [Span { start: 61, end: 64 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["cat"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
 semantic error: Bindings mismatch:
@@ -16075,9 +14808,6 @@ rebuilt        : ScopeId(1): ["change", "listenable"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T"]
 rebuilt        : ScopeId(2): []
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
 semantic error: Bindings mismatch:
@@ -16094,9 +14824,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("decorator")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctionExpressionAssignment.ts
 semantic error: Bindings mismatch:
@@ -16219,9 +14946,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(42): Some("thing")
 rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: ["box", "createAndUnbox", "log", "map", "tap"]
-rebuilt        : ["box", "createAndUnbox", "log", "map", "tap", "thing"]
 
 tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
 semantic error: Bindings mismatch:
@@ -16233,9 +14957,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(43): Some("filter")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["ReadonlyArray", "exists", "pipe"]
-rebuilt        : ["es", "exists", "filter", "pipe"]
 
 tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
 semantic error: Bindings mismatch:
@@ -16256,17 +14977,11 @@ tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatching.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Component", "ComponentProps", "ElementRef", "ThumbProps"]
 rebuilt        : ScopeId(0): ["Component"]
-Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nonNullableAndObjectIntersections.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["NonNullableNew", "NonNullableOld", "T0", "T1", "T2", "T3", "T4", "T6", "TestNew", "TestOld"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["NonNullable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
 semantic error: Bindings mismatch:
@@ -16300,9 +15015,6 @@ tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericInd
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Ordering", "Query", "QueryHandler", "StateNodesConfig", "StateSchema"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["NonNullable", "StateNode"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
 semantic error: Bindings mismatch:
@@ -16313,9 +15025,6 @@ tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartially
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
 semantic error: Bindings mismatch:
@@ -16333,14 +15042,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("cfoo")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : ["cafoo", "cfoo"]
-
-tasks/coverage/typescript/tests/cases/compiler/nonnullAssertionPropegatesContextualType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["SVGRectElement", "document"]
-rebuilt        : ["document"]
 
 tasks/coverage/typescript/tests/cases/compiler/nounusedTypeParameterConstraint.ts
 semantic error: Bindings mismatch:
@@ -16392,9 +15093,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("union")
 rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : ["Object", "union"]
 
 tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
 semantic error: Bindings mismatch:
@@ -16406,9 +15104,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("union")
 rebuilt        : ReferenceId(9): None
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : ["Object", "union"]
 
 tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
 semantic error: Bindings mismatch:
@@ -16422,14 +15117,6 @@ rebuilt        : ScopeId(0): ["f1", "f2"]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "a"]
 rebuilt        : ScopeId(4): ["a"]
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/objectLitGetterSetter.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "PropertyDescriptor", "eval"]
-rebuilt        : ["Object", "eval"]
 
 tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.ts
 semantic error: Bindings mismatch:
@@ -16487,17 +15174,11 @@ rebuilt        : ScopeId(0): ["prepare", "rest"]
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("test")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["File", "setupImages"]
-rebuilt        : ["setupImages", "test"]
 
 tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ObservableInput", "ObservedValueOf", "Subscribable", "asObservable"]
 rebuilt        : ScopeId(0): ["asObservable"]
-Unresolved references mismatch:
-after transform: ["Observable", "from", "of"]
-rebuilt        : ["from", "of"]
 
 tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 semantic error: Bindings mismatch:
@@ -16514,9 +15195,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/compiler/optionalConstructorArgInSuper.ts
 semantic error: Symbol reference IDs mismatch:
@@ -16535,9 +15213,6 @@ tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "Test", "UnNullify", "v"]
 rebuilt        : ScopeId(0): ["v"]
-Unresolved references mismatch:
-after transform: ["NonNullable", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overload2.ts
 semantic error: Scope flags mismatch:
@@ -16687,9 +15362,6 @@ tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
 semantic error: Bindings mismatch:
@@ -16738,11 +15410,6 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 
-tasks/coverage/typescript/tests/cases/compiler/overloadResolutionWithAny.ts
-semantic error: Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/overloadRet.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
@@ -16763,9 +15430,6 @@ rebuilt        : ScopeId(0): ["AsyncLoader", "load"]
 Bindings mismatch:
 after transform: ScopeId(4): ["TResult"]
 rebuilt        : ScopeId(1): []
-Unresolved references mismatch:
-after transform: ["Exclude", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadedStaticMethodSpecialization.ts
 semantic error: Bindings mismatch:
@@ -16777,11 +15441,6 @@ rebuilt        : ScopeId(2): ["v"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Number", "String", "f"]
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
 semantic error: Bindings mismatch:
@@ -16838,9 +15497,6 @@ rebuilt        : ScopeId(0): ["b", "foo"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "_x"]
 rebuilt        : ScopeId(1): ["_x"]
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/parseJsxExtends1.ts
 semantic error: Bindings mismatch:
@@ -16849,9 +15505,6 @@ rebuilt        : ScopeId(0): ["Foo", "_jsxFileName"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/parseShortform.ts
 semantic error: Bindings mismatch:
@@ -16868,17 +15521,11 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("keys")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : ["keys"]
 
 tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Obj", "PartialUser", "User", "getUserName", "isUser"]
 rebuilt        : ScopeId(0): ["getUserName", "isUser"]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientClodule.ts
 semantic error: Symbol flags mismatch:
@@ -16912,9 +15559,6 @@ rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(8), ReferenceId(21)]
 rebuilt        : SymbolId(2): []
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(11), ReferenceId(15)]
-rebuilt        : [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
 semantic error: Bindings mismatch:
@@ -17035,9 +15679,6 @@ rebuilt        : ScopeId(15): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(47): [ReferenceId(111), ReferenceId(116), ReferenceId(121), ReferenceId(126), ReferenceId(131), ReferenceId(136), ReferenceId(141), ReferenceId(146), ReferenceId(151), ReferenceId(156), ReferenceId(161), ReferenceId(166), ReferenceId(171)]
 rebuilt        : SymbolId(3): []
-Unresolved references mismatch:
-after transform: ["PromiseLike", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
 semantic error: Bindings mismatch:
@@ -18455,28 +17096,11 @@ rebuilt        : ReferenceId(245): None
 Reference symbol mismatch:
 after transform: ReferenceId(249): Some("p")
 rebuilt        : ReferenceId(248): None
-Unresolved references mismatch:
-after transform: ["Error", "Promise", "undefined"]
-rebuilt        : ["Error", "Promise", "p", "undefined", "x"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(9), ReferenceId(18), ReferenceId(34), ReferenceId(36), ReferenceId(49), ReferenceId(51), ReferenceId(73), ReferenceId(76), ReferenceId(89), ReferenceId(91), ReferenceId(104), ReferenceId(106), ReferenceId(128), ReferenceId(131), ReferenceId(153), ReferenceId(156), ReferenceId(169), ReferenceId(171), ReferenceId(184), ReferenceId(186), ReferenceId(199), ReferenceId(201), ReferenceId(203), ReferenceId(206), ReferenceId(208), ReferenceId(210), ReferenceId(213), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222), ReferenceId(223), ReferenceId(225), ReferenceId(226), ReferenceId(228), ReferenceId(231), ReferenceId(233), ReferenceId(235), ReferenceId(238), ReferenceId(241), ReferenceId(243), ReferenceId(245), ReferenceId(247), ReferenceId(248), ReferenceId(250), ReferenceId(251), ReferenceId(252), ReferenceId(254), ReferenceId(255), ReferenceId(257), ReferenceId(258), ReferenceId(259), ReferenceId(261), ReferenceId(262), ReferenceId(263), ReferenceId(265), ReferenceId(266), ReferenceId(267), ReferenceId(268), ReferenceId(270), ReferenceId(271), ReferenceId(272)]
-rebuilt        : [ReferenceId(8), ReferenceId(17), ReferenceId(33), ReferenceId(35), ReferenceId(48), ReferenceId(50), ReferenceId(72), ReferenceId(75), ReferenceId(88), ReferenceId(90), ReferenceId(103), ReferenceId(105), ReferenceId(127), ReferenceId(130), ReferenceId(152), ReferenceId(155), ReferenceId(168), ReferenceId(170), ReferenceId(183), ReferenceId(185), ReferenceId(198), ReferenceId(200), ReferenceId(202), ReferenceId(205), ReferenceId(207), ReferenceId(209), ReferenceId(212), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(221), ReferenceId(222), ReferenceId(224), ReferenceId(225), ReferenceId(227), ReferenceId(230), ReferenceId(232), ReferenceId(234), ReferenceId(237), ReferenceId(240), ReferenceId(242), ReferenceId(244), ReferenceId(246), ReferenceId(247), ReferenceId(249), ReferenceId(250), ReferenceId(251), ReferenceId(253), ReferenceId(255), ReferenceId(257), ReferenceId(259)]
 
 tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["$$x", "IPromise"]
 rebuilt        : ScopeId(0): ["$$x"]
-Unresolved references mismatch:
-after transform: ["CPromise", "convert", "load"]
-rebuilt        : ["convert", "load"]
-
-tasks/coverage/typescript/tests/cases/compiler/promiseTypeInferenceUnion.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise", "PromiseLike"]
-rebuilt        : ["Promise"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14), ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
 semantic error: Bindings mismatch:
@@ -18941,23 +17565,11 @@ rebuilt        : ReferenceId(245): None
 Reference symbol mismatch:
 after transform: ReferenceId(249): Some("p")
 rebuilt        : ReferenceId(248): None
-Unresolved references mismatch:
-after transform: ["Error", "Promise", "undefined"]
-rebuilt        : ["Error", "Promise", "p", "undefined", "x"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(9), ReferenceId(18), ReferenceId(34), ReferenceId(36), ReferenceId(49), ReferenceId(51), ReferenceId(73), ReferenceId(76), ReferenceId(89), ReferenceId(91), ReferenceId(104), ReferenceId(106), ReferenceId(128), ReferenceId(131), ReferenceId(153), ReferenceId(156), ReferenceId(169), ReferenceId(171), ReferenceId(184), ReferenceId(186), ReferenceId(199), ReferenceId(201), ReferenceId(203), ReferenceId(206), ReferenceId(208), ReferenceId(210), ReferenceId(213), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222), ReferenceId(223), ReferenceId(225), ReferenceId(226), ReferenceId(228), ReferenceId(231), ReferenceId(233), ReferenceId(235), ReferenceId(238), ReferenceId(241), ReferenceId(243), ReferenceId(245), ReferenceId(247), ReferenceId(248), ReferenceId(250), ReferenceId(251)]
-rebuilt        : [ReferenceId(8), ReferenceId(17), ReferenceId(33), ReferenceId(35), ReferenceId(48), ReferenceId(50), ReferenceId(72), ReferenceId(75), ReferenceId(88), ReferenceId(90), ReferenceId(103), ReferenceId(105), ReferenceId(127), ReferenceId(130), ReferenceId(152), ReferenceId(155), ReferenceId(168), ReferenceId(170), ReferenceId(183), ReferenceId(185), ReferenceId(198), ReferenceId(200), ReferenceId(202), ReferenceId(205), ReferenceId(207), ReferenceId(209), ReferenceId(212), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(221), ReferenceId(222), ReferenceId(224), ReferenceId(225), ReferenceId(227), ReferenceId(230), ReferenceId(232), ReferenceId(234), ReferenceId(237), ReferenceId(240), ReferenceId(242), ReferenceId(244), ReferenceId(246), ReferenceId(247), ReferenceId(249), ReferenceId(250)]
 
 tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["T1", "T2", "T3", "f1", "f2", "x3"]
 rebuilt        : ScopeId(0): ["f1", "f2", "x3"]
-Unresolved references mismatch:
-after transform: ["Error", "Promise"]
-rebuilt        : ["Promise"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
 semantic error: Bindings mismatch:
@@ -18982,9 +17594,6 @@ rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(28)]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
 semantic error: Bindings mismatch:
@@ -19016,17 +17625,11 @@ tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Curry", "R", "Tools"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["NonNullable", "Parameters", "R", "Record", "ReturnType", "Tools", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Any/Cast", "Any/Compute", "Any/Extends", "Any/Implements", "Any/Key", "Any/Kind", "Any/Type", "Any/_Internal", "Any/x", "Boolean/Boolean", "Boolean/Not", "Function/Curry", "Function/Function", "Function/Parameters", "Function/Return", "Iteration/Format", "Iteration/Iteration", "Iteration/IterationOf", "Iteration/Key", "Iteration/Next", "Iteration/Pos", "Iteration/Prev", "Iteration/_Internal", "List/Append", "List/Concat", "List/Drop", "List/Keys", "List/Length", "List/List", "List/NonNullable", "List/ObjectOf", "List/Prepend", "List/Reverse", "List/Tail", "List/_Internal", "Number/Number", "Number/NumberOf", "Number/_Internal", "Object/At", "Object/Keys", "Object/ListOf", "Object/Merge", "Object/NonNullable", "Object/Omit", "Object/Overwrite", "Object/Pick", "Object/_Internal", "Union/Exclude", "Union/Has", "Union/Keys", "Union/NonNullable", "Union/Union"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude", "Function", "ReadonlyArray", "Required"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -19070,9 +17673,6 @@ rebuilt        : ReferenceId(17): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("x")
 rebuilt        : ReferenceId(18): None
-Unresolved references mismatch:
-after transform: ["React"]
-rebuilt        : ["Bar", "React", "_Bar", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
 semantic error: Bindings mismatch:
@@ -19119,9 +17719,6 @@ rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("condition1")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Checkbox", "OtherRadio", "Radio", "condition1", "condition2"]
 
 tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM.tsx
 semantic error: Bindings mismatch:
@@ -19133,9 +17730,6 @@ rebuilt        : SymbolId(1): [ReferenceId(0)]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("Tag")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Tag"]
 
 tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM2.tsx
 semantic error: Bindings mismatch:
@@ -19147,17 +17741,6 @@ rebuilt        : SymbolId(1): [ReferenceId(0)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("Tag")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : ["Tag"]
-
-tasks/coverage/typescript/tests/cases/compiler/readonlyFloat32ArrayAssignableWithFloat32Array.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Float32Array", "Readonly"]
-rebuilt        : ["Float32Array"]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(1), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
 semantic error: Missing SymbolId: Foo
@@ -19218,14 +17801,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation1
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["abc", "base", "xyz"]
-rebuilt        : ["xyz"]
-Unresolved reference IDs mismatch for "xyz":
-after transform: [ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
 semantic error: Missing SymbolId: TypeScript2
@@ -19289,9 +17864,6 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AllKeys", "Base", "CanBeExpanded", "Expand", "ExpandResult", "Expand_", "Expand__", "Join", "KeysCanBeExpanded", "KeysCanBeExpanded_", "PrefixWith", "Role", "SplitAC", "SplitWithAllPossibleCombinations", "UseQueryOptions", "UseQueryOptions2", "UseQueryOptions3", "UseQueryOptions4", "User", "X", "t", "y1", "y2"]
 rebuilt        : ScopeId(0): ["t", "y1", "y2"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalEvaluationNonInfinite.ts
 semantic error: Bindings mismatch:
@@ -19303,17 +17875,11 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ClassSpec", "Converted", "DefaultsDeep", "MaybeMergePrivateSpecs", "MaybeMergePrivateSuperSpec", "MergePrivateSpecs", "MergePrivateSuperSpec", "SimplifyPrivateSpec", "UnionToIntersection", "_Array", "z"]
 rebuilt        : ScopeId(0): ["z"]
-Unresolved references mismatch:
-after transform: ["NonNullable", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveExcessPropertyChecks.ts
 semantic error: Bindings mismatch:
@@ -19364,17 +17930,11 @@ tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1", "Test2", "s1", "s2", "x"]
 rebuilt        : ScopeId(0): ["s1", "s2", "x"]
-Unresolved references mismatch:
-after transform: ["Test1", "Test2"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test1", "Test2", "s1", "s2", "x"]
 rebuilt        : ScopeId(0): ["s1", "s2", "x"]
-Unresolved references mismatch:
-after transform: ["Test1", "Test2"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
 semantic error: Bindings mismatch:
@@ -19409,9 +17969,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("c")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
 semantic error: Missing SymbolId: Foo
@@ -19444,17 +18001,11 @@ rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
-Unresolved reference IDs mismatch for "C":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
-rebuilt        : [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D", "F"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["E"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveReverseMappedType.ts
 semantic error: Bindings mismatch:
@@ -19521,9 +18072,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(51): Some("opt3")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : ["opt1", "opt2", "opt3"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison.ts
 semantic error: Bindings mismatch:
@@ -19675,11 +18223,6 @@ Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 39, end: 45 }]
 rebuilt        : SymbolId(0): []
 
-tasks/coverage/typescript/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Math", "RegExpExecArray", "RegExpMatchArray", "undefined"]
-rebuilt        : ["Math", "undefined"]
-
 tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "DiscriminatedUnion", "Model"]
@@ -19690,9 +18233,6 @@ rebuilt        : ScopeId(3): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
 semantic error: Bindings mismatch:
@@ -19710,9 +18250,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("x")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/reorderProperties.ts
 semantic error: Bindings mismatch:
@@ -19841,9 +18378,6 @@ tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["test"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["mstring"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/resolutionCandidateFromPackageJsonField2.ts
 semantic error: Bindings mismatch:
@@ -19900,9 +18434,6 @@ rebuilt        : SymbolId(0): Span { start: 56, end: 68 }
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 56, end: 68 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName2.ts
 semantic error: Bindings mismatch:
@@ -19979,9 +18510,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("nullUnion")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["nullUnion", "undefinedUnion"]
 
 tasks/coverage/typescript/tests/cases/compiler/returnInfiniteIntersection.ts
 semantic error: Bindings mismatch:
@@ -20053,12 +18581,6 @@ rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(19)]
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("A")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: ["Array", "arguments"]
-rebuilt        : ["A", "Array", "arguments"]
-Unresolved reference IDs mismatch for "Array":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
 semantic error: Bindings mismatch:
@@ -20085,25 +18607,16 @@ tasks/coverage/typescript/tests/cases/compiler/reverseMappedTupleContext.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["CompilerOptions", "Definition", "KeepLiteralStrings", "Schema", "created1", "created2", "result1", "result2", "result4"]
 rebuilt        : ScopeId(0): ["created1", "created2", "result1", "result2", "result4"]
-Unresolved references mismatch:
-after transform: ["Record", "create", "test1", "test2", "test4"]
-rebuilt        : ["create", "test1", "test2", "test4"]
 
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["InferFromMapped", "Inferred", "LiteralType", "Mapped", "MappedLiteralType", "Test1"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Tuple"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["EventTarget", "Extract", "HTMLButtonElement", "Parameters", "bindAll"]
-rebuilt        : ["bindAll"]
 
 tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts
 semantic error: Bindings mismatch:
@@ -20117,9 +18630,6 @@ tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyExtractor", "Extractor", "Identifier", "StringLiteral", "identifierExtractor", "myUnion", "stringExtractor"]
 rebuilt        : ScopeId(0): ["identifierExtractor", "myUnion", "stringExtractor"]
-Unresolved references mismatch:
-after transform: ["const", "createExtractor", "isIdentifier", "isStringLiteral", "unionType"]
-rebuilt        : ["createExtractor", "isIdentifier", "isStringLiteral", "unionType"]
 
 tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation.ts
 semantic error: Bindings mismatch:
@@ -20133,9 +18643,6 @@ rebuilt        : ScopeId(0): ["X", "o"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("window")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["window"]
 
 tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
 semantic error: Bindings mismatch:
@@ -20197,9 +18704,6 @@ rebuilt        : ReferenceId(11): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("ps")
 rebuilt        : ReferenceId(14): None
-Unresolved references mismatch:
-after transform: ["Math", "Promise"]
-rebuilt        : ["Math", "ps"]
 
 tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalWithInteriorConditionalIsRelated.ts
 semantic error: Bindings mismatch:
@@ -20225,9 +18729,6 @@ tasks/coverage/typescript/tests/cases/compiler/singletonLabeledTuple.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Alias", "AliasOptional", "AliasRest", "AliasedRest", "Labeled", "Literal", "LiteralRest", "Normal", "NormalRest"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/sliceResultCast.ts
 semantic error: Bindings mismatch:
@@ -20236,9 +18737,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("x")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
 semantic error: Missing SymbolId: sas
@@ -20331,9 +18829,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("window")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["window"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
 semantic error: Missing SymbolId: Q
@@ -20462,9 +18957,6 @@ rebuilt        : ReferenceId(108): None
 Reference symbol mismatch:
 after transform: ReferenceId(115): Some("console")
 rebuilt        : ReferenceId(112): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForArrayBindingPattern2.ts
 semantic error: Bindings mismatch:
@@ -20542,9 +19034,6 @@ rebuilt        : ReferenceId(172): None
 Reference symbol mismatch:
 after transform: ReferenceId(183): Some("console")
 rebuilt        : ReferenceId(178): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForArrayBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -20613,9 +19102,6 @@ rebuilt        : ReferenceId(94): None
 Reference symbol mismatch:
 after transform: ReferenceId(101): Some("console")
 rebuilt        : ReferenceId(98): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2.ts
 semantic error: Bindings mismatch:
@@ -20684,9 +19170,6 @@ rebuilt        : ReferenceId(147): None
 Reference symbol mismatch:
 after transform: ReferenceId(158): Some("console")
 rebuilt        : ReferenceId(154): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -20728,9 +19211,6 @@ rebuilt        : ReferenceId(52): None
 Reference symbol mismatch:
 after transform: ReferenceId(62): Some("console")
 rebuilt        : ReferenceId(56): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern2.ts
 semantic error: Bindings mismatch:
@@ -20808,9 +19288,6 @@ rebuilt        : ReferenceId(176): None
 Reference symbol mismatch:
 after transform: ReferenceId(194): Some("console")
 rebuilt        : ReferenceId(184): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -20852,9 +19329,6 @@ rebuilt        : ReferenceId(52): None
 Reference symbol mismatch:
 after transform: ReferenceId(62): Some("console")
 rebuilt        : ReferenceId(56): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues2.ts
 semantic error: Bindings mismatch:
@@ -20932,9 +19406,6 @@ rebuilt        : ReferenceId(176): None
 Reference symbol mismatch:
 after transform: ReferenceId(194): Some("console")
 rebuilt        : ReferenceId(184): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfArrayBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21012,9 +19483,6 @@ rebuilt        : ReferenceId(80): None
 Reference symbol mismatch:
 after transform: ReferenceId(88): Some("console")
 rebuilt        : ReferenceId(84): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfArrayBindingPattern2.ts
 semantic error: Bindings mismatch:
@@ -21092,9 +19560,6 @@ rebuilt        : ReferenceId(121): None
 Reference symbol mismatch:
 after transform: ReferenceId(130): Some("console")
 rebuilt        : ReferenceId(126): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfArrayBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21163,9 +19628,6 @@ rebuilt        : ReferenceId(70): None
 Reference symbol mismatch:
 after transform: ReferenceId(78): Some("console")
 rebuilt        : ReferenceId(74): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfArrayBindingPatternDefaultValues2.ts
 semantic error: Bindings mismatch:
@@ -21234,9 +19696,6 @@ rebuilt        : ReferenceId(107): None
 Reference symbol mismatch:
 after transform: ReferenceId(117): Some("console")
 rebuilt        : ReferenceId(113): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfObjectBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21278,9 +19737,6 @@ rebuilt        : ReferenceId(30): None
 Reference symbol mismatch:
 after transform: ReferenceId(34): Some("console")
 rebuilt        : ReferenceId(32): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfObjectBindingPattern2.ts
 semantic error: Bindings mismatch:
@@ -21358,9 +19814,6 @@ rebuilt        : ReferenceId(107): None
 Reference symbol mismatch:
 after transform: ReferenceId(114): Some("console")
 rebuilt        : ReferenceId(112): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21402,9 +19855,6 @@ rebuilt        : ReferenceId(30): None
 Reference symbol mismatch:
 after transform: ReferenceId(36): Some("console")
 rebuilt        : ReferenceId(32): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues2.ts
 semantic error: Bindings mismatch:
@@ -21482,9 +19932,6 @@ rebuilt        : ReferenceId(107): None
 Reference symbol mismatch:
 after transform: ReferenceId(116): Some("console")
 rebuilt        : ReferenceId(112): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterNestedObjectBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21499,9 +19946,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterNestedObjectBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21516,9 +19960,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("console")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterObjectBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21533,9 +19974,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParameterObjectBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21550,9 +19988,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParametertArrayBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21570,9 +20005,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParametertArrayBindingPattern2.ts
 semantic error: Bindings mismatch:
@@ -21590,9 +20022,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParametertArrayBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21610,9 +20039,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringParametertArrayBindingPatternDefaultValues2.ts
 semantic error: Bindings mismatch:
@@ -21627,9 +20053,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatement.ts
 semantic error: Bindings mismatch:
@@ -21641,9 +20064,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatement1.ts
 semantic error: Bindings mismatch:
@@ -21655,9 +20075,6 @@ rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
 after transform: ReferenceId(18): Some("console")
 rebuilt        : ReferenceId(16): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21666,9 +20083,6 @@ rebuilt        : ScopeId(0): ["nameA", "nameA2", "nameC", "numberA2", "numberA3"
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern2.ts
 semantic error: Bindings mismatch:
@@ -21677,9 +20091,6 @@ rebuilt        : ScopeId(0): ["multiRobotA", "multiRobotAInfo", "multiRobotB", "
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern3.ts
 semantic error: Bindings mismatch:
@@ -21688,9 +20099,6 @@ rebuilt        : ScopeId(0): ["getMultiRobotB", "getRobotB", "multiRobotA", "mul
 Reference symbol mismatch:
 after transform: ReferenceId(62): Some("console")
 rebuilt        : ReferenceId(57): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPatternDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21699,9 +20107,6 @@ rebuilt        : ScopeId(0): ["nameA", "nameA2", "nameC", "numberA2", "numberA3"
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPatternDefaultValues2.ts
 semantic error: Bindings mismatch:
@@ -21710,9 +20115,6 @@ rebuilt        : ScopeId(0): ["multiRobotA", "multiRobotB", "nameMA", "nameMB", 
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("console")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPatternDefaultValues3.ts
 semantic error: Bindings mismatch:
@@ -21721,9 +20123,6 @@ rebuilt        : ScopeId(0): ["getMultiRobotB", "getRobotB", "multiRobotA", "mul
 Reference symbol mismatch:
 after transform: ReferenceId(57): Some("console")
 rebuilt        : ReferenceId(52): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21735,9 +20134,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementNestedObjectBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -21749,9 +20145,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementNestedObjectBindingPatternWithDefaultValues.ts
 semantic error: Bindings mismatch:
@@ -21763,9 +20156,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignment.ts
 semantic error: Symbol reference IDs mismatch:
@@ -21859,9 +20249,6 @@ tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ErrorMsg", "Predicate", "Result", "Spec", "SpecArray", "SpecFunction", "SpecObject", "SpecValue"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Array", "Partial", "ReadonlyArray", "spected", "true"]
-rebuilt        : ["spected"]
 
 tasks/coverage/typescript/tests/cases/compiler/specializationError.ts
 semantic error: Bindings mismatch:
@@ -21963,9 +20350,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("foo2")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : ["Array", "foo1", "foo2"]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
 semantic error: Bindings mismatch:
@@ -21995,9 +20379,6 @@ rebuilt        : SymbolId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("b")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["b"]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadObjectPermutations.ts
 semantic error: Bindings mismatch:
@@ -22102,9 +20483,6 @@ rebuilt        : ReferenceId(31): None
 Reference symbol mismatch:
 after transform: ReferenceId(32): Some("a")
 rebuilt        : ReferenceId(32): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts
 semantic error: Bindings mismatch:
@@ -22113,17 +20491,11 @@ rebuilt        : ScopeId(0): ["x"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("m")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["m"]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadOfObjectLiteralAssignableToIndexSignature.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["RecordOfRecords", "RecordOfRecordsOrEmpty", "foo", "recordOfRecords", "recordsOfRecordsOrEmpty"]
 rebuilt        : ScopeId(0): ["foo", "recordOfRecords", "recordsOfRecordsOrEmpty"]
-Unresolved references mismatch:
-after transform: ["Record", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -22135,18 +20507,10 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ReadonlyData", "clone", "data"]
 rebuilt        : ScopeId(0): ["clone", "data"]
 
-tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTupleTypes.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const", "foo", "fx1", "fx2"]
-rebuilt        : ["foo", "fx1", "fx2"]
-
 tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["SelectorMap"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/stackDepthLimitCastingType.ts
 semantic error: Bindings mismatch:
@@ -22266,9 +20630,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution.ts
 semantic error: Symbol reference IDs mismatch:
@@ -22320,9 +20681,6 @@ rebuilt        : ScopeId(3): []
 Bindings mismatch:
 after transform: ScopeId(7): ["T"]
 rebuilt        : ScopeId(5): []
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 semantic error: Bindings mismatch:
@@ -22334,9 +20692,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("someVal2")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Required"]
-rebuilt        : ["someVal", "someVal2"]
 
 tasks/coverage/typescript/tests/cases/compiler/structural1.ts
 semantic error: Missing SymbolId: M
@@ -22365,9 +20720,6 @@ tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimit
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyStyledComponent", "Defaultize", "FORWARD_REF_STATICS", "ForwardRefExoticBase", "IntrinsicElementsKeys", "KNOWN_STATICS", "MEMO_STATICS", "NonReactStatics", "REACT_STATICS", "React", "ReactDefaultizedProps", "StyledComponent", "StyledComponentBase", "StyledComponentInnerAttrs", "StyledComponentInnerComponent", "StyledComponentInnerOtherProps", "StyledComponentProps", "StyledComponentPropsWithAs", "StyledComponentPropsWithRef", "WithChildrenIfReactComponentClass", "WithOptionalTheme"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "JSX", "Omit", "Partial", "Pick", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
 semantic error: Bindings mismatch:
@@ -22392,9 +20744,6 @@ tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesCons
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FFG", "M", "O", "X"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["ReturnType"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType1.ts
 semantic error: Bindings mismatch:
@@ -22410,9 +20759,6 @@ tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericInde
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
 semantic error: Bindings mismatch:
@@ -22421,25 +20767,16 @@ rebuilt        : ScopeId(0): ["makeEntityStore", "myTest"]
 Bindings mismatch:
 after transform: ScopeId(8): ["T", "config"]
 rebuilt        : ScopeId(1): ["config"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bar1", "Bar2", "Foo1", "Foo2"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Set"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Bug", "BugHelper", "Q", "R", "UnionKeys"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Exclude"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
 semantic error: Bindings mismatch:
@@ -22475,14 +20812,6 @@ rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(5)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Number"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
 semantic error: Missing SymbolId: test
@@ -22515,16 +20844,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(2): []
 rebuilt        : SymbolId(3): [ReferenceId(4)]
 
-tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
-semantic error: Unresolved reference IDs mismatch for "B":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType2.ts
-semantic error: Unresolved reference IDs mismatch for "B":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
-
 tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
 semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(Class | Interface)
@@ -22543,11 +20862,6 @@ rebuilt        : ScopeId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(1): []
-
-tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
-semantic error: Unresolved reference IDs mismatch for "B":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/switchComparableCompatForBrands.ts
 semantic error: Symbol reference IDs mismatch:
@@ -22616,9 +20930,6 @@ rebuilt        : ScopeId(0): ["c", "e", "foo", "promise"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("E")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["C", "Foo", "Promise"]
-rebuilt        : ["C", "E", "Foo", "Promise"]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnums.ts
 semantic error: Missing SymbolId: M
@@ -22867,11 +21178,6 @@ Reference symbol mismatch:
 after transform: ReferenceId(2): Some("ns")
 rebuilt        : ReferenceId(10): Some("ns")
 
-tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
 semantic error: Missing SymbolId: n
 Missing SymbolId: _n
@@ -22912,9 +21218,6 @@ tasks/coverage/typescript/tests/cases/compiler/templateLiteralConstantEvaluation
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection.ts
 semantic error: Bindings mismatch:
@@ -22943,17 +21246,11 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("lowercasePath")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Lowercase"]
-rebuilt        : ["lowercasePath", "options1", "path"]
 
 tasks/coverage/typescript/tests/cases/compiler/templateLiteralIntersection4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Provider", "StateHook", "StoreUtils", "useAge", "useStore", "useUsername"]
 rebuilt        : ScopeId(0): ["Provider", "useAge", "useStore", "useUsername"]
-Unresolved references mismatch:
-after transform: ["Capitalize", "Omit", "createStore"]
-rebuilt        : ["createStore"]
 
 tasks/coverage/typescript/tests/cases/compiler/templateLiteralsAndDecoratorMetadata.ts
 semantic error: Bindings mismatch:
@@ -22962,9 +21259,6 @@ rebuilt        : ScopeId(0): ["Greeter"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("format")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["format"]
 
 tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
 semantic error: Missing SymbolId: A
@@ -23052,9 +21346,6 @@ tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.t
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParameterConstraints.ts
 semantic error: Bindings mismatch:
@@ -23068,9 +21359,6 @@ rebuilt        : ScopeId(4): ["params"]
 Bindings mismatch:
 after transform: ScopeId(8): ["T0"]
 rebuilt        : ScopeId(7): []
-Unresolved references mismatch:
-after transform: ["Error", "this"]
-rebuilt        : ["Error"]
 
 tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
 semantic error: Bindings mismatch:
@@ -23079,12 +21367,6 @@ rebuilt        : ScopeId(0): ["CoachMarkAnchorDecorator"]
 Bindings mismatch:
 after transform: ScopeId(5): ["P", "anchor"]
 rebuilt        : ScopeId(2): ["anchor"]
-Unresolved references mismatch:
-after transform: ["Component", "Readonly"]
-rebuilt        : ["Component"]
-Unresolved reference IDs mismatch for "Component":
-after transform: [ReferenceId(6), ReferenceId(9)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/thisTypeAsConstraint.ts
 semantic error: Bindings mismatch:
@@ -23142,9 +21424,6 @@ rebuilt        : SymbolId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("props")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["props"]
 
 tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3.ts
 semantic error: Bindings mismatch:
@@ -23158,9 +21437,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("decorator")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsObjectLiteral.tsx
 semantic error: Bindings mismatch:
@@ -23183,9 +21459,6 @@ rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(5), ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(5): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Date", "React"]
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
 semantic error: Bindings mismatch:
@@ -23202,12 +21475,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DiscriminatorFalse", "DiscriminatorTrue", "JSX", "Props", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
-Unresolved references mismatch:
-after transform: ["Comp", "JSX", "parseInt", "require", "true", "undefined"]
-rebuilt        : ["Comp", "parseInt", "require", "undefined"]
-Unresolved reference IDs mismatch for "Comp":
-after transform: [ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(25)]
-rebuilt        : [ReferenceId(2), ReferenceId(7), ReferenceId(11), ReferenceId(16)]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxFragmentChildrenCheck.ts
 semantic error: Bindings mismatch:
@@ -23216,9 +21483,6 @@ rebuilt        : ScopeId(0): ["MyComponent", "_jsxFileName"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUnions.tsx
 semantic error: Bindings mismatch:
@@ -23230,9 +21494,6 @@ rebuilt        : ScopeId(1): ["props"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(22), ReferenceId(25), ReferenceId(28)]
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(12), ReferenceId(16)]
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
 semantic error: Bindings mismatch:
@@ -23241,12 +21502,6 @@ rebuilt        : ScopeId(0): ["CustomButton", "React", "_jsxFileName"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(1): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["Button", "HTMLButtonElement"]
-rebuilt        : ["Button"]
-Unresolved reference IDs mismatch for "Button":
-after transform: [ReferenceId(9), ReferenceId(12)]
-rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxResolveExternalModuleExportsTypes.ts
 semantic error: Bindings mismatch:
@@ -23265,12 +21520,6 @@ tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFilterDataPro
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["React", "ReactElement", "RootHappy", "RootNotHappy", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["React", "RootHappy", "RootNotHappy", "_jsxFileName"]
-Unresolved reference IDs mismatch for "NotHappy":
-after transform: [ReferenceId(2), ReferenceId(5)]
-rebuilt        : [ReferenceId(1)]
-Unresolved reference IDs mismatch for "Happy":
-after transform: [ReferenceId(3), ReferenceId(8)]
-rebuilt        : [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
 semantic error: Bindings mismatch:
@@ -23279,9 +21528,6 @@ rebuilt        : ScopeId(0): ["AnimalComponent", "_jsxFileName", "_reactJsxRunti
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(8), ReferenceId(11), ReferenceId(13), ReferenceId(16)]
 rebuilt        : SymbolId(2): [ReferenceId(4), ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["JSX", "require", "undefined"]
-rebuilt        : ["require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 semantic error: Bindings mismatch:
@@ -23314,9 +21560,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(37): Some("$q")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["$q"]
 
 tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference2.ts
 semantic error: Bindings mismatch:
@@ -23327,9 +21570,6 @@ tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Set1", "Set2", "State", "newState", "state"]
 rebuilt        : ScopeId(0): ["newState", "state"]
-Unresolved references mismatch:
-after transform: ["Exclude", "Pick", "Required", "set"]
-rebuilt        : ["set"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
 semantic error: Bindings mismatch:
@@ -23346,17 +21586,11 @@ tasks/coverage/typescript/tests/cases/compiler/typeAliasDoesntMakeModuleInstanti
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "m"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSharedSymbol.ts
 semantic error: Bindings mismatch:
@@ -23405,9 +21639,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "iterable"]
 rebuilt        : ScopeId(1): ["iterable"]
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType2.ts
 semantic error: Bindings mismatch:
@@ -23416,9 +21647,6 @@ rebuilt        : ScopeId(1): ["inner", "iterable"]
 Bindings mismatch:
 after transform: ScopeId(2): ["U", "res", "u"]
 rebuilt        : ScopeId(2): ["res", "u"]
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
 semantic error: Bindings mismatch:
@@ -23454,28 +21682,6 @@ Bindings mismatch:
 after transform: ScopeId(3): ["T"]
 rebuilt        : ScopeId(1): []
 
-tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorNarrowPrimitivesInUnion.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Number", "String", "true"]
-rebuilt        : ["Array", "Boolean", "Number", "String"]
-
-tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
-semantic error: Unresolved reference IDs mismatch for "BigInt":
-after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
-rebuilt        : [ReferenceId(16), ReferenceId(31)]
-Unresolved reference IDs mismatch for "String":
-after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
-rebuilt        : [ReferenceId(1), ReferenceId(19)]
-Unresolved reference IDs mismatch for "Number":
-after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
-rebuilt        : [ReferenceId(4), ReferenceId(22)]
-Unresolved reference IDs mismatch for "Boolean":
-after transform: [ReferenceId(7), ReferenceId(20), ReferenceId(30)]
-rebuilt        : [ReferenceId(7), ReferenceId(25)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(13), ReferenceId(21), ReferenceId(33)]
-rebuilt        : [ReferenceId(13), ReferenceId(28)]
-
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["arrayLikeOrIterable"]
@@ -23486,9 +21692,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("arrayLikeOrIterable")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["ArrayLike", "Iterable", "PropertyKey", "hasOwnProperty"]
-rebuilt        : ["arrayLikeOrIterable", "hasOwnProperty"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
 semantic error: Bindings mismatch:
@@ -23500,9 +21703,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("arrayLikeOrIterable")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["ArrayLike", "Iterable", "PropertyKey", "hasOwnProperty"]
-rebuilt        : ["arrayLikeOrIterable", "hasOwnProperty"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty1.ts
 semantic error: Bindings mismatch:
@@ -23531,9 +21731,6 @@ rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("m")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["m"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts
 semantic error: Bindings mismatch:
@@ -23557,14 +21754,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("m")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["m"]
-
-tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty3.ts
 semantic error: Bindings mismatch:
@@ -23601,9 +21790,6 @@ rebuilt        : ReferenceId(11): None
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("cIndex")
 rebuilt        : ReferenceId(13): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["aIndex", "bIndex", "cIndex"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
 semantic error: Missing SymbolId: Foo
@@ -23676,9 +21862,6 @@ rebuilt        : ScopeId(4): ["array"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(13), ReferenceId(15), ReferenceId(18)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
-Unresolved references mismatch:
-after transform: ["Array", "Date", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceReturnTypeCallback.ts
 semantic error: Bindings mismatch:
@@ -23714,15 +21897,6 @@ Missing ReferenceId: require
 Bindings mismatch:
 after transform: ScopeId(0): ["React", "TProps", "TranslationEntry", "Translations", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
-Unresolved references mismatch:
-after transform: ["JSX", "T", "require"]
-rebuilt        : ["T", "require"]
-Unresolved reference IDs mismatch for "T":
-after transform: [ReferenceId(9), ReferenceId(11)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeLiteralCallback.ts
 semantic error: Bindings mismatch:
@@ -23733,9 +21907,6 @@ tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualR
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AsyncSequenceFactory", "SequenceFactory", "SyncSequenceFactory", "asyncFactory", "looserAsyncFactory", "looserSyncFactory", "syncFactory"]
 rebuilt        : ScopeId(0): ["asyncFactory", "looserAsyncFactory", "looserSyncFactory", "syncFactory"]
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterAndArgumentOfSameName1.ts
 semantic error: Symbol flags mismatch:
@@ -23750,9 +21921,6 @@ rebuilt        : SymbolId(1): [ReferenceId(0)]
 Symbol redeclarations mismatch:
 after transform: SymbolId(1): [Span { start: 29, end: 33 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Number"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterAsElementType.ts
 semantic error: Bindings mismatch:
@@ -23839,9 +22007,6 @@ rebuilt        : ScopeId(2): ["i", "n"]
 Bindings mismatch:
 after transform: ScopeId(6): ["K", "T", "array", "prop", "result"]
 rebuilt        : ScopeId(3): ["array", "prop", "result"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraints.ts
 semantic error: Bindings mismatch:
@@ -23884,9 +22049,6 @@ rebuilt        : ScopeId(0): ["b"]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("f")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeParameterListWithTrailingComma1.ts
 semantic error: Bindings mismatch:
@@ -23919,9 +22081,6 @@ tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Options", "Test"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
 semantic error: Bindings mismatch:
@@ -23936,9 +22095,6 @@ rebuilt        : ScopeId(2): ["narrow"]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "value"]
 rebuilt        : ScopeId(3): ["value"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicateStructuralMatch.ts
 semantic error: Bindings mismatch:
@@ -23972,9 +22128,6 @@ rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("test")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["test"]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscriminant.ts
 semantic error: Bindings mismatch:
@@ -23998,22 +22151,11 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("fruit2")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: ["const", "isOneOf"]
-rebuilt        : ["fruit", "fruit2", "isOneOf"]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Or", "f"]
 rebuilt        : ScopeId(0): ["f"]
-
-tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
-semantic error: Unresolved reference IDs mismatch for "isString":
-after transform: [ReferenceId(0), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
-Unresolved reference IDs mismatch for "isNumber":
-after transform: [ReferenceId(1), ReferenceId(5)]
-rebuilt        : [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
 semantic error: Bindings mismatch:
@@ -24027,9 +22169,6 @@ rebuilt        : ScopeId(0): ["isNotNull", "title", "x"]
 Bindings mismatch:
 after transform: ScopeId(2): ["A", "x"]
 rebuilt        : ScopeId(1): ["x"]
-Unresolved references mismatch:
-after transform: ["NonNullable", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
 semantic error: Bindings mismatch:
@@ -24191,9 +22330,6 @@ rebuilt        : SymbolId(54): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(51): []
 rebuilt        : SymbolId(54): [ReferenceId(60)]
-Unresolved references mismatch:
-after transform: ["SubModule1", "SubSubModule1", "TopLevelModule1", "TopLevelModule2"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
 semantic error: Symbol flags mismatch:
@@ -24251,9 +22387,6 @@ rebuilt        : ScopeId(21): ["a"]
 Reference flags mismatch:
 after transform: ReferenceId(7): ReferenceFlags(Type)
 rebuilt        : ReferenceId(2): ReferenceFlags(Read)
-Unresolved references mismatch:
-after transform: ["Partial", "Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typedArrays.ts
 semantic error: Bindings mismatch:
@@ -24262,9 +22395,6 @@ rebuilt        : ScopeId(8): ["mapFn", "obj", "typedArrays"]
 Bindings mismatch:
 after transform: ScopeId(11): ["T", "mapFn", "obj", "thisArg", "typedArrays"]
 rebuilt        : ScopeId(11): ["mapFn", "obj", "thisArg", "typedArrays"]
-Unresolved references mismatch:
-after transform: ["ArrayLike", "Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
-rebuilt        : ["Float32Array", "Float64Array", "Int16Array", "Int32Array", "Int8Array", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray"]
 
 tasks/coverage/typescript/tests/cases/compiler/typedGenericPrototypeMember.ts
 semantic error: Bindings mismatch:
@@ -24292,9 +22422,6 @@ rebuilt        : ScopeId(0): ["myFunction"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "arg"]
 rebuilt        : ScopeId(1): ["arg"]
-Unresolved references mismatch:
-after transform: ["Record", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
 semantic error: Symbol flags mismatch:
@@ -24351,14 +22478,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(13): Some("Collection")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Collection"]
-
-tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
 semantic error: Bindings mismatch:
@@ -24469,9 +22588,6 @@ rebuilt        : ReferenceId(24): None
 Reference symbol mismatch:
 after transform: ReferenceId(25): Some("b")
 rebuilt        : ReferenceId(25): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["b"]
 
 tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError1.ts
 semantic error: Bindings mismatch:
@@ -24513,9 +22629,6 @@ rebuilt        : ReferenceId(10): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("index")
 rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["index", "lineTokens", "token", "tokens"]
 
 tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
 semantic error: Bindings mismatch:
@@ -24535,9 +22648,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("s")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : ["s", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/undefinedInferentialTyping.ts
 semantic error: Bindings mismatch:
@@ -24600,9 +22710,6 @@ rebuilt        : ScopeId(0): ["e2"]
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("e")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["e"]
 
 tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
 semantic error: Bindings mismatch:
@@ -24619,9 +22726,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "ab"]
 
 tasks/coverage/typescript/tests/cases/compiler/unionOfArraysFilterCall.ts
 semantic error: Bindings mismatch:
@@ -24638,9 +22742,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(32): Some("a")
 rebuilt        : ReferenceId(17): None
-Unresolved references mismatch:
-after transform: ["Array", "Bar", "Baz", "Foo", "Promise", "Test"]
-rebuilt        : ["a", "tmp"]
 
 tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
 semantic error: Bindings mismatch:
@@ -24669,9 +22770,6 @@ rebuilt        : SymbolId(1): [ReferenceId(0)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 semantic error: Bindings mismatch:
@@ -24680,14 +22778,6 @@ rebuilt        : ScopeId(0): ["k", "run"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("val")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["val"]
-
-tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
-semantic error: Unresolved references mismatch:
-after transform: ["Capitalize", "upperFirst"]
-rebuilt        : ["upperFirst"]
 
 tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.ts
 semantic error: Bindings mismatch:
@@ -24741,12 +22831,6 @@ rebuilt        : ScopeId(1): ["arr", "zz"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "arr"]
 rebuilt        : ScopeId(3): ["arr"]
-Unresolved reference IDs mismatch for "Int32Array":
-after transform: [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(7), ReferenceId(9), ReferenceId(13)]
-rebuilt        : [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
 semantic error: Bindings mismatch:
@@ -24758,19 +22842,11 @@ rebuilt        : ScopeId(1): ["p"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Promise", "Symbol"]
-rebuilt        : ["Symbol"]
 
 tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyType", "myUnusedFunction", "myVar"]
 rebuilt        : ScopeId(0): ["myUnusedFunction", "myVar"]
-
-tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 semantic error: Bindings mismatch:
@@ -24782,9 +22858,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("s")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["s"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedClassesinNamespace3.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -24842,9 +22915,6 @@ rebuilt        : ScopeId(0): ["Animal"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("console")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersDeferred.ts
 semantic error: Missing SymbolId: N
@@ -24874,9 +22944,6 @@ tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAlia
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I3", "handler1", "handler2", "handler3", "handler4", "handler5", "handler6", "x", "y"]
 rebuilt        : ScopeId(0): ["x", "y"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterface.ts
 semantic error: Bindings mismatch:
@@ -24956,9 +23023,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(17): Some("a")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
 semantic error: Missing SymbolId: ts
@@ -25118,9 +23182,6 @@ rebuilt        : ReferenceId(80): None
 Reference symbol mismatch:
 after transform: ReferenceId(82): Some("dec")
 rebuilt        : ReferenceId(82): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/usedImportNotElidedInJs.ts
 semantic error: Cannot use import statement outside a module
@@ -25135,38 +23196,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-semantic error: Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(6)]
-Unresolved reference IDs mismatch for "Int16Array":
-after transform: [ReferenceId(4), ReferenceId(5)]
-rebuilt        : [ReferenceId(2)]
-Unresolved reference IDs mismatch for "BigUint64Array":
-after transform: [ReferenceId(18), ReferenceId(19)]
-rebuilt        : [ReferenceId(9)]
-Unresolved reference IDs mismatch for "BigInt64Array":
-after transform: [ReferenceId(16), ReferenceId(17)]
-rebuilt        : [ReferenceId(8)]
-Unresolved reference IDs mismatch for "Uint8Array":
-after transform: [ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(1)]
-Unresolved reference IDs mismatch for "Int32Array":
-after transform: [ReferenceId(8), ReferenceId(9)]
-rebuilt        : [ReferenceId(4)]
-Unresolved reference IDs mismatch for "Int8Array":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
-Unresolved reference IDs mismatch for "Uint16Array":
-after transform: [ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "Uint32Array":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(5)]
-Unresolved reference IDs mismatch for "Float64Array":
-after transform: [ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(7)]
-
 tasks/coverage/typescript/tests/cases/compiler/varArgsOnConstructorTypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "I1", "reg"]
@@ -25179,9 +23208,6 @@ tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccess
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Action1", "MessageEventLike", "PostMessageObject", "Source", "Target", "WindowLike", "f1"]
 rebuilt        : ScopeId(0): ["f1"]
-Unresolved references mismatch:
-after transform: ["AddEventListenerOptions", "EventListenerOrEventListenerObject", "Window", "WindowEventMap"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
 semantic error: Bindings mismatch:
@@ -25235,9 +23261,6 @@ rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("a")
 rebuilt        : ReferenceId(15): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "a2", "b", "b2"]
 
 tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
 semantic error: Bindings mismatch:
@@ -25325,24 +23348,11 @@ tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithU
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "I", "P1", "P2", "X", "_i", "i", "p2"]
 rebuilt        : ScopeId(0): ["_i", "i", "p2"]
-Unresolved references mismatch:
-after transform: ["Pick", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-
-tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_dom.ts
-semantic error: Unresolved references mismatch:
-after transform: ["HTMLElement"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_webworker.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Worker"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/visSyntax.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -25363,9 +23373,6 @@ rebuilt        : ScopeId(1): ["arg1", "func"]
 Bindings mismatch:
 after transform: ScopeId(7): ["P", "props"]
 rebuilt        : ScopeId(4): ["props"]
-Unresolved references mismatch:
-after transform: ["Readonly", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
 semantic error: Bindings mismatch:
@@ -25380,33 +23387,21 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("foo")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: ["console", "undefined"]
-rebuilt        : ["console", "foo", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DataDef", "Instance", "Options", "PropsDefinition", "ThisTypedOptions", "WatchHandler"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Readonly", "Record", "ThisType", "test"]
-rebuilt        : ["test"]
 
 tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["DataDef", "Instance", "Options", "PropsDefinition", "ThisTypedOptions", "WatchHandler"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Readonly", "Record", "ThisType", "test"]
-rebuilt        : ["test"]
 
 tasks/coverage/typescript/tests/cases/compiler/weakTypeAndPrimitiveNarrowing.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LiteralsAndWeakTypes", "PrimitivesAndWeakTypes", "g", "h"]
 rebuilt        : ScopeId(0): ["g", "h"]
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/wideningWithTopLevelTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -25435,9 +23430,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("g")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Generator"]
-rebuilt        : ["g"]
 
 tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty1.ts
 semantic error: Bindings mismatch:
@@ -25451,9 +23443,6 @@ rebuilt        : ScopeId(0): ["p", "q", "x"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("E3")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["M1", "cls"]
-rebuilt        : ["E3", "M1"]
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
 semantic error: Bindings mismatch:
@@ -25508,16 +23497,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction1_es2017.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise", "someOtherFunction"]
-rebuilt        : ["someOtherFunction"]
-
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
 semantic error: Missing SymbolId: M
 Missing SymbolId: _M
@@ -25552,9 +23531,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("p")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["mp", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncUseStrict_es2017.ts
 semantic error: Bindings mismatch:
@@ -25566,9 +23542,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["a", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression1_es2017.ts
 semantic error: Bindings mismatch:
@@ -25580,9 +23553,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression2_es2017.ts
 semantic error: Bindings mismatch:
@@ -25594,9 +23564,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression3_es2017.ts
 semantic error: Bindings mismatch:
@@ -25608,9 +23575,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression4_es2017.ts
 semantic error: Bindings mismatch:
@@ -25622,9 +23586,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression5_es2017.ts
 semantic error: Bindings mismatch:
@@ -25633,9 +23594,6 @@ rebuilt        : ScopeId(0): ["func"]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("p")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression1_es2017.ts
 semantic error: Bindings mismatch:
@@ -25650,9 +23608,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression2_es2017.ts
 semantic error: Bindings mismatch:
@@ -25667,9 +23622,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression3_es2017.ts
 semantic error: Bindings mismatch:
@@ -25684,9 +23636,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression4_es2017.ts
 semantic error: Bindings mismatch:
@@ -25704,9 +23653,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "pfn"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression5_es2017.ts
 semantic error: Bindings mismatch:
@@ -25724,9 +23670,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression6_es2017.ts
 semantic error: Bindings mismatch:
@@ -25744,9 +23687,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression7_es2017.ts
 semantic error: Bindings mismatch:
@@ -25764,9 +23704,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression8_es2017.ts
 semantic error: Bindings mismatch:
@@ -25784,9 +23721,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "po"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitClassExpression_es2017.ts
 semantic error: Bindings mismatch:
@@ -25795,9 +23729,6 @@ rebuilt        : ScopeId(0): ["func"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["C", "Promise"]
-rebuilt        : ["p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
 semantic error: Bindings mismatch:
@@ -25806,39 +23737,6 @@ rebuilt        : ScopeId(0): ["f"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("a")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["a"]
-
-tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration11_es2017.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration14_es2017.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration1_es2017.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction1_es5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise", "someOtherFunction"]
-rebuilt        : ["someOtherFunction"]
-
-tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitNestedClasses_es5.ts
-semantic error: Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
 semantic error: Missing SymbolId: M
@@ -25874,9 +23772,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("p")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["mp", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncImportedPromise_es5.ts
 semantic error: Bindings mismatch:
@@ -25908,9 +23803,6 @@ rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Promise", "X"]
-rebuilt        : ["Promise"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncUseStrict_es5.ts
 semantic error: Bindings mismatch:
@@ -25922,9 +23814,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["a", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression1_es5.ts
 semantic error: Bindings mismatch:
@@ -25936,9 +23825,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression2_es5.ts
 semantic error: Bindings mismatch:
@@ -25950,9 +23836,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression3_es5.ts
 semantic error: Bindings mismatch:
@@ -25964,9 +23847,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression4_es5.ts
 semantic error: Bindings mismatch:
@@ -25978,9 +23858,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression5_es5.ts
 semantic error: Bindings mismatch:
@@ -25989,9 +23866,6 @@ rebuilt        : ScopeId(0): ["func"]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("p")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression1_es5.ts
 semantic error: Bindings mismatch:
@@ -26006,9 +23880,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression2_es5.ts
 semantic error: Bindings mismatch:
@@ -26023,9 +23894,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression3_es5.ts
 semantic error: Bindings mismatch:
@@ -26040,9 +23908,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression4_es5.ts
 semantic error: Bindings mismatch:
@@ -26060,9 +23925,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "pfn"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression5_es5.ts
 semantic error: Bindings mismatch:
@@ -26080,9 +23942,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression6_es5.ts
 semantic error: Bindings mismatch:
@@ -26100,9 +23959,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression7_es5.ts
 semantic error: Bindings mismatch:
@@ -26120,9 +23976,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression8_es5.ts
 semantic error: Bindings mismatch:
@@ -26140,9 +23993,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "po"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitClassExpression_es5.ts
 semantic error: Bindings mismatch:
@@ -26151,9 +24001,6 @@ rebuilt        : ScopeId(0): ["func"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["C", "Promise"]
-rebuilt        : ["p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitUnion_es5.ts
 semantic error: Bindings mismatch:
@@ -26174,42 +24021,11 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("e")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : ["a", "b", "c", "d", "e"]
-
-tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration11_es5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration14_es5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1_es5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType_es6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["PromiseAlias", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise", "someOtherFunction"]
-rebuilt        : ["someOtherFunction"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
 semantic error: Missing SymbolId: M
@@ -26245,9 +24061,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("p")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["mp", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncUseStrict_es6.ts
 semantic error: Bindings mismatch:
@@ -26259,9 +24072,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : ["a", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
 semantic error: Identifier `x` has already been declared
@@ -26276,9 +24086,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
 semantic error: Bindings mismatch:
@@ -26290,9 +24097,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
 semantic error: Bindings mismatch:
@@ -26304,9 +24108,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
 semantic error: Bindings mismatch:
@@ -26318,9 +24119,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("a")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
 semantic error: Bindings mismatch:
@@ -26329,9 +24127,6 @@ rebuilt        : ScopeId(0): ["func"]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("p")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["after", "before", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
 semantic error: Bindings mismatch:
@@ -26346,9 +24141,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
 semantic error: Bindings mismatch:
@@ -26363,9 +24155,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
 semantic error: Bindings mismatch:
@@ -26380,9 +24169,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before", "fn"]
-rebuilt        : ["a", "after", "before", "fn", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression4_es6.ts
 semantic error: Bindings mismatch:
@@ -26400,9 +24186,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "pfn"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression5_es6.ts
 semantic error: Bindings mismatch:
@@ -26420,9 +24203,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression6_es6.ts
 semantic error: Bindings mismatch:
@@ -26440,9 +24220,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
 semantic error: Bindings mismatch:
@@ -26460,9 +24237,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "o", "p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
 semantic error: Bindings mismatch:
@@ -26480,9 +24254,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("a")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Promise", "after", "before"]
-rebuilt        : ["a", "after", "before", "po"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitClassExpression_es6.ts
 semantic error: Bindings mismatch:
@@ -26491,9 +24262,6 @@ rebuilt        : ScopeId(0): ["func"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("p")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["C", "Promise"]
-rebuilt        : ["p"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitUnion_es6.ts
 semantic error: Bindings mismatch:
@@ -26514,32 +24282,11 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("e")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["PromiseLike"]
-rebuilt        : ["a", "b", "c", "d", "e"]
-
-tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "a"]
 rebuilt        : ScopeId(1): ["a"]
-Unresolved references mismatch:
-after transform: ["AsyncGenerator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
 semantic error: Missing SymbolId: M
@@ -26580,9 +24327,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/clas
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts
 semantic error: Bindings mismatch:
@@ -26600,16 +24344,6 @@ rebuilt        : SymbolId(1): [ReferenceId(4)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(11), ReferenceId(15)]
 rebuilt        : SymbolId(10): [ReferenceId(9)]
-
-tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/derivedTypeDoesNotRequireExtendsClause.ts
 semantic error: Symbol reference IDs mismatch:
@@ -26720,9 +24454,6 @@ rebuilt        : ScopeId(3): []
 Bindings mismatch:
 after transform: ScopeId(7): ["T"]
 rebuilt        : ScopeId(5): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithOptionalParameters.ts
 semantic error: Bindings mismatch:
@@ -26770,11 +24501,6 @@ Bindings mismatch:
 after transform: ScopeId(5): ["T"]
 rebuilt        : ScopeId(5): []
 
-tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithNoConstructorOrBaseClass.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "U"]
@@ -26818,14 +24544,6 @@ rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(6), ReferenceId(7), R
 Symbol reference IDs mismatch:
 after transform: SymbolId(13): [ReferenceId(14)]
 rebuilt        : SymbolId(13): []
-Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesIndexersWithAssignmentCompatibility.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers.ts
 semantic error: Symbol reference IDs mismatch:
@@ -26848,9 +24566,6 @@ rebuilt        : SymbolId(8): [ReferenceId(6), ReferenceId(15), ReferenceId(16),
 Symbol reference IDs mismatch:
 after transform: SymbolId(24): [ReferenceId(46)]
 rebuilt        : SymbolId(24): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPublicMembers.ts
 semantic error: Symbol reference IDs mismatch:
@@ -26865,9 +24580,6 @@ rebuilt        : SymbolId(8): [ReferenceId(6), ReferenceId(15), ReferenceId(16),
 Symbol reference IDs mismatch:
 after transform: SymbolId(24): [ReferenceId(46)]
 rebuilt        : SymbolId(24): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember2.ts
 semantic error: Bindings mismatch:
@@ -26886,11 +24598,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndSta
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
-
-tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Record", "console"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName2.ts
 semantic error: Symbol reference IDs mismatch:
@@ -26966,9 +24673,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AnyCtor", "Base", "MyClass", "Properties", "Types", "mine", "value"]
 rebuilt        : ScopeId(0): ["Base", "MyClass", "mine", "value"]
-Unresolved references mismatch:
-after transform: ["classWithProperties", "const"]
-rebuilt        : ["classWithProperties"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
 semantic error: Bindings mismatch:
@@ -26995,9 +24699,6 @@ rebuilt        : SymbolId(2): [ReferenceId(4)]
 Symbol redeclarations mismatch:
 after transform: SymbolId(8): [Span { start: 558, end: 579 }]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializationOrdering1.ts
 semantic error: Symbol reference IDs mismatch:
@@ -27031,9 +24732,6 @@ rebuilt        : ScopeId(4): []
 Bindings mismatch:
 after transform: ScopeId(7): ["T"]
 rebuilt        : ScopeId(7): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
 semantic error: Bindings mismatch:
@@ -27045,9 +24743,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("Mup")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Mup"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
 semantic error: Classes may not have a static property named prototype
@@ -27159,9 +24854,6 @@ rebuilt        : ScopeId(124): [SymbolId(78), SymbolId(79)]
 Scope flags mismatch:
 after transform: ScopeId(124): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(124): ScopeFlags(Function)
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisInInstanceMemberInitializer.ts
 semantic error: Bindings mismatch:
@@ -27213,14 +24905,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignm
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["D", "o", "obj", "x"]
 rebuilt        : ScopeId(0): ["o", "obj", "x"]
-Unresolved references mismatch:
-after transform: ["fn", "true"]
-rebuilt        : ["fn"]
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const", "f"]
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
 semantic error: Bindings mismatch:
@@ -27237,9 +24921,6 @@ rebuilt        : ScopeId(12): ["bar", "foo", "window"]
 Bindings mismatch:
 after transform: ScopeId(17): ["Window", "bar", "foo", "window"]
 rebuilt        : ScopeId(15): ["bar", "foo", "window"]
-Unresolved references mismatch:
-after transform: ["Error", "console", "const", "undefined"]
-rebuilt        : ["Error", "console", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowComputedPropertyNames.ts
 semantic error: Bindings mismatch:
@@ -27248,14 +24929,6 @@ rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4"]
 Bindings mismatch:
 after transform: ScopeId(12): ["K", "key", "obj"]
 rebuilt        : ScopeId(11): ["key", "obj"]
-Unresolved references mismatch:
-after transform: ["Record", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDoWhileStatement.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function", "RegExp", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
 semantic error: Bindings mismatch:
@@ -27279,19 +24952,11 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("config")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["config"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["TestTscCompile", "TestTscEdit", "VerifyTscEditDiscrepanciesInput", "testTscCompile", "verifyTscEditDiscrepancies"]
 rebuilt        : ScopeId(0): ["testTscCompile", "verifyTscEditDiscrepancies"]
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
 semantic error: Bindings mismatch:
@@ -27327,19 +24992,6 @@ rebuilt        : ReferenceId(9): None
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("c")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["c"]
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForOfStatement.ts
-semantic error: Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForStatement.ts
-semantic error: Unresolved references mismatch:
-after transform: ["RegExp", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
 semantic error: Bindings mismatch:
@@ -27354,9 +25006,6 @@ rebuilt        : ScopeId(12): ["data"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(15): [ReferenceId(29), ReferenceId(30)]
 rebuilt        : SymbolId(11): [ReferenceId(23)]
-Unresolved references mismatch:
-after transform: ["Error", "JSON", "RegExp"]
-rebuilt        : ["Error", "JSON"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
 semantic error: Bindings mismatch:
@@ -27398,14 +25047,6 @@ rebuilt        : ReferenceId(11): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("c")
 rebuilt        : ReferenceId(12): None
-Unresolved references mismatch:
-after transform: ["Error", "Number", "undefined"]
-rebuilt        : ["Error", "Number", "c", "undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceOfGuardPrimitives.ts
-semantic error: Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(11)]
-rebuilt        : [ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
 semantic error: Bindings mismatch:
@@ -27436,9 +25077,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("value")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["value"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTruthiness.ts
 semantic error: Bindings mismatch:
@@ -27464,20 +25102,11 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("obj")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["envVar", "obj"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(5): ["T", "fn", "promises"]
 rebuilt        : ScopeId(5): ["fn", "promises"]
-Unresolved references mismatch:
-after transform: ["Awaited", "Error", "Math", "Promise", "String", "const", "undefined"]
-rebuilt        : ["Error", "Math", "Promise", "String", "undefined"]
-Unresolved reference IDs mismatch for "Error":
-after transform: [ReferenceId(0), ReferenceId(4), ReferenceId(15), ReferenceId(22), ReferenceId(29)]
-rebuilt        : [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/switchWithConstrainedTypeVariable.ts
 semantic error: Bindings mismatch:
@@ -27502,9 +25131,6 @@ tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsNestedAs
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(16)]
 rebuilt        : SymbolId(0): [ReferenceId(11)]
-Unresolved references mismatch:
-after transform: ["Object", "RegExpExecArray", "getFooOrNull", "getStringOrNumberOrNull"]
-rebuilt        : ["getFooOrNull", "getStringOrNumberOrNull"]
 
 tasks/coverage/typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts
 semantic error: Bindings mismatch:
@@ -27525,36 +25151,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Array", "Boolean", "Date", "Error", "EvalError", "Function", "IArguments", "Infinity", "JSON", "Math", "NaN", "Number", "Object", "PropertyDescriptor", "PropertyDescriptorMap", "RangeError", "ReferenceError", "RegExp", "RegExpExecArray", "String", "SyntaxError", "T", "TypeError", "URIError"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "dec"]
@@ -27568,14 +25164,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function", "dec"]
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter5.ts
 semantic error: Bindings mismatch:
@@ -27584,9 +25172,6 @@ rebuilt        : ScopeId(0): ["BulkEditPreviewProvider"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("IFoo")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["IFoo"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedBlockScopedClass1.ts
 semantic error: Symbol reference IDs mismatch:
@@ -27613,9 +25198,6 @@ rebuilt        : ScopeId(0): ["Testing123"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Something"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsCommonJS2.ts
 semantic error: Bindings mismatch:
@@ -27624,9 +25206,6 @@ rebuilt        : ScopeId(0): ["Testing123"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Something"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsSystem1.ts
 semantic error: Bindings mismatch:
@@ -27635,9 +25214,6 @@ rebuilt        : ScopeId(0): ["Testing123"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Something"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassExportsSystem2.ts
 semantic error: Bindings mismatch:
@@ -27646,9 +25222,6 @@ rebuilt        : ScopeId(0): ["Testing123"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("Something")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Something"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassFromExternalModule.ts
 semantic error: Bindings mismatch:
@@ -27662,19 +25235,6 @@ rebuilt        : ScopeId(0): ["A", "B"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod14.ts
 semantic error: Bindings mismatch:
@@ -27683,9 +25243,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("decorator")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod15.ts
 semantic error: Bindings mismatch:
@@ -27694,9 +25251,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("decorator")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod16.ts
 semantic error: Bindings mismatch:
@@ -27705,9 +25259,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("decorator")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod18.ts
 semantic error: Bindings mismatch:
@@ -27716,9 +25267,6 @@ rebuilt        : ScopeId(0): ["Foo"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("decorator")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod19.ts
 semantic error: Bindings mismatch:
@@ -27736,60 +25284,16 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("decorator")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "dec"]
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter2.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Object", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
-semantic error: Unresolved references mismatch:
-after transform: ["PropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol", "decorator"]
-rebuilt        : ["Symbol"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata.ts
 semantic error: Bindings mismatch:
@@ -27801,9 +25305,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("decorator")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
 semantic error: Bindings mismatch:
@@ -27815,9 +25316,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("decorator")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
 semantic error: Missing SymbolId: Services
@@ -27839,11 +25337,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(1): []
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression2ES2020.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpression4ES2020.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "console"]
@@ -27857,14 +25350,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("console")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD4.ts
 semantic error: Bindings mismatch:
@@ -27888,19 +25373,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
 semantic error: Bindings mismatch:
@@ -27924,9 +25396,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsAMD.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -27942,11 +25411,6 @@ Please consider using `export default <value>;`, or add @babel/plugin-transform-
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
 semantic error: Cannot assign to 'arguments' in strict mode
-
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem4.ts
 semantic error: Bindings mismatch:
@@ -27970,14 +25434,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Promise"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInUMD4.ts
 semantic error: Bindings mismatch:
@@ -28001,9 +25457,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("console")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
 semantic error: Bindings mismatch:
@@ -28018,9 +25471,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("whatToLoad")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: ["Promise", "ValidSomeCondition", "getSpecifier"]
-rebuilt        : ["ValidSomeCondition", "directory", "getSpecifier", "moduleFile", "whatToLoad"]
 
 tasks/coverage/typescript/tests/cases/conformance/enums/enumBasics.ts
 semantic error: Bindings mismatch:
@@ -28133,9 +25583,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Export)
 Symbol redeclarations mismatch:
 after transform: SymbolId(0): [Span { start: 45, end: 52 }, Span { start: 78, end: 85 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Cat", "Dog"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
 semantic error: Missing SymbolId: M1
@@ -28382,9 +25829,6 @@ rebuilt        : ReferenceId(140): Some("A")
 Reference symbol mismatch:
 after transform: ReferenceId(14): Some("A")
 rebuilt        : ReferenceId(142): Some("A")
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Color"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
 semantic error: Bindings mismatch:
@@ -28400,18 +25844,10 @@ Symbol flags mismatch:
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
 
-tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Intl", "console", "const"]
-rebuilt        : ["Intl", "console"]
-
 tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisTypeIndexAccess.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["w_e"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["globalThis"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMeta.ts
 semantic error: The only valid meta property for import is import.meta
@@ -28421,16 +25857,6 @@ tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMetaNa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["global"]
 rebuilt        : ScopeId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
-semantic error: Unresolved reference IDs mismatch for "Intl":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-
-tasks/coverage/typescript/tests/cases/conformance/es2020/localesObjectArgument.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date", "Intl", "Readonly"]
-rebuilt        : ["Date", "Intl"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
 semantic error: Bindings mismatch:
@@ -28471,9 +25897,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("i")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment2.ts
 semantic error: Bindings mismatch:
@@ -28533,9 +25956,6 @@ rebuilt        : ReferenceId(16): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("result")
 rebuilt        : ReferenceId(17): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c", "result"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts
 semantic error: Bindings mismatch:
@@ -28559,9 +25979,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("result")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c", "result"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment9.ts
 semantic error: Bindings mismatch:
@@ -28573,17 +25990,9 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("x")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
 semantic error: Expected `,` but found `string`
-
-tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPIs.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Intl", "const"]
-rebuilt        : ["Intl"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
 semantic error: Bindings mismatch:
@@ -28592,9 +26001,6 @@ rebuilt        : ScopeId(0): ["C", "c", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.ts
 semantic error: Bindings mismatch:
@@ -28603,9 +26009,6 @@ rebuilt        : ScopeId(0): ["C", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty14.ts
 semantic error: Bindings mismatch:
@@ -28614,9 +26017,6 @@ rebuilt        : ScopeId(0): ["C", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty15.ts
 semantic error: Bindings mismatch:
@@ -28625,9 +26025,6 @@ rebuilt        : ScopeId(0): ["C", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["Symbol", "bar", "foo"]
-rebuilt        : ["bar", "foo"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty16.ts
 semantic error: Bindings mismatch:
@@ -28636,33 +26033,21 @@ rebuilt        : ScopeId(0): ["C", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "i"]
 rebuilt        : ScopeId(0): ["i"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5)]
-rebuilt        : [ReferenceId(0), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(9)]
-rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "I"]
 rebuilt        : ScopeId(0): ["C"]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty28.ts
 semantic error: Symbol reference IDs mismatch:
@@ -28673,27 +26058,11 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
-semantic error: Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
-semantic error: Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
 semantic error: Missing SymbolId: M
@@ -28757,9 +26126,6 @@ rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Unresolved references mismatch:
-after transform: ["Symbol", "SymbolConstructor"]
-rebuilt        : ["Symbol"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
 semantic error: Missing SymbolId: M
@@ -28785,17 +26151,11 @@ tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I2", "I3", "I4", "mySymbol"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
 semantic error: Bindings mismatch:
@@ -28845,9 +26205,6 @@ rebuilt        : ScopeId(0): ["Base", "D"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("Factory")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Factory"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression1.ts
 semantic error: Bindings mismatch:
@@ -29049,21 +26406,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "J"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TypedPropertyDescriptor", "dec"]
-rebuilt        : ["dec"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "dec"]
-rebuilt        : ["dec"]
-
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/declarationInAmbientContext.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "c", "d"]
@@ -29076,9 +26418,6 @@ rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4"]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("yadda")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["yadda"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES5.ts
 semantic error: Bindings mismatch:
@@ -29108,9 +26447,6 @@ rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4"]
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("yadda")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["yadda"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts
 semantic error: Bindings mismatch:
@@ -29129,9 +26465,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("v")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["v"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
 semantic error: Symbol reference IDs mismatch:
@@ -29153,11 +26486,6 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
-tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of57.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["X", "Y", "arr"]
@@ -29165,37 +26493,14 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("arr")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["arr"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration7_es6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T"]
 rebuilt        : ScopeId(2): []
 
-tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ClassDecorator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ClassDecorator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ClassDecorator"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJS.ts
 semantic error: 'with' statements are not allowed
-
-tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
-semantic error: Unresolved references mismatch:
-after transform: ["ClassDecorator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1-amd.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -29257,25 +26562,12 @@ rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("console")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["console"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts
-semantic error: Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModuleES6.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-
-tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray11.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall11.ts
 semantic error: Bindings mismatch:
@@ -29291,48 +26583,21 @@ tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateSt
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f", "x"]
 rebuilt        : ScopeId(0): ["f", "x"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f", "x"]
 rebuilt        : ScopeId(0): ["f", "x"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution2_ES6.ts
-semantic error: Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypedTags.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateStringsWithTypedTagsES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f"]
 rebuilt        : ScopeId(0): ["f"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplateUntypedTagCall01.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments1.ts
 semantic error: Bindings mismatch:
@@ -29344,14 +26609,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(34): Some("obj")
 rebuilt        : ReferenceId(14): None
-Unresolved references mismatch:
-after transform: ["Array", "TemplateStringsArray", "f", "g"]
-rebuilt        : ["f", "g", "obj"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
 semantic error: Missing SymbolId: M
@@ -29370,100 +26627,21 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch:
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck10.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck11.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck17.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck19.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck2.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck26.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck27.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck28.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator", "Symbol"]
-rebuilt        : ["Symbol"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable", "Iterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck3.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable", "Iterator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck38.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterator", "foo", "undefined"]
-rebuilt        : ["foo", "undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable", "Symbol", "foo", "undefined"]
-rebuilt        : ["Symbol", "foo", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
 semantic error: Bindings mismatch:
@@ -29472,9 +26650,6 @@ rebuilt        : ScopeId(0): ["Nothing1", "Nothing2", "Nothing3", "strategy"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "gen", "stratName"]
 rebuilt        : ScopeId(1): ["gen", "stratName"]
-Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnum.ts
 semantic error: Bindings mismatch:
@@ -29538,9 +26713,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("dec")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticPrivate.ts
 semantic error: Bindings mismatch:
@@ -29552,9 +26724,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("dec")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-static.ts
 semantic error: Bindings mismatch:
@@ -29578,9 +26747,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("dec")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-staticPrivate.ts
 semantic error: Bindings mismatch:
@@ -29595,9 +26761,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.1.ts
 semantic error: Bindings mismatch:
@@ -29606,9 +26769,6 @@ rebuilt        : ScopeId(0): ["C", "method"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.2.ts
 semantic error: Bindings mismatch:
@@ -29623,9 +26783,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.3.ts
 semantic error: Bindings mismatch:
@@ -29634,9 +26791,6 @@ rebuilt        : ScopeId(0): ["C", "x"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.4.ts
 semantic error: Bindings mismatch:
@@ -29645,9 +26799,6 @@ rebuilt        : ScopeId(0): ["C", "method"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.5.ts
 semantic error: Bindings mismatch:
@@ -29662,9 +26813,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("dec")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.6.ts
 semantic error: Bindings mismatch:
@@ -29673,9 +26821,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.es5.ts
 semantic error: Bindings mismatch:
@@ -29684,9 +26829,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.ts
 semantic error: Bindings mismatch:
@@ -29695,9 +26837,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commentPreservation.ts
 semantic error: Bindings mismatch:
@@ -29769,9 +26908,6 @@ rebuilt        : ReferenceId(20): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("dec")
 rebuilt        : ReferenceId(21): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
 semantic error: Missing SymbolId: _Example
@@ -29802,9 +26938,6 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("deco")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["deco"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
 semantic error: Bindings mismatch:
@@ -29813,9 +26946,6 @@ rebuilt        : ScopeId(0): ["Example"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("deco")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["deco"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-multipleDecorators.ts
 semantic error: Bindings mismatch:
@@ -29827,9 +26957,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("dec2")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec1", "dec2"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-outerThisReference.ts
 semantic error: Bindings mismatch:
@@ -29862,9 +26989,6 @@ rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("dec")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-parameterProperties.ts
 semantic error: Bindings mismatch:
@@ -29873,9 +26997,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("bound")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["bound"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-setFunctionName.ts
 semantic error: Bindings mismatch:
@@ -29884,9 +27005,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-simpleTransformation.ts
 semantic error: Bindings mismatch:
@@ -29895,9 +27013,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStatic.ts
 semantic error: Bindings mismatch:
@@ -29912,9 +27027,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAccessor.ts
 semantic error: Bindings mismatch:
@@ -29929,9 +27041,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivate.ts
 semantic error: Bindings mismatch:
@@ -29940,9 +27049,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivateAccessor.ts
 semantic error: Bindings mismatch:
@@ -29951,9 +27057,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-static.ts
 semantic error: Bindings mismatch:
@@ -29968,9 +27071,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAccessor.ts
 semantic error: Bindings mismatch:
@@ -29988,9 +27088,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("dec")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivate.ts
 semantic error: Bindings mismatch:
@@ -30002,9 +27099,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("dec")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts
 semantic error: Bindings mismatch:
@@ -30016,9 +27110,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("dec")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStatic.ts
 semantic error: Bindings mismatch:
@@ -30033,9 +27124,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticPrivate.ts
 semantic error: Bindings mismatch:
@@ -30044,9 +27132,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-static.ts
 semantic error: Bindings mismatch:
@@ -30061,9 +27146,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-staticPrivate.ts
 semantic error: Bindings mismatch:
@@ -30075,9 +27157,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("dec")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.1.ts
 semantic error: Bindings mismatch:
@@ -30086,9 +27165,6 @@ rebuilt        : ScopeId(0): ["method"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.2.ts
 semantic error: Bindings mismatch:
@@ -30103,9 +27179,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("dec")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.3.ts
 semantic error: Bindings mismatch:
@@ -30114,9 +27187,6 @@ rebuilt        : ScopeId(0): ["x"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.4.ts
 semantic error: Bindings mismatch:
@@ -30125,9 +27195,6 @@ rebuilt        : ScopeId(0): ["method"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.5.ts
 semantic error: Bindings mismatch:
@@ -30142,9 +27209,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("dec")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.6.ts
 semantic error: Bindings mismatch:
@@ -30153,9 +27217,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Base"]
-rebuilt        : ["Base", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
 semantic error: Bindings mismatch:
@@ -30227,9 +27288,6 @@ rebuilt        : ReferenceId(20): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("dec")
 rebuilt        : ReferenceId(21): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.1.ts
 semantic error: Bindings mismatch:
@@ -30259,9 +27317,6 @@ rebuilt        : ReferenceId(13): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("dec")
 rebuilt        : ReferenceId(15): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.10.ts
 semantic error: Bindings mismatch:
@@ -30327,9 +27382,6 @@ rebuilt        : ReferenceId(18): None
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("dec")
 rebuilt        : ReferenceId(19): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.11.ts
 semantic error: Bindings mismatch:
@@ -30347,9 +27399,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("dec")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.2.ts
 semantic error: Bindings mismatch:
@@ -30400,9 +27449,6 @@ rebuilt        : ReferenceId(15): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("dec")
 rebuilt        : ReferenceId(16): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.3.ts
 semantic error: Bindings mismatch:
@@ -30426,9 +27472,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("dec")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.4.ts
 semantic error: Bindings mismatch:
@@ -30470,9 +27513,6 @@ rebuilt        : ReferenceId(10): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("obj")
 rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec", "obj"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.5.ts
 semantic error: Bindings mismatch:
@@ -30496,9 +27536,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("obj")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec", "obj", "x"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.6.ts
 semantic error: Bindings mismatch:
@@ -30522,9 +27559,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("obj")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec", "obj", "x"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.7.ts
 semantic error: Bindings mismatch:
@@ -30548,9 +27582,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("obj")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec", "obj", "x"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.8.ts
 semantic error: Bindings mismatch:
@@ -30559,9 +27590,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.9.ts
 semantic error: `export = <value>;` is only supported when compiling modules to CommonJS.
@@ -30571,9 +27599,6 @@ tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-cont
 semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["Args", "Return", "This", "bound", "source"]
 rebuilt        : ScopeId(4): ["bound", "source"]
-Unresolved references mismatch:
-after transform: ["ClassMethodDecoratorContext", "console"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.1.ts
 semantic error: Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -30660,9 +27685,6 @@ rebuilt        : ReferenceId(24): None
 Reference symbol mismatch:
 after transform: ReferenceId(25): Some("x")
 rebuilt        : ReferenceId(25): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["g", "h", "x"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.3.ts
 semantic error: Bindings mismatch:
@@ -30674,9 +27696,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("g")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["g"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-preservesThis.ts
 semantic error: Bindings mismatch:
@@ -30691,12 +27710,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("instance")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["DecoratorContext", "DecoratorProvider"]
-rebuilt        : ["DecoratorProvider", "instance"]
-Unresolved reference IDs mismatch for "DecoratorProvider":
-after transform: [ReferenceId(0), ReferenceId(4), ReferenceId(8)]
-rebuilt        : [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata5.ts
 semantic error: Bindings mismatch:
@@ -30705,9 +27718,6 @@ rebuilt        : ScopeId(0): ["C"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("metadata")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["metadata"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
 semantic error: Bindings mismatch:
@@ -30734,28 +27744,16 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | Export)
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(2): [ReferenceId(23), ReferenceId(24), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31)]
-Unresolved references mismatch:
-after transform: ["Array", "Map", "foo"]
-rebuilt        : ["Map", "foo"]
-Unresolved reference IDs mismatch for "Map":
-after transform: [ReferenceId(0), ReferenceId(4)]
-rebuilt        : [ReferenceId(21)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "myArray", "myArray2", "temp", "temp1", "temp2", "temp3", "temp4"]
 rebuilt        : ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "temp", "temp1", "temp2", "temp3", "temp4"]
-Unresolved references mismatch:
-after transform: ["Array", "Number", "String", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "myArray", "myArray2", "temp", "temp1", "temp2"]
 rebuilt        : ScopeId(0): ["a0", "a1", "a2", "a3", "a4", "a5", "b0", "b1", "c0", "c1", "c2", "c3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "temp", "temp1", "temp2"]
-Unresolved references mismatch:
-after transform: ["Array", "Number", "String", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOpEmitParens.ts
 semantic error: Bindings mismatch:
@@ -30770,9 +27768,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("x")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts
 semantic error: Bindings mismatch:
@@ -30783,9 +27778,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["AOrArrA", "a", "arr", "x"]
 rebuilt        : ScopeId(0): ["a", "arr", "x"]
-Unresolved references mismatch:
-after transform: ["RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithAnyAndEveryType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -30797,9 +27789,6 @@ rebuilt        : ScopeId(1): ["k", "n", "v"]
 Bindings mismatch:
 after transform: ScopeId(2): ["K", "T", "k", "n", "vs"]
 rebuilt        : ScopeId(2): ["k", "n", "vs"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNumberAndEnum.ts
 semantic error: Bindings mismatch:
@@ -30840,9 +27829,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(31), ReferenceId(33), ReferenceId(45)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(37), ReferenceId(39)]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnum.ts
 semantic error: Bindings mismatch:
@@ -30903,9 +27889,6 @@ rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(7): [ReferenceId(13)]
 rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -30966,9 +27949,6 @@ rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(34), ReferenceId(266)]
 rebuilt        : SymbolId(1): [ReferenceId(7)]
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeEnumAndNumber.ts
 semantic error: Bindings mismatch:
@@ -31049,24 +28029,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(9)]
 rebuilt        : SymbolId(5): []
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
-semantic error: Unresolved reference IDs mismatch for "StaticToString":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(1)]
-Unresolved reference IDs mismatch for "StaticToNumber":
-after transform: [ReferenceId(3), ReferenceId(5)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "NormalToString":
-after transform: [ReferenceId(6), ReferenceId(8)]
-rebuilt        : [ReferenceId(5)]
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Function", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -31542,20 +28508,11 @@ rebuilt        : ReferenceId(184): None
 Reference symbol mismatch:
 after transform: ReferenceId(259): Some("lhs0")
 rebuilt        : ReferenceId(185): None
-Unresolved references mismatch:
-after transform: ["A", "B", "Rhs10", "Rhs11", "Rhs12", "Rhs13", "Rhs7", "Rhs8", "Rhs9", "Symbol", "globalThis", "true"]
-rebuilt        : ["A", "B", "Rhs10", "Rhs11", "Rhs12", "Rhs13", "Rhs7", "Rhs8", "Rhs9", "lhs0", "lhs1", "lhs2", "lhs3", "lhs4", "obj", "rhs0", "rhs1", "rhs14", "rhs15", "rhs2", "rhs3", "rhs4", "rhs5", "rhs6"]
-Unresolved reference IDs mismatch for "A":
-after transform: [ReferenceId(237), ReferenceId(239)]
-rebuilt        : [ReferenceId(175)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSIsSubtypeOfFunction.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "f1", "f2", "f3", "f4", "r1", "r2", "r3", "r4", "r5", "r6", "x"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "r1", "r2", "r3", "r4", "r5", "r6", "x"]
-Unresolved references mismatch:
-after transform: ["Function", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithTypeParameters.ts
 semantic error: Bindings mismatch:
@@ -31577,56 +28534,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/comm
 semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["T1", "T2", "resultIsT1", "x", "y"]
 rebuilt        : ScopeId(4): ["resultIsT1", "x", "y"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandAnyType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandBooleanType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandNumberType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandObjectType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : ["Date"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandStringType.ts
-semantic error: Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(29), ReferenceId(38)]
-rebuilt        : [ReferenceId(28), ReferenceId(37)]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorsMultipleOperators.ts
-semantic error: Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(33), ReferenceId(36)]
-rebuilt        : [ReferenceId(32), ReferenceId(35)]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsBooleanType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsNumberType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsAnyType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditoinIsStringType.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorWithIdenticalBCT.ts
 semantic error: Symbol reference IDs mismatch:
@@ -31664,9 +28571,6 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(1)]
 rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Number"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/generatedContextualTyping.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -31682,18 +28586,10 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/iterableContextualTyping1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["T", "g", "tempStrs", "x"]
 rebuilt        : ScopeId(1): ["g", "tempStrs", "x"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping1.ts
 semantic error: Bindings mismatch:
@@ -31721,17 +28617,11 @@ rebuilt        : ScopeId(6): ["y"]
 Bindings mismatch:
 after transform: ScopeId(10): ["T", "x"]
 rebuilt        : ScopeId(7): ["x"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined", "x"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/taggedTemplateContextualTyping2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["FuncType1", "FuncType2", "tempTag2"]
 rebuilt        : ScopeId(0): ["tempTag2"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray", "undefined", "x"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/elementAccess/stringEnumInElementAccess01.ts
 semantic error: Bindings mismatch:
@@ -31755,25 +28645,16 @@ rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("e")
 rebuilt        : ReferenceId(6): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["e", "item"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpread.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "X", "a", "foo", "obj", "xa", "z"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "foo", "obj", "xa", "z"]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/callWithSpreadES6.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "X", "a", "foo", "obj", "xa", "z"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "foo", "obj", "xa", "z"]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpread.ts
 semantic error: Bindings mismatch:
@@ -31803,9 +28684,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/type
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "C", "a", "b", "c"]
 rebuilt        : ScopeId(1): ["a", "b", "c"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
 semantic error: Missing SymbolId: M
@@ -31829,9 +28707,6 @@ rebuilt        : ScopeId(0): ["gg"]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("o")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: ["g"]
-rebuilt        : ["g", "o"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
 semantic error: Bindings mismatch:
@@ -31914,9 +28789,6 @@ rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("d4")
 rebuilt        : ReferenceId(15): None
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : ["a1", "a2", "a3", "a4", "b1", "b2", "b3", "b4", "c1", "c2", "c3", "c4", "d1", "d2", "d3", "d4", "foo"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator2.ts
 semantic error: Bindings mismatch:
@@ -31949,9 +28821,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("a9")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator3.ts
 semantic error: Bindings mismatch:
@@ -31975,9 +28844,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(6): Some("a6")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["a1", "a2", "a3", "a4", "a5", "a6"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator7.ts
 semantic error: Bindings mismatch:
@@ -32007,9 +28873,6 @@ rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("c")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator8.ts
 semantic error: Bindings mismatch:
@@ -32030,9 +28893,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("b")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator9.ts
 semantic error: Bindings mismatch:
@@ -32044,9 +28904,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("f")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["f"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator_es2020.ts
 semantic error: Bindings mismatch:
@@ -32187,9 +29044,6 @@ rebuilt        : ReferenceId(43): None
 Reference symbol mismatch:
 after transform: ReferenceId(45): Some("b")
 rebuilt        : ReferenceId(44): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["a", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator_not_strict.ts
 semantic error: Bindings mismatch:
@@ -32222,17 +29076,11 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(9): Some("a9")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: ["true"]
-rebuilt        : ["a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(30): [ReferenceId(11)]
 rebuilt        : SymbolId(30): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.2.ts
 semantic error: Bindings mismatch:
@@ -32247,9 +29095,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("o3")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o1", "o2", "o3"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.ts
 semantic error: Bindings mismatch:
@@ -32339,9 +29184,6 @@ rebuilt        : ReferenceId(27): None
 Reference symbol mismatch:
 after transform: ReferenceId(31): Some("o2")
 rebuilt        : ReferenceId(28): None
-Unresolved references mismatch:
-after transform: ["incr"]
-rebuilt        : ["incr", "o1", "o2", "o3", "o4", "o5"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainInference.ts
 semantic error: Bindings mismatch:
@@ -32356,9 +29198,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("value")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["value"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/parentheses.ts
 semantic error: Bindings mismatch:
@@ -32388,9 +29227,6 @@ rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("o1")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o1", "o2", "o3", "o4"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.2.ts
 semantic error: Bindings mismatch:
@@ -32411,9 +29247,6 @@ rebuilt        : ReferenceId(3): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("o3")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o1", "o2", "o3"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.ts
 semantic error: Bindings mismatch:
@@ -32467,9 +29300,6 @@ rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("o2")
 rebuilt        : ReferenceId(15): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o1", "o2", "o3", "o4", "o5", "o6"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInference.ts
 semantic error: Bindings mismatch:
@@ -32499,9 +29329,6 @@ rebuilt        : ReferenceId(18): None
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("ofnu")
 rebuilt        : ReferenceId(21): None
-Unresolved references mismatch:
-after transform: ["unbox"]
-rebuilt        : ["fnu", "ofnu", "osu", "su", "unbox"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.2.ts
 semantic error: Bindings mismatch:
@@ -32516,9 +29343,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("o3")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o1", "o2", "o3"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.ts
 semantic error: Bindings mismatch:
@@ -32551,9 +29375,6 @@ rebuilt        : ReferenceId(7): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("o2")
 rebuilt        : ReferenceId(8): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o1", "o2", "o3", "o4", "o5", "o6"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
 semantic error: Bindings mismatch:
@@ -32634,9 +29455,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "Beast", "Legged", "Winged", "X", "Y", "Z", "beastFoo", "f1", "hasLegs", "hasWings", "identifyBeast", "isB", "union"]
 rebuilt        : ScopeId(0): ["beastFoo", "f1", "hasLegs", "hasWings", "identifyBeast", "isB", "union"]
-Unresolved references mismatch:
-after transform: ["Object", "isX", "isY", "isZ", "log"]
-rebuilt        : ["isX", "isY", "isZ", "log"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsPrimitiveIntersection.ts
 semantic error: Bindings mismatch:
@@ -32661,11 +29479,6 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGua
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(19)]
 rebuilt        : SymbolId(6): []
-
-tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "isString1", "isString2"]
-rebuilt        : ["isString1", "isString2"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOf.ts
 semantic error: Symbol reference IDs mismatch:
@@ -32717,9 +29530,6 @@ rebuilt        : ScopeId(22): ["keys", "obj"]
 Bindings mismatch:
 after transform: ScopeId(25): ["S", "reducer", "rootReducer"]
 rebuilt        : ScopeId(25): ["reducer", "rootReducer"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNumber.ts
 semantic error: Symbol reference IDs mismatch:
@@ -32759,9 +29569,6 @@ rebuilt        : SymbolId(23): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(28): [ReferenceId(39)]
 rebuilt        : SymbolId(28): []
-Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
 semantic error: Missing SymbolId: m
@@ -32836,11 +29643,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_asConstArrays.ts
-semantic error: Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Predicates", "p"]
@@ -32850,17 +29652,11 @@ tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/t
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["StringOrNumberFunc", "fn", "obj", "obj2"]
 rebuilt        : ScopeId(0): ["fn", "obj", "obj2"]
-Unresolved references mismatch:
-after transform: ["Function"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_ensureInterfaceImpl.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Movable", "car"]
 rebuilt        : ScopeId(0): ["car"]
-Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance1.ts
 semantic error: Bindings mismatch:
@@ -33087,9 +29883,6 @@ rebuilt        : SymbolId(12): []
 Symbol flags mismatch:
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable | ConstVariable)
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["N"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target5.ts
 semantic error: Bindings mismatch:
@@ -33216,9 +30009,6 @@ rebuilt        : SymbolId(12): []
 Symbol flags mismatch:
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable | ConstVariable)
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["N"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target5.ts
 semantic error: Bindings mismatch:
@@ -33378,9 +30168,6 @@ rebuilt        : ScopeId(0): ["C", "C1", "C2", "C3", "x", "y"]
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("dec")
 rebuilt        : ReferenceId(11): None
-Unresolved references mismatch:
-after transform: ["f"]
-rebuilt        : ["dec", "f"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
 semantic error: Cannot use `await` as an identifier in an async context
@@ -33401,9 +30188,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/ambie
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "ns"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/cjsImportInES2015.ts
 semantic error: Bindings mismatch:
@@ -33427,9 +30211,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/expor
 semantic error: Symbol flags mismatch:
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable)
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/implementsClause.ts
 semantic error: Bindings mismatch:
@@ -33526,25 +30307,10 @@ semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
-tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-2.ts
-semantic error: Unresolved reference IDs mismatch for "Math2d":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-
 tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-3.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-4.ts
-semantic error: Unresolved reference IDs mismatch for "Math2d":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-
-tasks/coverage/typescript/tests/cases/conformance/externalModules/umd1.ts
-semantic error: Unresolved reference IDs mismatch for "Foo":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/umd3.ts
 semantic error: Symbol reference IDs mismatch:
@@ -33590,22 +30356,11 @@ rebuilt        : ScopeId(0): ["fb", "fn"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
-Unresolved references mismatch:
-after transform: ["ThisParameterType"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
-semantic error: Unresolved references mismatch:
-after transform: ["IterableIterator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "f1"]
 rebuilt        : ScopeId(0): ["f1"]
-Unresolved references mismatch:
-after transform: ["Iterator"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
 semantic error: Missing SymbolId: _Directive
@@ -33675,9 +30430,6 @@ rebuilt        : SymbolId(19): [ReferenceId(25), ReferenceId(27)]
 Reference symbol mismatch:
 after transform: ReferenceId(90): Some("StepResult")
 rebuilt        : ReferenceId(31): Some("StepResult")
-Unresolved references mismatch:
-after transform: ["AsyncGenerator", "Generator", "Partial", "Record", "Symbol", "f1", "f2"]
-rebuilt        : ["Symbol", "f1", "f2"]
 
 tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes7.ts
 semantic error: Bindings mismatch:
@@ -34004,17 +30756,11 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(8)]
 rebuilt        : SymbolId(3): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "b", "c", "d", "r", "r2", "r3"]
 rebuilt        : ScopeId(0): ["b", "c", "d", "r", "r2", "r3"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
 semantic error: Missing SymbolId: G
@@ -34055,9 +30801,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclaratio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C20", "C21", "C22", "C23", "C3", "C4", "C5", "C6", "C7", "Constructor", "EX", "I1", "I10", "I11", "I12", "I13", "I2", "I20", "I21", "I22", "I23", "I3", "I4", "I5", "I6", "I7", "Identifiable", "NX", "T1", "T10", "T11", "T12", "T13", "T2", "T3", "T4", "T5", "T6", "T7"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C20", "C21", "C22", "C23", "C3", "C4", "C5", "C6", "C7"]
-Unresolved references mismatch:
-after transform: ["CX", "Constructor", "NX", "Partial", "Readonly", "fx"]
-rebuilt        : ["Constructor"]
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty.ts
 semantic error: Bindings mismatch:
@@ -34093,9 +30836,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclaratio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f", "r1", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["f", "r1", "r2", "r3", "r4"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -34104,9 +30844,6 @@ tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclaratio
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "f", "r", "r2", "r3", "r4"]
 rebuilt        : ScopeId(0): ["f", "r", "r2", "r3", "r4"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClass.ts
 semantic error: Bindings mismatch:
@@ -34115,9 +30852,6 @@ rebuilt        : ScopeId(0): ["Foo", "f", "i", "r1", "r2", "r3"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(6)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
 semantic error: Missing SymbolId: A
@@ -34444,17 +31178,11 @@ rebuilt        : SymbolId(13): SymbolFlags(Class)
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): []
 rebuilt        : SymbolId(13): [ReferenceId(9)]
-Unresolved references mismatch:
-after transform: ["A", "X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "X", "l", "p"]
 rebuilt        : ScopeId(0): ["l", "p"]
-Unresolved references mismatch:
-after transform: ["A", "X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -34463,9 +31191,6 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMer
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "X", "l", "p"]
 rebuilt        : ScopeId(0): ["l", "p"]
-Unresolved references mismatch:
-after transform: ["A", "X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedModulesOfTheSameName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -34844,9 +31569,6 @@ rebuilt        : SymbolId(13): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("moduleA")
 rebuilt        : ReferenceId(6): Some("moduleA")
-Unresolved references mismatch:
-after transform: ["fundule", "moduleA"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleBody/moduleWithStatementsOfEveryKind.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -34889,9 +31611,6 @@ rebuilt        : ScopeId(0): ["test1", "test2"]
 Symbol flags mismatch:
 after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | ConstVariable | Export)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable)
-Unresolved references mismatch:
-after transform: ["mod1", "mod2", "pack1", "pack2"]
-rebuilt        : ["mod2", "pack2"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
 semantic error: Cannot use export statement outside a module
@@ -34973,11 +31692,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["LoadCallback"]
 rebuilt        : ScopeId(0): []
 
-tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocTypeTag.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Function", "Promise"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/overloadTag3.ts
 semantic error: Cannot use export statement outside a module
 
@@ -35001,12 +31715,6 @@ rebuilt        : ScopeId(0): ["Comp", "React", "_jsxFileName", "_reactJsxRuntime
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(18)]
 rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(21)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
 semantic error: Bindings mismatch:
@@ -35042,9 +31750,6 @@ rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(7): Some("React")
 rebuilt        : ReferenceId(12): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(19)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 semantic error: Missing SymbolId: React
@@ -35052,15 +31757,6 @@ Missing ReferenceId: require
 Bindings mismatch:
 after transform: ScopeId(0): ["Props", "React", "Test", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["React", "Test", "_jsxFileName", "_reactJsxRuntime"]
-Unresolved references mismatch:
-after transform: ["Foo", "JSX", "require", "true"]
-rebuilt        : ["Foo", "require"]
-Unresolved reference IDs mismatch for "Foo":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(15), ReferenceId(18)]
-rebuilt        : [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(23)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
 semantic error: Missing SymbolId: React
@@ -35074,12 +31770,6 @@ rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(20)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
 semantic error: Missing SymbolId: React
@@ -35099,12 +31789,6 @@ rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29)
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(59)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
 semantic error: Missing SymbolId: React
@@ -35124,12 +31808,6 @@ rebuilt        : SymbolId(6): [ReferenceId(11), ReferenceId(20), ReferenceId(29)
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(59)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
 semantic error: Missing SymbolId: React
@@ -35137,9 +31815,6 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(15)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 semantic error: Bindings mismatch:
@@ -35151,9 +31826,6 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(4)]
-Unresolved references mismatch:
-after transform: ["Component", "Readonly", "require"]
-rebuilt        : ["Component", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
 semantic error: Bindings mismatch:
@@ -35165,9 +31837,6 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(12), ReferenceId(16)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
-Unresolved references mismatch:
-after transform: ["Exclude", "Promise", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxUnionSFXContextualTypeInferredCorrectly.tsx
 semantic error: Bindings mismatch:
@@ -35176,9 +31845,6 @@ rebuilt        : ScopeId(0): ["ComponentWithUnion", "HereIsTheError", "React", "
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(3), ReferenceId(6), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(7)]
-Unresolved references mismatch:
-after transform: ["console", "true"]
-rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
 semantic error: Missing SymbolId: React
@@ -35186,9 +31852,6 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
 semantic error: Bindings mismatch:
@@ -35210,9 +31873,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("React")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 semantic error: Bindings mismatch:
@@ -35299,9 +31959,6 @@ rebuilt        : ReferenceId(97): None
 Reference symbol mismatch:
 after transform: ReferenceId(32): Some("z")
 rebuilt        : ReferenceId(98): None
-Unresolved references mismatch:
-after transform: ["require"]
-rebuilt        : ["Child", "Component", "Composite", "Composite2", "Namespace", "bar", "foo", "require", "y", "z"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
 semantic error: Bindings mismatch:
@@ -35330,9 +31987,6 @@ rebuilt        : SymbolId(3): [ReferenceId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
 semantic error: Bindings mismatch:
@@ -35346,12 +32000,6 @@ rebuilt        : ScopeId(0): ["ShortDetails", "_jsxFileName"]
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("React")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["JSX", "React"]
-rebuilt        : ["React"]
-Unresolved reference IDs mismatch for "React":
-after transform: [ReferenceId(2)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
 semantic error: Missing SymbolId: React
@@ -35365,9 +32013,6 @@ rebuilt        : SymbolId(3): [ReferenceId(6)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
 semantic error: Missing SymbolId: React
@@ -35381,12 +32026,6 @@ rebuilt        : SymbolId(3): [ReferenceId(6)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["require", "true"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName1.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -35401,11 +32040,6 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
 
-tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName5.tsx
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "foo", "t"]
@@ -35413,16 +32047,6 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "foo", "t"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
-
-tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName8.tsx
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName9.tsx
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
 semantic error: Missing SymbolId: Dotted
@@ -35536,9 +32160,6 @@ rebuilt        : ReferenceId(36): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("__proto__")
 rebuilt        : ReferenceId(37): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React", "__proto__"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit1.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -35561,9 +32182,6 @@ rebuilt        : ReferenceId(4): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("Foo")
 rebuilt        : ReferenceId(5): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Foo", "React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 semantic error: Bindings mismatch:
@@ -35640,9 +32258,6 @@ rebuilt        : ReferenceId(26): None
 Reference symbol mismatch:
 after transform: ReferenceId(26): Some("React")
 rebuilt        : ReferenceId(27): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType1.tsx
 semantic error: Missing SymbolId: React
@@ -35668,9 +32283,6 @@ rebuilt        : SymbolId(7): [ReferenceId(7)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(18), ReferenceId(20), ReferenceId(27)]
 rebuilt        : SymbolId(10): [ReferenceId(11)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(30)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
 semantic error: Missing SymbolId: React
@@ -35684,9 +32296,6 @@ rebuilt        : ScopeId(1): ["Component"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(7)]
 rebuilt        : SymbolId(4): [ReferenceId(3)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
 semantic error: Missing SymbolId: React
@@ -35709,9 +32318,6 @@ rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
 semantic error: Missing SymbolId: React
@@ -35734,9 +32340,6 @@ rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
 semantic error: Missing SymbolId: React
@@ -35759,9 +32362,6 @@ rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
 semantic error: Missing SymbolId: React
@@ -35784,9 +32384,6 @@ rebuilt        : ReferenceId(2): Some("React")
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(5): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(11)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
 semantic error: Missing SymbolId: React
@@ -35800,15 +32397,6 @@ rebuilt        : ScopeId(1): ["props"]
 Bindings mismatch:
 after transform: ScopeId(3): ["U", "props"]
 rebuilt        : ScopeId(2): ["props"]
-Unresolved references mismatch:
-after transform: ["Component", "JSX", "require"]
-rebuilt        : ["Component", "require"]
-Unresolved reference IDs mismatch for "Component":
-after transform: [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : [ReferenceId(3), ReferenceId(7)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
 semantic error: Missing SymbolId: React
@@ -35822,15 +32410,6 @@ rebuilt        : ScopeId(1): ["props"]
 Bindings mismatch:
 after transform: ScopeId(3): ["U", "props"]
 rebuilt        : ScopeId(2): ["props"]
-Unresolved references mismatch:
-after transform: ["Component", "JSX", "require"]
-rebuilt        : ["Component", "require"]
-Unresolved reference IDs mismatch for "Component":
-after transform: [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-rebuilt        : [ReferenceId(3), ReferenceId(7)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(14)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
 semantic error: Missing SymbolId: React
@@ -35847,12 +32426,6 @@ rebuilt        : SymbolId(4): [ReferenceId(4)]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(9)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 semantic error: Bindings mismatch:
@@ -35880,9 +32453,6 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("A")
 rebuilt        : ReferenceId(2): None
-Unresolved reference IDs mismatch for "A":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
 semantic error: Bindings mismatch:
@@ -35917,12 +32487,6 @@ Missing ReferenceId: require
 Bindings mismatch:
 after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x"]
-Unresolved reference IDs mismatch for "MyComp":
-after transform: [ReferenceId(4), ReferenceId(5)]
-rebuilt        : [ReferenceId(3)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
 semantic error: Missing SymbolId: React
@@ -35930,12 +32494,6 @@ Missing ReferenceId: require
 Bindings mismatch:
 after transform: ScopeId(0): ["Prop", "React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
 rebuilt        : ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime", "x", "x1"]
-Unresolved reference IDs mismatch for "MyComp":
-after transform: [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9)]
-rebuilt        : [ReferenceId(3), ReferenceId(6)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 semantic error: Bindings mismatch:
@@ -36004,9 +32562,6 @@ rebuilt        : ReferenceId(52): None
 Reference symbol mismatch:
 after transform: ReferenceId(57): Some("React")
 rebuilt        : ReferenceId(55): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit2.tsx
 semantic error: Bindings mismatch:
@@ -36027,9 +32582,6 @@ rebuilt        : ReferenceId(13): None
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("React")
 rebuilt        : ReferenceId(18): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit3.tsx
 semantic error: Bindings mismatch:
@@ -36065,9 +32617,6 @@ rebuilt        : ReferenceId(12): None
 Reference symbol mismatch:
 after transform: ReferenceId(19): Some("Bar")
 rebuilt        : ReferenceId(13): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Bar", "Foo", "React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit5.tsx
 semantic error: Bindings mismatch:
@@ -36107,9 +32656,6 @@ rebuilt        : ReferenceId(12): None
 Reference symbol mismatch:
 after transform: ReferenceId(15): Some("React")
 rebuilt        : ReferenceId(14): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
 semantic error: Bindings mismatch:
@@ -36126,9 +32672,6 @@ rebuilt        : ReferenceId(35): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("__proto__")
 rebuilt        : ReferenceId(40): None
-Unresolved references mismatch:
-after transform: ["require"]
-rebuilt        : ["__proto__", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
 semantic error: Bindings mismatch:
@@ -36167,9 +32710,6 @@ rebuilt        : ReferenceId(21): None
 Reference symbol mismatch:
 after transform: ReferenceId(24): Some("React")
 rebuilt        : ReferenceId(23): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.tsx
 semantic error: Bindings mismatch:
@@ -36193,9 +32733,6 @@ rebuilt        : ReferenceId(8): None
 Reference symbol mismatch:
 after transform: ReferenceId(10): Some("React")
 rebuilt        : ReferenceId(10): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["React"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
 semantic error: Missing SymbolId: React
@@ -36209,9 +32746,6 @@ rebuilt        : SymbolId(3): [ReferenceId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(5): [ReferenceId(6)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
 semantic error: Missing SymbolId: React
@@ -36225,9 +32759,6 @@ rebuilt        : SymbolId(3): [ReferenceId(3)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(5): [ReferenceId(6)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(8)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
 semantic error: Missing SymbolId: React
@@ -36241,9 +32772,6 @@ rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
 semantic error: Missing SymbolId: React
@@ -36257,12 +32785,6 @@ rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(11), ReferenceId(16),
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["require", "true"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(37)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
 semantic error: Missing SymbolId: React
@@ -36273,9 +32795,6 @@ rebuilt        : ScopeId(0): ["ChildComponent", "Component", "React", "_jsxFileN
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(11)]
 rebuilt        : SymbolId(6): [ReferenceId(4), ReferenceId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
 semantic error: Missing SymbolId: React
@@ -36286,9 +32805,6 @@ rebuilt        : ScopeId(0): ["AnotherComponent", "Component", "React", "_jsxFil
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(5): [ReferenceId(3)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(10)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
 semantic error: Missing SymbolId: React
@@ -36302,9 +32818,6 @@ rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(13)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
 semantic error: Missing SymbolId: React
@@ -36318,12 +32831,6 @@ rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10)]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved references mismatch:
-after transform: ["require", "true"]
-rebuilt        : ["require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(17)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
 semantic error: Missing SymbolId: React
@@ -36337,9 +32844,6 @@ rebuilt        : SymbolId(6): [ReferenceId(6), ReferenceId(11)]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(16)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
 semantic error: Missing SymbolId: React
@@ -36353,9 +32857,6 @@ rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(9), ReferenceId(13), 
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("React")
 rebuilt        : ReferenceId(2): Some("React")
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(29)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 semantic error: Spread children are not supported in React.
@@ -36370,29 +32871,11 @@ Missing ReferenceId: require
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
-Unresolved references mismatch:
-after transform: ["JSX", "OneThing", "require"]
-rebuilt        : ["OneThing", "require"]
-Unresolved reference IDs mismatch for "OneThing":
-after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47)]
-rebuilt        : [ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(13), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(31), ReferenceId(34), ReferenceId(37)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(50)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Context", "_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "obj2", "three1", "three2", "three3", "two1", "two2", "two3", "two4", "two5"]
-Unresolved references mismatch:
-after transform: ["JSX", "ThreeThing", "ZeroThingOrTwoThing", "require"]
-rebuilt        : ["ThreeThing", "ZeroThingOrTwoThing", "require"]
-Unresolved reference IDs mismatch for "ThreeThing":
-after transform: [ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(34), ReferenceId(37), ReferenceId(40)]
-rebuilt        : [ReferenceId(20), ReferenceId(23), ReferenceId(26)]
-Unresolved reference IDs mismatch for "ZeroThingOrTwoThing":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(19), ReferenceId(22), ReferenceId(25), ReferenceId(28), ReferenceId(31)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12), ReferenceId(16)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
 semantic error: Missing SymbolId: React
@@ -36403,12 +32886,6 @@ rebuilt        : ScopeId(0): ["MainButton", "React", "_jsxFileName", "_reactJsxR
 Symbol reference IDs mismatch:
 after transform: SymbolId(11): [ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(55), ReferenceId(58), ReferenceId(61), ReferenceId(64), ReferenceId(67), ReferenceId(70), ReferenceId(73), ReferenceId(76), ReferenceId(79)]
 rebuilt        : SymbolId(6): [ReferenceId(7), ReferenceId(10), ReferenceId(13), ReferenceId(17), ReferenceId(21), ReferenceId(25), ReferenceId(29), ReferenceId(33), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49)]
-Unresolved references mismatch:
-after transform: ["JSX", "console", "require"]
-rebuilt        : ["console", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(82)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
 semantic error: Missing SymbolId: React
@@ -36422,9 +32899,6 @@ rebuilt        : ScopeId(1): ["attr"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(9)]
 rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(8)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(12)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
 semantic error: Missing SymbolId: React
@@ -36438,9 +32912,6 @@ rebuilt        : SymbolId(3): [ReferenceId(5)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(13)]
 rebuilt        : SymbolId(6): [ReferenceId(13)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(18)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
 semantic error: Missing SymbolId: React
@@ -36451,21 +32922,6 @@ rebuilt        : ScopeId(0): ["Baz", "React", "_jsxFileName", "_react", "_reactJ
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "U", "a0", "a1", "key1", "value"]
 rebuilt        : ScopeId(1): ["a0", "a1", "key1", "value"]
-Unresolved references mismatch:
-after transform: ["Array", "ComponentWithTwoAttributes", "InferParamComponent", "JSX", "Link", "require"]
-rebuilt        : ["ComponentWithTwoAttributes", "InferParamComponent", "Link", "require"]
-Unresolved reference IDs mismatch for "Link":
-after transform: [ReferenceId(13), ReferenceId(15), ReferenceId(30), ReferenceId(33)]
-rebuilt        : [ReferenceId(14), ReferenceId(18)]
-Unresolved reference IDs mismatch for "ComponentWithTwoAttributes":
-after transform: [ReferenceId(5), ReferenceId(8), ReferenceId(24), ReferenceId(28)]
-rebuilt        : [ReferenceId(4), ReferenceId(9)]
-Unresolved reference IDs mismatch for "InferParamComponent":
-after transform: [ReferenceId(23), ReferenceId(36)]
-rebuilt        : [ReferenceId(22)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(39), ReferenceId(40)]
-rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
 semantic error: Missing SymbolId: React
@@ -36476,18 +32932,6 @@ rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
 rebuilt        : ScopeId(1): ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "arg1", "arg2"]
-Unresolved references mismatch:
-after transform: ["JSX", "Link", "OverloadComponent", "require"]
-rebuilt        : ["Link", "OverloadComponent", "require"]
-Unresolved reference IDs mismatch for "Link":
-after transform: [ReferenceId(27), ReferenceId(29), ReferenceId(51), ReferenceId(54)]
-rebuilt        : [ReferenceId(32), ReferenceId(36)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(57)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-Unresolved reference IDs mismatch for "OverloadComponent":
-after transform: [ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(17), ReferenceId(20), ReferenceId(30), ReferenceId(33), ReferenceId(36), ReferenceId(39), ReferenceId(42), ReferenceId(45), ReferenceId(48)]
-rebuilt        : [ReferenceId(3), ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22), ReferenceId(27)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
 semantic error: Missing SymbolId: React
@@ -36501,21 +32945,6 @@ rebuilt        : ScopeId(1): ["a1", "a2", "arg"]
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "a1", "a2", "a3", "a4", "arg"]
 rebuilt        : ScopeId(2): ["a1", "a2", "a3", "a4", "arg"]
-Unresolved references mismatch:
-after transform: ["Component", "ComponentSpecific", "ComponentSpecific1", "JSX", "require"]
-rebuilt        : ["Component", "ComponentSpecific", "ComponentSpecific1", "require"]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(38)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
-Unresolved reference IDs mismatch for "Component":
-after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(20), ReferenceId(23)]
-rebuilt        : [ReferenceId(3), ReferenceId(7)]
-Unresolved reference IDs mismatch for "ComponentSpecific":
-after transform: [ReferenceId(12), ReferenceId(16), ReferenceId(18), ReferenceId(26), ReferenceId(32), ReferenceId(35)]
-rebuilt        : [ReferenceId(11), ReferenceId(19), ReferenceId(23)]
-Unresolved reference IDs mismatch for "ComponentSpecific1":
-after transform: [ReferenceId(14), ReferenceId(29)]
-rebuilt        : [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 semantic error: Missing SymbolId: React
@@ -36529,9 +32958,6 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(43), ReferenceId(46), ReferenceId(49), ReferenceId(52), ReferenceId(55), ReferenceId(58), ReferenceId(61), ReferenceId(64), ReferenceId(67), ReferenceId(70), ReferenceId(73), ReferenceId(76), ReferenceId(79), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(91)]
 rebuilt        : SymbolId(3): [ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(17), ReferenceId(20), ReferenceId(23), ReferenceId(26), ReferenceId(29), ReferenceId(32), ReferenceId(35), ReferenceId(38), ReferenceId(41), ReferenceId(44), ReferenceId(47), ReferenceId(50), ReferenceId(53), ReferenceId(56), ReferenceId(59), ReferenceId(62)]
-Unresolved reference IDs mismatch for "require":
-after transform: [ReferenceId(96)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeErrors.tsx
 semantic error: Symbol reference IDs mismatch:
@@ -36583,9 +33009,6 @@ tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolutionMod
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Default", "Import", "ImportRelative", "Require", "RequireRelative"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["x"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolvesWithoutExportsDiagnostic1.ts
 semantic error: Bindings mismatch:
@@ -36635,9 +33058,6 @@ rebuilt        : ScopeId(0): ["HTML5Element", "blogPost"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("doc")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Document", "Element", "HTMLElement"]
-rebuilt        : ["HTMLElement", "doc"]
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 semantic error: Bindings mismatch:
@@ -36646,9 +33066,6 @@ rebuilt        : ScopeId(0): ["HTML5Element", "blogPost"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("doc")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Document", "Element", "HTMLElement"]
-rebuilt        : ["HTMLElement", "doc"]
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForJsonImport.ts
 semantic error: Bindings mismatch:
@@ -36657,9 +33074,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("val")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["val"]
 
 tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFilesForNodeNativeModules.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -36906,9 +33320,6 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDecla
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["string", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Unresolved reference IDs mismatch for "string":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration12.ts
 semantic error: Bindings mismatch:
@@ -37030,9 +33441,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("a")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a"]
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolIndexer1.ts
 semantic error: Bindings mismatch:
@@ -37057,9 +33465,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(2): Some("C")
 rebuilt        : ReferenceId(2): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["A", "B", "C"]
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOptionalTypeMembers1.ts
 semantic error: Bindings mismatch:
@@ -37070,9 +33475,6 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOverl
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Document"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["HTMLCanvasElement", "HTMLDivElement", "HTMLElement", "HTMLSpanElement"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer1.ts
 semantic error: Bindings mismatch:
@@ -37083,37 +33485,11 @@ tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/par
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty4.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
 semantic error: Cannot use export statement outside a module
@@ -37122,9 +33498,6 @@ tasks/coverage/typescript/tests/cases/conformance/salsa/inferingFromAny.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "a", "t"]
 rebuilt        : ScopeId(0): ["a", "t"]
-Unresolved references mismatch:
-after transform: ["Partial"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/salsa/moduleExportAlias.ts
 semantic error: `import lib = require(...);` is only supported when compiling modules to CommonJS.
@@ -37205,15 +33578,6 @@ rebuilt        : ReferenceId(17): Some("M")
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("M")
 rebuilt        : ReferenceId(18): Some("M")
-Unresolved references mismatch:
-after transform: ["Date", "M", "Object", "undefined"]
-rebuilt        : ["Date", "Object", "undefined"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(8), ReferenceId(9)]
-rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
 semantic error: Missing SymbolId: M
@@ -37288,9 +33652,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("dec")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Symbol"]
-rebuilt        : ["Symbol", "dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.1.ts
 semantic error: Bindings mismatch:
@@ -37299,9 +33660,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.10.ts
 semantic error: Bindings mismatch:
@@ -37310,9 +33668,6 @@ rebuilt        : ScopeId(0): ["after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.11.ts
 semantic error: Bindings mismatch:
@@ -37321,9 +33676,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.12.ts
 semantic error: Bindings mismatch:
@@ -37332,9 +33684,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.2.ts
 semantic error: Bindings mismatch:
@@ -37343,9 +33692,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.3.ts
 semantic error: Bindings mismatch:
@@ -37354,9 +33700,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.4.ts
 semantic error: Bindings mismatch:
@@ -37365,9 +33708,6 @@ rebuilt        : ScopeId(0): ["before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.5.ts
 semantic error: Bindings mismatch:
@@ -37376,9 +33716,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.6.ts
 semantic error: Bindings mismatch:
@@ -37387,9 +33724,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.7.ts
 semantic error: Bindings mismatch:
@@ -37398,9 +33732,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.8.ts
 semantic error: Bindings mismatch:
@@ -37409,9 +33740,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.9.ts
 semantic error: Bindings mismatch:
@@ -37420,9 +33748,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.1.ts
 semantic error: Bindings mismatch:
@@ -37431,9 +33756,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.10.ts
 semantic error: Bindings mismatch:
@@ -37442,9 +33764,6 @@ rebuilt        : ScopeId(0): ["after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.11.ts
 semantic error: Bindings mismatch:
@@ -37453,9 +33772,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.12.ts
 semantic error: Bindings mismatch:
@@ -37464,9 +33780,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.2.ts
 semantic error: Bindings mismatch:
@@ -37475,9 +33788,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.3.ts
 semantic error: Bindings mismatch:
@@ -37486,9 +33796,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.4.ts
 semantic error: Bindings mismatch:
@@ -37497,9 +33804,6 @@ rebuilt        : ScopeId(0): ["before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.5.ts
 semantic error: Bindings mismatch:
@@ -37508,9 +33812,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.6.ts
 semantic error: Bindings mismatch:
@@ -37519,9 +33820,6 @@ rebuilt        : ScopeId(0): ["C", "before"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.7.ts
 semantic error: Bindings mismatch:
@@ -37530,9 +33828,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.8.ts
 semantic error: Bindings mismatch:
@@ -37541,9 +33836,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.9.ts
 semantic error: Bindings mismatch:
@@ -37552,9 +33844,6 @@ rebuilt        : ScopeId(0): ["C", "after"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("dec")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/validMultipleVariableDeclarations.ts
 semantic error: Bindings mismatch:
@@ -37569,11 +33858,6 @@ rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(9)]
 rebuilt        : SymbolId(7): []
-
-tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
 semantic error: Missing SymbolId: M
@@ -37623,15 +33907,6 @@ rebuilt        : ReferenceId(17): Some("M")
 Reference symbol mismatch:
 after transform: ReferenceId(29): Some("M")
 rebuilt        : ReferenceId(18): Some("M")
-Unresolved references mismatch:
-after transform: ["Date", "M", "Object", "undefined"]
-rebuilt        : ["Date", "Object", "undefined"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(8), ReferenceId(9)]
-rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(10), ReferenceId(11)]
-rebuilt        : [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
 semantic error: Bindings mismatch:
@@ -37720,9 +33995,6 @@ rebuilt        : ScopeId(0): ["C", "D", "fn1", "fn10", "fn11", "fn12", "fn13", "
 Symbol reference IDs mismatch:
 after transform: SymbolId(9): [ReferenceId(4), ReferenceId(7), ReferenceId(8), ReferenceId(10)]
 rebuilt        : SymbolId(8): [ReferenceId(2), ReferenceId(3)]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwInEnclosingStatements.ts
 semantic error: Bindings mismatch:
@@ -37806,14 +34078,6 @@ rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(25)]
 rebuilt        : SymbolId(11): []
-Unresolved reference IDs mismatch for "undefined":
-after transform: [ReferenceId(11), ReferenceId(14)]
-rebuilt        : [ReferenceId(11)]
-
-tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
-semantic error: Unresolved references mismatch:
-after transform: ["AsyncIterable", "AsyncIterableIterator", "AsyncIterator", "Promise", "PromiseLike"]
-rebuilt        : ["Promise"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
 semantic error: Bindings mismatch:
@@ -37825,17 +34089,11 @@ rebuilt        : ScopeId(1): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(9), ReferenceId(11)]
 rebuilt        : SymbolId(4): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["const", "true"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionAwaitOperand.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Obj", "fn1"]
 rebuilt        : ScopeId(0): ["fn1"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(4)]
-rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionReturnType.ts
 semantic error: Bindings mismatch:
@@ -37844,12 +34102,6 @@ rebuilt        : ScopeId(0): ["copyExtensions", "fn1", "fn2", "fn3", "fn4"]
 Reference symbol mismatch:
 after transform: ReferenceId(23): Some("test")
 rebuilt        : ReferenceId(4): None
-Unresolved references mismatch:
-after transform: ["Context", "Error", "Promise", "PromiseLike", "getProcessTree", "scanMetadata"]
-rebuilt        : ["Error", "Promise", "getProcessTree", "scanMetadata", "test"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(24), ReferenceId(31), ReferenceId(34), ReferenceId(37)]
-rebuilt        : [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(11)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializer.ts
 semantic error: Bindings mismatch:
@@ -37909,9 +34161,6 @@ rebuilt        : ReferenceId(15): None
 Reference symbol mismatch:
 after transform: ReferenceId(21): Some("iterableOfPromise")
 rebuilt        : ReferenceId(17): None
-Unresolved references mismatch:
-after transform: ["AsyncIterable", "Iterable", "Promise"]
-rebuilt        : ["asyncIterable", "iterable", "iterableOfPromise"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
 semantic error: Bindings mismatch:
@@ -37920,9 +34169,6 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("x")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionNarrowing.ts
 semantic error: Bindings mismatch:
@@ -37937,9 +34183,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("q")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : ["q", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
 semantic error: Bindings mismatch:
@@ -37987,9 +34230,6 @@ rebuilt        : ReferenceId(5): None
 Reference symbol mismatch:
 after transform: ReferenceId(16): Some("obj")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: ["f", "f2"]
-rebuilt        : ["a", "b", "f", "f2", "obj"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference3.ts
 semantic error: Bindings mismatch:
@@ -38001,9 +34241,6 @@ rebuilt        : ReferenceId(1): None
 Reference symbol mismatch:
 after transform: ReferenceId(11): Some("b")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: ["Array", "ReadonlyArray", "Set", "Symbol", "from"]
-rebuilt        : ["Array", "a", "b", "from"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
 semantic error: Bindings mismatch:
@@ -38025,9 +34262,6 @@ rebuilt        : ScopeId(1): ["d1", "d2"]
 Bindings mismatch:
 after transform: ScopeId(8): ["T", "_value"]
 rebuilt        : ScopeId(2): ["_value"]
-Unresolved references mismatch:
-after transform: ["Object", "Promise", "mock", "true"]
-rebuilt        : ["Object", "mock"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/intersection/operatorsAndIntersectionTypes.ts
 semantic error: Bindings mismatch:
@@ -38038,17 +34272,11 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTy
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "Item", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Unresolved references mismatch:
-after transform: ["Error", "g", "true"]
-rebuilt        : ["Error", "g"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "A2", "Item", "assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
 rebuilt        : ScopeId(0): ["assertNever", "f1", "f10", "f11", "f12", "f13", "f2", "f20", "f21", "f3", "f4", "f5"]
-Unresolved references mismatch:
-after transform: ["Error", "g", "true"]
-rebuilt        : ["Error", "g"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes1.ts
 semantic error: Bindings mismatch:
@@ -38133,17 +34361,11 @@ rebuilt        : SymbolId(84): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(102): [ReferenceId(112), ReferenceId(113), ReferenceId(120)]
 rebuilt        : SymbolId(84): [ReferenceId(80), ReferenceId(82)]
-Unresolved references mismatch:
-after transform: ["NonNullable", "Object", "Record", "f", "nonWidening", "true", "widening"]
-rebuilt        : ["Object", "f", "nonWidening", "widening"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes1.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Falsy", "f1", "f2", "f3", "f4", "f5", "one", "oneOrTwo", "two", "zero"]
 rebuilt        : ScopeId(0): ["f1", "f2", "f3", "f4", "f5", "one", "oneOrTwo", "two", "zero"]
-Unresolved references mismatch:
-after transform: ["true", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
 semantic error: Bindings mismatch:
@@ -38167,9 +34389,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(16), ReferenceId(33), ReferenceId(34), ReferenceId(38), ReferenceId(98)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(18), ReferenceId(35), ReferenceId(36), ReferenceId(40)]
-Unresolved references mismatch:
-after transform: ["g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8", "true", "undefined"]
-rebuilt        : ["g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8", "undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndDestructuring.ts
 semantic error: Bindings mismatch:
@@ -38199,9 +34418,6 @@ rebuilt        : ReferenceId(6): None
 Reference symbol mismatch:
 after transform: ReferenceId(8): Some("x")
 rebuilt        : ReferenceId(7): None
-Unresolved references mismatch:
-after transform: ["const"]
-rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes1.ts
 semantic error: Bindings mismatch:
@@ -38256,9 +34472,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingDef
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "E", "F", "G", "x1", "x2", "x3", "x4", "x5"]
 rebuilt        : ScopeId(0): ["x1", "x2", "x3", "x4", "x5"]
-Unresolved references mismatch:
-after transform: ["Capitalize", "Lowercase"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/stringMappingReduction.ts
 semantic error: Bindings mismatch:
@@ -38270,9 +34483,6 @@ rebuilt        : ScopeId(1): ["eventQrl"]
 Reference symbol mismatch:
 after transform: ReferenceId(24): Some("_virtualOn")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: ["Capitalize", "Lowercase"]
-rebuilt        : ["_virtualOn"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/literal/templateLiteralTypes6.ts
 semantic error: Bindings mismatch:
@@ -38435,9 +34645,6 @@ rebuilt        : ReferenceId(82): None
 Reference symbol mismatch:
 after transform: ReferenceId(120): Some("E")
 rebuilt        : ReferenceId(90): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["E"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes3.ts
 semantic error: Bindings mismatch:
@@ -38466,9 +34673,6 @@ rebuilt        : ScopeId(4): ["Y"]
 Bindings mismatch:
 after transform: ScopeId(5): ["E"]
 rebuilt        : ScopeId(5): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints.ts
 semantic error: Bindings mismatch:
@@ -38492,25 +34696,16 @@ rebuilt        : ScopeId(5): ["obj"]
 Bindings mismatch:
 after transform: ScopeId(7): ["T", "bar", "rest", "targetProps"]
 rebuilt        : ScopeId(6): ["bar", "rest", "targetProps"]
-Unresolved references mismatch:
-after transform: ["Exclude", "Extract", "Pick", "Record"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSignatureModifiers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Identity", "Obj1", "Obj10", "Obj11", "Obj12", "Obj13", "Obj2", "Obj3", "Obj4", "Obj5", "Obj6", "Obj7", "Obj8", "Obj9", "Res1", "Res10", "Res11", "Res12", "Res13", "Res2", "Res3", "Res4", "Res5", "Res6", "Res7", "Res8", "Res9", "StrippingIdentity", "StrippingPick"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Pick"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["B", "BP", "BPR", "BR", "Boxified", "Foo", "T", "TP", "TPR", "TR", "b00", "b01", "b02", "b03", "b04", "f1", "f2", "f3", "f4", "v00", "v01", "v02", "v03", "v04"]
 rebuilt        : ScopeId(0): ["b00", "b01", "b02", "b03", "b04", "f1", "f2", "f3", "f4", "v00", "v01", "v02", "v03", "v04"]
-Unresolved references mismatch:
-after transform: ["Partial", "Pick", "Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts
 semantic error: Bindings mismatch:
@@ -38540,17 +34735,11 @@ rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(3), ReferenceId(12), ReferenceId(19)]
 rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["Extract"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "K", "K0", "K1", "KA", "KB", "KC", "KD", "Keys", "Keys1", "Keys2", "M", "M0", "M1", "R1", "R2", "T1", "T2", "T3", "T4", "V0", "V1"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeBracketAccessIndexSignature.ts
 semantic error: Bindings mismatch:
@@ -38582,9 +34771,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCa
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Function", "I", "i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
 rebuilt        : ScopeId(0): ["i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfFunction.ts
 semantic error: Bindings mismatch:
@@ -38595,9 +34781,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCo
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Function", "I", "i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
 rebuilt        : ScopeId(0): ["i", "r1", "r1b", "r1c", "r1d", "r1e", "r2", "r2b", "r2c", "r2d", "r2e", "x"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithConstructSignatureHidingMembersOfFunction.ts
 semantic error: Bindings mismatch:
@@ -38660,9 +34843,6 @@ rebuilt        : ScopeId(0): ["C", "c", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOnlyPublicMembersEquivalentToInterface2.ts
 semantic error: Bindings mismatch:
@@ -38671,9 +34851,6 @@ rebuilt        : ScopeId(0): ["C", "c", "i"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(4)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOptionalParameter.ts
 semantic error: Bindings mismatch:
@@ -38710,9 +34887,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSi
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I", "I2", "I3", "T", "a", "a2"]
 rebuilt        : ScopeId(0): ["a", "a2"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesThatDifferOnlyByReturnType3.ts
 semantic error: Bindings mismatch:
@@ -38768,9 +34942,6 @@ rebuilt        : ScopeId(4): []
 Bindings mismatch:
 after transform: ScopeId(13): ["T"]
 rebuilt        : ScopeId(6): []
-Unresolved references mismatch:
-after transform: ["String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts
 semantic error: Bindings mismatch:
@@ -38975,11 +35146,6 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Boolean", "a", "b", "c", "d", "x"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "x"]
 
-tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Boolean", "Object"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/extendNumberInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Number", "a", "b", "c", "d", "x"]
@@ -38998,19 +35164,11 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(4), ReferenceId(6), ReferenceId(12)]
 rebuilt        : SymbolId(4): [ReferenceId(6), ReferenceId(8)]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extendStringInterface.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["String", "a", "b", "c", "d", "x"]
 rebuilt        : ScopeId(0): ["a", "b", "c", "d", "x"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/validStringAssignments.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -39025,14 +35183,6 @@ rebuilt        : ScopeId(2): ["a"]
 Symbol reference IDs mismatch:
 after transform: SymbolId(6): [ReferenceId(9)]
 rebuilt        : SymbolId(6): []
-Unresolved references mismatch:
-after transform: ["undefined"]
-rebuilt        : []
-
-tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedValues.ts
-semantic error: Unresolved reference IDs mismatch for "undefined":
-after transform: [ReferenceId(0), ReferenceId(2)]
-rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.ts
 semantic error: Bindings mismatch:
@@ -39061,9 +35211,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/rest/objectRestReadonly.
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["ObjType", "foo", "obj", "rest"]
 rebuilt        : ScopeId(0): ["foo", "obj", "rest"]
-Unresolved references mismatch:
-after transform: ["Readonly"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/arrayOfFunctionTypes3.ts
 semantic error: Bindings mismatch:
@@ -39074,9 +35221,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLite
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteral.ts
 semantic error: Bindings mismatch:
@@ -39106,9 +35250,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLite
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryOnClass.ts
 semantic error: Bindings mismatch:
@@ -39164,11 +35305,6 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 
-tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
-semantic error: Unresolved references mismatch:
-after transform: ["this"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpread.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "Header", "a", "addAfter", "addBefore", "anything", "c", "changeTypeAfter", "changeTypeBoth", "combined", "combinedAfter", "combinedNestedChangeType", "conditionalSpreadBoolean", "conditionalSpreadNumber", "conditionalSpreadString", "container", "cplus", "exclusive", "f", "from16326", "genericSpread", "getter", "nested", "o", "o2", "op", "overlap", "overlapConflict", "override", "overwriteId", "propertyNested", "shortCutted", "spreadAny", "spreadC", "spreadFunc", "spreadNonPrimitive", "swap"]
@@ -39183,18 +35319,10 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(32): [ReferenceId(36), ReferenceId(37)]
 rebuilt        : SymbolId(31): [ReferenceId(33)]
 
-tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedComplexity.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Record"]
-rebuilt        : []
-
 tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedNullCheckPerf.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Props", "parseWithSpread"]
 rebuilt        : ScopeId(0): ["parseWithSpread"]
-Unresolved references mismatch:
-after transform: ["Record", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadContextualTypedBindingPattern.ts
 semantic error: Bindings mismatch:
@@ -39206,9 +35334,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("alice")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["alice", "bob"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadExcessProperty.ts
 semantic error: Bindings mismatch:
@@ -39222,9 +35347,6 @@ rebuilt        : ScopeId(0): ["x"]
 Reference symbol mismatch:
 after transform: ReferenceId(0): Some("o")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["o"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesProperty.ts
 semantic error: Bindings mismatch:
@@ -39242,9 +35364,6 @@ rebuilt        : ReferenceId(2): None
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("abq")
 rebuilt        : ReferenceId(3): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["ab", "abq"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion4.ts
 semantic error: Bindings mismatch:
@@ -39256,9 +35375,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("b")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf01.ts
 semantic error: Bindings mismatch:
@@ -39321,9 +35437,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClass
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C1", "C2", "C3", "C5", "Foo"]
 rebuilt        : ScopeId(0): ["C1", "C2", "C3", "C5"]
-Unresolved references mismatch:
-after transform: ["Date", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
 semantic error: Bindings mismatch:
@@ -39332,17 +35445,11 @@ rebuilt        : ScopeId(0): ["problemFunction"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T", "name"]
 rebuilt        : ScopeId(2): ["name"]
-Unresolved references mismatch:
-after transform: ["callsCallback", "isCorrect", "this"]
-rebuilt        : ["callsCallback", "isCorrect"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "I1", "I2", "I3"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals.ts
 semantic error: Bindings mismatch:
@@ -39353,9 +35460,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTagge
 semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["T", "strings"]
 rebuilt        : ScopeId(2): ["strings"]
-Unresolved references mismatch:
-after transform: ["TemplateStringsArray"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTuples.ts
 semantic error: Bindings mismatch:
@@ -39374,17 +35478,11 @@ rebuilt        : ScopeId(0): ["fa1", "fa2", "fb1", "fb2", "fb3", "output"]
 Reference symbol mismatch:
 after transform: ReferenceId(37): Some("input")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["test"]
-rebuilt        : ["input", "test"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["GetKeys", "GetResult", "MultiKeyMap", "id1", "matches", "x"]
 rebuilt        : ScopeId(0): ["id1", "matches", "x"]
-Unresolved references mismatch:
-after transform: ["Iterable"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts
 semantic error: Bindings mismatch:
@@ -39393,9 +35491,6 @@ rebuilt        : ScopeId(0): ["output"]
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("tuple")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["tuple"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
 semantic error: Bindings mismatch:
@@ -39462,9 +35557,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/interfaceDoe
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["StringTree", "StringTreeArray", "x"]
 rebuilt        : ScopeId(0): ["x"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
 semantic error: Bindings mismatch:
@@ -39519,9 +35611,6 @@ rebuilt        : ScopeId(6): []
 Bindings mismatch:
 after transform: ScopeId(8): ["T"]
 rebuilt        : ScopeId(8): []
-Unresolved references mismatch:
-after transform: ["String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
 semantic error: Bindings mismatch:
@@ -39539,9 +35628,6 @@ rebuilt        : ScopeId(4): ["x"]
 Bindings mismatch:
 after transform: ScopeId(6): ["T"]
 rebuilt        : ScopeId(5): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction.ts
 semantic error: Bindings mismatch:
@@ -39568,12 +35654,6 @@ rebuilt        : ScopeId(11): ["x", "y"]
 Bindings mismatch:
 after transform: ScopeId(17): ["T", "U", "x", "y"]
 rebuilt        : ScopeId(12): ["x", "y"]
-Unresolved references mismatch:
-after transform: ["Date", "Function"]
-rebuilt        : ["Function"]
-Unresolved reference IDs mismatch for "Function":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(58)]
-rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction3.ts
 semantic error: Bindings mismatch:
@@ -39643,9 +35723,6 @@ rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(3): ["U", "x"]
 rebuilt        : ScopeId(3): ["x"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints2.ts
 semantic error: Bindings mismatch:
@@ -39679,9 +35756,6 @@ rebuilt        : ScopeId(3): ["g", "x"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "x"]
 rebuilt        : ScopeId(4): ["x"]
-Unresolved references mismatch:
-after transform: ["Date", "Number"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne2.ts
 semantic error: Bindings mismatch:
@@ -39696,9 +35770,6 @@ rebuilt        : ScopeId(4): []
 Bindings mismatch:
 after transform: ScopeId(5): ["T", "U", "x"]
 rebuilt        : ScopeId(5): ["x"]
-Unresolved references mismatch:
-after transform: ["Date", "Number"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints.ts
 semantic error: Bindings mismatch:
@@ -39710,9 +35781,6 @@ rebuilt        : ScopeId(1): []
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "a", "x"]
 rebuilt        : ScopeId(3): ["a", "x"]
-Unresolved reference IDs mismatch for "Date":
-after transform: [ReferenceId(0), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(24)]
-rebuilt        : [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
 semantic error: Bindings mismatch:
@@ -39822,9 +35890,6 @@ rebuilt        : ScopeId(17): []
 Bindings mismatch:
 after transform: ScopeId(24): ["T", "U", "V"]
 rebuilt        : ScopeId(18): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope.ts
 semantic error: Bindings mismatch:
@@ -39874,9 +35939,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(2), ReferenceId(45)]
 rebuilt        : SymbolId(4): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Date", "Function", "Number", "Object", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignableToEveryType2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -39981,9 +36043,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(28)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance4.ts
 semantic error: Bindings mismatch:
@@ -40012,9 +36071,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(28)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance2.ts
 semantic error: Bindings mismatch:
@@ -40029,9 +36085,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(28)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance4.ts
 semantic error: Bindings mismatch:
@@ -40060,9 +36113,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(28)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/everyTypeAssignableToAny.ts
 semantic error: Bindings mismatch:
@@ -40086,9 +36136,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(5): [ReferenceId(2), ReferenceId(59)]
 rebuilt        : SymbolId(4): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Date", "Function", "Number", "Object", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
 semantic error: Bindings mismatch:
@@ -40097,9 +36144,6 @@ rebuilt        : ScopeId(0): ["hasOwn", "target", "toString"]
 Reference symbol mismatch:
 after transform: ReferenceId(3): Some("source")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["source"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignableToEveryType.ts
 semantic error: Bindings mismatch:
@@ -40123,9 +36167,6 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(2), ReferenceId(23)]
 rebuilt        : SymbolId(3): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Date", "Function", "Number", "Object", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum.ts
 semantic error: Bindings mismatch:
@@ -40163,14 +36204,6 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(2), ReferenceId(45)]
 rebuilt        : SymbolId(3): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Date", "Function", "Number", "Object", "String", "undefined"]
-rebuilt        : ["undefined"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/arrayLiteralWithMultipleBestCommonTypes.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfConditionalExpressions.ts
 semantic error: Bindings mismatch:
@@ -40185,9 +36218,6 @@ rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(4): [ReferenceId(4)]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/bestCommonTypeOfConditionalExpressions2.ts
 semantic error: Bindings mismatch:
@@ -40221,9 +36251,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCo
 semantic error: Bindings mismatch:
 after transform: ScopeId(14): ["T", "x"]
 rebuilt        : ScopeId(14): ["x"]
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
-rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
 semantic error: Missing SymbolId: _Derived
@@ -40291,9 +36318,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(1): Some("y")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 semantic error: Bindings mismatch:
@@ -40442,9 +36466,6 @@ rebuilt        : SymbolId(47): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(80): [ReferenceId(13), ReferenceId(28)]
 rebuilt        : SymbolId(47): [ReferenceId(3)]
-Unresolved references mismatch:
-after transform: ["Date", "Object", "RegExp", "RegExpMatchArray", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfAny.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -40544,9 +36565,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(39), ReferenceId(204)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "Object", "foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"]
-rebuilt        : ["foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
 semantic error: Missing SymbolId: Errors
@@ -40623,9 +36641,6 @@ rebuilt        : SymbolId(3): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(38), ReferenceId(52), ReferenceId(60), ReferenceId(111), ReferenceId(115)]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
-rebuilt        : ["foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures4.ts
 semantic error: Bindings mismatch:
@@ -40726,9 +36741,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(39), ReferenceId(204)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Date", "Object", "foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"]
-rebuilt        : ["foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
 semantic error: Missing SymbolId: Errors
@@ -40763,9 +36775,6 @@ rebuilt        : SymbolId(3): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(38), ReferenceId(57), ReferenceId(61), ReferenceId(112), ReferenceId(121)]
 rebuilt        : SymbolId(4): []
-Unresolved references mismatch:
-after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
-rebuilt        : ["foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures4.ts
 semantic error: Bindings mismatch:
@@ -40794,9 +36803,6 @@ rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(2): [ReferenceId(28)]
 rebuilt        : SymbolId(2): []
-Unresolved references mismatch:
-after transform: ["Array", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembers4.ts
 semantic error: Symbol reference IDs mismatch:
@@ -40894,9 +36900,6 @@ rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch:
 after transform: SymbolId(8): [ReferenceId(19), ReferenceId(25)]
 rebuilt        : SymbolId(6): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignatures.ts
 semantic error: Bindings mismatch:
@@ -40943,9 +36946,6 @@ rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(11): [ReferenceId(16), ReferenceId(17), ReferenceId(33), ReferenceId(41)]
 rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithCallSignaturesDifferingParamCounts.ts
 semantic error: Bindings mismatch:
@@ -41045,9 +37045,6 @@ rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(9): [ReferenceId(13), ReferenceId(14), ReferenceId(22), ReferenceId(30)]
 rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithConstructSignaturesDifferingParamCounts.ts
 semantic error: Bindings mismatch:
@@ -41164,9 +37161,6 @@ rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(15): [ReferenceId(30), ReferenceId(31), ReferenceId(56), ReferenceId(69)]
 rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Date", "Number", "RegExp", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints2.ts
 semantic error: Bindings mismatch:
@@ -41205,9 +37199,6 @@ rebuilt        : SymbolId(12): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(29): [ReferenceId(54), ReferenceId(55), ReferenceId(100), ReferenceId(118)]
 rebuilt        : SymbolId(13): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Date", "Number", "RegExp", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByConstraints3.ts
 semantic error: Bindings mismatch:
@@ -41284,9 +37275,6 @@ rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(15): [ReferenceId(20), ReferenceId(21), ReferenceId(37), ReferenceId(45)]
 rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingByReturnType2.ts
 semantic error: Bindings mismatch:
@@ -41319,9 +37307,6 @@ rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(15): [ReferenceId(33), ReferenceId(34), ReferenceId(59), ReferenceId(72)]
 rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts.ts
 semantic error: Bindings mismatch:
@@ -41354,9 +37339,6 @@ rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(28): [ReferenceId(24), ReferenceId(25), ReferenceId(44), ReferenceId(61)]
 rebuilt        : SymbolId(7): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterCounts2.ts
 semantic error: Bindings mismatch:
@@ -41365,9 +37347,6 @@ rebuilt        : ScopeId(0): ["a", "foo1", "foo13", "foo14", "foo14b", "foo15", 
 Symbol reference IDs mismatch:
 after transform: SymbolId(10): [ReferenceId(10), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericCallSignaturesDifferingTypeParameterNames.ts
 semantic error: Bindings mismatch:
@@ -41522,9 +37501,6 @@ rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(26), ReferenceId(27), ReferenceId(41), ReferenceId(54)]
 rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Number", "RegExp", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints2.ts
 semantic error: Bindings mismatch:
@@ -41557,9 +37533,6 @@ rebuilt        : SymbolId(9): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(24): [ReferenceId(48), ReferenceId(49), ReferenceId(80), ReferenceId(98)]
 rebuilt        : SymbolId(10): []
-Unresolved references mismatch:
-after transform: ["Array", "Boolean", "Number", "RegExp", "String"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByConstraints3.ts
 semantic error: Bindings mismatch:
@@ -41624,9 +37597,6 @@ rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(18), ReferenceId(19), ReferenceId(21), ReferenceId(29), ReferenceId(37)]
 rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingByReturnType2.ts
 semantic error: Bindings mismatch:
@@ -41653,9 +37623,6 @@ rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(12): [ReferenceId(29), ReferenceId(30), ReferenceId(44), ReferenceId(57)]
 rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
 semantic error: Bindings mismatch:
@@ -41682,9 +37649,6 @@ rebuilt        : SymbolId(4): []
 Symbol reference IDs mismatch:
 after transform: SymbolId(25): [ReferenceId(26), ReferenceId(27), ReferenceId(37), ReferenceId(54)]
 rebuilt        : SymbolId(5): []
-Unresolved references mismatch:
-after transform: ["Date", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterNames.ts
 semantic error: Bindings mismatch:
@@ -42084,9 +38048,6 @@ rebuilt        : ScopeId(13): ["a", "x"]
 Bindings mismatch:
 after transform: ScopeId(36): ["T", "x"]
 rebuilt        : ScopeId(14): ["x"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/bivariantInferences.ts
 semantic error: Bindings mismatch:
@@ -42098,9 +38059,6 @@ rebuilt        : ReferenceId(0): None
 Reference symbol mismatch:
 after transform: ReferenceId(5): Some("b")
 rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["ReadonlyArray"]
-rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
 semantic error: Bindings mismatch:
@@ -42146,9 +38104,6 @@ tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeIn
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "t"]
 rebuilt        : ScopeId(1): ["t"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
 semantic error: Bindings mismatch:
@@ -42238,17 +38193,11 @@ rebuilt        : SymbolId(16): [ReferenceId(6), ReferenceId(10)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(18): [ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(20)]
 rebuilt        : SymbolId(17): [ReferenceId(7), ReferenceId(9)]
-Unresolved references mismatch:
-after transform: ["Date", "Object", "RegExp"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithNonSymmetricSubtypes.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["T", "r", "x", "y"]
 rebuilt        : ScopeId(1): ["r", "x", "y"]
-Unresolved references mismatch:
-after transform: ["Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs2.ts
 semantic error: Bindings mismatch:
@@ -42314,9 +38263,6 @@ rebuilt        : ScopeId(1): ["x"]
 Bindings mismatch:
 after transform: ScopeId(2): ["T", "arg", "b", "d", "e", "r2"]
 rebuilt        : ScopeId(2): ["arg", "b", "d", "e", "r2"]
-Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts
 semantic error: Bindings mismatch:
@@ -42328,9 +38274,6 @@ rebuilt        : ScopeId(2): ["arg", "b", "r2"]
 Bindings mismatch:
 after transform: ScopeId(3): ["T", "U", "arg", "b", "d", "e", "r2", "u"]
 rebuilt        : ScopeId(3): ["arg", "b", "d", "e", "r2", "u"]
-Unresolved references mismatch:
-after transform: ["Date", "Object"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndNumericIndexer.ts
 semantic error: Bindings mismatch:
@@ -42345,9 +38288,6 @@ rebuilt        : ScopeId(3): ["arg", "b", "d", "r2"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "arg", "b", "d", "r2"]
 rebuilt        : ScopeId(4): ["arg", "b", "d", "r2"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndStringIndexer.ts
 semantic error: Bindings mismatch:
@@ -42362,9 +38302,6 @@ rebuilt        : ScopeId(3): ["arg", "b", "d", "r2"]
 Bindings mismatch:
 after transform: ScopeId(4): ["T", "U", "arg", "b", "d", "r2"]
 rebuilt        : ScopeId(4): ["arg", "b", "d", "r2"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments.ts
 semantic error: Missing SymbolId: NonGenericParameter
@@ -42533,9 +38470,6 @@ rebuilt        : SymbolId(2): [ReferenceId(4), ReferenceId(7), ReferenceId(10)]
 Symbol reference IDs mismatch:
 after transform: SymbolId(17): [ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(45), ReferenceId(48), ReferenceId(51)]
 rebuilt        : SymbolId(8): [ReferenceId(15), ReferenceId(19), ReferenceId(23)]
-Unresolved references mismatch:
-after transform: ["Partial", "Record", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 semantic error: Bindings mismatch:
@@ -42549,12 +38483,6 @@ rebuilt        : ScopeId(0): ["bookTable", "f", "insertOnConflictDoNothing"]
 Bindings mismatch:
 after transform: ScopeId(11): ["Def", "Req", "_conflictTarget", "_table"]
 rebuilt        : ScopeId(1): ["_conflictTarget", "_table"]
-Unresolved references mismatch:
-after transform: ["Col", "ConflictTarget", "Error", "Table", "Write"]
-rebuilt        : ["ConflictTarget", "Error"]
-Unresolved reference IDs mismatch for "ConflictTarget":
-after transform: [ReferenceId(22), ReferenceId(24), ReferenceId(33), ReferenceId(39)]
-rebuilt        : [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
 semantic error: Bindings mismatch:
@@ -42590,12 +38518,6 @@ rebuilt        : ReferenceId(24): None
 Reference symbol mismatch:
 after transform: ReferenceId(53): Some("mbp")
 rebuilt        : ReferenceId(26): None
-Unresolved references mismatch:
-after transform: ["Math", "Object", "Promise", "f1", "f2", "pigify", "undefined"]
-rebuilt        : ["Math", "Object", "Promise", "f1", "f2", "mbp", "pigify", "undefined"]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(54), ReferenceId(56)]
-rebuilt        : [ReferenceId(27)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
 semantic error: Bindings mismatch:
@@ -42652,9 +38574,6 @@ rebuilt        : ReferenceId(22): None
 Reference symbol mismatch:
 after transform: ReferenceId(122): Some("b")
 rebuilt        : ReferenceId(23): None
-Unresolved references mismatch:
-after transform: ["AsyncIterator", "Component", "Iterable", "Iterator", "Omit", "Promise", "PromiseLike", "concatMaybe", "foo", "foo1", "foo2", "true", "withRouter"]
-rebuilt        : ["MyComponent", "a", "ab", "b", "concatMaybe", "f1", "f2", "foo", "foo1", "foo2", "g1", "g2", "sa", "sx", "withRouter"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeCallSignatures.ts
 semantic error: Bindings mismatch:
@@ -42670,25 +38589,16 @@ tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWith
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["I1", "I11", "I2", "I21", "arrayI1OrI2", "arrayOrI11OrI21", "i1", "i11", "i11Ori21", "i1Ori2", "i2", "i21"]
 rebuilt        : ScopeId(0): ["arrayI1OrI2", "arrayOrI11OrI21", "i1", "i11", "i11Ori21", "i1Ori2", "i2", "i21"]
-Unresolved references mismatch:
-after transform: ["Array"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes3.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Correct", "Err", "SomeReturnType", "example"]
 rebuilt        : ScopeId(0): ["example"]
-Unresolved references mismatch:
-after transform: ["true", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures2.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "a1", "a2", "a3", "f1", "f2", "f3", "n1", "n2", "n3", "s1", "s2", "s3"]
 rebuilt        : ScopeId(0): ["a1", "a2", "a3", "f1", "f2", "f3", "n1", "n2", "n3", "s1", "s2", "s3"]
-Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures3.ts
 semantic error: Symbol reference IDs mismatch:
@@ -42720,14 +38630,6 @@ rebuilt        : ScopeId(0): ["result"]
 Reference symbol mismatch:
 after transform: ReferenceId(4): Some("f")
 rebuilt        : ReferenceId(0): None
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["f"]
-
-tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeIndexSignature.ts
-semantic error: Unresolved references mismatch:
-after transform: ["Date"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction.ts
 semantic error: Bindings mismatch:
@@ -42900,15 +38802,6 @@ rebuilt        : ReferenceId(135): None
 Reference symbol mismatch:
 after transform: ReferenceId(177): Some("s")
 rebuilt        : ReferenceId(136): None
-Unresolved references mismatch:
-after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "N", "Promise", "Symbol", "f", "g"]
-rebuilt        : ["Math", "N", "Promise", "Symbol", "c", "constType", "f", "g", "i", "l", "o", "s"]
-Unresolved reference IDs mismatch for "N":
-after transform: [ReferenceId(86), ReferenceId(90), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(99), ReferenceId(101), ReferenceId(102), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(130), ReferenceId(132), ReferenceId(137), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(145), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(154), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : [ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId(71), ReferenceId(73), ReferenceId(74), ReferenceId(82), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(88), ReferenceId(89), ReferenceId(91), ReferenceId(92), ReferenceId(102), ReferenceId(104), ReferenceId(108), ReferenceId(110), ReferenceId(114), ReferenceId(116), ReferenceId(118), ReferenceId(119), ReferenceId(123), ReferenceId(125), ReferenceId(127), ReferenceId(129), ReferenceId(131)]
-Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(82), ReferenceId(164)]
-rebuilt        : [ReferenceId(60)]
 
 tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookupAmd.ts
 semantic error: Bindings mismatch:

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,9 +1,10 @@
 commit: 12619ffe
 
-Passed: 287/953
+Passed: 335/953
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
+* babel-preset-react
 * babel-plugin-transform-react-display-name
 * babel-plugin-transform-react-jsx-self
 * babel-plugin-transform-react-jsx-source
@@ -1921,7 +1922,7 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 
-# babel-preset-typescript (4/10)
+# babel-preset-typescript (5/10)
 * jsx-compat/ts-invalid/input.ts
   x Expected `>` but found `/`
    ,-[tasks/coverage/babel/packages/babel-preset-typescript/test/fixtures/jsx-compat/ts-invalid/input.ts:1:7]
@@ -1932,12 +1933,6 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * node-extensions/import-in-cts/input.cts
-
-
-* node-extensions/type-assertion-in-ts/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "x"]
-  | rebuilt        : ["x"]
 
 
 * node-extensions/type-param-arrow-in-ts/input.ts
@@ -1965,19 +1960,7 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 
-# babel-plugin-transform-typescript (45/151)
-* cast/as-expression/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "x"]
-  | rebuilt        : ["x"]
-
-
-* cast/type-assertion/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "x"]
-  | rebuilt        : ["x"]
-
-
+# babel-plugin-transform-typescript (54/151)
 * class/accessor-allowDeclareFields-false/input.ts
   x TS(18010): An accessibility modifier cannot be used with a private
   | identifier.
@@ -2004,10 +1987,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   x Bindings mismatch:
   | after transform: ScopeId(1): ["T"]
   | rebuilt        : ScopeId(1): []
-
-  x Unresolved references mismatch:
-  | after transform: ["D", "I"]
-  | rebuilt        : ["D"]
 
 
 * declarations/const-enum/input.ts
@@ -2097,10 +2076,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   x Symbol redeclarations mismatch:
   | after transform: SymbolId(0): [Span { start: 41, end: 48 }]
   | rebuilt        : SymbolId(0): []
-
-  x Unresolved references mismatch:
-  | after transform: ["Cat", "Dog"]
-  | rebuilt        : []
 
 
 * enum/enum-merging-inner-references-shadow/input.ts
@@ -2481,12 +2456,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | rebuilt        : SymbolId(0): []
 
 
-* exports/declare-shadowed/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["Signal", "Signal2"]
-  | rebuilt        : []
-
-
 * exports/declared-types/input.ts
   x Output mismatch
   x Bindings mismatch:
@@ -2558,10 +2527,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ReferenceId(11): ReferenceFlags(Read)
   | rebuilt        : ReferenceId(3): ReferenceFlags(Read | Type)
 
-  x Unresolved references mismatch:
-  | after transform: ["Bar", "C", "M", "N", "f"]
-  | rebuilt        : ["Bar", "E", "x"]
-
 
 * exports/export-const-enums/input.ts
   x Scope flags mismatch:
@@ -2625,29 +2590,17 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
   | rebuilt        : ScopeId(0): ["a"]
 
-  x Unresolved references mismatch:
-  | after transform: ["PromiseLike"]
-  | rebuilt        : []
-
 
 * exports/issue-9916-2/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb"]
   | rebuilt        : ScopeId(0): []
 
-  x Unresolved references mismatch:
-  | after transform: ["PromiseLike"]
-  | rebuilt        : []
-
 
 * exports/issue-9916-3/input.ts
   x Bindings mismatch:
   | after transform: ScopeId(0): ["PromiseRejectCb", "PromiseResolveCb", "a"]
   | rebuilt        : ScopeId(0): ["a"]
-
-  x Unresolved references mismatch:
-  | after transform: ["PromiseLike"]
-  | rebuilt        : []
 
 
 * exports/type-only-export-specifier-1/input.ts
@@ -2926,10 +2879,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   x Reference symbol mismatch:
   | after transform: ReferenceId(4): Some("AliasModule")
   | rebuilt        : ReferenceId(3): Some("AliasModule")
-
-  x Unresolved reference IDs mismatch for "LongNameModule":
-  | after transform: [ReferenceId(1), ReferenceId(5)]
-  | rebuilt        : [ReferenceId(1)]
 
 
 * namespace/clobber-class/input.ts
@@ -3672,10 +3621,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ScopeId(0): ["Platform"]
   | rebuilt        : ScopeId(0): []
 
-  x Unresolved references mismatch:
-  | after transform: ["Platform"]
-  | rebuilt        : []
-
 
 * namespace/module-nested/input.ts
   x Missing SymbolId: src
@@ -4392,10 +4337,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | after transform: ReferenceId(0): Some("A")
   | rebuilt        : ReferenceId(0): None
 
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["A"]
-
 
 * optimize-const-enums/export-const-enum/input.ts
   x Output mismatch
@@ -4618,151 +4559,8 @@ failed to resolve query: failed to parse the rest of input: ...''
   | ReferenceId(28), ReferenceId(29)]
 
 
-* type-arguments/call/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "f"]
-  | rebuilt        : ["f"]
 
-
-* type-arguments/expr/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "f"]
-  | rebuilt        : ["f"]
-
-
-* type-arguments/new/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["C", "T"]
-  | rebuilt        : ["C"]
-
-
-* type-arguments/optional-call/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["Q", "T", "f", "x"]
-  | rebuilt        : ["f", "x"]
-
-
-* type-arguments/tagged-template/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["T", "f"]
-  | rebuilt        : ["f"]
-
-
-* type-arguments/tsx/input.ts
-  x Unresolved reference IDs mismatch for "C":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-
-
-
-# babel-preset-react (4/9)
-* preset-options/development/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* preset-options/development-runtime-automatic/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(2)]
-
-
-* preset-options/empty-options/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(2)]
-
-
-* preset-options/runtime-automatic/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(2)]
-
-
-* preset-options/runtime-classic/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-
-# babel-plugin-transform-react-jsx (100/142)
-* react/adds-appropriate-newlines-when-using-spread-attribute/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/arrow-functions/input.js
-  x Unresolved references mismatch:
-  | after transform: ["React", "this"]
-  | rebuilt        : ["React"]
-
-
-* react/assignment/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/dont-coerce-expression-containers/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/honor-custom-jsx-comment/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/honor-custom-jsx-comment-if-jsx-pragma-option-set/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/honor-custom-jsx-pragma-option/input.js
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-allow-constructor-as-prop/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-allow-deeper-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-allow-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
-  x Unresolved reference IDs mismatch for "Composite":
-  | after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(12), ReferenceId(14)]
-  | rebuilt        : [ReferenceId(6), ReferenceId(9)]
-
-  x Unresolved reference IDs mismatch for "Composite2":
-  | after transform: [ReferenceId(7), ReferenceId(15)]
-  | rebuilt        : [ReferenceId(11)]
-
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(8)]
-  | rebuilt        : [ReferenceId(2)]
-
-
+# babel-plugin-transform-react-jsx (132/142)
 * react/should-disallow-valueless-key/input.js
   ! Please provide an explicit key value. Using "key" as a shorthand for
   | "key={true}" is not allowed.
@@ -4789,18 +4587,6 @@ failed to resolve query: failed to parse the rest of input: ...''
   | rebuilt        : SymbolId(0): [ReferenceId(4)]
 
 
-* react/should-have-correct-comma-in-nested-children/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
-  | rebuilt        : [ReferenceId(4)]
-
-
-* react/should-not-add-quotes-to-identifier-names/input.js
-  x Unresolved reference IDs mismatch for "F":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
 * react/should-throw-error-namespaces-if-not-flag/input.js
   ! Namespace tags are not supported by default. React's JSX doesn't support
   | namespace tags. You can set `throwIfNamespace: false` to bypass this
@@ -4811,101 +4597,14 @@ failed to resolve query: failed to parse the rest of input: ...''
    `----
 
 
-* react/this-tag-name/input.js
-  x Unresolved references mismatch:
-  | after transform: ["React", "this"]
-  | rebuilt        : ["React"]
-
-
-* react/weird-symbols/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-  | rebuilt        : [ReferenceId(2)]
-
-
-* react/wraps-props-in-react-spread-for-first-spread-attributes/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/wraps-props-in-react-spread-for-last-spread-attributes/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react/wraps-props-in-react-spread-for-middle-spread-attributes/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/adds-appropriate-newlines-when-using-spread-attribute/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/arrow-functions/input.js
-  x Unresolved references mismatch:
-  | after transform: ["this"]
-  | rebuilt        : []
-
-
-* react-automatic/assignment/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
 * react-automatic/does-not-add-source-self-automatic/input.mjs
 transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `development`, `throwIfNamespace`, `pure`, `importSource`, `pragma`, `pragmaFrag`, `useBuiltIns`, `useSpread`, `refresh`
-
-* react-automatic/dont-coerce-expression-containers/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
 
 * react-automatic/handle-fragments-with-key/input.js
   x Symbol reference IDs mismatch:
   | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
   | ReferenceId(2)]
   | rebuilt        : SymbolId(0): [ReferenceId(1)]
-
-
-* react-automatic/should-allow-constructor-as-prop/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/should-allow-deeper-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/should-allow-js-namespacing/input.js
-  x Unresolved reference IDs mismatch for "Namespace":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
-  x Unresolved reference IDs mismatch for "Composite":
-  | after transform: [ReferenceId(2), ReferenceId(3), ReferenceId(5),
-  | ReferenceId(6), ReferenceId(12), ReferenceId(16)]
-  | rebuilt        : [ReferenceId(6), ReferenceId(9)]
-
-  x Unresolved reference IDs mismatch for "Composite2":
-  | after transform: [ReferenceId(7), ReferenceId(14)]
-  | rebuilt        : [ReferenceId(11)]
-
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(8)]
-  | rebuilt        : [ReferenceId(2)]
 
 
 * react-automatic/should-disallow-valueless-key/input.js
@@ -4934,18 +4633,6 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
   | rebuilt        : SymbolId(2): [ReferenceId(4)]
 
 
-* react-automatic/should-have-correct-comma-in-nested-children/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(7)]
-  | rebuilt        : [ReferenceId(4)]
-
-
-* react-automatic/should-not-add-quotes-to-identifier-names/input.js
-  x Unresolved reference IDs mismatch for "F":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
-
-
 * react-automatic/should-throw-error-namespaces-if-not-flag/input.js
   ! Namespace tags are not supported by default. React's JSX doesn't support
   | namespace tags. You can set `throwIfNamespace: false` to bypass this
@@ -4956,32 +4643,8 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
    `----
 
 
-* react-automatic/this-tag-name/input.js
-  x Unresolved references mismatch:
-  | after transform: ["this"]
-  | rebuilt        : []
 
-
-* react-automatic/weird-symbols/input.js
-  x Unresolved reference IDs mismatch for "Text":
-  | after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-  | rebuilt        : [ReferenceId(2)]
-
-
-* react-automatic/wraps-props-in-react-spread-for-last-spread-attributes/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-* react-automatic/wraps-props-in-react-spread-for-middle-spread-attributes/input.js
-  x Unresolved reference IDs mismatch for "Component":
-  | after transform: [ReferenceId(0), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(1)]
-
-
-
-# babel-plugin-transform-react-jsx-development (6/10)
+# babel-plugin-transform-react-jsx-development (7/10)
 * cross-platform/disallow-__self-as-jsx-attribute/input.js
   ! Duplicate __self prop found.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-jsx-development/test/fixtures/cross-platform/disallow-__self-as-jsx-attribute/input.js:1:14]
@@ -4996,12 +4659,6 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
  1 | var x = <div __source={source}></div>;
    :              ^^^^^^^^
    `----
-
-
-* cross-platform/handle-fragments-with-key/input.js
-  x Unresolved reference IDs mismatch for "React":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-  | rebuilt        : [ReferenceId(2)]
 
 
 * cross-platform/within-ts-module-block/input.ts

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,19 +1,13 @@
 commit: 12619ffe
 
-Passed: 10/37
+Passed: 11/37
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-arrow-functions
 
 
-# babel-plugin-transform-typescript (2/8)
-* class-property-definition/input.ts
-  x Unresolved references mismatch:
-  | after transform: ["const"]
-  | rebuilt        : []
-
-
+# babel-plugin-transform-typescript (3/8)
 * computed-constant-value/input.ts
   x Missing ReferenceId: Infinity
 
@@ -70,16 +64,6 @@ Passed: 10/37
   x Symbol flags mismatch:
   | after transform: SymbolId(16): SymbolFlags(RegularEnum)
   | rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-
-  x Unresolved references mismatch:
-  | after transform: ["Infinity", "NaN"]
-  | rebuilt        : ["Infinity"]
-
-  x Unresolved reference IDs mismatch for "Infinity":
-  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2),
-  | ReferenceId(3)]
-  | rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8),
-  | ReferenceId(12)]
 
 
 * elimination-declare/input.ts
@@ -317,11 +301,6 @@ Passed: 10/37
   | after transform: ReferenceId(53): Some("_c5")
   | rebuilt        : ReferenceId(53): None
 
-  x Unresolved references mismatch:
-  | after transform: ["X", "memo", "module", "useContext"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "X", "memo", "module",
-  | "useContext"]
-
 
 * refresh/does-not-consider-require-like-methods-to-be-hocs/input.jsx
   x Symbol reference IDs mismatch:
@@ -349,10 +328,6 @@ Passed: 10/37
   | after transform: ReferenceId(21): Some("_c")
   | rebuilt        : ReferenceId(17): None
 
-  x Unresolved references mismatch:
-  | after transform: ["foo", "gk", "require", "requireCond"]
-  | rebuilt        : ["$RefreshReg$", "foo", "gk", "require", "requireCond"]
-
 
 * refresh/does-not-get-tripped-by-iifes/input.jsx
   x Bindings mismatch:
@@ -376,10 +351,6 @@ Passed: 10/37
   | after transform: ReferenceId(3): Some("_s")
   | rebuilt        : ReferenceId(1): None
 
-  x Unresolved references mismatch:
-  | after transform: ["item", "useFoo"]
-  | rebuilt        : ["$RefreshSig$", "item", "useFoo"]
-
 
 * refresh/generates-signatures-for-function-declarations-calling-hooks/input.jsx
   x Symbol reference IDs mismatch:
@@ -399,10 +370,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(10): Some("_c")
   | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "useState"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "useState"]
 
 
 * refresh/generates-signatures-for-function-expressions-calling-hooks/input.jsx
@@ -505,11 +472,6 @@ Passed: 10/37
   | after transform: ReferenceId(51): Some("_c6")
   | rebuilt        : ReferenceId(51): None
 
-  x Unresolved references mismatch:
-  | after transform: ["React", "ref", "useState"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React", "ref",
-  | "useState"]
-
 
 * refresh/generates-valid-signature-for-exotic-ways-to-call-hooks/input.jsx
   x Missing ScopeId
@@ -540,11 +502,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(21): Some("_c")
   | rebuilt        : ReferenceId(21): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "useFancyEffect", "useThePlatform"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React",
-  | "useFancyEffect", "useThePlatform"]
 
 
 * refresh/includes-custom-hooks-into-the-signatures/input.jsx
@@ -588,10 +545,6 @@ Passed: 10/37
   | after transform: ReferenceId(23): Some("_c")
   | rebuilt        : ReferenceId(23): None
 
-  x Unresolved references mismatch:
-  | after transform: ["React"]
-  | rebuilt        : ["$RefreshReg$", "$RefreshSig$", "React"]
-
 
 * refresh/registers-capitalized-identifiers-in-hoc-calls/input.jsx
   x Symbol reference IDs mismatch:
@@ -633,10 +586,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(20): Some("_c4")
   | rebuilt        : ReferenceId(20): None
-
-  x Unresolved references mismatch:
-  | after transform: ["hoc"]
-  | rebuilt        : ["$RefreshReg$", "hoc"]
 
 
 * refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
@@ -737,10 +686,6 @@ Passed: 10/37
   | after transform: ReferenceId(63): Some("_c6")
   | rebuilt        : ReferenceId(54): None
 
-  x Unresolved references mismatch:
-  | after transform: ["funny", "hoc", "styled", "wow"]
-  | rebuilt        : ["$RefreshReg$", "funny", "hoc", "styled", "wow"]
-
 
 * refresh/registers-identifiers-used-in-react-create-element-at-definition-site/input.jsx
   x Output mismatch
@@ -797,11 +742,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(55): Some("_c6")
   | rebuilt        : ReferenceId(55): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "funny", "hoc", "jsx", "styled", "wow"]
-  | rebuilt        : ["$RefreshReg$", "React", "funny", "hoc", "jsx",
-  | "styled", "wow"]
 
 
 * refresh/registers-likely-hocs-with-inline-functions-1/input.jsx
@@ -901,10 +841,6 @@ Passed: 10/37
   | after transform: ReferenceId(32): Some("_c8")
   | rebuilt        : ReferenceId(32): None
 
-  x Unresolved references mismatch:
-  | after transform: ["React", "forwardRef", "memo"]
-  | rebuilt        : ["$RefreshReg$", "React", "forwardRef", "memo"]
-
 
 * refresh/registers-likely-hocs-with-inline-functions-2/input.jsx
   x Symbol reference IDs mismatch:
@@ -945,10 +881,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(10): Some("_c3")
   | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: ["React", "forwardRef"]
-  | rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
 
 
 * refresh/registers-likely-hocs-with-inline-functions-3/input.jsx
@@ -991,10 +923,6 @@ Passed: 10/37
   | after transform: ReferenceId(10): Some("_c3")
   | rebuilt        : ReferenceId(10): None
 
-  x Unresolved references mismatch:
-  | after transform: ["React", "forwardRef"]
-  | rebuilt        : ["$RefreshReg$", "React", "forwardRef"]
-
 
 * refresh/registers-top-level-exported-function-declarations/input.jsx
   x Symbol reference IDs mismatch:
@@ -1029,10 +957,6 @@ Passed: 10/37
   | after transform: ReferenceId(18): Some("_c3")
   | rebuilt        : ReferenceId(17): None
 
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
 
 * refresh/registers-top-level-exported-named-arrow-functions/input.jsx
   x Symbol reference IDs mismatch:
@@ -1059,10 +983,6 @@ Passed: 10/37
   | after transform: ReferenceId(14): Some("_c2")
   | rebuilt        : ReferenceId(12): None
 
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
 
 * refresh/registers-top-level-function-declarations/input.jsx
   x Symbol reference IDs mismatch:
@@ -1087,10 +1007,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(11): Some("_c2")
   | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
 
 
 * refresh/registers-top-level-variable-declarations-with-arrow-functions/input.jsx
@@ -1126,10 +1042,6 @@ Passed: 10/37
   | after transform: ReferenceId(16): Some("_c3")
   | rebuilt        : ReferenceId(15): None
 
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
-
 
 * refresh/registers-top-level-variable-declarations-with-function-expressions/input.jsx
   x Symbol reference IDs mismatch:
@@ -1154,10 +1066,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(11): Some("_c2")
   | rebuilt        : ReferenceId(10): None
-
-  x Unresolved references mismatch:
-  | after transform: []
-  | rebuilt        : ["$RefreshReg$"]
 
 
 * refresh/supports-typescript-namespace-syntax/input.tsx
@@ -1279,15 +1187,6 @@ Passed: 10/37
   | after transform: ReferenceId(11): Some("_c")
   | rebuilt        : ReferenceId(10): None
 
-  x Unresolved references mismatch:
-  | after transform: ["Foo", "X", "useContext"]
-  | rebuilt        : ["Foo", "X", "import.meta.refreshReg",
-  | "import.meta.refreshSig", "useContext"]
-
-  x Unresolved reference IDs mismatch for "Foo":
-  | after transform: [ReferenceId(2), ReferenceId(5)]
-  | rebuilt        : [ReferenceId(5)]
-
 
 * refresh/uses-original-function-declaration-if-it-get-reassigned/input.jsx
   x Symbol reference IDs mismatch:
@@ -1298,10 +1197,6 @@ Passed: 10/37
   x Reference symbol mismatch:
   | after transform: ReferenceId(6): Some("_c")
   | rebuilt        : ReferenceId(6): None
-
-  x Unresolved references mismatch:
-  | after transform: ["connect"]
-  | rebuilt        : ["$RefreshReg$", "connect"]
 
 
 


### PR DESCRIPTION
As I said in https://github.com/oxc-project/oxc/pull/5298#discussion_r1734689525. The `unresolved_references` check is incorrect. In the meantime, I found that `check_reference` contained the `unresolved_references` check, so I removed it