### PR TITLE
refactor(linter): fix indentation in `nextjs/no_script_component_in_head` rule

### DIFF
--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -100,31 +100,33 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        r#"import Script from "next/script";
-			     const Head = ({children}) => children
+        r#"
+            import Script from "next/script";
+			const Head = ({children}) => children
 
-			    export default function Index() {
-			      return (
+			export default function Index() {
+			    return (
 			        <Head>
-			          <Script></Script>
+			            <Script></Script>
 			        </Head>
-			      );
-			    }
-			    "#,
+			    );
+			}
+		"#,
     ];
 
     let fail = vec![
         r#"
-			      import Head from "next/head";
-			      import Script from "next/script";
+			import Head from "next/head";
+			import Script from "next/script";
 
-			      export default function Index() {
-			        return (
-			            <Head>
-			              <Script></Script>
-			            </Head>
-			        );
-			      }"#,
+			export default function Index() {
+			    return (
+			        <Head>
+			            <Script></Script>
+			        </Head>
+			    );
+		    }
+        "#,
     ];
 
     Tester::new(NoScriptComponentInHead::NAME, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/no_script_component_in_head.snap
+++ b/crates/oxc_linter/src/snapshots/no_script_component_in_head.snap
@@ -2,10 +2,10 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-next(no-script-component-in-head): Prevent usage of `next/script` in `next/head` component.
-   ╭─[no_script_component_in_head.tsx:7:17]
- 6 │                     return (
- 7 │                         <Head>
-   ·                          ────
- 8 │                           <Script></Script>
+   ╭─[no_script_component_in_head.tsx:7:13]
+ 6 │                 return (
+ 7 │                     <Head>
+   ·                      ────
+ 8 │                         <Script></Script>
    ╰────
   help: See https://nextjs.org/docs/messages/no-script-component-in-head


### PR DESCRIPTION
Style nit. Fix indentation in test cases.