### PR TITLE
refactor(transformer/object-rest-spread): move plugin-relates files to `object_rest_spread` mod

### DIFF
--- a/crates/oxc_transformer/src/es2018/mod.rs
+++ b/crates/oxc_transformer/src/es2018/mod.rs
@@ -1,6 +1,4 @@
-mod object_rest;
 mod object_rest_spread;
-mod object_spread;
 mod options;
 
 pub use object_rest_spread::{ObjectRestSpread, ObjectRestSpreadOptions};

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/mod.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/mod.rs
@@ -28,12 +28,14 @@
 
 use crate::context::Ctx;
 
+use object_rest::ObjectRest;
+use object_spread::ObjectSpread;
 use oxc_ast::ast::*;
 use oxc_traverse::{Traverse, TraverseCtx};
 use serde::Deserialize;
 use std::rc::Rc;
-
-use super::{object_rest::ObjectRest, object_spread::ObjectSpread};
+mod object_rest;
+mod object_spread;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/object_rest.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/object_rest.rs
@@ -24,8 +24,9 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-object-rest-spread>
 //! * Object rest/spread TC39 proposal: <https://github.com/tc39/proposal-object-rest-spread>
 
-use super::object_rest_spread::ObjectRestSpreadOptions;
 use crate::context::Ctx;
+
+use super::ObjectRestSpreadOptions;
 
 pub struct ObjectRest<'a> {
     _ctx: Ctx<'a>,

--- a/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread/object_spread.rs
@@ -26,13 +26,14 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-object-rest-spread>
 //! * Object rest/spread TC39 proposal: <https://github.com/tc39/proposal-object-rest-spread>
 
-use super::object_rest_spread::ObjectRestSpreadOptions;
 use crate::context::Ctx;
 
 use oxc_ast::ast::*;
 use oxc_semantic::{ReferenceFlags, SymbolId};
 use oxc_span::SPAN;
 use oxc_traverse::{Traverse, TraverseCtx};
+
+use super::ObjectRestSpreadOptions;
 
 pub struct ObjectSpread<'a> {
     _ctx: Ctx<'a>,


### PR DESCRIPTION
Both `object_spread` and `object_rest` belong to `object_rest_object`, so moving them to the plugin mod makes the file structure clearer