### PR TITLE
chore(bench): include fixers in linter benchmarks

### DIFF
--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -6,7 +6,7 @@ use std::{
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, LintOptions, Linter};
+use oxc_linter::{AllowWarnDeny, FixKind, LintOptions, Linter};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -43,6 +43,7 @@ fn bench_linter(criterion: &mut Criterion) {
                 ];
                 let lint_options = LintOptions::default()
                     .with_filter(filter)
+                    .with_fix(FixKind::All)
                     .with_import_plugin(true)
                     .with_jsdoc_plugin(true)
                     .with_jest_plugin(true)


### PR DESCRIPTION
Fixing code is an important part of linter logic. We want to make sure fixers for each rule, and the code responsible for applying those fixes, are included in benchmarks.

As it currently stands, fixer closures are applied regardless of whether the user wants fixers to be applied. However, this is an implementation detail and is subject to change. I  also want to bench the performance of `Fixer`.