### PR TITLE
refactor(linter): shorten code in `react/jsx_no_useless_fragment`

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -164,17 +164,13 @@ fn is_html_element(elem_name: &JSXElementName) -> bool {
 
 fn is_jsx_fragment(elem: &JSXOpeningElement) -> bool {
     match &elem.name {
-        JSXElementName::IdentifierReference(ident) => ident.name.as_str() == "Fragment",
+        JSXElementName::IdentifierReference(ident) => ident.name == "Fragment",
         JSXElementName::MemberExpression(mem_expr) => {
-            if mem_expr.property.name.as_str() != "Fragment" {
-                return false;
+            if let JSXMemberExpressionObject::IdentifierReference(ident) = &mem_expr.object {
+                ident.name == "React" && mem_expr.property.name == "Fragment"
+            } else {
+                false
             }
-
-            let JSXMemberExpressionObject::IdentifierReference(ident) = &mem_expr.object else {
-                return false;
-            };
-
-            return ident.name.as_str() == "React";
         }
         JSXElementName::NamespacedName(_) | JSXElementName::Identifier(_) => false,
     }


### PR DESCRIPTION
Shorten code. Also do the enum match first, as its cheaper than a string comparison.