### PR TITLE
refactor(parser): add `TSImportAttributesKeyword` as the attributes keyword

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1144,8 +1144,18 @@ pub struct TSImportType<'a> {
 pub struct TSImportAttributes<'a> {
     #[serde(flatten)]
     pub span: Span,
-    pub attributes_keyword: IdentifierName<'a>, // `with` or `assert`
+    pub attributes_keyword: TSImportAttributesKeyword,
     pub elements: Vec<'a, TSImportAttribute<'a>>,
+}
+
+#[ast]
+#[derive(Debug, Hash)]
+#[generate_derive(CloneIn)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
+#[serde(untagged)]
+pub enum TSImportAttributesKeyword {
+    With = 0,
+    Assert = 1,
 }
 
 #[ast(visit)]

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1128,20 +1128,23 @@ const _: () = {
     assert!(size_of::<TSTypeQueryExprName>() == 16usize);
     assert!(align_of::<TSTypeQueryExprName>() == 8usize);
 
-    assert!(size_of::<TSImportType>() == 120usize);
+    assert!(size_of::<TSImportType>() == 104usize);
     assert!(align_of::<TSImportType>() == 8usize);
     assert!(offset_of!(TSImportType, span) == 0usize);
     assert!(offset_of!(TSImportType, is_type_of) == 8usize);
     assert!(offset_of!(TSImportType, parameter) == 16usize);
     assert!(offset_of!(TSImportType, qualifier) == 32usize);
     assert!(offset_of!(TSImportType, attributes) == 48usize);
-    assert!(offset_of!(TSImportType, type_parameters) == 112usize);
+    assert!(offset_of!(TSImportType, type_parameters) == 96usize);
 
-    assert!(size_of::<TSImportAttributes>() == 64usize);
+    assert!(size_of::<TSImportAttributes>() == 48usize);
     assert!(align_of::<TSImportAttributes>() == 8usize);
     assert!(offset_of!(TSImportAttributes, span) == 0usize);
     assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8usize);
-    assert!(offset_of!(TSImportAttributes, elements) == 32usize);
+    assert!(offset_of!(TSImportAttributes, elements) == 16usize);
+
+    assert!(size_of::<TSImportAttributesKeyword>() == 1usize);
+    assert!(align_of::<TSImportAttributesKeyword>() == 1usize);
 
     assert!(size_of::<TSImportAttribute>() == 56usize);
     assert!(align_of::<TSImportAttribute>() == 8usize);
@@ -2529,20 +2532,23 @@ const _: () = {
     assert!(size_of::<TSTypeQueryExprName>() == 8usize);
     assert!(align_of::<TSTypeQueryExprName>() == 4usize);
 
-    assert!(size_of::<TSImportType>() == 72usize);
+    assert!(size_of::<TSImportType>() == 60usize);
     assert!(align_of::<TSImportType>() == 4usize);
     assert!(offset_of!(TSImportType, span) == 0usize);
     assert!(offset_of!(TSImportType, is_type_of) == 8usize);
     assert!(offset_of!(TSImportType, parameter) == 12usize);
     assert!(offset_of!(TSImportType, qualifier) == 20usize);
     assert!(offset_of!(TSImportType, attributes) == 28usize);
-    assert!(offset_of!(TSImportType, type_parameters) == 68usize);
+    assert!(offset_of!(TSImportType, type_parameters) == 56usize);
 
-    assert!(size_of::<TSImportAttributes>() == 40usize);
+    assert!(size_of::<TSImportAttributes>() == 28usize);
     assert!(align_of::<TSImportAttributes>() == 4usize);
     assert!(offset_of!(TSImportAttributes, span) == 0usize);
     assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8usize);
-    assert!(offset_of!(TSImportAttributes, elements) == 24usize);
+    assert!(offset_of!(TSImportAttributes, elements) == 12usize);
+
+    assert!(size_of::<TSImportAttributesKeyword>() == 1usize);
+    assert!(align_of::<TSImportAttributesKeyword>() == 1usize);
 
     assert!(size_of::<TSImportAttribute>() == 36usize);
     assert!(align_of::<TSImportAttribute>() == 4usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -11768,7 +11768,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_import_attributes(
         self,
         span: Span,
-        attributes_keyword: IdentifierName<'a>,
+        attributes_keyword: TSImportAttributesKeyword,
         elements: Vec<'a, TSImportAttribute<'a>>,
     ) -> TSImportAttributes<'a> {
         TSImportAttributes { span, attributes_keyword, elements }
@@ -11786,7 +11786,7 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_import_attributes(
         self,
         span: Span,
-        attributes_keyword: IdentifierName<'a>,
+        attributes_keyword: TSImportAttributesKeyword,
         elements: Vec<'a, TSImportAttribute<'a>>,
     ) -> Box<'a, TSImportAttributes<'a>> {
         Box::new_in(self.ts_import_attributes(span, attributes_keyword, elements), self.allocator)

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3171,6 +3171,16 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttributes<'old_all
     }
 }
 
+impl<'alloc> CloneIn<'alloc> for TSImportAttributesKeyword {
+    type Cloned = TSImportAttributesKeyword;
+    fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::With => TSImportAttributesKeyword::With,
+            Self::Assert => TSImportAttributesKeyword::Assert,
+        }
+    }
+}
+
 impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for TSImportAttribute<'old_alloc> {
     type Cloned = TSImportAttribute<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -2154,7 +2154,6 @@ pub mod walk {
         it: &TSImportAttributes<'a>,
     ) {
         // NOTE: AstKind doesn't exists!
-        visitor.visit_identifier_name(&it.attributes_keyword);
         visitor.visit_ts_import_attribute_list(&it.elements);
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -2227,7 +2227,6 @@ pub mod walk_mut {
         it: &mut TSImportAttributes<'a>,
     ) {
         // NOTE: AstType doesn't exists!
-        visitor.visit_identifier_name(&mut it.attributes_keyword);
         visitor.visit_ts_import_attribute_list(&mut it.elements);
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3339,6 +3339,15 @@ impl<'a> Gen for TSImportAttributes<'a> {
     }
 }
 
+impl Gen for TSImportAttributesKeyword {
+    fn gen(&self, p: &mut Codegen, _: Context) {
+        match self {
+            Self::With => p.print_str("with"),
+            Self::Assert => p.print_str("assert"),
+        }
+    }
+}
+
 impl<'a> Gen for TSImportAttribute<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         self.name.gen(p, ctx);

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1003,8 +1003,14 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         self.expect(Kind::LCurly)?;
         let attributes_keyword = match self.cur_kind() {
-            Kind::Assert if !self.cur_token().is_on_new_line => self.parse_identifier_name()?,
-            Kind::With => self.parse_identifier_name()?,
+            Kind::Assert if !self.cur_token().is_on_new_line => {
+                self.bump_any();
+                TSImportAttributesKeyword::Assert
+            }
+            Kind::With => {
+                self.bump_any();
+                TSImportAttributesKeyword::With
+            }
             _ => {
                 return Err(self.unexpected());
             }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -288,39 +288,38 @@ pub(crate) enum AncestorType {
     TSImportTypeQualifier = 260,
     TSImportTypeAttributes = 261,
     TSImportTypeTypeParameters = 262,
-    TSImportAttributesAttributesKeyword = 263,
-    TSImportAttributesElements = 264,
-    TSImportAttributeName = 265,
-    TSImportAttributeValue = 266,
-    TSFunctionTypeThisParam = 267,
-    TSFunctionTypeParams = 268,
-    TSFunctionTypeReturnType = 269,
-    TSFunctionTypeTypeParameters = 270,
-    TSConstructorTypeParams = 271,
-    TSConstructorTypeReturnType = 272,
-    TSConstructorTypeTypeParameters = 273,
-    TSMappedTypeTypeParameter = 274,
-    TSMappedTypeNameType = 275,
-    TSMappedTypeTypeAnnotation = 276,
-    TSTemplateLiteralTypeQuasis = 277,
-    TSTemplateLiteralTypeTypes = 278,
-    TSAsExpressionExpression = 279,
-    TSAsExpressionTypeAnnotation = 280,
-    TSSatisfiesExpressionExpression = 281,
-    TSSatisfiesExpressionTypeAnnotation = 282,
-    TSTypeAssertionExpression = 283,
-    TSTypeAssertionTypeAnnotation = 284,
-    TSImportEqualsDeclarationId = 285,
-    TSImportEqualsDeclarationModuleReference = 286,
-    TSExternalModuleReferenceExpression = 287,
-    TSNonNullExpressionExpression = 288,
-    DecoratorExpression = 289,
-    TSExportAssignmentExpression = 290,
-    TSNamespaceExportDeclarationId = 291,
-    TSInstantiationExpressionExpression = 292,
-    TSInstantiationExpressionTypeParameters = 293,
-    JSDocNullableTypeTypeAnnotation = 294,
-    JSDocNonNullableTypeTypeAnnotation = 295,
+    TSImportAttributesElements = 263,
+    TSImportAttributeName = 264,
+    TSImportAttributeValue = 265,
+    TSFunctionTypeThisParam = 266,
+    TSFunctionTypeParams = 267,
+    TSFunctionTypeReturnType = 268,
+    TSFunctionTypeTypeParameters = 269,
+    TSConstructorTypeParams = 270,
+    TSConstructorTypeReturnType = 271,
+    TSConstructorTypeTypeParameters = 272,
+    TSMappedTypeTypeParameter = 273,
+    TSMappedTypeNameType = 274,
+    TSMappedTypeTypeAnnotation = 275,
+    TSTemplateLiteralTypeQuasis = 276,
+    TSTemplateLiteralTypeTypes = 277,
+    TSAsExpressionExpression = 278,
+    TSAsExpressionTypeAnnotation = 279,
+    TSSatisfiesExpressionExpression = 280,
+    TSSatisfiesExpressionTypeAnnotation = 281,
+    TSTypeAssertionExpression = 282,
+    TSTypeAssertionTypeAnnotation = 283,
+    TSImportEqualsDeclarationId = 284,
+    TSImportEqualsDeclarationModuleReference = 285,
+    TSExternalModuleReferenceExpression = 286,
+    TSNonNullExpressionExpression = 287,
+    DecoratorExpression = 288,
+    TSExportAssignmentExpression = 289,
+    TSNamespaceExportDeclarationId = 290,
+    TSInstantiationExpressionExpression = 291,
+    TSInstantiationExpressionTypeParameters = 292,
+    JSDocNullableTypeTypeAnnotation = 293,
+    JSDocNonNullableTypeTypeAnnotation = 294,
 }
 
 /// Ancestor type used in AST traversal.
@@ -827,8 +826,6 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSImportTypeAttributes as u16,
     TSImportTypeTypeParameters(TSImportTypeWithoutTypeParameters<'a, 't>) =
         AncestorType::TSImportTypeTypeParameters as u16,
-    TSImportAttributesAttributesKeyword(TSImportAttributesWithoutAttributesKeyword<'a, 't>) =
-        AncestorType::TSImportAttributesAttributesKeyword as u16,
     TSImportAttributesElements(TSImportAttributesWithoutElements<'a, 't>) =
         AncestorType::TSImportAttributesElements as u16,
     TSImportAttributeName(TSImportAttributeWithoutName<'a, 't>) =
@@ -1749,10 +1746,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_import_attributes(self) -> bool {
-        matches!(
-            self,
-            Self::TSImportAttributesAttributesKeyword(_) | Self::TSImportAttributesElements(_)
-        )
+        matches!(self, Self::TSImportAttributesElements(_))
     }
 
     #[inline]
@@ -12092,28 +12086,6 @@ pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS: usize =
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSImportAttributesWithoutAttributesKeyword<'a, 't>(
-    pub(crate) *const TSImportAttributes<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSImportAttributesWithoutAttributesKeyword<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn elements(self) -> &'t Vec<'a, TSImportAttribute<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS)
-                as *const Vec<'a, TSImportAttribute<'a>>)
-        }
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
 pub struct TSImportAttributesWithoutElements<'a, 't>(
     pub(crate) *const TSImportAttributes<'a>,
     pub(crate) PhantomData<&'t ()>,
@@ -12126,10 +12098,10 @@ impl<'a, 't> TSImportAttributesWithoutElements<'a, 't> {
     }
 
     #[inline]
-    pub fn attributes_keyword(self) -> &'t IdentifierName<'a> {
+    pub fn attributes_keyword(self) -> &'t TSImportAttributesKeyword {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
-                as *const IdentifierName<'a>)
+                as *const TSImportAttributesKeyword)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5157,16 +5157,9 @@ pub(crate) unsafe fn walk_ts_import_attributes<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_import_attributes(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSImportAttributesAttributesKeyword(
-        ancestor::TSImportAttributesWithoutAttributesKeyword(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSImportAttributesElements(
+        ancestor::TSImportAttributesWithoutElements(node, PhantomData),
     ));
-    walk_identifier_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
-            as *mut IdentifierName,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::TSImportAttributesElements);
     for item in (*((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS)
         as *mut Vec<TSImportAttribute>))
         .iter_mut()


### PR DESCRIPTION
related: https://github.com/oxc-project/oxc/pull/4610#discussion_r1703145948

The attributes keyword has only two determined values: `assert` and `with`.

