### PR TITLE
feat(linter): add fixer for `no-console`

### DIFF
--- a/crates/oxc_linter/src/snapshots/no_console.snap
+++ b/crates/oxc_linter/src/snapshots/no_console.snap
@@ -6,75 +6,88 @@ source: crates/oxc_linter/src/tester.rs
  1 │ console.log()
    ·         ───
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.log(foo)
    ·         ───
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.error(foo)
    ·         ─────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.info(foo)
    ·         ────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.warn(foo)
    ·         ────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.log(foo)
    ·         ───
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.error(foo)
    ·         ─────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.info(foo)
    ·         ────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.warn(foo)
    ·         ────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.log(foo)
    ·         ───
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.error(foo)
    ·         ─────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.info(foo)
    ·         ────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:9]
  1 │ console.warn(foo)
    ·         ────
    ╰────
+  help: Delete this code.


### PR DESCRIPTION
 - adds a simple fixer for `no-console` eslint lint rule, removeing the `console.log` invokation.
 - i plan to enhance this in future to be more similar to cargo clippy's removal of `dbg!` macros. if it thinks there's something in there that might have a side effect (e.g. call expression), the call expresion is kept