### PR TITLE
ci(benchmark/transformer): enable all > es6 plugins

### DIFF
--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -6,7 +6,7 @@ use oxc_parser::{Parser, ParserReturn};
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFiles;
-use oxc_transformer::{TransformOptions, Transformer};
+use oxc_transformer::{EnvOptions, Targets, TransformOptions, Transformer};
 
 fn bench_transformer(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("transformer");
@@ -41,7 +41,17 @@ fn bench_transformer(criterion: &mut Criterion) {
                 let trivias_copy = trivias.clone();
 
                 runner.run(|| {
-                    let transform_options = TransformOptions::default();
+                    let env_options = EnvOptions {
+                        // >= ES2016
+                        targets: Targets::from_query("chrome 51"),
+                        ..Default::default()
+                    };
+                    let mut transform_options =
+                        TransformOptions::from_preset_env(&env_options).unwrap();
+
+                    // Enable React related plugins
+                    transform_options.react.development = true;
+
                     let ret = Transformer::new(
                         &allocator,
                         Path::new(&file.file_name),


### PR DESCRIPTION
There is a bug in the react refresh plugin, I will fix it in follow-up PR and enable the plugin in the benchmark