### PR TITLE
feat(ast)!: remove `JSXMemberExpressionObject::Identifier` variant

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -231,7 +231,6 @@ pub struct JSXMemberExpression<'a> {
 #[cfg_attr(feature = "serialize", derive(Serialize, Tsify))]
 #[serde(untagged)]
 pub enum JSXMemberExpressionObject<'a> {
-    Identifier(Box<'a, JSXIdentifier<'a>>) = 0,
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 1,
     MemberExpression(Box<'a, JSXMemberExpression<'a>>) = 2,
 }

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -44,7 +44,6 @@ impl<'a> fmt::Display for JSXMemberExpression<'a> {
 impl<'a> fmt::Display for JSXMemberExpressionObject<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Identifier(id) => id.fmt(f),
             Self::IdentifierReference(id) => id.fmt(f),
             Self::MemberExpression(expr) => expr.fmt(f),
         }

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -12971,37 +12971,6 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.jsx_member_expression(span, object, property), self.allocator)
     }
 
-    /// Build a [`JSXMemberExpressionObject::Identifier`]
-    ///
-    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// - span: The [`Span`] covering this node
-    /// - name: The name of the identifier.
-    #[inline]
-    pub fn jsx_member_expression_object_jsx_identifier<A>(
-        self,
-        span: Span,
-        name: A,
-    ) -> JSXMemberExpressionObject<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXMemberExpressionObject::Identifier(self.alloc(self.jsx_identifier(span, name)))
-    }
-
-    /// Convert a [`JSXIdentifier`] into a [`JSXMemberExpressionObject::Identifier`]
-    #[inline]
-    pub fn jsx_member_expression_object_from_jsx_identifier<T>(
-        self,
-        inner: T,
-    ) -> JSXMemberExpressionObject<'a>
-    where
-        T: IntoIn<'a, Box<'a, JSXIdentifier<'a>>>,
-    {
-        JSXMemberExpressionObject::Identifier(inner.into_in(self.allocator))
-    }
-
     /// Build a [`JSXMemberExpressionObject::IdentifierReference`]
     ///
     /// This node contains a [`IdentifierReference`] that will be stored in the memory arena.

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3517,7 +3517,6 @@ impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'
     type Cloned = JSXMemberExpressionObject<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         match self {
-            Self::Identifier(it) => JSXMemberExpressionObject::Identifier(it.clone_in(allocator)),
             Self::IdentifierReference(it) => {
                 JSXMemberExpressionObject::IdentifierReference(it.clone_in(allocator))
             }

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -2054,7 +2054,6 @@ impl<'a> GetSpan for JSXMemberExpression<'a> {
 impl<'a> GetSpan for JSXMemberExpressionObject<'a> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => it.span(),
             Self::IdentifierReference(it) => it.span(),
             Self::MemberExpression(it) => it.span(),
         }

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -2054,7 +2054,6 @@ impl<'a> GetSpanMut for JSXMemberExpression<'a> {
 impl<'a> GetSpanMut for JSXMemberExpressionObject<'a> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => it.span_mut(),
             Self::IdentifierReference(it) => it.span_mut(),
             Self::MemberExpression(it) => it.span_mut(),
         }

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -3341,7 +3341,6 @@ pub mod walk {
         let kind = AstKind::JSXMemberExpressionObject(visitor.alloc(it));
         visitor.enter_node(kind);
         match it {
-            JSXMemberExpressionObject::Identifier(it) => visitor.visit_jsx_identifier(it),
             JSXMemberExpressionObject::IdentifierReference(it) => {
                 visitor.visit_identifier_reference(it)
             }

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -3508,7 +3508,6 @@ pub mod walk_mut {
         let kind = AstType::JSXMemberExpressionObject;
         visitor.enter_node(kind);
         match it {
-            JSXMemberExpressionObject::Identifier(it) => visitor.visit_jsx_identifier(it),
             JSXMemberExpressionObject::IdentifierReference(it) => {
                 visitor.visit_identifier_reference(it)
             }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2243,7 +2243,6 @@ impl<'a> Gen for JSXIdentifier<'a> {
 impl<'a> Gen for JSXMemberExpressionObject<'a> {
     fn gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
-            Self::Identifier(ident) => ident.gen(p, ctx),
             Self::IdentifierReference(ident) => ident.gen(p, ctx),
             Self::MemberExpression(member_expr) => member_expr.gen(p, ctx),
         }

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -44,7 +44,6 @@ fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a Identifi
 fn get_member_ident<'a>(mut expr: &'a JSXMemberExpression<'a>) -> Option<&'a IdentifierReference> {
     loop {
         match &expr.object {
-            JSXMemberExpressionObject::Identifier(_) => return None,
             JSXMemberExpressionObject::IdentifierReference(ident) => return Some(ident),
             JSXMemberExpressionObject::MemberExpression(next_expr) => {
                 expr = next_expr;

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -442,10 +442,6 @@ impl<'a> ParserImpl<'a> {
         }
         match (&lhs.object, &rhs.object) {
             (
-                JSXMemberExpressionObject::Identifier(lhs),
-                JSXMemberExpressionObject::Identifier(rhs),
-            ) => lhs.name == rhs.name,
-            (
                 JSXMemberExpressionObject::IdentifierReference(lhs),
                 JSXMemberExpressionObject::IdentifierReference(rhs),
             ) => lhs.name == rhs.name,

--- a/crates/oxc_transformer/src/react/jsx.rs
+++ b/crates/oxc_transformer/src/react/jsx.rs
@@ -782,16 +782,13 @@ impl<'a> ReactJsx<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let object = match &expr.object {
-            JSXMemberExpressionObject::Identifier(ident) => {
+            JSXMemberExpressionObject::IdentifierReference(ident) => {
                 if ident.name == "this" {
                     self.ast().expression_this(ident.span)
                 } else {
                     let ident = get_read_identifier_reference(ident.span, ident.name.clone(), ctx);
                     self.ast().expression_from_identifier_reference(ident)
                 }
-            }
-            JSXMemberExpressionObject::IdentifierReference(ident) => {
-                self.ast().expression_from_identifier_reference(ident.as_ref().clone())
             }
             JSXMemberExpressionObject::MemberExpression(expr) => {
                 self.transform_jsx_member_expression(expr, ctx)

--- a/crates/oxc_traverse/src/context/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/context/ast_operations/gather_node_parts.rs
@@ -485,7 +485,6 @@ impl<'a> GatherNodeParts<'a> for JSXMemberExpression<'a> {
 impl<'a> GatherNodeParts<'a> for JSXMemberExpressionObject<'a> {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         match self {
-            JSXMemberExpressionObject::Identifier(ident) => ident.gather(f),
             JSXMemberExpressionObject::IdentifierReference(ident) => ident.gather(f),
             JSXMemberExpressionObject::MemberExpression(expr) => expr.gather(f),
         }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3329,9 +3329,6 @@ pub(crate) unsafe fn walk_jsx_member_expression_object<'a, Tr: Traverse<'a>>(
 ) {
     traverser.enter_jsx_member_expression_object(&mut *node, ctx);
     match &mut *node {
-        JSXMemberExpressionObject::Identifier(node) => {
-            walk_jsx_identifier(traverser, (&mut **node) as *mut _, ctx)
-        }
         JSXMemberExpressionObject::IdentifierReference(node) => {
             walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
         }

--- a/tasks/coverage/semantic_typescript.snap
+++ b/tasks/coverage/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: a709f989
 
 semantic_typescript Summary:
 AST Parsed     : 6479/6479 (100.00%)
-Positive Passed: 3460/6479 (53.40%)
+Positive Passed: 3459/6479 (53.39%)
 tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 semantic error: Symbol reference IDs mismatch:
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -35323,10 +35323,10 @@ Reference symbol mismatch:
 after transform: ReferenceId(9): Some("Component")
 rebuilt        : ReferenceId(48): None
 Reference symbol mismatch:
-after transform: ReferenceId(10): Some("Namespace")
+after transform: ReferenceId(76): Some("Namespace")
 rebuilt        : ReferenceId(51): None
 Reference symbol mismatch:
-after transform: ReferenceId(11): Some("Namespace")
+after transform: ReferenceId(79): Some("Namespace")
 rebuilt        : ReferenceId(54): None
 Reference symbol mismatch:
 after transform: ReferenceId(12): Some("Component")
@@ -35469,20 +35469,28 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
 
+tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName5.tsx
+semantic error: Unresolved references mismatch:
+after transform: ["this"]
+rebuilt        : []
+
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["JSX", "_jsxFileName", "_reactJsxRuntime", "foo", "t"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime", "foo", "t"]
+Symbol reference IDs mismatch:
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(1)]
+rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName8.tsx
-semantic error: Unresolved reference IDs mismatch for "this":
-after transform: [ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(2)]
+semantic error: Unresolved references mismatch:
+after transform: ["this"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName9.tsx
-semantic error: Unresolved reference IDs mismatch for "this":
-after transform: [ReferenceId(1), ReferenceId(2)]
-rebuilt        : [ReferenceId(2)]
+semantic error: Unresolved references mismatch:
+after transform: ["this"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
 semantic error: Missing SymbolId: Dotted
@@ -35507,7 +35515,7 @@ Symbol reference IDs mismatch:
 after transform: SymbolId(5): []
 rebuilt        : SymbolId(6): [ReferenceId(2)]
 Reference symbol mismatch:
-after transform: ReferenceId(1): Some("Dotted")
+after transform: ReferenceId(8): Some("Dotted")
 rebuilt        : ReferenceId(13): Some("Dotted")
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
@@ -35908,6 +35916,9 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "JSX", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
+Reference symbol mismatch:
+after transform: ReferenceId(2): Some("A")
+rebuilt        : ReferenceId(2): None
 Unresolved reference IDs mismatch for "A":
 after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(2)]

--- a/tasks/transform_conformance/babel.snap.md
+++ b/tasks/transform_conformance/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 3bcfee23
 
-Passed: 318/1021
+Passed: 314/1021
 
 # All Passed:
 * babel-plugin-transform-optional-catch-binding
@@ -4852,8 +4852,11 @@ TS(18010)
 
 
 
-# babel-plugin-transform-react-jsx (119/144)
+# babel-plugin-transform-react-jsx (115/144)
 * react/arrow-functions/input.js
+  x Unresolved references mismatch:
+  | after transform: ["React", "this"]
+  | rebuilt        : ["React"]
 
 
 * react/dont-coerce-expression-containers/input.js
@@ -4876,6 +4879,18 @@ TS(18010)
 
 * react/honor-custom-jsx-pragma-option/input.js
   x Unresolved reference IDs mismatch for "Foo":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
+
+
+* react/should-allow-deeper-js-namespacing/input.js
+  x Unresolved reference IDs mismatch for "Namespace":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
+
+
+* react/should-allow-js-namespacing/input.js
+  x Unresolved reference IDs mismatch for "Namespace":
   | after transform: [ReferenceId(0), ReferenceId(1)]
   | rebuilt        : [ReferenceId(1)]
 
@@ -4924,9 +4939,9 @@ TS(18010)
 
 
 * react/this-tag-name/input.js
-  x Unresolved reference IDs mismatch for "this":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
+  x Unresolved references mismatch:
+  | after transform: ["React", "this"]
+  | rebuilt        : ["React"]
 
 
 * react/weird-symbols/input.js
@@ -4936,6 +4951,9 @@ TS(18010)
 
 
 * react-automatic/arrow-functions/input.js
+  x Unresolved references mismatch:
+  | after transform: ["this"]
+  | rebuilt        : []
 
 
 * react-automatic/does-not-add-source-self-automatic/input.mjs
@@ -4949,8 +4967,21 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 * react-automatic/handle-fragments-with-key/input.js
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+  | after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1),
+  | ReferenceId(2)]
   | rebuilt        : SymbolId(0): [ReferenceId(1)]
+
+
+* react-automatic/should-allow-deeper-js-namespacing/input.js
+  x Unresolved reference IDs mismatch for "Namespace":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
+
+
+* react-automatic/should-allow-js-namespacing/input.js
+  x Unresolved reference IDs mismatch for "Namespace":
+  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | rebuilt        : [ReferenceId(1)]
 
 
 * react-automatic/should-avoid-wrapping-in-extra-parens-if-not-needed/input.js
@@ -4997,9 +5028,9 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 
 * react-automatic/this-tag-name/input.js
-  x Unresolved reference IDs mismatch for "this":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
-  | rebuilt        : [ReferenceId(1)]
+  x Unresolved references mismatch:
+  | after transform: ["this"]
+  | rebuilt        : []
 
 
 * react-automatic/weird-symbols/input.js
@@ -5034,7 +5065,7 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 * cross-platform/handle-fragments-with-key/input.js
   x Unresolved reference IDs mismatch for "React":
-  | after transform: [ReferenceId(0), ReferenceId(1)]
+  | after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
   | rebuilt        : [ReferenceId(2)]
 
 

--- a/tasks/transform_conformance/oxc.snap.md
+++ b/tasks/transform_conformance/oxc.snap.md
@@ -640,57 +640,61 @@ Passed: 10/39
 * refresh/registers-identifiers-used-in-jsx-at-definition-site/input.jsx
   x Output mismatch
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(13): [ReferenceId(22), ReferenceId(44),
-  | ReferenceId(45)]
+  | after transform: SymbolId(9): [ReferenceId(17), ReferenceId(42)]
+  | rebuilt        : SymbolId(11): [ReferenceId(33)]
+
+  x Symbol reference IDs mismatch:
+  | after transform: SymbolId(13): [ReferenceId(22), ReferenceId(45),
+  | ReferenceId(46)]
   | rebuilt        : SymbolId(15): [ReferenceId(2), ReferenceId(45)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(14): [ReferenceId(24), ReferenceId(46),
-  | ReferenceId(47)]
+  | after transform: SymbolId(14): [ReferenceId(24), ReferenceId(47),
+  | ReferenceId(48)]
   | rebuilt        : SymbolId(16): [ReferenceId(5), ReferenceId(47)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(15): [ReferenceId(26), ReferenceId(48),
-  | ReferenceId(49)]
+  | after transform: SymbolId(15): [ReferenceId(26), ReferenceId(49),
+  | ReferenceId(50)]
   | rebuilt        : SymbolId(17): [ReferenceId(11), ReferenceId(49)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(16): [ReferenceId(28), ReferenceId(50),
-  | ReferenceId(51)]
+  | after transform: SymbolId(16): [ReferenceId(28), ReferenceId(51),
+  | ReferenceId(52)]
   | rebuilt        : SymbolId(18): [ReferenceId(34), ReferenceId(51)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(17): [ReferenceId(30), ReferenceId(52),
-  | ReferenceId(53)]
+  | after transform: SymbolId(17): [ReferenceId(30), ReferenceId(53),
+  | ReferenceId(54)]
   | rebuilt        : SymbolId(19): [ReferenceId(38), ReferenceId(53)]
 
   x Symbol reference IDs mismatch:
-  | after transform: SymbolId(18): [ReferenceId(32), ReferenceId(54),
-  | ReferenceId(55)]
+  | after transform: SymbolId(18): [ReferenceId(32), ReferenceId(55),
+  | ReferenceId(56)]
   | rebuilt        : SymbolId(20): [ReferenceId(42), ReferenceId(55)]
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(44): Some("_c")
+  | after transform: ReferenceId(45): Some("_c")
   | rebuilt        : ReferenceId(44): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(46): Some("_c2")
+  | after transform: ReferenceId(47): Some("_c2")
   | rebuilt        : ReferenceId(46): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(48): Some("_c3")
+  | after transform: ReferenceId(49): Some("_c3")
   | rebuilt        : ReferenceId(48): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(50): Some("_c4")
+  | after transform: ReferenceId(51): Some("_c4")
   | rebuilt        : ReferenceId(50): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(52): Some("_c5")
+  | after transform: ReferenceId(53): Some("_c5")
   | rebuilt        : ReferenceId(52): None
 
   x Reference symbol mismatch:
-  | after transform: ReferenceId(54): Some("_c6")
+  | after transform: ReferenceId(55): Some("_c6")
   | rebuilt        : ReferenceId(54): None
 
   x Unresolved references mismatch:


### PR DESCRIPTION
close: #5353 

`JSXMemberExpressionObject::Identifier` is dead code.