### PR TITLE
refactor(linter): shorten code in `jsx_a11y/aria_activedescendant_has_tabindex` rule

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -82,22 +82,12 @@ impl Rule for AriaActivedescendantHasTabindex {
             return;
         }
 
-        match &jsx_opening_el.name {
-            JSXElementName::Identifier(identifier) => {
-                ctx.diagnostic(aria_activedescendant_has_tabindex_diagnostic(
-                    identifier.span,
-                    identifier.name.as_str(),
-                ));
-            }
-
-            JSXElementName::IdentifierReference(identifier_reference) => {
-                ctx.diagnostic(aria_activedescendant_has_tabindex_diagnostic(
-                    identifier_reference.span,
-                    identifier_reference.name.as_str(),
-                ));
-            }
-            _ => {}
-        }
+        let (name, span) = match &jsx_opening_el.name {
+            JSXElementName::Identifier(id) => (id.name.as_str(), id.span),
+            JSXElementName::IdentifierReference(id) => (id.name.as_str(), id.span),
+            _ => return,
+        };
+        ctx.diagnostic(aria_activedescendant_has_tabindex_diagnostic(span, name));
     }
 }
 


### PR DESCRIPTION
Shorten code which was introduced in #5223.