### PR TITLE
refactor(transformer): remove unnecessary code from JSX transform

### DIFF
--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -706,11 +706,8 @@ impl<'a> ReactJsx<'a> {
             JSXElementName::Identifier(ident) => {
                 if ident.name == "this" {
                     self.ast().expression_this(ident.span)
-                } else if ident.name.chars().next().is_some_and(|c| c.is_ascii_lowercase()) {
-                    self.ast().expression_string_literal(ident.span, &ident.name)
                 } else {
-                    let ident = get_read_identifier_reference(ident.span, ident.name.clone(), ctx);
-                    self.ctx.ast.expression_from_identifier_reference(ident)
+                    self.ast().expression_string_literal(ident.span, &ident.name)
                 }
             }
             JSXElementName::IdentifierReference(ident) => {

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -5195,12 +5195,6 @@ tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["__foot", "_jsxFileName", "global", "thing"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "thing"]
-Reference symbol mismatch:
-after transform: ReferenceId(1): Some("__foot")
-rebuilt        : ReferenceId(1): None
-Unresolved references mismatch:
-after transform: ["React"]
-rebuilt        : ["React", "__foot"]
 
 tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst13.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -19022,14 +19016,11 @@ Reference symbol mismatch:
 after transform: ReferenceId(5): Some("x")
 rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
-after transform: ReferenceId(18): Some("_Bar")
-rebuilt        : ReferenceId(17): None
-Reference symbol mismatch:
 after transform: ReferenceId(6): Some("x")
-rebuilt        : ReferenceId(18): None
+rebuilt        : ReferenceId(17): None
 Unresolved references mismatch:
 after transform: ["React"]
-rebuilt        : ["Bar", "React", "_Bar", "x"]
+rebuilt        : ["Bar", "React", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
 semantic error: Bindings mismatch:


### PR DESCRIPTION
Follow-on after #5223.

JSX identifiers which start with a capital letter are now `JSXElementName::IdentifierReference`s, so no need to check for capitalized `JSXElementName::Identifier`s.