### PR TITLE
refactor(ast): reduce allocations in `AstBuilder::move_assignment_target`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -84,7 +84,8 @@ impl<'a> AstBuilder<'a> {
 
     #[inline]
     pub fn move_assignment_target(self, target: &mut AssignmentTarget<'a>) -> AssignmentTarget<'a> {
-        let dummy = self.simple_assignment_target_identifier_reference(Span::default(), "");
+        let dummy =
+            self.simple_assignment_target_identifier_reference(Span::default(), Atom::from(""));
         mem::replace(target, dummy.into())
     }
 


### PR DESCRIPTION
`AstBuilder::move_assignment_target` pass a static `Atom` instead of empty string to `AstBuilder::simple_assignment_target_identifier_reference`. This avoids a call to `alloc` to allocate an empty string in arena.