### PR TITLE
fix(transformer/arrow-functions): reaches `unreachable` when `<this.foo>` is inside an arrow function

### DIFF
--- a/crates/oxc_transformer/src/es2015/mod.rs
+++ b/crates/oxc_transformer/src/es2015/mod.rs
@@ -57,6 +57,16 @@ impl<'a> Traverse<'a> for ES2015<'a> {
         }
     }
 
+    fn enter_jsx_member_expression_object(
+        &mut self,
+        node: &mut JSXMemberExpressionObject<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if self.options.arrow_function.is_some() {
+            self.arrow_functions.enter_jsx_member_expression_object(node, ctx);
+        }
+    }
+
     fn enter_declaration(&mut self, decl: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.arrow_function.is_some() {
             self.arrow_functions.enter_declaration(decl, ctx);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -240,6 +240,14 @@ impl<'a> Traverse<'a> for Transformer<'a> {
         self.x3_es2015.enter_jsx_element_name(elem, ctx);
     }
 
+    fn enter_jsx_member_expression_object(
+        &mut self,
+        node: &mut JSXMemberExpressionObject<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        self.x3_es2015.enter_jsx_member_expression_object(node, ctx);
+    }
+
     fn enter_method_definition(
         &mut self,
         def: &mut MethodDefinition<'a>,

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -1,10 +1,9 @@
 commit: 3bcfee23
 
-Passed: 10/38
+Passed: 10/39
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
-* babel-plugin-transform-arrow-functions
 
 
 # babel-plugin-transform-nullish-coalescing-operator (0/1)
@@ -12,6 +11,14 @@ Passed: 10/38
   x Reference flags mismatch:
   | after transform: ReferenceId(3): ReferenceFlags(Write)
   | rebuilt        : ReferenceId(0): ReferenceFlags(Read | Write)
+
+
+
+# babel-plugin-transform-arrow-functions (1/2)
+* with-this-member-expression/input.jsx
+  x Unresolved references mismatch:
+  | after transform: ["this"]
+  | rebuilt        : []
 
 
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/input.jsx
@@ -1,0 +1,3 @@
+() => {
+  <this.foo></this.foo>
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-arrow-functions/test/fixtures/with-this-member-expression/output.js
@@ -1,0 +1,4 @@
+var _this = this;
+(function() {
+       <_this.foo></_this.foo>;
+});


### PR DESCRIPTION
Fixes: https://github.com/oxc-project/oxc/issues/5353#issuecomment-2321792915
