### PR TITLE
refactor(ast): remove `IdentifierName` from `TSThisParameter`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -41,7 +41,7 @@ export interface TSIndexSignatureName extends Span {
 pub struct TSThisParameter<'a> {
     #[serde(flatten)]
     pub span: Span,
-    pub this: IdentifierName<'a>,
+    pub this_span: Span,
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -785,11 +785,11 @@ const _: () = {
     assert!(size_of::<ModuleExportName>() == 40usize);
     assert!(align_of::<ModuleExportName>() == 8usize);
 
-    assert!(size_of::<TSThisParameter>() == 40usize);
+    assert!(size_of::<TSThisParameter>() == 24usize);
     assert!(align_of::<TSThisParameter>() == 8usize);
     assert!(offset_of!(TSThisParameter, span) == 0usize);
-    assert!(offset_of!(TSThisParameter, this) == 8usize);
-    assert!(offset_of!(TSThisParameter, type_annotation) == 32usize);
+    assert!(offset_of!(TSThisParameter, this_span) == 8usize);
+    assert!(offset_of!(TSThisParameter, type_annotation) == 16usize);
 
     assert!(size_of::<TSEnumDeclaration>() == 80usize);
     assert!(align_of::<TSEnumDeclaration>() == 8usize);
@@ -1037,13 +1037,13 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, type_annotation) == 40usize);
     assert!(offset_of!(TSIndexSignature, readonly) == 48usize);
 
-    assert!(size_of::<TSCallSignatureDeclaration>() == 72usize);
+    assert!(size_of::<TSCallSignatureDeclaration>() == 64usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 8usize);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0usize);
     assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 48usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 56usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 64usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 40usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 48usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 56usize);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);
@@ -2339,11 +2339,11 @@ const _: () = {
     assert!(size_of::<ModuleExportName>() == 24usize);
     assert!(align_of::<ModuleExportName>() == 4usize);
 
-    assert!(size_of::<TSThisParameter>() == 28usize);
+    assert!(size_of::<TSThisParameter>() == 20usize);
     assert!(align_of::<TSThisParameter>() == 4usize);
     assert!(offset_of!(TSThisParameter, span) == 0usize);
-    assert!(offset_of!(TSThisParameter, this) == 8usize);
-    assert!(offset_of!(TSThisParameter, type_annotation) == 24usize);
+    assert!(offset_of!(TSThisParameter, this_span) == 8usize);
+    assert!(offset_of!(TSThisParameter, type_annotation) == 16usize);
 
     assert!(size_of::<TSEnumDeclaration>() == 52usize);
     assert!(align_of::<TSEnumDeclaration>() == 4usize);
@@ -2591,13 +2591,13 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, type_annotation) == 24usize);
     assert!(offset_of!(TSIndexSignature, readonly) == 28usize);
 
-    assert!(size_of::<TSCallSignatureDeclaration>() == 48usize);
+    assert!(size_of::<TSCallSignatureDeclaration>() == 44usize);
     assert!(align_of::<TSCallSignatureDeclaration>() == 4usize);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0usize);
     assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 8usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 36usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 40usize);
-    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 44usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 32usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 36usize);
+    assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 40usize);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1usize);
     assert!(align_of::<TSMethodSignatureKind>() == 1usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7878,19 +7878,23 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - this
+    /// - this_span
     /// - type_annotation
     #[inline]
     pub fn ts_this_parameter<T1>(
         self,
         span: Span,
-        this: IdentifierName<'a>,
+        this_span: Span,
         type_annotation: T1,
     ) -> TSThisParameter<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
-        TSThisParameter { span, this, type_annotation: type_annotation.into_in(self.allocator) }
+        TSThisParameter {
+            span,
+            this_span,
+            type_annotation: type_annotation.into_in(self.allocator),
+        }
     }
 
     /// Builds a [`TSThisParameter`] and stores it in the memory arena.
@@ -7899,19 +7903,19 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// - span: The [`Span`] covering this node
-    /// - this
+    /// - this_span
     /// - type_annotation
     #[inline]
     pub fn alloc_ts_this_parameter<T1>(
         self,
         span: Span,
-        this: IdentifierName<'a>,
+        this_span: Span,
         type_annotation: T1,
     ) -> Box<'a, TSThisParameter<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(self.ts_this_parameter(span, this, type_annotation), self.allocator)
+        Box::new_in(self.ts_this_parameter(span, this_span, type_annotation), self.allocator)
     }
 
     /// Builds a [`TSEnumDeclaration`]

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -2278,7 +2278,7 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'old_alloc>
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSThisParameter {
             span: self.span.clone_in(allocator),
-            this: self.this.clone_in(allocator),
+            this_span: self.this_span.clone_in(allocator),
             type_annotation: self.type_annotation.clone_in(allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2378,7 +2378,7 @@ impl<'a> ContentEq for ModuleExportName<'a> {
 
 impl<'a> ContentEq for TSThisParameter<'a> {
     fn content_eq(&self, other: &Self) -> bool {
-        self.this.content_eq(&other.this) && self.type_annotation.content_eq(&other.type_annotation)
+        self.type_annotation.content_eq(&other.type_annotation)
     }
 }
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -2104,7 +2104,6 @@ pub mod walk {
     pub fn walk_ts_this_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisParameter<'a>) {
         let kind = AstKind::TSThisParameter(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_identifier_name(&it.this);
         if let Some(type_annotation) = &it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -2174,7 +2174,6 @@ pub mod walk_mut {
     ) {
         let kind = AstType::TSThisParameter;
         visitor.enter_node(kind);
-        visitor.visit_identifier_name(&mut it.this);
         if let Some(type_annotation) = &mut it.type_annotation {
             visitor.visit_ts_type_annotation(type_annotation);
         }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3161,7 +3161,7 @@ impl<'a> Gen for TSFunctionType<'a> {
 
 impl<'a> Gen for TSThisParameter<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
-        self.this.gen(p, ctx);
+        p.print_str("this");
         if let Some(type_annotation) = &self.type_annotation {
             p.print_str(": ");
             type_annotation.gen(p, ctx);

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -473,10 +473,11 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.parse_class_element_modifiers(true);
         self.eat_decorators()?;
-        let this = {
-            let (span, name) = self.parse_identifier_kind(Kind::This);
-            self.ast.identifier_name(span, name)
-        };
+
+        let this_span = self.start_span();
+        self.bump_any();
+        let this = self.end_span(this_span);
+
         let type_annotation = self.parse_ts_type_annotation()?;
         Ok(self.ast.ts_this_parameter(self.end_span(span), this, type_annotation))
     }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -212,115 +212,114 @@ pub(crate) enum AncestorType {
     JSXAttributeValue = 184,
     JSXSpreadAttributeArgument = 185,
     JSXSpreadChildExpression = 186,
-    TSThisParameterThis = 187,
-    TSThisParameterTypeAnnotation = 188,
-    TSEnumDeclarationId = 189,
-    TSEnumDeclarationMembers = 190,
-    TSEnumMemberId = 191,
-    TSEnumMemberInitializer = 192,
-    TSTypeAnnotationTypeAnnotation = 193,
-    TSLiteralTypeLiteral = 194,
-    TSConditionalTypeCheckType = 195,
-    TSConditionalTypeExtendsType = 196,
-    TSConditionalTypeTrueType = 197,
-    TSConditionalTypeFalseType = 198,
-    TSUnionTypeTypes = 199,
-    TSIntersectionTypeTypes = 200,
-    TSParenthesizedTypeTypeAnnotation = 201,
-    TSTypeOperatorTypeAnnotation = 202,
-    TSArrayTypeElementType = 203,
-    TSIndexedAccessTypeObjectType = 204,
-    TSIndexedAccessTypeIndexType = 205,
-    TSTupleTypeElementTypes = 206,
-    TSNamedTupleMemberElementType = 207,
-    TSNamedTupleMemberLabel = 208,
-    TSOptionalTypeTypeAnnotation = 209,
-    TSRestTypeTypeAnnotation = 210,
-    TSTypeReferenceTypeName = 211,
-    TSTypeReferenceTypeParameters = 212,
-    TSQualifiedNameLeft = 213,
-    TSQualifiedNameRight = 214,
-    TSTypeParameterInstantiationParams = 215,
-    TSTypeParameterName = 216,
-    TSTypeParameterConstraint = 217,
-    TSTypeParameterDefault = 218,
-    TSTypeParameterDeclarationParams = 219,
-    TSTypeAliasDeclarationId = 220,
-    TSTypeAliasDeclarationTypeParameters = 221,
-    TSTypeAliasDeclarationTypeAnnotation = 222,
-    TSClassImplementsExpression = 223,
-    TSClassImplementsTypeParameters = 224,
-    TSInterfaceDeclarationId = 225,
-    TSInterfaceDeclarationExtends = 226,
-    TSInterfaceDeclarationTypeParameters = 227,
-    TSInterfaceDeclarationBody = 228,
-    TSInterfaceBodyBody = 229,
-    TSPropertySignatureKey = 230,
-    TSPropertySignatureTypeAnnotation = 231,
-    TSIndexSignatureParameters = 232,
-    TSIndexSignatureTypeAnnotation = 233,
-    TSCallSignatureDeclarationThisParam = 234,
-    TSCallSignatureDeclarationParams = 235,
-    TSCallSignatureDeclarationReturnType = 236,
-    TSCallSignatureDeclarationTypeParameters = 237,
-    TSMethodSignatureKey = 238,
-    TSMethodSignatureThisParam = 239,
-    TSMethodSignatureParams = 240,
-    TSMethodSignatureReturnType = 241,
-    TSMethodSignatureTypeParameters = 242,
-    TSConstructSignatureDeclarationParams = 243,
-    TSConstructSignatureDeclarationReturnType = 244,
-    TSConstructSignatureDeclarationTypeParameters = 245,
-    TSIndexSignatureNameTypeAnnotation = 246,
-    TSInterfaceHeritageExpression = 247,
-    TSInterfaceHeritageTypeParameters = 248,
-    TSTypePredicateParameterName = 249,
-    TSTypePredicateTypeAnnotation = 250,
-    TSModuleDeclarationId = 251,
-    TSModuleDeclarationBody = 252,
-    TSModuleBlockDirectives = 253,
-    TSModuleBlockBody = 254,
-    TSTypeLiteralMembers = 255,
-    TSInferTypeTypeParameter = 256,
-    TSTypeQueryExprName = 257,
-    TSTypeQueryTypeParameters = 258,
-    TSImportTypeParameter = 259,
-    TSImportTypeQualifier = 260,
-    TSImportTypeAttributes = 261,
-    TSImportTypeTypeParameters = 262,
-    TSImportAttributesAttributesKeyword = 263,
-    TSImportAttributesElements = 264,
-    TSImportAttributeName = 265,
-    TSImportAttributeValue = 266,
-    TSFunctionTypeThisParam = 267,
-    TSFunctionTypeParams = 268,
-    TSFunctionTypeReturnType = 269,
-    TSFunctionTypeTypeParameters = 270,
-    TSConstructorTypeParams = 271,
-    TSConstructorTypeReturnType = 272,
-    TSConstructorTypeTypeParameters = 273,
-    TSMappedTypeTypeParameter = 274,
-    TSMappedTypeNameType = 275,
-    TSMappedTypeTypeAnnotation = 276,
-    TSTemplateLiteralTypeQuasis = 277,
-    TSTemplateLiteralTypeTypes = 278,
-    TSAsExpressionExpression = 279,
-    TSAsExpressionTypeAnnotation = 280,
-    TSSatisfiesExpressionExpression = 281,
-    TSSatisfiesExpressionTypeAnnotation = 282,
-    TSTypeAssertionExpression = 283,
-    TSTypeAssertionTypeAnnotation = 284,
-    TSImportEqualsDeclarationId = 285,
-    TSImportEqualsDeclarationModuleReference = 286,
-    TSExternalModuleReferenceExpression = 287,
-    TSNonNullExpressionExpression = 288,
-    DecoratorExpression = 289,
-    TSExportAssignmentExpression = 290,
-    TSNamespaceExportDeclarationId = 291,
-    TSInstantiationExpressionExpression = 292,
-    TSInstantiationExpressionTypeParameters = 293,
-    JSDocNullableTypeTypeAnnotation = 294,
-    JSDocNonNullableTypeTypeAnnotation = 295,
+    TSThisParameterTypeAnnotation = 187,
+    TSEnumDeclarationId = 188,
+    TSEnumDeclarationMembers = 189,
+    TSEnumMemberId = 190,
+    TSEnumMemberInitializer = 191,
+    TSTypeAnnotationTypeAnnotation = 192,
+    TSLiteralTypeLiteral = 193,
+    TSConditionalTypeCheckType = 194,
+    TSConditionalTypeExtendsType = 195,
+    TSConditionalTypeTrueType = 196,
+    TSConditionalTypeFalseType = 197,
+    TSUnionTypeTypes = 198,
+    TSIntersectionTypeTypes = 199,
+    TSParenthesizedTypeTypeAnnotation = 200,
+    TSTypeOperatorTypeAnnotation = 201,
+    TSArrayTypeElementType = 202,
+    TSIndexedAccessTypeObjectType = 203,
+    TSIndexedAccessTypeIndexType = 204,
+    TSTupleTypeElementTypes = 205,
+    TSNamedTupleMemberElementType = 206,
+    TSNamedTupleMemberLabel = 207,
+    TSOptionalTypeTypeAnnotation = 208,
+    TSRestTypeTypeAnnotation = 209,
+    TSTypeReferenceTypeName = 210,
+    TSTypeReferenceTypeParameters = 211,
+    TSQualifiedNameLeft = 212,
+    TSQualifiedNameRight = 213,
+    TSTypeParameterInstantiationParams = 214,
+    TSTypeParameterName = 215,
+    TSTypeParameterConstraint = 216,
+    TSTypeParameterDefault = 217,
+    TSTypeParameterDeclarationParams = 218,
+    TSTypeAliasDeclarationId = 219,
+    TSTypeAliasDeclarationTypeParameters = 220,
+    TSTypeAliasDeclarationTypeAnnotation = 221,
+    TSClassImplementsExpression = 222,
+    TSClassImplementsTypeParameters = 223,
+    TSInterfaceDeclarationId = 224,
+    TSInterfaceDeclarationExtends = 225,
+    TSInterfaceDeclarationTypeParameters = 226,
+    TSInterfaceDeclarationBody = 227,
+    TSInterfaceBodyBody = 228,
+    TSPropertySignatureKey = 229,
+    TSPropertySignatureTypeAnnotation = 230,
+    TSIndexSignatureParameters = 231,
+    TSIndexSignatureTypeAnnotation = 232,
+    TSCallSignatureDeclarationThisParam = 233,
+    TSCallSignatureDeclarationParams = 234,
+    TSCallSignatureDeclarationReturnType = 235,
+    TSCallSignatureDeclarationTypeParameters = 236,
+    TSMethodSignatureKey = 237,
+    TSMethodSignatureThisParam = 238,
+    TSMethodSignatureParams = 239,
+    TSMethodSignatureReturnType = 240,
+    TSMethodSignatureTypeParameters = 241,
+    TSConstructSignatureDeclarationParams = 242,
+    TSConstructSignatureDeclarationReturnType = 243,
+    TSConstructSignatureDeclarationTypeParameters = 244,
+    TSIndexSignatureNameTypeAnnotation = 245,
+    TSInterfaceHeritageExpression = 246,
+    TSInterfaceHeritageTypeParameters = 247,
+    TSTypePredicateParameterName = 248,
+    TSTypePredicateTypeAnnotation = 249,
+    TSModuleDeclarationId = 250,
+    TSModuleDeclarationBody = 251,
+    TSModuleBlockDirectives = 252,
+    TSModuleBlockBody = 253,
+    TSTypeLiteralMembers = 254,
+    TSInferTypeTypeParameter = 255,
+    TSTypeQueryExprName = 256,
+    TSTypeQueryTypeParameters = 257,
+    TSImportTypeParameter = 258,
+    TSImportTypeQualifier = 259,
+    TSImportTypeAttributes = 260,
+    TSImportTypeTypeParameters = 261,
+    TSImportAttributesAttributesKeyword = 262,
+    TSImportAttributesElements = 263,
+    TSImportAttributeName = 264,
+    TSImportAttributeValue = 265,
+    TSFunctionTypeThisParam = 266,
+    TSFunctionTypeParams = 267,
+    TSFunctionTypeReturnType = 268,
+    TSFunctionTypeTypeParameters = 269,
+    TSConstructorTypeParams = 270,
+    TSConstructorTypeReturnType = 271,
+    TSConstructorTypeTypeParameters = 272,
+    TSMappedTypeTypeParameter = 273,
+    TSMappedTypeNameType = 274,
+    TSMappedTypeTypeAnnotation = 275,
+    TSTemplateLiteralTypeQuasis = 276,
+    TSTemplateLiteralTypeTypes = 277,
+    TSAsExpressionExpression = 278,
+    TSAsExpressionTypeAnnotation = 279,
+    TSSatisfiesExpressionExpression = 280,
+    TSSatisfiesExpressionTypeAnnotation = 281,
+    TSTypeAssertionExpression = 282,
+    TSTypeAssertionTypeAnnotation = 283,
+    TSImportEqualsDeclarationId = 284,
+    TSImportEqualsDeclarationModuleReference = 285,
+    TSExternalModuleReferenceExpression = 286,
+    TSNonNullExpressionExpression = 287,
+    DecoratorExpression = 288,
+    TSExportAssignmentExpression = 289,
+    TSNamespaceExportDeclarationId = 290,
+    TSInstantiationExpressionExpression = 291,
+    TSInstantiationExpressionTypeParameters = 292,
+    JSDocNullableTypeTypeAnnotation = 293,
+    JSDocNonNullableTypeTypeAnnotation = 294,
 }
 
 /// Ancestor type used in AST traversal.
@@ -675,8 +674,6 @@ pub enum Ancestor<'a, 't> {
         AncestorType::JSXSpreadAttributeArgument as u16,
     JSXSpreadChildExpression(JSXSpreadChildWithoutExpression<'a, 't>) =
         AncestorType::JSXSpreadChildExpression as u16,
-    TSThisParameterThis(TSThisParameterWithoutThis<'a, 't>) =
-        AncestorType::TSThisParameterThis as u16,
     TSThisParameterTypeAnnotation(TSThisParameterWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSThisParameterTypeAnnotation as u16,
     TSEnumDeclarationId(TSEnumDeclarationWithoutId<'a, 't>) =
@@ -1493,7 +1490,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_this_parameter(self) -> bool {
-        matches!(self, Self::TSThisParameterThis(_) | Self::TSThisParameterTypeAnnotation(_))
+        matches!(self, Self::TSThisParameterTypeAnnotation(_))
     }
 
     #[inline]
@@ -9288,31 +9285,9 @@ impl<'a, 't> JSXSpreadChildWithoutExpression<'a, 't> {
 }
 
 pub(crate) const OFFSET_TS_THIS_PARAMETER_SPAN: usize = offset_of!(TSThisParameter, span);
-pub(crate) const OFFSET_TS_THIS_PARAMETER_THIS: usize = offset_of!(TSThisParameter, this);
+pub(crate) const OFFSET_TS_THIS_PARAMETER_THIS_SPAN: usize = offset_of!(TSThisParameter, this_span);
 pub(crate) const OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION: usize =
     offset_of!(TSThisParameter, type_annotation);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSThisParameterWithoutThis<'a, 't>(
-    pub(crate) *const TSThisParameter<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSThisParameterWithoutThis<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_THIS_PARAMETER_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
-        }
-    }
-}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -9328,11 +9303,8 @@ impl<'a, 't> TSThisParameterWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn this(self) -> &'t IdentifierName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_THIS_PARAMETER_THIS)
-                as *const IdentifierName<'a>)
-        }
+    pub fn this_span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_THIS_PARAMETER_THIS_SPAN) as *const Span) }
     }
 }
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3639,19 +3639,13 @@ pub(crate) unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_this_parameter(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSThisParameterThis(
-        ancestor::TSThisParameterWithoutThis(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSThisParameterTypeAnnotation(
+        ancestor::TSThisParameterWithoutTypeAnnotation(node, PhantomData),
     ));
-    walk_identifier_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_THIS_PARAMETER_THIS) as *mut IdentifierName,
-        ctx,
-    );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION)
         as *mut Option<Box<TSTypeAnnotation>>)
     {
-        ctx.retag_stack(AncestorType::TSThisParameterTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -14,9 +14,10 @@ define_derive! {
     pub struct DeriveContentEq;
 }
 
-const IGNORE_FIELDS: [(/* field name */ &str, /* field type */ &str); 5] = [
+const IGNORE_FIELDS: [(/* field name */ &str, /* field type */ &str); 6] = [
     ("span", "Span"),
     ("trailing_comma", "Span"),
+    ("this_span", "Span"),
     ("scope_id", "ScopeId"),
     ("symbol_id", "SymbolId"),
     ("reference_id", "ReferenceId"),


### PR DESCRIPTION
`TSThisParameter` does not need to include an `IdentifierName` which is always "this". Just storing the `Span` is sufficient.