### PR TITLE
refactor(diagnostic): change how diagnostic codes are rendered

### DIFF
--- a/crates/oxc_diagnostics/src/graphic_reporter.rs
+++ b/crates/oxc_diagnostics/src/graphic_reporter.rs
@@ -188,7 +188,7 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         diagnostic: &(dyn Diagnostic),
     ) -> fmt::Result {
-        self.render_header(f, diagnostic)?;
+        // self.render_header(f, diagnostic)?;
         writeln!(f)?;
         self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();
@@ -271,7 +271,12 @@ impl GraphicalReportHandler {
             opts = opts.word_splitter(word_splitter);
         }
 
-        let title = format!("{}", diagnostic.to_string().style(severity_style));
+        let title = if let Some(code) = diagnostic.code() {
+            format!("{code}: {diagnostic}")
+        } else {
+            diagnostic.to_string()
+        };
+        let title = format!("{}", title.style(severity_style));
         let title = textwrap::fill(&title, opts);
         writeln!(f, "{}", title)?;
 

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -75,9 +75,6 @@ pub struct OxcDiagnosticInner {
 
 impl fmt::Display for OxcDiagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.code.is_some() {
-            write!(f, "{}: ", &self.code)?;
-        }
         write!(f, "{}", &self.message)
     }
 }
@@ -102,8 +99,7 @@ impl Diagnostic for OxcDiagnostic {
     }
 
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        // self.code.is_some().then(|| Box::new(&self.code) as Box<dyn Display>)
-        None
+        self.code.is_some().then(|| Box::new(&self.code) as Box<dyn Display>)
     }
 }
 

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -2146,8 +2146,9 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * class/accessor-allowDeclareFields-false/input.ts
-  x TS(18010): An accessibility modifier cannot be used with a private
-  | identifier.
+TS(18010)
+
+  x An accessibility modifier cannot be used with a private identifier.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/accessor-allowDeclareFields-false/input.ts:8:3]
  7 |   abstract accessor prop6: number;
  8 |   private accessor #p: any;
@@ -2157,8 +2158,9 @@ failed to resolve query: failed to parse the rest of input: ...''
 
 
 * class/accessor-allowDeclareFields-true/input.ts
-  x TS(18010): An accessibility modifier cannot be used with a private
-  | identifier.
+TS(18010)
+
+  x An accessibility modifier cannot be used with a private identifier.
    ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/accessor-allowDeclareFields-true/input.ts:8:3]
  7 |   abstract accessor prop6: number;
  8 |   private accessor #p: any;


### PR DESCRIPTION
Preparation for upstack PRs. Graphical reporter diagnostics look exactly the same. This does, however, change `to_string()` to only show diagnostic messages, and not error codes + messages.