### PR TITLE
refactor(linter): improve docs for `react/jsx_no_target_blank` rule

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -91,15 +91,15 @@ impl JsxNoTargetBlank {
 declare_oxc_lint!(
     /// ### What it does
     /// This rule aims to prevent user generated link hrefs and form actions from creating security vulnerabilities by
-    /// requiring rel='noreferrer' for external link hrefs and form actions, and optionally any dynamically generated link
-    /// hrefs and form actions.
+    /// requiring `rel='noreferrer'` for external link hrefs and form actions, and optionally any dynamically generated
+    /// link hrefs and form actions.
     ///
     /// ### Why is this bad?
     ///
-    /// When creating a JSX element that has an a tag, it is often desired to have the link open in a new tab using the
-    /// target='_blank' attribute. Using this attribute unaccompanied by rel='noreferrer', however, is a severe security
-    /// vulnerability (see noreferrer docs and noopener docs for more details) This rules requires that you accompany
-    /// target='_blank' attributes with rel='noreferrer'.
+    /// When creating a JSX element that has an `a` tag, it is often desired to have the link open in a new tab using the
+    /// `target='_blank'` attribute. Using this attribute unaccompanied by `rel='noreferrer'`, however, is a severe security
+    /// vulnerability (see [`noreferrer` docs] and [`noopener` docs] for more details).
+    /// This rules requires that you accompany `target='_blank'` attributes with `rel='noreferrer'`.
     ///
     /// ### Example
     /// ```jsx
@@ -114,6 +114,9 @@ declare_oxc_lint!(
     /// var Hello = <a target='_blank' href="https://example.com/"></a>
     /// var Hello = <a target='_blank' href={dynamicLink}></a>
     /// ```
+    ///
+    /// [`noreferrer` docs]: https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
+    /// [`noopener` docs]: https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
     JsxNoTargetBlank,
     correctness
 );


### PR DESCRIPTION
Add formatting to docs and links to the pages which explain (somewhat) what is the security vulnerability this rule aims to prevent.