### PR TITLE
refactor(ast): box `TSThisParameter`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1715,7 +1715,7 @@ pub struct Function<'a> {
     ///   return this.admin;
     /// });
     /// ```
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub body: Option<Box<'a, FunctionBody<'a>>>,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -914,7 +914,7 @@ pub struct TSMethodSignature<'a> {
     pub computed: bool,
     pub optional: bool,
     pub kind: TSMethodSignatureKind,
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -1178,7 +1178,7 @@ pub enum TSImportAttributeName<'a> {
 pub struct TSFunctionType<'a> {
     #[serde(flatten)]
     pub span: Span,
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -146,7 +146,7 @@ impl<'a> AstBuilder<'a> {
             false,
             false,
             Option::<TSTypeParameterDeclaration>::None,
-            None,
+            None::<Box<'a, TSThisParameter<'a>>>,
             params,
             Option::<TSTypeAnnotation>::None,
             body,

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1028,7 +1028,7 @@ impl<'a> Function<'a> {
         generator: bool,
         r#async: bool,
         declare: bool,
-        this_param: Option<TSThisParameter<'a>>,
+        this_param: Option<Box<'a, TSThisParameter<'a>>>,
         params: Box<'a, FormalParameters<'a>>,
         body: Option<Box<'a, FunctionBody<'a>>>,
         type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -538,7 +538,7 @@ const _: () = {
     assert!(offset_of!(BindingRestElement, span) == 0usize);
     assert!(offset_of!(BindingRestElement, argument) == 8usize);
 
-    assert!(size_of::<Function>() == 136usize);
+    assert!(size_of::<Function>() == 104usize);
     assert!(align_of::<Function>() == 8usize);
     assert!(offset_of!(Function, r#type) == 0usize);
     assert!(offset_of!(Function, span) == 4usize);
@@ -548,10 +548,10 @@ const _: () = {
     assert!(offset_of!(Function, declare) == 50usize);
     assert!(offset_of!(Function, type_parameters) == 56usize);
     assert!(offset_of!(Function, this_param) == 64usize);
-    assert!(offset_of!(Function, params) == 104usize);
-    assert!(offset_of!(Function, return_type) == 112usize);
-    assert!(offset_of!(Function, body) == 120usize);
-    assert!(offset_of!(Function, scope_id) == 128usize);
+    assert!(offset_of!(Function, params) == 72usize);
+    assert!(offset_of!(Function, return_type) == 80usize);
+    assert!(offset_of!(Function, body) == 88usize);
+    assert!(offset_of!(Function, scope_id) == 96usize);
 
     assert!(size_of::<FunctionType>() == 1usize);
     assert!(align_of::<FunctionType>() == 1usize);
@@ -1042,7 +1042,7 @@ const _: () = {
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
 
-    assert!(size_of::<TSMethodSignature>() == 104usize);
+    assert!(size_of::<TSMethodSignature>() == 72usize);
     assert!(align_of::<TSMethodSignature>() == 8usize);
     assert!(offset_of!(TSMethodSignature, span) == 0usize);
     assert!(offset_of!(TSMethodSignature, key) == 8usize);
@@ -1050,10 +1050,10 @@ const _: () = {
     assert!(offset_of!(TSMethodSignature, optional) == 25usize);
     assert!(offset_of!(TSMethodSignature, kind) == 26usize);
     assert!(offset_of!(TSMethodSignature, this_param) == 32usize);
-    assert!(offset_of!(TSMethodSignature, params) == 72usize);
-    assert!(offset_of!(TSMethodSignature, return_type) == 80usize);
-    assert!(offset_of!(TSMethodSignature, type_parameters) == 88usize);
-    assert!(offset_of!(TSMethodSignature, scope_id) == 96usize);
+    assert!(offset_of!(TSMethodSignature, params) == 40usize);
+    assert!(offset_of!(TSMethodSignature, return_type) == 48usize);
+    assert!(offset_of!(TSMethodSignature, type_parameters) == 56usize);
+    assert!(offset_of!(TSMethodSignature, scope_id) == 64usize);
 
     assert!(size_of::<TSConstructSignatureDeclaration>() == 40usize);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 8usize);
@@ -1152,13 +1152,13 @@ const _: () = {
     assert!(size_of::<TSImportAttributeName>() == 32usize);
     assert!(align_of::<TSImportAttributeName>() == 8usize);
 
-    assert!(size_of::<TSFunctionType>() == 72usize);
+    assert!(size_of::<TSFunctionType>() == 40usize);
     assert!(align_of::<TSFunctionType>() == 8usize);
     assert!(offset_of!(TSFunctionType, span) == 0usize);
     assert!(offset_of!(TSFunctionType, this_param) == 8usize);
-    assert!(offset_of!(TSFunctionType, params) == 48usize);
-    assert!(offset_of!(TSFunctionType, return_type) == 56usize);
-    assert!(offset_of!(TSFunctionType, type_parameters) == 64usize);
+    assert!(offset_of!(TSFunctionType, params) == 16usize);
+    assert!(offset_of!(TSFunctionType, return_type) == 24usize);
+    assert!(offset_of!(TSFunctionType, type_parameters) == 32usize);
 
     assert!(size_of::<TSConstructorType>() == 40usize);
     assert!(align_of::<TSConstructorType>() == 8usize);
@@ -1939,7 +1939,7 @@ const _: () = {
     assert!(offset_of!(BindingRestElement, span) == 0usize);
     assert!(offset_of!(BindingRestElement, argument) == 8usize);
 
-    assert!(size_of::<Function>() == 84usize);
+    assert!(size_of::<Function>() == 60usize);
     assert!(align_of::<Function>() == 4usize);
     assert!(offset_of!(Function, r#type) == 0usize);
     assert!(offset_of!(Function, span) == 4usize);
@@ -1949,10 +1949,10 @@ const _: () = {
     assert!(offset_of!(Function, declare) == 34usize);
     assert!(offset_of!(Function, type_parameters) == 36usize);
     assert!(offset_of!(Function, this_param) == 40usize);
-    assert!(offset_of!(Function, params) == 68usize);
-    assert!(offset_of!(Function, return_type) == 72usize);
-    assert!(offset_of!(Function, body) == 76usize);
-    assert!(offset_of!(Function, scope_id) == 80usize);
+    assert!(offset_of!(Function, params) == 44usize);
+    assert!(offset_of!(Function, return_type) == 48usize);
+    assert!(offset_of!(Function, body) == 52usize);
+    assert!(offset_of!(Function, scope_id) == 56usize);
 
     assert!(size_of::<FunctionType>() == 1usize);
     assert!(align_of::<FunctionType>() == 1usize);
@@ -2443,7 +2443,7 @@ const _: () = {
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
 
-    assert!(size_of::<TSMethodSignature>() == 64usize);
+    assert!(size_of::<TSMethodSignature>() == 40usize);
     assert!(align_of::<TSMethodSignature>() == 4usize);
     assert!(offset_of!(TSMethodSignature, span) == 0usize);
     assert!(offset_of!(TSMethodSignature, key) == 8usize);
@@ -2451,10 +2451,10 @@ const _: () = {
     assert!(offset_of!(TSMethodSignature, optional) == 17usize);
     assert!(offset_of!(TSMethodSignature, kind) == 18usize);
     assert!(offset_of!(TSMethodSignature, this_param) == 20usize);
-    assert!(offset_of!(TSMethodSignature, params) == 48usize);
-    assert!(offset_of!(TSMethodSignature, return_type) == 52usize);
-    assert!(offset_of!(TSMethodSignature, type_parameters) == 56usize);
-    assert!(offset_of!(TSMethodSignature, scope_id) == 60usize);
+    assert!(offset_of!(TSMethodSignature, params) == 24usize);
+    assert!(offset_of!(TSMethodSignature, return_type) == 28usize);
+    assert!(offset_of!(TSMethodSignature, type_parameters) == 32usize);
+    assert!(offset_of!(TSMethodSignature, scope_id) == 36usize);
 
     assert!(size_of::<TSConstructSignatureDeclaration>() == 24usize);
     assert!(align_of::<TSConstructSignatureDeclaration>() == 4usize);
@@ -2553,13 +2553,13 @@ const _: () = {
     assert!(size_of::<TSImportAttributeName>() == 20usize);
     assert!(align_of::<TSImportAttributeName>() == 4usize);
 
-    assert!(size_of::<TSFunctionType>() == 48usize);
+    assert!(size_of::<TSFunctionType>() == 24usize);
     assert!(align_of::<TSFunctionType>() == 4usize);
     assert!(offset_of!(TSFunctionType, span) == 0usize);
     assert!(offset_of!(TSFunctionType, this_param) == 8usize);
-    assert!(offset_of!(TSFunctionType, params) == 36usize);
-    assert!(offset_of!(TSFunctionType, return_type) == 40usize);
-    assert!(offset_of!(TSFunctionType, type_parameters) == 44usize);
+    assert!(offset_of!(TSFunctionType, params) == 12usize);
+    assert!(offset_of!(TSFunctionType, return_type) == 16usize);
+    assert!(offset_of!(TSFunctionType, type_parameters) == 20usize);
 
     assert!(size_of::<TSConstructorType>() == 24usize);
     assert!(align_of::<TSConstructorType>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -842,7 +842,7 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - body
     #[inline]
-    pub fn expression_function<T1, T2, T3, T4>(
+    pub fn expression_function<T1, T2, T3, T4, T5>(
         self,
         r#type: FunctionType,
         span: Span,
@@ -851,16 +851,17 @@ impl<'a> AstBuilder<'a> {
         r#async: bool,
         declare: bool,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
+        body: T5,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Expression::FunctionExpression(self.alloc(self.function(
             r#type,
@@ -4188,7 +4189,7 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - body
     #[inline]
-    pub fn declaration_function<T1, T2, T3, T4>(
+    pub fn declaration_function<T1, T2, T3, T4, T5>(
         self,
         r#type: FunctionType,
         span: Span,
@@ -4197,16 +4198,17 @@ impl<'a> AstBuilder<'a> {
         r#async: bool,
         declare: bool,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
+        body: T5,
     ) -> Declaration<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Declaration::FunctionDeclaration(self.alloc(self.function(
             r#type,
@@ -5727,7 +5729,7 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - body
     #[inline]
-    pub fn function<T1, T2, T3, T4>(
+    pub fn function<T1, T2, T3, T4, T5>(
         self,
         r#type: FunctionType,
         span: Span,
@@ -5736,16 +5738,17 @@ impl<'a> AstBuilder<'a> {
         r#async: bool,
         declare: bool,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
+        body: T5,
     ) -> Function<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
             r#type,
@@ -5755,7 +5758,7 @@ impl<'a> AstBuilder<'a> {
             r#async,
             declare,
             type_parameters: type_parameters.into_in(self.allocator),
-            this_param,
+            this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
             body: body.into_in(self.allocator),
@@ -5780,7 +5783,7 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - body
     #[inline]
-    pub fn alloc_function<T1, T2, T3, T4>(
+    pub fn alloc_function<T1, T2, T3, T4, T5>(
         self,
         r#type: FunctionType,
         span: Span,
@@ -5789,16 +5792,17 @@ impl<'a> AstBuilder<'a> {
         r#async: bool,
         declare: bool,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
+        body: T5,
     ) -> Box<'a, Function<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Box::new_in(
             self.function(
@@ -7637,7 +7641,7 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - body
     #[inline]
-    pub fn export_default_declaration_kind_function<T1, T2, T3, T4>(
+    pub fn export_default_declaration_kind_function<T1, T2, T3, T4, T5>(
         self,
         r#type: FunctionType,
         span: Span,
@@ -7646,16 +7650,17 @@ impl<'a> AstBuilder<'a> {
         r#async: bool,
         declare: bool,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
+        body: T5,
     ) -> ExportDefaultDeclarationKind<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         ExportDefaultDeclarationKind::FunctionDeclaration(self.alloc(self.function(
             r#type,
@@ -8746,18 +8751,19 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - type_parameters
     #[inline]
-    pub fn ts_type_function_type<T1, T2, T3>(
+    pub fn ts_type_function_type<T1, T2, T3, T4>(
         self,
         span: Span,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        this_param: T1,
+        params: T2,
+        return_type: T3,
+        type_parameters: T4,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSType::TSFunctionType(self.alloc(self.ts_function_type(
             span,
@@ -10806,22 +10812,23 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - type_parameters
     #[inline]
-    pub fn ts_signature_method_signature<T1, T2, T3>(
+    pub fn ts_signature_method_signature<T1, T2, T3, T4>(
         self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        this_param: T1,
+        params: T2,
+        return_type: T3,
+        type_parameters: T4,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSSignature::TSMethodSignature(self.alloc(self.ts_method_signature(
             span,
@@ -10983,22 +10990,23 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - type_parameters
     #[inline]
-    pub fn ts_method_signature<T1, T2, T3>(
+    pub fn ts_method_signature<T1, T2, T3, T4>(
         self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        this_param: T1,
+        params: T2,
+        return_type: T3,
+        type_parameters: T4,
     ) -> TSMethodSignature<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSMethodSignature {
             span,
@@ -11006,7 +11014,7 @@ impl<'a> AstBuilder<'a> {
             computed,
             optional,
             kind,
-            this_param,
+            this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
             type_parameters: type_parameters.into_in(self.allocator),
@@ -11029,22 +11037,23 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - type_parameters
     #[inline]
-    pub fn alloc_ts_method_signature<T1, T2, T3>(
+    pub fn alloc_ts_method_signature<T1, T2, T3, T4>(
         self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        this_param: T1,
+        params: T2,
+        return_type: T3,
+        type_parameters: T4,
     ) -> Box<'a, TSMethodSignature<'a>>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         Box::new_in(
             self.ts_method_signature(
@@ -11888,22 +11897,23 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - type_parameters
     #[inline]
-    pub fn ts_function_type<T1, T2, T3>(
+    pub fn ts_function_type<T1, T2, T3, T4>(
         self,
         span: Span,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        this_param: T1,
+        params: T2,
+        return_type: T3,
+        type_parameters: T4,
     ) -> TSFunctionType<'a>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSFunctionType {
             span,
-            this_param,
+            this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
             type_parameters: type_parameters.into_in(self.allocator),
@@ -11921,18 +11931,19 @@ impl<'a> AstBuilder<'a> {
     /// - return_type
     /// - type_parameters
     #[inline]
-    pub fn alloc_ts_function_type<T1, T2, T3>(
+    pub fn alloc_ts_function_type<T1, T2, T3, T4>(
         self,
         span: Span,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T1,
-        return_type: T2,
-        type_parameters: T3,
+        this_param: T1,
+        params: T2,
+        return_type: T3,
+        type_parameters: T4,
     ) -> Box<'a, TSFunctionType<'a>>
     where
-        T1: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         Box::new_in(
             self.ts_function_type(span, this_param, params, return_type, type_parameters),

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -1,7 +1,8 @@
+use oxc_allocator::Box;
 use oxc_ast::ast::{
     ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
-    ObjectExpression, ObjectPropertyKind, TSLiteral, TSMethodSignatureKind, TSTupleElement, TSType,
-    TSTypeOperatorOperator,
+    ObjectExpression, ObjectPropertyKind, TSLiteral, TSMethodSignatureKind, TSThisParameter,
+    TSTupleElement, TSType, TSTypeOperatorOperator,
 };
 use oxc_span::{GetSpan, Span, SPAN};
 
@@ -54,7 +55,7 @@ impl<'a> IsolatedDeclarations<'a> {
         return_type.map(|return_type| {
             self.ast.ts_type_function_type(
                 func.span,
-                None,
+                None::<Box<'a, TSThisParameter<'a>>>,
                 params,
                 return_type,
                 // SAFETY: `ast.copy` is unsound! We need to fix.

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -5547,10 +5547,10 @@ impl<'a, 't> FunctionWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -5628,10 +5628,10 @@ impl<'a, 't> FunctionWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -5798,10 +5798,10 @@ impl<'a, 't> FunctionWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -5879,10 +5879,10 @@ impl<'a, 't> FunctionWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -5960,10 +5960,10 @@ impl<'a, 't> FunctionWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -11079,10 +11079,10 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -11229,10 +11229,10 @@ impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -11300,10 +11300,10 @@ impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -11371,10 +11371,10 @@ impl<'a, 't> TSMethodSignatureWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -12241,10 +12241,10 @@ impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -12279,10 +12279,10 @@ impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -12317,10 +12317,10 @@ impl<'a, 't> TSFunctionTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -2286,10 +2286,10 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_THIS_PARAM)
-        as *mut Option<TSThisParameter>)
+        as *mut Option<Box<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::FunctionThisParam);
-        walk_ts_this_parameter(traverser, field as *mut _, ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FunctionParams);
     walk_formal_parameters(
@@ -4785,10 +4785,10 @@ pub(crate) unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-        as *mut Option<TSThisParameter>)
+        as *mut Option<Box<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureThisParam);
-        walk_ts_this_parameter(traverser, field as *mut _, ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSMethodSignatureParams);
     walk_formal_parameters(
@@ -5229,9 +5229,9 @@ pub(crate) unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
         ancestor::TSFunctionTypeWithoutThisParam(node, PhantomData),
     ));
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-        as *mut Option<TSThisParameter>)
+        as *mut Option<Box<TSThisParameter>>)
     {
-        walk_ts_this_parameter(traverser, field as *mut _, ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSFunctionTypeParams);
     walk_formal_parameters(


### PR DESCRIPTION
Box `TSThisParameter` in `Function`, `TSMethodSignature` and `TSFunctionType`. I assume `function(this: Whatever) {}` is a fairly rare syntax in TS code, and obviously never occurs in JS code, so it takes up a lot of space in `Function` for this uncommon case.

This change reduces `Function` from 136 bytes to 104.