### PR TITLE
feat(ast): add and auto-generate `WithBindingIdentifier` trait

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -16,6 +16,7 @@ src:
   - 'crates/oxc_ast/src/generated/derive_clone_in.rs'
   - 'crates/oxc_ast/src/generated/derive_get_span.rs'
   - 'crates/oxc_ast/src/generated/derive_get_span_mut.rs'
+  - 'crates/oxc_ast/src/generated/derive_symbol_traits.rs'
   - 'crates/oxc_ast/src/generated/visit.rs'
   - 'crates/oxc_ast/src/generated/visit_mut.rs'
   - 'tasks/ast_codegen/src/**'

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1261,6 +1261,7 @@ pub struct VariableDeclarator<'a> {
     pub span: Span,
     #[serde(skip)]
     pub kind: VariableDeclarationKind,
+    #[symbol(binding, recurse)]
     pub id: BindingPattern<'a>,
     pub init: Option<Expression<'a>>,
     pub definite: bool,
@@ -1563,6 +1564,7 @@ pub struct CatchClause<'a> {
 pub struct CatchParameter<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding, recurse)]
     pub pattern: BindingPattern<'a>,
 }
 
@@ -1589,6 +1591,7 @@ pub struct BindingPattern<'a> {
     #[serde(flatten)]
     #[tsify(type = "(BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern)")]
     #[span]
+    #[symbol(binding, recurse)]
     pub kind: BindingPatternKind<'a>,
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub optional: bool,
@@ -1621,6 +1624,7 @@ pub enum BindingPatternKind<'a> {
 pub struct AssignmentPattern<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding, recurse)]
     pub left: BindingPattern<'a>,
     pub right: Expression<'a>,
 }
@@ -1649,6 +1653,7 @@ pub struct BindingProperty<'a> {
     #[serde(flatten)]
     pub span: Span,
     pub key: PropertyKey<'a>,
+    #[symbol(binding, recurse)]
     pub value: BindingPattern<'a>,
     pub shorthand: bool,
     pub computed: bool,
@@ -1677,6 +1682,7 @@ pub struct ArrayPattern<'a> {
 pub struct BindingRestElement<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding, recurse)]
     pub argument: BindingPattern<'a>,
 }
 
@@ -1695,6 +1701,7 @@ pub struct Function<'a> {
     pub r#type: FunctionType,
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding, optional)]
     pub id: Option<BindingIdentifier<'a>>,
     pub generator: bool,
     pub r#async: bool,
@@ -1762,6 +1769,7 @@ pub struct FormalParameter<'a> {
     #[serde(flatten)]
     pub span: Span,
     pub decorators: Vec<'a, Decorator<'a>>,
+    #[symbol(binding, recurse)]
     pub pattern: BindingPattern<'a>,
     pub accessibility: Option<TSAccessibility>,
     pub readonly: bool,
@@ -1858,6 +1866,7 @@ pub struct Class<'a> {
     /// ```
     pub decorators: Vec<'a, Decorator<'a>>,
     /// Class identifier, AKA the name
+    #[symbol(binding, optional)]
     pub id: Option<BindingIdentifier<'a>>,
     #[scope(enter_before)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -2355,6 +2364,7 @@ pub struct ImportSpecifier<'a> {
     /// import { Foo as Bar } from 'foo';
     /// //              ^^^
     /// ```
+    #[symbol]
     pub local: BindingIdentifier<'a>,
     pub import_kind: ImportOrExportKind,
 }
@@ -2375,6 +2385,7 @@ pub struct ImportDefaultSpecifier<'a> {
     #[serde(flatten)]
     pub span: Span,
     /// The name of the imported symbol.
+    #[symbol]
     pub local: BindingIdentifier<'a>,
 }
 
@@ -2392,6 +2403,7 @@ pub struct ImportDefaultSpecifier<'a> {
 pub struct ImportNamespaceSpecifier<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol]
     pub local: BindingIdentifier<'a>,
 }
 

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1701,7 +1701,7 @@ pub struct Function<'a> {
     pub r#type: FunctionType,
     #[serde(flatten)]
     pub span: Span,
-    #[symbol(binding, optional)]
+    #[symbol]
     pub id: Option<BindingIdentifier<'a>>,
     pub generator: bool,
     pub r#async: bool,
@@ -1866,7 +1866,7 @@ pub struct Class<'a> {
     /// ```
     pub decorators: Vec<'a, Decorator<'a>>,
     /// Class identifier, AKA the name
-    #[symbol(binding, optional)]
+    #[symbol]
     pub id: Option<BindingIdentifier<'a>>,
     #[scope(enter_before)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -71,6 +71,7 @@ pub struct TSThisParameter<'a> {
 pub struct TSEnumDeclaration<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding)]
     pub id: BindingIdentifier<'a>,
     #[scope(enter_before)]
     pub members: Vec<'a, TSEnumMember<'a>>,
@@ -728,6 +729,7 @@ pub struct TSTypeParameterInstantiation<'a> {
 pub struct TSTypeParameter<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding)]
     pub name: BindingIdentifier<'a>,
     pub constraint: Option<TSType<'a>>,
     pub default: Option<TSType<'a>>,
@@ -756,6 +758,7 @@ pub struct TSTypeParameterDeclaration<'a> {
 pub struct TSTypeAliasDeclaration<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding)]
     pub id: BindingIdentifier<'a>,
     #[scope(enter_before)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -802,6 +805,7 @@ pub struct TSInterfaceDeclaration<'a> {
     #[serde(flatten)]
     pub span: Span,
     /// The identifier (name) of the interface.
+    #[symbol(binding)]
     pub id: BindingIdentifier<'a>,
     #[scope(enter_before)]
     pub extends: Option<Vec<'a, TSInterfaceHeritage<'a>>>,
@@ -1287,6 +1291,7 @@ pub struct TSTypeAssertion<'a> {
 pub struct TSImportEqualsDeclaration<'a> {
     #[serde(flatten)]
     pub span: Span,
+    #[symbol(binding)]
     pub id: BindingIdentifier<'a>,
     pub module_reference: TSModuleReference<'a>,
     pub import_kind: ImportOrExportKind,

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1,4 +1,4 @@
-use crate::ast::*;
+use crate::{ast::*, WithBindingIdentifier};
 
 use std::{borrow::Cow, cell::Cell, fmt, hash::Hash};
 
@@ -996,6 +996,23 @@ impl<'a> BindingPatternKind<'a> {
 
     pub fn is_assignment_pattern(&self) -> bool {
         matches!(self, Self::AssignmentPattern(_))
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for BindingPatternKind<'a> {
+    fn symbol_id(&self) -> Option<oxc_syntax::symbol::SymbolId> {
+        match self {
+            Self::BindingIdentifier(ident) => ident.symbol_id.get(),
+            Self::AssignmentPattern(assign) => assign.left.kind.symbol_id(),
+            _ => None,
+        }
+    }
+    fn name(&self) -> Option<Atom<'a>> {
+        match self {
+            Self::BindingIdentifier(ident) => Some(ident.name.clone()),
+            Self::AssignmentPattern(assign) => assign.left.kind.name(),
+            _ => None,
+        }
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_symbol_traits.rs
+++ b/crates/oxc_ast/src/generated/derive_symbol_traits.rs
@@ -1,0 +1,210 @@
+use oxc_syntax::symbol::SymbolId;
+
+#[allow(clippy::wildcard_imports)]
+use crate::ast::*;
+use crate::WithBindingIdentifier;
+use oxc_span::Atom;
+
+impl<'a> WithBindingIdentifier<'a> for VariableDeclarator<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.id.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for CatchParameter<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.pattern.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.pattern.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for BindingPattern<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.kind.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.kind.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for AssignmentPattern<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.left.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.left.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for BindingProperty<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.value.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.value.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for BindingRestElement<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.argument.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.argument.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for Function<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.as_ref().and_then(|id| id.symbol_id.get())
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.id.as_ref().map(|id| id.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for FormalParameter<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.pattern.symbol_id()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.pattern.name()
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for Class<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.as_ref().and_then(|id| id.symbol_id.get())
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        self.id.as_ref().map(|id| id.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for ImportSpecifier<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.local.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.local.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for ImportDefaultSpecifier<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.local.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.local.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for ImportNamespaceSpecifier<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.local.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.local.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for TSEnumDeclaration<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.id.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for TSTypeParameter<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.name.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.name.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for TSTypeAliasDeclaration<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.id.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for TSInterfaceDeclaration<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.id.name.clone())
+    }
+}
+
+impl<'a> WithBindingIdentifier<'a> for TSImportEqualsDeclaration<'a> {
+    #[inline]
+    fn symbol_id(&self) -> Option<SymbolId> {
+        self.id.symbol_id.get()
+    }
+
+    #[inline]
+    fn name(&self) -> Option<Atom<'a>> {
+        Some(self.id.name.clone())
+    }
+}

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -34,7 +34,10 @@ mod ast_impl;
 mod ast_kind_impl;
 pub mod precedence;
 pub mod syntax_directed_operations;
+mod traits;
 mod trivia;
+
+pub use traits::*;
 
 mod generated {
     #[cfg(debug_assertions)]
@@ -44,6 +47,7 @@ mod generated {
     pub mod derive_clone_in;
     pub mod derive_get_span;
     pub mod derive_get_span_mut;
+    pub mod derive_symbol_traits;
     pub mod visit;
     pub mod visit_mut;
 }

--- a/crates/oxc_ast/src/traits/get_binding_identifier.rs
+++ b/crates/oxc_ast/src/traits/get_binding_identifier.rs
@@ -1,8 +1,28 @@
 use oxc_span::Atom;
 use oxc_syntax::symbol::SymbolId;
 
+/// Trait for accessing a [`BindingIdentifier`](`crate::ast::BindingIdentifier`)
+/// within an AST Node. Most often used on nodes that create symbol bindings.
 pub trait WithBindingIdentifier<'a> {
+    /// Get the [`SymbolId`] bound to this AST node.
+    ///
+    /// Will return [`None`] if:
+    /// 1. The AST node does not create a symbol binding, such as anonymous
+    ///    function expressions,
+    /// 2. Semantic analysis has been skipped, or
+    /// 3. The symbol binding is within a destructuring pattern and cannot be uniquely
+    ///    identified.
     fn symbol_id(&self) -> Option<SymbolId>;
 
+    /// Get the identifier name of the symbol this AST node binds.
+    ///
+    /// Will return [`None`] if:
+    /// 1. The AST node does not create a symbol binding, such as anonymous
+    ///   function expressions,
+    /// 2. The symbol binding is within a destructuring pattern and cannot be uniquely
+    ///    identified.
+    ///
+    /// Note that identifier names are determined at parse time, so this method
+    /// is unaffected by semantic analysis.
     fn name(&self) -> Option<Atom<'a>>;
 }

--- a/crates/oxc_ast/src/traits/get_binding_identifier.rs
+++ b/crates/oxc_ast/src/traits/get_binding_identifier.rs
@@ -1,0 +1,8 @@
+use oxc_span::Atom;
+use oxc_syntax::symbol::SymbolId;
+
+pub trait WithBindingIdentifier<'a> {
+    fn symbol_id(&self) -> Option<SymbolId>;
+
+    fn name(&self) -> Option<Atom<'a>>;
+}

--- a/crates/oxc_ast/src/traits/mod.rs
+++ b/crates/oxc_ast/src/traits/mod.rs
@@ -1,0 +1,3 @@
+mod get_binding_identifier;
+
+pub use get_binding_identifier::WithBindingIdentifier;

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -163,7 +163,10 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// The only purpose is to allow the occurrence of helper attributes used with the `tasks/ast_tools`.
 ///
 /// Read [`macro@ast`] for further details.
-#[proc_macro_derive(Ast, attributes(scope, visit, span, generate_derive, clone_in, serde, tsify))]
+#[proc_macro_derive(
+    Ast,
+    attributes(scope, symbol, visit, span, generate_derive, clone_in, serde, tsify)
+)]
 pub fn ast_derive(_item: TokenStream) -> TokenStream {
     TokenStream::new()
 }
@@ -196,3 +199,9 @@ pub fn derive_clone_in(item: TokenStream) -> TokenStream {
         _ => panic!("At the moment `CloneIn` derive macro only works for types without lifetimes and/or generic params"),
     }
 }
+
+// #[proc_macro_attribute]
+// pub fn symbol(args: TokenStream, input: TokenStream, ) -> TokenStream {
+//     // TokenStream::new()
+//     input
+// }

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -119,6 +119,33 @@ fn assert_generated_derives(attrs: &[syn::Attribute]) -> TokenStream2 {
 /// However, Instead of expanding the derive at compile-time, We do this process on PR submits via `ast_tools` code generation.
 /// These derived implementations would be output in the `crates/oxc_ast/src/generated` directory.
 ///
+/// ## `#[symbol]`
+///
+/// This attribute hints that a field stores an identifier binding or reference.
+/// It gets used to derive several useful traits for the entire node struct.
+///
+/// There are two variants of this attribute:
+/// 1. `#[symbol(binding[, ...opts])]` - hints that this field contains a
+///    `BindingIdentifier`. You may also use `#[symbol]` as a shorthand for this.
+/// 2. `#[symbol(reference[, ...opts])]` - hints that this field contains an
+///    `IdentifierReference`. **NOTE that this is not yet implemented.**
+///
+/// ### Example
+/// ```ignore
+/// // simplified Function node
+/// struct Function<'a> {
+///   #[symbol]
+///   id: Option<BindingIdentifier<'a>>,
+///   body: Option<FunctionBody<'a>>
+/// }
+/// ```
+///
+/// ### `#[symbol(binding[, ...opts])]` Options
+/// The `binding` variant contains the following options. All options are
+/// optional flags that can be combined.
+/// - `recurse`: the field is a recursive binding, i.e. this field stores a
+///   struct that itself has a field marked as `#[symbol(binding)]`.
+///
 /// # Derive Helper Attributes:
 ///
 /// These are helper attributes that are only meaningful when their respective trait is derived via `generate_derive`.
@@ -199,9 +226,3 @@ pub fn derive_clone_in(item: TokenStream) -> TokenStream {
         _ => panic!("At the moment `CloneIn` derive macro only works for types without lifetimes and/or generic params"),
     }
 }
-
-// #[proc_macro_attribute]
-// pub fn symbol(args: TokenStream, input: TokenStream, ) -> TokenStream {
-//     // TokenStream::new()
-//     input
-// }

--- a/tasks/ast_tools/src/generators/derive_symbol_traits.rs
+++ b/tasks/ast_tools/src/generators/derive_symbol_traits.rs
@@ -1,0 +1,94 @@
+use proc_macro2::TokenStream;
+
+use crate::{
+    codegen::LateCtx,
+    markers::{SymbolBinding, SymbolMarkers},
+    output,
+    schema::{FieldDef, GetIdent, StructDef, TypeDef},
+};
+use quote::quote;
+
+use super::{define_generator, Generator, GeneratorOutput};
+
+define_generator! {
+    pub struct DeriveSymbolTraitsGenerator;
+}
+
+impl Generator for DeriveSymbolTraitsGenerator {
+    fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
+        let impls: Vec<_> = ctx
+            .schema()
+            .into_iter()
+            .filter_map(TypeDef::as_struct)
+            .filter_map(|struct_def| {
+                struct_def.fields.iter().find_map(|field| {
+                    field
+                        .markers
+                        .binding
+                        .as_ref()
+                        .and_then(SymbolMarkers::as_binding)
+                        .map(|binding| (struct_def, field, binding))
+                })
+            })
+            .map(generate_symbol_id_impl)
+            .collect();
+
+        let stream = quote! {
+            use oxc_syntax::symbol::SymbolId;
+
+            ///@@line_break
+            #[allow(clippy::wildcard_imports)]
+            use crate::ast::*;
+            use crate::WithBindingIdentifier;
+            use oxc_span::Atom;
+
+            ///@@line_break
+            #(#impls)*
+        };
+
+        GeneratorOutput::Stream((output(crate::AST_CRATE, "derive_symbol_traits.rs"), stream))
+    }
+}
+
+fn generate_symbol_id_impl(
+    (def, field, binding): (&StructDef, &FieldDef, &SymbolBinding),
+) -> TokenStream {
+    let struct_name = &def.ident();
+    let field_name = field.ident().unwrap();
+    let (symbol_id_impl, name_impl) = if binding.optional {
+        if binding.recurse {
+            (
+                quote! { self.#field_name.as_ref().and_then(WithBindingIdentifier::symbol_id) },
+                quote! { self.#field_name.as_ref().map(WithBindingIdentifier::name) },
+            )
+        } else {
+            (
+                quote! { self.#field_name.as_ref().and_then(|id| id.symbol_id.get()) },
+                quote! { self.#field_name.as_ref().map(|id| id.name.clone()) },
+            )
+        }
+    } else if binding.recurse {
+        (quote! { self.#field_name.symbol_id() }, quote! { self.#field_name.name() })
+    } else {
+        (
+            quote! { self.#field_name.symbol_id.get() },
+            quote! { Some(self.#field_name.name.clone()) },
+        )
+    };
+
+    quote! {
+        ///@@line_break
+        impl<'a> WithBindingIdentifier<'a> for #struct_name<'a> {
+            #[inline]
+            fn symbol_id(&self) -> Option<SymbolId> {
+                #symbol_id_impl
+            }
+
+            ///@@line_break
+            #[inline]
+            fn name(&self) -> Option<Atom<'a>> {
+                #name_impl
+            }
+        }
+    }
+}

--- a/tasks/ast_tools/src/generators/derive_symbol_traits.rs
+++ b/tasks/ast_tools/src/generators/derive_symbol_traits.rs
@@ -55,7 +55,9 @@ fn generate_symbol_id_impl(
 ) -> TokenStream {
     let struct_name = &def.ident();
     let field_name = field.ident().unwrap();
-    let (symbol_id_impl, name_impl) = if binding.optional {
+    let analysis = field.typ.analysis();
+    let is_optional = analysis.is_optional();
+    let (symbol_id_impl, name_impl) = if is_optional {
         if binding.recurse {
             (
                 quote! { self.#field_name.as_ref().and_then(WithBindingIdentifier::symbol_id) },

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -9,6 +9,7 @@ mod ast_builder;
 mod ast_kind;
 mod derive_clone_in;
 mod derive_get_span;
+mod derive_symbol_traits;
 mod visit;
 
 pub use assert_layouts::AssertLayouts;
@@ -16,6 +17,7 @@ pub use ast_builder::AstBuilderGenerator;
 pub use ast_kind::AstKindGenerator;
 pub use derive_clone_in::DeriveCloneIn;
 pub use derive_get_span::{DeriveGetSpan, DeriveGetSpanMut};
+pub use derive_symbol_traits::DeriveSymbolTraitsGenerator;
 pub use visit::{VisitGenerator, VisitMutGenerator};
 
 /// Inserts a newline in the `TokenStream`.
@@ -103,6 +105,22 @@ impl GeneratorOutput {
     }
 }
 
+/// Define a [`Generator`] struct.
+///
+/// # Example
+/// ```ignore
+/// use ast_tools::codegen::LateCtx;
+/// use ast_tools::generators::{define_generator, Generator, GeneratorOutput};
+///
+/// define_generator! {
+///     pub struct MyGenerator;
+/// }
+/// impl Generator for MyGenerator {
+///     fn generate(&mut self, ctx: &LateCtx) -> GeneratorOutput {
+///         // generate code here
+///     }
+/// }
+/// ```
 macro_rules! define_generator {
     ($vis:vis struct $ident:ident $($lifetime:lifetime)? $($rest:tt)*) => {
         $vis struct $ident $($lifetime)? $($rest)*

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -18,8 +18,8 @@ mod util;
 use fmt::{cargo_fmt, pretty_print};
 use generators::{
     AssertLayouts, AstBuilderGenerator, AstKindGenerator, DeriveCloneIn, DeriveGetSpan,
-    DeriveGetSpanMut, GeneratedDataStream, GeneratedTokenStream, Generator, GeneratorOutput,
-    VisitGenerator, VisitMutGenerator,
+    DeriveGetSpanMut, DeriveSymbolTraitsGenerator, GeneratedDataStream, GeneratedTokenStream,
+    Generator, GeneratorOutput, VisitGenerator, VisitMutGenerator,
 };
 use passes::{CalcLayout, Linker};
 use util::{write_all_to, NormalizeError};
@@ -66,6 +66,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .gen(DeriveCloneIn)
         .gen(DeriveGetSpan)
         .gen(DeriveGetSpanMut)
+        .gen(DeriveSymbolTraitsGenerator)
         .gen(VisitGenerator)
         .gen(VisitMutGenerator)
         .generate()?;

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -74,9 +74,6 @@ pub enum SymbolMarkers {
 
 #[derive(Default, Debug, Clone)]
 pub struct SymbolBinding {
-    /// `true` if it's possible for the `BindingIdentifier` to not exist (e.g.
-    /// the field has type `Option<BindingIdentifier<'a>>`).
-    pub optional: bool,
     /// `recurse` option was set, indicating that trait implementations should
     /// call methods on the binding-marked property.
     pub recurse: bool,
@@ -278,9 +275,6 @@ impl Parse for SymbolBinding {
         let idents = input.parse_terminated(Ident::parse, Token![,])?;
         for ident in idents {
             match ident.to_string().as_str() {
-                "optional" => {
-                    symbol.optional = true;
-                }
                 "recurse" => {
                     symbol.recurse = true;
                 }

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -4,7 +4,10 @@ use serde::Serialize;
 use crate::{
     codegen,
     layout::KnownLayout,
-    markers::{get_derive_attributes, get_scope_attribute, get_scope_markers, get_visit_markers},
+    markers::{
+        get_derive_attributes, get_scope_attribute, get_scope_markers, get_symbol_markers,
+        get_visit_markers,
+    },
     rust_ast as rust,
     util::{unexpanded_macro_err, TypeExt},
     Result, TypeId,
@@ -111,6 +114,7 @@ fn parse_inner_markers(attrs: &Vec<syn::Attribute>) -> Result<InnerMarkers> {
         span: attrs.iter().any(|a| a.path().is_ident("span")),
         visit: get_visit_markers(attrs)?,
         scope: get_scope_markers(attrs)?,
+        binding: get_symbol_markers(attrs)?,
         derive_attributes: get_derive_attributes(attrs)?,
     })
 }

--- a/tasks/ast_tools/src/util.rs
+++ b/tasks/ast_tools/src/util.rs
@@ -118,7 +118,7 @@ impl<'a> TypeIdentResult<'a> {
 
 // TODO: remove me
 #[allow(dead_code)]
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize)]
 pub enum TypeWrapper {
     None,
     Box,
@@ -140,6 +140,11 @@ pub struct TypeAnalysis {
     // pub name: String,
     #[serde(skip)]
     pub typ: Type,
+}
+impl TypeAnalysis {
+    pub fn is_optional(&self) -> bool {
+        matches!(self.wrapper, TypeWrapper::Opt | TypeWrapper::OptBox | TypeWrapper::OptVec)
+    }
 }
 
 impl TypeExt for Type {


### PR DESCRIPTION
# What This PR Does
1. adds a `WithBindingIdentifier` trait for accessing `BindingIdentifiers` on relevant AST nodes in a standard way.
2. adds a generator to `ast_tools` that auto-implements this trait for most AST nodes.
3. Minor cleanup and docs for `ast_tools` that I did as I figured out how things worked.