### PR TITLE
feat(linter) catch more cases for `misrefactored-assign-op`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/misrefactored_assign_op.rs
@@ -98,6 +98,7 @@ fn assignment_target_eq_expr<'a>(
     right_expr: &Expression<'_>,
     ctx: &LintContext<'a>,
 ) -> bool {
+    let right_expr = right_expr.get_inner_expression();
     if let Some(simple_assignment_target) = assignment_target.as_simple_assignment_target() {
         return match simple_assignment_target {
             SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) => {
@@ -215,6 +216,10 @@ fn test() {
         "a &= a & 1;",
         //~^ ERROR: variable appears on both sides of an assignment operation
         "a *= a * a;",
+        //~^ ERROR: variable appears on both sides of an assignment operation
+        "a *= a * (a as number);",
+        //~^ ERROR: variable appears on both sides of an assignment operation
+        "a *= (a as string) * (a as number);",
         //~^ ERROR: variable appears on both sides of an assignment operation
     ];
 

--- a/crates/oxc_linter/src/snapshots/misrefactored_assign_op.snap
+++ b/crates/oxc_linter/src/snapshots/misrefactored_assign_op.snap
@@ -70,3 +70,31 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────
    ╰────
   help: Did you mean `a *= a`?
+
+  ⚠ oxc(misrefactored-assign-op): Misrefactored assign op. Variable appears on both sides of an assignment operation
+   ╭─[misrefactored_assign_op.tsx:1:1]
+ 1 │ a *= a * (a as number);
+   · ──────────────────────
+   ╰────
+  help: Did you mean `a *= (a as number)`?
+
+  ⚠ oxc(misrefactored-assign-op): Misrefactored assign op. Variable appears on both sides of an assignment operation
+   ╭─[misrefactored_assign_op.tsx:1:1]
+ 1 │ a *= a * (a as number);
+   · ──────────────────────
+   ╰────
+  help: Did you mean `a *= a`?
+
+  ⚠ oxc(misrefactored-assign-op): Misrefactored assign op. Variable appears on both sides of an assignment operation
+   ╭─[misrefactored_assign_op.tsx:1:1]
+ 1 │ a *= (a as string) * (a as number);
+   · ──────────────────────────────────
+   ╰────
+  help: Did you mean `a *= (a as number)`?
+
+  ⚠ oxc(misrefactored-assign-op): Misrefactored assign op. Variable appears on both sides of an assignment operation
+   ╭─[misrefactored_assign_op.tsx:1:1]
+ 1 │ a *= (a as string) * (a as number);
+   · ──────────────────────────────────
+   ╰────
+  help: Did you mean `a *= (a as string)`?

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -237,8 +237,8 @@ pub fn is_same_member_expression(
     ) = (left, right)
     {
         if !is_same_reference(
-            left.expression.without_parenthesized(),
-            right.expression.without_parenthesized(),
+            left.expression.get_inner_expression(),
+            right.expression.get_inner_expression(),
             ctx,
         ) {
             return false;
@@ -246,8 +246,8 @@ pub fn is_same_member_expression(
     }
 
     return is_same_reference(
-        left.object().without_parenthesized(),
-        right.object().without_parenthesized(),
+        left.object().get_inner_expression(),
+        right.object().get_inner_expression(),
         ctx,
     );
 }


### PR DESCRIPTION
changes from using `without_parenthesis` to using `get_inner_expression` to ignore type casts, non null assertions ect.

this helps catch more error cases