### PR TITLE
fix(linter): mark the class/function in the new expression as used

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -59,6 +59,11 @@ impl<'s, 'a> Symbol<'s, 'a> {
                     };
                     return body.span.contains_inclusive(self.span()) && body.statements.len() == 1 && !self.get_snippet(body.span).starts_with('{')
                 }
+                // new (class CustomRenderer{})
+                // new (function() {})
+                AstKind::NewExpression(_) => {
+                    return true;
+                }
                 _ => {
                     parent.kind().debug_name();
                     return false;

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -42,6 +42,9 @@ impl<'s, 'a> Symbol<'s, 'a> {
                 // e.g. var foo = function bar() { }
                 // we don't want to check for violations on `bar`, just `foo`
                 | AstKind::VariableDeclarator(_)
+                // new (class CustomRenderer{})
+                // new (function() {})
+                | AstKind::NewExpression(_)
                 => {
                     return true;
                 }
@@ -58,11 +61,6 @@ impl<'s, 'a> Symbol<'s, 'a> {
                         return false;
                     };
                     return body.span.contains_inclusive(self.span()) && body.statements.len() == 1 && !self.get_snippet(body.span).starts_with('{')
-                }
-                // new (class CustomRenderer{})
-                // new (function() {})
-                AstKind::NewExpression(_) => {
-                    return true;
                 }
                 _ => {
                     parent.kind().debug_name();

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -14,9 +14,9 @@ fn test_vars_simple() {
         ("let _a = 1", Some(json!([{ "varsIgnorePattern": "^_" }]))),
         ("const { foo: _foo, baz } = obj; f(baz);", Some(json!([{ "varsIgnorePattern": "^_" }]))),
         (
-            r#"export const rendered = marked(markdown, {
-                    renderer: new (class CustomRenderer extends Renderer {})(),
-               });"#,
+            r"export const rendered = marked(markdown, {
+                  renderer: new (class CustomRenderer extends Renderer {})(),
+              });",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -13,6 +13,12 @@ fn test_vars_simple() {
         ("let a = 1; if (true) { console.log(a) }", None),
         ("let _a = 1", Some(json!([{ "varsIgnorePattern": "^_" }]))),
         ("const { foo: _foo, baz } = obj; f(baz);", Some(json!([{ "varsIgnorePattern": "^_" }]))),
+        (
+            r#"export const rendered = marked(markdown, {
+                    renderer: new (class CustomRenderer extends Renderer {})(),
+               });"#,
+            None,
+        ),
     ];
     let fail = vec![
         ("let a = 1", None),


### PR DESCRIPTION
- Fix: #5274 