### PR TITLE
docs(transformer): add documentation for `Targets::get_targets`

### DIFF
--- a/crates/oxc_transformer/src/env/targets/query.rs
+++ b/crates/oxc_transformer/src/env/targets/query.rs
@@ -29,6 +29,13 @@ impl Default for Targets {
 }
 
 impl Targets {
+    /// Parse the query and return the parsed Versions.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// * The query is not supported.
+    /// * The query is invalid.
     pub fn get_targets(self) -> Result<Versions, Error> {
         match self {
             Targets::Versions(v) => Ok(v),


### PR DESCRIPTION
`Targets` will be public in follow-up PRs.