### PR TITLE
fix(parser): treat JSX element tags starting with `_` or `$` as `IdentifierReference`s

### DIFF
--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -20,9 +20,12 @@ impl<'a> fmt::Display for JSXIdentifier<'a> {
 }
 
 impl<'a> JSXIdentifier<'a> {
-    /// Determines whether the given current identifier is a reference
+    /// Determines whether the given current identifier is a reference.
+    ///
+    /// References begin with a capital letter, `_` or `$`.
+    /// <https://babeljs.io/repl#?code_lz=DwMQ9mAED0B8DcAoYAzCMHIPpqnJwAJLhkkA&presets=react>
     pub fn is_reference(&self) -> bool {
-        self.name.chars().next().map_or(false, char::is_uppercase)
+        self.name.chars().next().map_or(false, |c| c.is_uppercase() || c == '_' || c == '$')
     }
 }
 

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -5195,6 +5195,12 @@ tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreReactNamespace.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["__foot", "_jsxFileName", "global", "thing"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "thing"]
+Reference symbol mismatch:
+after transform: ReferenceId(0): Some("__foot")
+rebuilt        : ReferenceId(1): None
+Unresolved references mismatch:
+after transform: ["React"]
+rebuilt        : ["React", "__foot"]
 
 tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst13.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -19016,11 +19022,14 @@ Reference symbol mismatch:
 after transform: ReferenceId(5): Some("x")
 rebuilt        : ReferenceId(14): None
 Reference symbol mismatch:
-after transform: ReferenceId(6): Some("x")
+after transform: ReferenceId(6): Some("_Bar")
 rebuilt        : ReferenceId(17): None
+Reference symbol mismatch:
+after transform: ReferenceId(7): Some("x")
+rebuilt        : ReferenceId(18): None
 Unresolved references mismatch:
 after transform: ["React"]
-rebuilt        : ["Bar", "React", "x"]
+rebuilt        : ["Bar", "React", "_Bar", "x"]
 
 tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
 semantic error: Bindings mismatch:


### PR DESCRIPTION
#5223 added a new variant `JSXElementName::IdentifierReference` for JSX identifiers which are treated as references (e.g. `<Foo>`) as opposed to `JSXElementName::Identifier` which is for lowercase (e.g. `<div>`).

But we were incorrectly categorizing identifiers beginning with `_` or `$` - these should also be treated as references.

(as discussed in https://github.com/oxc-project/oxc/pull/5339#issuecomment-2321037779)