### PR TITLE
refactor(linter): add `LintFilter`

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::{
     context::LintContext,
     fixer::FixKind,
     frameworks::FrameworkFlags,
-    options::{AllowWarnDeny, OxlintOptions},
+    options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind, OxlintOptions},
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleWithSeverity},
     service::{LintService, LintServiceOptions},
 };

--- a/crates/oxc_linter/src/options/allow_warn_deny.rs
+++ b/crates/oxc_linter/src/options/allow_warn_deny.rs
@@ -1,4 +1,4 @@
-use std::convert::From;
+use std::{convert::From, fmt};
 
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use schemars::{schema::SchemaObject, JsonSchema};
@@ -18,6 +18,14 @@ impl AllowWarnDeny {
 
     pub fn is_allow(self) -> bool {
         self == Self::Allow
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Warn => "warn",
+            Self::Deny => "deny",
+        }
     }
 }
 
@@ -62,6 +70,11 @@ impl TryFrom<&Number> for AllowWarnDeny {
                 r#"Failed to parse rule severity, expected one of `0`, `1` or `2`, but got {value:?}"#
             ))),
         }
+    }
+}
+impl fmt::Display for AllowWarnDeny {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
     }
 }
 

--- a/crates/oxc_linter/src/options/filter.rs
+++ b/crates/oxc_linter/src/options/filter.rs
@@ -1,0 +1,265 @@
+use crate::RuleCategory;
+
+use super::{plugins::LintPlugins, AllowWarnDeny};
+use std::{borrow::Cow, fmt};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct LintFilter(AllowWarnDeny, LintFilterKind);
+impl LintFilter {
+    /// # Errors
+    ///
+    /// If `kind` is an empty string, or is a `<plugin>/<rule>` filter but is missing either the
+    /// plugin or the rule.
+    pub fn new<F: TryInto<LintFilterKind>>(
+        severity: AllowWarnDeny,
+        kind: F,
+    ) -> Result<Self, <F as TryInto<LintFilterKind>>::Error> {
+        Ok(Self(severity, kind.try_into()?))
+    }
+
+    #[must_use]
+    pub fn allow<F: Into<LintFilterKind>>(kind: F) -> Self {
+        Self(AllowWarnDeny::Allow, kind.into())
+    }
+
+    #[must_use]
+    pub fn warn<F: Into<LintFilterKind>>(kind: F) -> Self {
+        Self(AllowWarnDeny::Warn, kind.into())
+    }
+
+    #[must_use]
+    pub fn deny<F: Into<LintFilterKind>>(kind: F) -> Self {
+        Self(AllowWarnDeny::Deny, kind.into())
+    }
+
+    #[inline]
+    pub fn severity(&self) -> AllowWarnDeny {
+        self.0
+    }
+
+    #[inline]
+    pub fn kind(&self) -> &LintFilterKind {
+        &self.1
+    }
+}
+
+impl Default for LintFilter {
+    fn default() -> Self {
+        Self(AllowWarnDeny::Warn, LintFilterKind::Category(RuleCategory::Correctness))
+    }
+}
+
+impl From<LintFilter> for (AllowWarnDeny, LintFilterKind) {
+    fn from(val: LintFilter) -> Self {
+        (val.0, val.1)
+    }
+}
+impl<'a> From<&'a LintFilter> for (AllowWarnDeny, &'a LintFilterKind) {
+    fn from(val: &'a LintFilter) -> Self {
+        (val.0, &val.1)
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum LintFilterKind {
+    Generic(Cow<'static, str>),
+    /// e.g. `no-const-assign` or `eslint/no-const-assign`
+    Rule(LintPlugins, Cow<'static, str>),
+    /// e.g. `correctness`
+    Category(RuleCategory),
+    // TODO: plugin + category? e.g `-A react:correctness`
+}
+
+impl LintFilterKind {
+    /// # Errors
+    ///
+    /// If `filter` is an empty string, or is a `<plugin>/<rule>` filter but is missing either the
+    /// plugin or the rule.
+    pub fn parse(filter: Cow<'static, str>) -> Result<Self, InvalidFilterKind> {
+        if filter.is_empty() {
+            return Err(InvalidFilterKind::Empty);
+        }
+
+        if filter.contains('/') {
+            // this is an unfortunate amount of code duplication, but it needs to be done for
+            // `filter` to live long enough to avoid a String allocation for &'static str
+            let (plugin, rule) = match filter {
+                Cow::Borrowed(filter) => {
+                    let mut parts = filter.splitn(2, '/');
+
+                    let plugin = parts
+                        .next()
+                        .ok_or(InvalidFilterKind::PluginMissing(Cow::Borrowed(filter)))?;
+                    if plugin.is_empty() {
+                        return Err(InvalidFilterKind::PluginMissing(Cow::Borrowed(filter)));
+                    }
+
+                    let rule = parts
+                        .next()
+                        .ok_or(InvalidFilterKind::RuleMissing(Cow::Borrowed(filter)))?;
+                    if rule.is_empty() {
+                        return Err(InvalidFilterKind::RuleMissing(Cow::Borrowed(filter)));
+                    }
+
+                    (LintPlugins::from(plugin), Cow::Borrowed(rule))
+                }
+                Cow::Owned(filter) => {
+                    let mut parts = filter.splitn(2, '/');
+
+                    let plugin = parts
+                        .next()
+                        .ok_or_else(|| InvalidFilterKind::PluginMissing(filter.clone().into()))?;
+                    if plugin.is_empty() {
+                        return Err(InvalidFilterKind::PluginMissing(filter.into()));
+                    }
+
+                    let rule = parts
+                        .next()
+                        .ok_or_else(|| InvalidFilterKind::RuleMissing(filter.clone().into()))?;
+                    if rule.is_empty() {
+                        return Err(InvalidFilterKind::RuleMissing(filter.into()));
+                    }
+
+                    (LintPlugins::from(plugin), Cow::Owned(rule.to_string()))
+                }
+            };
+            Ok(LintFilterKind::Rule(plugin, rule))
+        } else {
+            match RuleCategory::try_from(filter.as_ref()) {
+                Ok(category) => Ok(LintFilterKind::Category(category)),
+                Err(()) => Ok(LintFilterKind::Generic(filter)),
+            }
+        }
+    }
+}
+
+impl TryFrom<String> for LintFilterKind {
+    type Error = InvalidFilterKind;
+
+    #[inline]
+    fn try_from(filter: String) -> Result<Self, Self::Error> {
+        Self::parse(Cow::Owned(filter))
+    }
+}
+
+impl TryFrom<&'static str> for LintFilterKind {
+    type Error = InvalidFilterKind;
+
+    #[inline]
+    fn try_from(filter: &'static str) -> Result<Self, Self::Error> {
+        Self::parse(Cow::Borrowed(filter))
+    }
+}
+
+impl TryFrom<Cow<'static, str>> for LintFilterKind {
+    type Error = InvalidFilterKind;
+
+    #[inline]
+    fn try_from(filter: Cow<'static, str>) -> Result<Self, Self::Error> {
+        Self::parse(filter)
+    }
+}
+
+impl From<RuleCategory> for LintFilterKind {
+    #[inline]
+    fn from(category: RuleCategory) -> Self {
+        LintFilterKind::Category(category)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidFilterKind {
+    Empty,
+    PluginMissing(Cow<'static, str>),
+    RuleMissing(Cow<'static, str>),
+}
+
+impl fmt::Display for InvalidFilterKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Empty => "Filter cannot be empty.".fmt(f),
+            Self::PluginMissing(filter) => {
+                write!(
+                    f,
+                    "Filter '{filter}' must match <plugin>/<rule> but is missing a plugin name."
+                )
+            }
+            Self::RuleMissing(filter) => {
+                write!(
+                    f,
+                    "Filter '{filter}' must match <plugin>/<rule> but is missing a rule name."
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for InvalidFilterKind {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_from_category() {
+        let correctness: LintFilter = LintFilter::new(AllowWarnDeny::Warn, "correctness").unwrap();
+        assert_eq!(correctness.severity(), AllowWarnDeny::Warn);
+        assert!(
+            matches!(correctness.kind(), LintFilterKind::Category(RuleCategory::Correctness)),
+            "{:?}",
+            correctness.kind()
+        );
+    }
+
+    #[test]
+    fn test_eslint_deny() {
+        let filter = LintFilter::deny(LintFilterKind::try_from("no-const-assign").unwrap());
+        assert_eq!(filter.severity(), AllowWarnDeny::Deny);
+        assert_eq!(filter.kind(), &LintFilterKind::Generic("no-const-assign".into()));
+
+        let filter = LintFilter::deny(LintFilterKind::try_from("eslint/no-const-assign").unwrap());
+        assert_eq!(filter.severity(), AllowWarnDeny::Deny);
+        assert_eq!(
+            filter.kind(),
+            &LintFilterKind::Rule(LintPlugins::from("eslint"), "no-const-assign".into())
+        );
+        assert!(matches!(filter.kind(), LintFilterKind::Rule(_, _)));
+    }
+
+    #[test]
+    fn test_parse() {
+        let test_cases: Vec<(&'static str, LintFilterKind)> = vec![
+            ("import/namespace", LintFilterKind::Rule(LintPlugins::IMPORT, "namespace".into())),
+            (
+                "react-hooks/exhaustive-deps",
+                LintFilterKind::Rule(LintPlugins::REACT, "exhaustive-deps".into()),
+            ),
+            // categories
+            ("nursery", LintFilterKind::Category("nursery".try_into().unwrap())),
+            ("perf", LintFilterKind::Category("perf".try_into().unwrap())),
+            // misc
+            ("not-a-valid-filter", LintFilterKind::Generic("not-a-valid-filter".into())),
+        ];
+
+        for (input, expected) in test_cases {
+            let actual = LintFilterKind::try_from(input).unwrap();
+            assert_eq!(actual, expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        let test_cases = vec!["/rules-of-hooks", "import/", "", "/", "//"];
+
+        for input in test_cases {
+            let actual = LintFilterKind::parse(Cow::Borrowed(input));
+            assert!(
+                actual.is_err(),
+                "input '{input}' produced filter '{:?}' but it should have errored",
+                actual.unwrap()
+            );
+        }
+    }
+}

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -73,19 +73,6 @@ pub enum RuleCategory {
 }
 
 impl RuleCategory {
-    pub fn from(input: &str) -> Option<Self> {
-        match input {
-            "correctness" => Some(Self::Correctness),
-            "suspicious" => Some(Self::Suspicious),
-            "pedantic" => Some(Self::Pedantic),
-            "perf" => Some(Self::Perf),
-            "style" => Some(Self::Style),
-            "restriction" => Some(Self::Restriction),
-            "nursery" => Some(Self::Nursery),
-            _ => None,
-        }
-    }
-
     pub fn description(self) -> &'static str {
         match self {
             Self::Correctness => "Code that is outright wrong or useless.",
@@ -97,6 +84,21 @@ impl RuleCategory {
                 "Lints which prevent the use of language and library features. Must not be enabled as a whole, should be considered on a case-by-case basis before enabling."
             }
             Self::Nursery => "New lints that are still under development.",
+        }
+    }
+}
+impl TryFrom<&str> for RuleCategory {
+    type Error = ();
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        match input {
+            "correctness" => Ok(Self::Correctness),
+            "suspicious" => Ok(Self::Suspicious),
+            "pedantic" => Ok(Self::Pedantic),
+            "perf" => Ok(Self::Perf),
+            "style" => Ok(Self::Style),
+            "restriction" => Ok(Self::Restriction),
+            "nursery" => Ok(Self::Nursery),
+            _ => Err(()),
         }
     }
 }

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -6,7 +6,7 @@ use std::{
 
 use oxc_allocator::Allocator;
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use oxc_linter::{AllowWarnDeny, FixKind, Linter, OxlintOptions};
+use oxc_linter::{AllowWarnDeny, FixKind, LintFilter, Linter, OxlintOptions};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -38,8 +38,8 @@ fn bench_linter(criterion: &mut Criterion) {
                     .build_module_record(PathBuf::new(), program)
                     .build(program);
                 let filter = vec![
-                    (AllowWarnDeny::Deny, "all".into()),
-                    (AllowWarnDeny::Deny, "nursery".into()),
+                    LintFilter::new(AllowWarnDeny::Deny, "all").unwrap(),
+                    LintFilter::new(AllowWarnDeny::Deny, "nursery").unwrap(),
                 ];
                 let lint_options = OxlintOptions::default()
                     .with_filter(filter)


### PR DESCRIPTION
Formalizes `(AllowWarnDeny, String)` into `LintFilter` and `LintFilterKind`.

Filters can be one of three variants:
- `category`: for enabling/disabling an entire category. Corresponds to strings
  that are parseable into `RuleCategory`
- `rule`: for enabling/disabling an single rule. This variant also stores the
  plugin name. Corresponds to the string `<plugin>/<rule>`
- `generic`: everything else. `"all"` falls under this one.

Note that if users use `<plugin>/<rule>` filters that are malformed, `oxlint`
will now error. Missing plugins (e.g. for `vue/foobar` will have their plugins
parsed as "eslint" and fail silently. This is consistent with current behavior.